### PR TITLE
Implement suggestions in #35

### DIFF
--- a/gkr-graph/examples/series_connection_alt.rs
+++ b/gkr-graph/examples/series_connection_alt.rs
@@ -99,9 +99,10 @@ fn main() -> Result<(), GKRGraphError> {
         graph_builder.add_node_with_witness(
             "input",
             &input_circuit,
-            vec![PredType::Source],
+            vec![PredType::Source(0)],
             challenge,
-            vec![input_circuit_wires_in.clone()],
+            vec![vec![input_circuit_wires_in.clone()]],
+            1,
         )?
     };
     let pad_with_one = graph_builder.add_node_with_witness(
@@ -109,7 +110,8 @@ fn main() -> Result<(), GKRGraphError> {
         &pad_with_one_circuit,
         vec![PredType::PredWire(NodeOutputType::WireOut(input, 0))],
         vec![],
-        vec![vec![]],
+        vec![],
+        1,
     )?;
     let mut input_size = input_circuit_wires_in.len();
     let inv_sum = graph_builder.add_node_with_witness(
@@ -119,7 +121,8 @@ fn main() -> Result<(), GKRGraphError> {
             pad_with_one,
         ))],
         vec![],
-        vec![vec![]; input_size / 2],
+        vec![],
+        input_size >> 1,
     )?;
     input_size >>= 1;
     let mut frac_sum_input = inv_sum;
@@ -131,7 +134,8 @@ fn main() -> Result<(), GKRGraphError> {
                 frac_sum_input,
             ))],
             vec![],
-            vec![vec![]; input_size / 2],
+            vec![],
+            input_size >> 1,
         )?;
         input_size >>= 1;
     }

--- a/gkr-graph/src/prover.rs
+++ b/gkr-graph/src/prover.rs
@@ -1,6 +1,6 @@
 use gkr::{structs::IOPProverPhase2Message, utils::MultilinearExtensionFromVectors};
 use goldilocks::SmallField;
-use itertools::izip;
+use itertools::{chain, izip, Itertools};
 use std::mem;
 use transcript::Transcript;
 
@@ -44,10 +44,10 @@ impl<F: SmallField> IOPProverState<F> {
                     sumcheck_eval_values,
                 } = &proof.sumcheck_proofs.last().unwrap().1;
                 izip!(sumcheck_proofs, sumcheck_eval_values).for_each(|(proof, evals)| {
-                    izip!(0.., &node.preds, evals).for_each(|(wire_id, pred, eval)| match pred {
-                        PredType::Source => {
+                    izip!(&node.preds, evals).for_each(|(pred, eval)| match pred {
+                        PredType::Source(wire_id) => {
                             debug_assert_eq!(
-                                witness.wires_in_ref()[wire_id]
+                                witness.wires_in_ref()[*wire_id as usize]
                                     .as_slice()
                                     .mle(
                                         node.circuit.max_wires_in_num_vars,
@@ -57,21 +57,39 @@ impl<F: SmallField> IOPProverState<F> {
                                 *eval
                             );
                         }
-                        PredType::PredWire(out) | PredType::PredWireTrans(out) => match out {
-                            NodeOutputType::OutputLayer(id) => {
-                                output_evals[*id].push((proof.point.clone(), *eval))
+                        PredType::PredWire(out)
+                        | PredType::PredWireTrans(out)
+                        | PredType::PredWireDup(out) => {
+                            let point = match pred {
+                                PredType::PredWire(_) => proof.point.clone(),
+                                PredType::PredWireTrans(_) => {
+                                    let mid = proof.point.len() - witness.instance_num_vars();
+                                    let (lo, hi) = proof.point.split_at(mid);
+                                    chain![hi, lo].copied().collect_vec()
+                                }
+                                PredType::PredWireDup(_) => {
+                                    let dedup_num_vars =
+                                        proof.point.len() - witness.instance_num_vars();
+                                    proof.point[..dedup_num_vars].to_vec()
+                                }
+                                _ => unreachable!(),
+                            };
+                            match out {
+                                NodeOutputType::OutputLayer(id) => {
+                                    output_evals[*id].push((point, *eval))
+                                }
+                                NodeOutputType::WireOut(id, wire_id) => {
+                                    wires_out_evals[*id]
+                                        .resize(*wire_id as usize + 1, (vec![], F::ZERO));
+                                    let evals = &mut wires_out_evals[*id][*wire_id as usize];
+                                    assert!(
+                                        evals.0.is_empty() && evals.1.is_zero_vartime(),
+                                        "unimplemented",
+                                    );
+                                    *evals = (point, *eval);
+                                }
                             }
-                            NodeOutputType::WireOut(id, wire_id) => {
-                                wires_out_evals[*id]
-                                    .resize(*wire_id as usize + 1, (vec![], F::ZERO));
-                                let evals = &mut wires_out_evals[*id][*wire_id as usize];
-                                assert!(
-                                    evals.0.is_empty() && evals.1.is_zero_vartime(),
-                                    "unimplemented",
-                                );
-                                *evals = (proof.point.clone(), *eval);
-                            }
-                        },
+                        }
                     });
                 });
 

--- a/gkr-graph/src/structs.rs
+++ b/gkr-graph/src/structs.rs
@@ -41,9 +41,10 @@ pub enum NodeOutputType {
 /// be one wire_out instance connected to one wire_in instance, or one wire_out
 /// connected to multiple wire_in instances.
 pub enum PredType {
-    Source,
+    Source(WireId),
     PredWire(NodeOutputType),
     PredWireTrans(NodeOutputType),
+    PredWireDup(NodeOutputType),
 }
 
 pub struct CircuitNode<F: SmallField> {


### PR DESCRIPTION
- Allow multiple `sources` when `add_node_with_witness`, and make `PredType::Source` be `PredType::Source(WireId)` for speficying which source to use.
- `add_node_with_witness` now needs to specify number of instances, because we couldn't always get the info from sources (some node might not have source).
- Implement `PredWireTrans` and `PredWireDup`