### PR TITLE
Singer utils refactor

### DIFF
--- a/singer-utils/Cargo.toml
+++ b/singer-utils/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "singer-utils"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+ff.workspace = true
+goldilocks.workspace = true
+
+gkr = { path = "../gkr" }
+itertools = "0.12.0"
+simple-frontend = { version = "0.1.0", path = "../simple-frontend" }
+gkr-graph = { version = "0.1.0", path = "../gkr-graph" }

--- a/singer-utils/src/chip_handler.rs
+++ b/singer-utils/src/chip_handler.rs
@@ -1,0 +1,261 @@
+use goldilocks::SmallField;
+use simple_frontend::structs::{CellId, ChallengeId, CircuitBuilder, MixedCell, WitnessId};
+
+use crate::{
+    constants::OpcodeType,
+    error::UtilError,
+    structs::{ChipChallenges, UInt},
+};
+
+pub mod bytecode;
+pub mod calldata;
+pub mod global_state;
+pub mod memory;
+pub mod ram_handler;
+pub mod range;
+pub mod rom_handler;
+pub mod stack;
+
+pub trait BytecodeChipOperations<Ext: SmallField>: ROMOperations<Ext> {
+    fn bytecode_with_pc_opcode(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        pc: &[CellId],
+        opcode: OpcodeType,
+    );
+
+    fn bytecode_with_pc_byte(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        pc: &[CellId],
+        byte: CellId,
+    );
+}
+
+pub trait StackChipOperations<Ext: SmallField>: OAMOperations<Ext> {
+    fn stack_push(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        stack_top: MixedCell<Ext>,
+        stack_ts: &[CellId],
+        values: &[CellId],
+    );
+
+    fn stack_pop(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        stack_top: MixedCell<Ext>,
+        stack_ts: &[CellId],
+        values: &[CellId],
+    );
+}
+
+pub trait RangeChipOperations<Ext: SmallField>: ROMOperations<Ext> {
+    fn range_check_stack_top(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        stack_top: MixedCell<Ext>,
+    ) -> Result<(), UtilError>;
+
+    fn range_check_uint<const M: usize, const C: usize>(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        uint: &UInt<M, C>,
+        range_value_witness: Option<&[CellId]>,
+    ) -> Result<UInt<M, C>, UtilError>;
+
+    fn range_check_bytes(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        bytes: &[CellId],
+    ) -> Result<(), UtilError>;
+}
+
+pub trait MemoryChipOperations<Ext: SmallField>: RAMOperations<Ext> {
+    fn mem_load(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        offset: &[CellId],
+        old_ts: &[CellId],
+        cur_ts: &[CellId],
+        byte: CellId,
+    );
+
+    fn mem_store(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        offset: &[CellId],
+        old_ts: &[CellId],
+        cur_ts: &[CellId],
+        old_byte: CellId,
+        cur_byte: CellId,
+    );
+}
+
+pub trait CalldataChipOperations<Ext: SmallField>: ROMOperations<Ext> {
+    fn calldataload(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        offset: &[CellId],
+        data: &[CellId],
+    );
+}
+
+pub trait GlobalStateChipOperations<F: SmallField> {
+    fn state_in(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<F>,
+        pc: &[CellId],
+        stack_ts: &[CellId],
+        memory_ts: &[CellId],
+        stack_top: CellId,
+        clk: CellId,
+    );
+
+    fn state_out(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<F>,
+        pc: &[CellId],
+        stack_ts: &[CellId],
+        memory_ts: &[CellId],
+        stack_top: MixedCell<F>,
+        clk: MixedCell<F>,
+    );
+}
+
+pub trait ROMOperations<Ext: SmallField> {
+    fn rom_load(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        key: &[CellId],
+        value: &[CellId],
+    );
+
+    fn rom_load_mixed(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        key: &[MixedCell<Ext>],
+        value: &[MixedCell<Ext>],
+    );
+
+    fn finalize(self, circuit_builder: &mut CircuitBuilder<Ext>) -> Option<(WitnessId, usize)>;
+}
+
+// Once access memory
+pub trait OAMOperations<Ext: SmallField> {
+    fn oam_load(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        old_ts: &[CellId],
+        key: &[CellId],
+        value: &[CellId],
+    );
+
+    fn oam_load_mixed(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        old_ts: &[MixedCell<Ext>],
+        key: &[MixedCell<Ext>],
+        value: &[MixedCell<Ext>],
+    );
+
+    fn oam_store(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        ts: &[CellId],
+        key: &[CellId],
+        value: &[CellId],
+    );
+
+    fn oam_store_mixed(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        ts: &[MixedCell<Ext>],
+        key: &[MixedCell<Ext>],
+        value: &[MixedCell<Ext>],
+    );
+
+    fn finalize(
+        self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+    ) -> (Option<(WitnessId, usize)>, Option<(WitnessId, usize)>);
+}
+
+pub trait RAMOperations<Ext: SmallField>: OAMOperations<Ext> {
+    fn ram_load(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        old_ts: &[CellId],
+        cur_ts: &[CellId],
+        key: &[CellId],
+        value: &[CellId],
+    );
+
+    fn ram_load_mixed(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        old_ts: &[MixedCell<Ext>],
+        cur_ts: &[MixedCell<Ext>],
+        key: &[MixedCell<Ext>],
+        value: &[MixedCell<Ext>],
+    );
+
+    fn ram_store(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        old_ts: &[CellId],
+        cur_ts: &[CellId],
+        key: &[CellId],
+        old_value: &[CellId],
+        cur_value: &[CellId],
+    );
+
+    fn ram_store_mixed(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        old_ts: &[MixedCell<Ext>],
+        cur_ts: &[MixedCell<Ext>],
+        key: &[MixedCell<Ext>],
+        old_value: &[MixedCell<Ext>],
+        cur_value: &[MixedCell<Ext>],
+    );
+}
+
+impl Default for ChipChallenges {
+    fn default() -> Self {
+        Self {
+            record_rlc: 1,
+            record_item_rlc: 0,
+        }
+    }
+}
+
+impl ChipChallenges {
+    pub fn new(record_rlc: ChallengeId, record_item_rlc: ChallengeId) -> Self {
+        Self {
+            record_rlc,
+            record_item_rlc,
+        }
+    }
+    pub fn bytecode(&self) -> ChallengeId {
+        self.record_rlc
+    }
+    pub fn stack(&self) -> ChallengeId {
+        self.record_rlc
+    }
+    pub fn global_state(&self) -> ChallengeId {
+        self.record_rlc
+    }
+    pub fn mem(&self) -> ChallengeId {
+        self.record_rlc
+    }
+    pub fn range(&self) -> ChallengeId {
+        self.record_rlc
+    }
+    pub fn calldata(&self) -> ChallengeId {
+        self.record_rlc
+    }
+    pub fn record_item_rlc(&self) -> ChallengeId {
+        self.record_item_rlc
+    }
+}

--- a/singer-utils/src/chip_handler/bytecode.rs
+++ b/singer-utils/src/chip_handler/bytecode.rs
@@ -1,0 +1,48 @@
+use goldilocks::SmallField;
+use itertools::Itertools;
+use simple_frontend::structs::{CellId, CircuitBuilder, MixedCell};
+
+use crate::{
+    constants::OpcodeType,
+    structs::{ROMHandler, ROMType},
+};
+
+use super::{BytecodeChipOperations, ROMOperations};
+
+impl<Ext: SmallField> BytecodeChipOperations<Ext> for ROMHandler<Ext> {
+    fn bytecode_with_pc_opcode(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        pc: &[CellId],
+        opcode: OpcodeType,
+    ) {
+        let key = [
+            vec![MixedCell::Constant(Ext::BaseField::from(
+                ROMType::Bytecode as u64,
+            ))],
+            pc.iter().map(|&x| x.into()).collect_vec(),
+        ]
+        .concat();
+        self.rom_load_mixed(
+            circuit_builder,
+            &key,
+            &[MixedCell::Constant(Ext::BaseField::from(opcode as u64))],
+        );
+    }
+
+    fn bytecode_with_pc_byte(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        pc: &[CellId],
+        byte: CellId,
+    ) {
+        let key = [
+            vec![MixedCell::Constant(Ext::BaseField::from(
+                ROMType::Bytecode as u64,
+            ))],
+            pc.iter().map(|&x| x.into()).collect_vec(),
+        ]
+        .concat();
+        self.rom_load_mixed(circuit_builder, &key, &[byte.into()]);
+    }
+}

--- a/singer-utils/src/chip_handler/calldata.rs
+++ b/singer-utils/src/chip_handler/calldata.rs
@@ -1,0 +1,26 @@
+use goldilocks::SmallField;
+use itertools::Itertools;
+use simple_frontend::structs::{CellId, CircuitBuilder, MixedCell};
+
+use crate::structs::{ROMHandler, ROMType};
+
+use super::{CalldataChipOperations, ROMOperations};
+
+impl<Ext: SmallField> CalldataChipOperations<Ext> for ROMHandler<Ext> {
+    fn calldataload(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        offset: &[CellId],
+        data: &[CellId],
+    ) {
+        let key = [
+            vec![MixedCell::Constant(Ext::BaseField::from(
+                ROMType::Calldata as u64,
+            ))],
+            offset.iter().map(|&x| x.into()).collect_vec(),
+        ]
+        .concat();
+        let data = data.iter().map(|&x| x.into()).collect_vec();
+        self.rom_load_mixed(circuit_builder, &key, &data);
+    }
+}

--- a/singer-utils/src/chip_handler/global_state.rs
+++ b/singer-utils/src/chip_handler/global_state.rs
@@ -1,0 +1,52 @@
+use goldilocks::SmallField;
+use simple_frontend::structs::{CellId, CircuitBuilder, MixedCell};
+
+use crate::structs::{RAMHandler, RAMType};
+
+use super::{GlobalStateChipOperations, OAMOperations};
+
+impl<Ext: SmallField> GlobalStateChipOperations<Ext> for RAMHandler<Ext> {
+    fn state_in(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        pc: &[CellId],
+        stack_ts: &[CellId],
+        memory_ts: &[CellId],
+        stack_top: CellId,
+        clk: CellId,
+    ) {
+        let key = [
+            vec![MixedCell::Constant(Ext::BaseField::from(
+                RAMType::GlobalState as u64,
+            ))],
+            pc.iter().map(|&x| x.into()).collect::<Vec<_>>(),
+            stack_ts.iter().map(|&x| x.into()).collect::<Vec<_>>(),
+            memory_ts.iter().map(|&x| x.into()).collect::<Vec<_>>(),
+            vec![stack_top.into(), clk.into()],
+        ]
+        .concat();
+        self.oam_load_mixed(circuit_builder, &[], &key, &[]);
+    }
+
+    fn state_out(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        pc: &[CellId],
+        stack_ts: &[CellId],
+        memory_ts: &[CellId],
+        stack_top: MixedCell<Ext>,
+        clk: MixedCell<Ext>,
+    ) {
+        let key = [
+            vec![MixedCell::Constant(Ext::BaseField::from(
+                RAMType::GlobalState as u64,
+            ))],
+            pc.iter().map(|&x| x.into()).collect::<Vec<_>>(),
+            stack_ts.iter().map(|&x| x.into()).collect::<Vec<_>>(),
+            memory_ts.iter().map(|&x| x.into()).collect::<Vec<_>>(),
+            vec![stack_top.into(), clk.into()],
+        ]
+        .concat();
+        self.oam_store_mixed(circuit_builder, &[], &key, &[]);
+    }
+}

--- a/singer-utils/src/chip_handler/memory.rs
+++ b/singer-utils/src/chip_handler/memory.rs
@@ -1,0 +1,57 @@
+use goldilocks::SmallField;
+use itertools::Itertools;
+use simple_frontend::structs::{CellId, CircuitBuilder, MixedCell};
+
+use crate::structs::{RAMHandler, RAMType};
+
+use super::{MemoryChipOperations, RAMOperations};
+
+impl<Ext: SmallField> MemoryChipOperations<Ext> for RAMHandler<Ext> {
+    fn mem_load(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        offset: &[CellId],
+        old_ts: &[CellId],
+        cur_ts: &[CellId],
+        byte: CellId,
+    ) {
+        let key = [
+            vec![MixedCell::Constant(Ext::BaseField::from(
+                RAMType::Memory as u64,
+            ))],
+            offset.iter().map(|&x| x.into()).collect_vec(),
+        ]
+        .concat();
+        let old_ts = old_ts.iter().map(|&x| x.into()).collect_vec();
+        let cur_ts = cur_ts.iter().map(|&x| x.into()).collect_vec();
+        self.ram_load_mixed(circuit_builder, &old_ts, &cur_ts, &key, &[byte.into()]);
+    }
+
+    fn mem_store(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        offset: &[CellId],
+        old_ts: &[CellId],
+        cur_ts: &[CellId],
+        old_byte: CellId,
+        cur_byte: CellId,
+    ) {
+        let key = [
+            vec![MixedCell::Constant(Ext::BaseField::from(
+                RAMType::Memory as u64,
+            ))],
+            offset.iter().map(|&x| x.into()).collect_vec(),
+        ]
+        .concat();
+        let old_ts = old_ts.iter().map(|&x| x.into()).collect_vec();
+        let cur_ts = cur_ts.iter().map(|&x| x.into()).collect_vec();
+        self.ram_store_mixed(
+            circuit_builder,
+            &old_ts,
+            &cur_ts,
+            &key,
+            &[old_byte.into()],
+            &[cur_byte.into()],
+        );
+    }
+}

--- a/singer-utils/src/chip_handler/ram_handler.rs
+++ b/singer-utils/src/chip_handler/ram_handler.rs
@@ -1,0 +1,156 @@
+use ff::Field;
+use goldilocks::SmallField;
+use simple_frontend::structs::{CellId, CircuitBuilder, ExtCellId, MixedCell, WitnessId};
+
+use crate::structs::{ChipChallenges, RAMHandler};
+
+use super::{OAMOperations, RAMOperations};
+
+impl<Ext: SmallField> RAMHandler<Ext> {
+    pub fn new(challenge: &ChipChallenges) -> Self {
+        Self {
+            rd_records: Vec::new(),
+            wt_records: Vec::new(),
+            challenge: challenge.clone(),
+        }
+    }
+}
+
+impl<Ext: SmallField> OAMOperations<Ext> for RAMHandler<Ext> {
+    fn oam_load(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        old_ts: &[CellId],
+        key: &[CellId],
+        value: &[CellId],
+    ) {
+        let out = circuit_builder.create_ext_cell();
+        let mut items = old_ts.to_vec();
+        items.extend(key.to_vec());
+        items.extend(value.to_vec());
+        circuit_builder.rlc(&out, &items, self.challenge.record_rlc);
+        self.rd_records.push(out);
+    }
+
+    fn oam_load_mixed(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        old_ts: &[MixedCell<Ext>],
+        key: &[MixedCell<Ext>],
+        value: &[MixedCell<Ext>],
+    ) {
+        let out = circuit_builder.create_ext_cell();
+        let mut items = old_ts.to_vec();
+        items.extend(key.to_vec());
+        items.extend(value.to_vec());
+        circuit_builder.rlc_mixed(&out, &items, self.challenge.record_rlc);
+        self.rd_records.push(out);
+    }
+
+    fn oam_store(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        cur_ts: &[CellId],
+        key: &[CellId],
+        value: &[CellId],
+    ) {
+        let out = circuit_builder.create_ext_cell();
+        let mut items = cur_ts.to_vec();
+        items.extend(key.to_vec());
+        items.extend(value.to_vec());
+        circuit_builder.rlc(&out, &items, self.challenge.record_rlc);
+        self.wt_records.push(out);
+    }
+
+    fn oam_store_mixed(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        cur_ts: &[MixedCell<Ext>],
+        key: &[MixedCell<Ext>],
+        value: &[MixedCell<Ext>],
+    ) {
+        let out = circuit_builder.create_ext_cell();
+        let mut items = cur_ts.to_vec();
+        items.extend(key.to_vec());
+        items.extend(value.to_vec());
+        circuit_builder.rlc_mixed(&out, &items, self.challenge.record_rlc);
+        self.wt_records.push(out);
+    }
+
+    fn finalize(
+        self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+    ) -> (Option<(WitnessId, usize)>, Option<(WitnessId, usize)>) {
+        let mut pad_with_one = |records: &mut Vec<ExtCellId<Ext>>| {
+            if records.len() == 0 {
+                return None;
+            }
+            let count = records.len().next_power_of_two() - records.len();
+            for _ in 0..count {
+                let out = circuit_builder.create_ext_cell();
+                circuit_builder.add_const(out.cells[0], Ext::BaseField::ONE);
+                records.push(out);
+            }
+            Some((
+                circuit_builder.create_witness_out_from_exts(&records),
+                records.len(),
+            ))
+        };
+
+        let mut rd_records = self.rd_records;
+        let mut wt_records = self.wt_records;
+        (pad_with_one(&mut rd_records), pad_with_one(&mut wt_records))
+    }
+}
+
+impl<Ext: SmallField> RAMOperations<Ext> for RAMHandler<Ext> {
+    fn ram_load(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        old_ts: &[CellId],
+        cur_ts: &[CellId],
+        key: &[CellId],
+        value: &[CellId],
+    ) {
+        self.oam_load(circuit_builder, old_ts, key, value);
+        self.oam_store(circuit_builder, cur_ts, key, value);
+    }
+
+    fn ram_load_mixed(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        old_ts: &[MixedCell<Ext>],
+        cur_ts: &[MixedCell<Ext>],
+        key: &[MixedCell<Ext>],
+        value: &[MixedCell<Ext>],
+    ) {
+        self.oam_load_mixed(circuit_builder, old_ts, key, value);
+        self.oam_store_mixed(circuit_builder, cur_ts, key, value);
+    }
+
+    fn ram_store(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        old_ts: &[CellId],
+        cur_ts: &[CellId],
+        key: &[CellId],
+        old_value: &[CellId],
+        cur_value: &[CellId],
+    ) {
+        self.oam_load(circuit_builder, old_ts, key, old_value);
+        self.oam_store(circuit_builder, cur_ts, key, cur_value);
+    }
+
+    fn ram_store_mixed(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        old_ts: &[MixedCell<Ext>],
+        cur_ts: &[MixedCell<Ext>],
+        key: &[MixedCell<Ext>],
+        old_value: &[MixedCell<Ext>],
+        cur_value: &[MixedCell<Ext>],
+    ) {
+        self.oam_load_mixed(circuit_builder, old_ts, key, old_value);
+        self.oam_store_mixed(circuit_builder, cur_ts, key, cur_value);
+    }
+}

--- a/singer-utils/src/chip_handler/range.rs
+++ b/singer-utils/src/chip_handler/range.rs
@@ -1,0 +1,150 @@
+use ff::Field;
+use goldilocks::SmallField;
+use simple_frontend::structs::{CellId, CircuitBuilder, MixedCell};
+
+use crate::{
+    constants::{RANGE_CHIP_BIT_WIDTH, STACK_TOP_BIT_WIDTH},
+    error::UtilError,
+    structs::{PCUInt, ROMHandler, TSUInt, UInt},
+    uint::UIntAddSub,
+};
+
+use super::RangeChipOperations;
+
+impl<F: SmallField> RangeChipOperations<F> for ROMHandler<F> {
+    fn range_check_stack_top(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<F>,
+        stack_top: MixedCell<F>,
+    ) -> Result<(), UtilError> {
+        self.small_range_check(circuit_builder, stack_top, STACK_TOP_BIT_WIDTH)
+    }
+
+    /// Check the range of stack values within [0, 1 << STACK_VALUE_BYTE_WIDTH * 8).
+    /// Return the verified values.
+    fn range_check_uint<const M: usize, const C: usize>(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<F>,
+        uint: &UInt<M, C>,
+        range_value_witness: Option<&[CellId]>,
+    ) -> Result<UInt<M, C>, UtilError>
+    where
+        F: SmallField,
+    {
+        let n_cell = (M + C - 1) / C;
+        if C <= RANGE_CHIP_BIT_WIDTH {
+            for value in uint.values().iter().take(n_cell - 1) {
+                self.small_range_check(circuit_builder, (*value).into(), C)?;
+            }
+            self.small_range_check(circuit_builder, uint.values()[n_cell - 1].into(), M % C)?;
+            Ok((*uint).clone())
+        } else if let Some(range_values) = range_value_witness {
+            let range_value = UInt::<M, C>::from_range_values(circuit_builder, range_values)?;
+            uint.assert_eq(circuit_builder, &range_value);
+            let b: usize = M.min(C);
+            let chunk_size = (b + RANGE_CHIP_BIT_WIDTH - 1) / RANGE_CHIP_BIT_WIDTH;
+            for chunk in range_values.chunks(chunk_size) {
+                for i in 0..chunk_size - 1 {
+                    self.small_range_check(circuit_builder, chunk[i].into(), RANGE_CHIP_BIT_WIDTH)?;
+                }
+                self.small_range_check(
+                    circuit_builder,
+                    chunk[chunk_size - 1].into(),
+                    b - (chunk_size - 1) * RANGE_CHIP_BIT_WIDTH,
+                )?;
+            }
+            Ok(range_value)
+        } else {
+            Err(UtilError::ChipError)
+        }
+    }
+
+    fn range_check_bytes(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<F>,
+        bytes: &[CellId],
+    ) -> Result<(), UtilError> {
+        for byte in bytes {
+            self.small_range_check(circuit_builder, (*byte).into(), 8)?;
+        }
+        Ok(())
+    }
+}
+
+impl<F: SmallField> ROMHandler<F> {
+    fn small_range_check(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<F>,
+        value: MixedCell<F>,
+        bit_width: usize,
+    ) -> Result<(), UtilError> {
+        if bit_width > RANGE_CHIP_BIT_WIDTH {
+            return Err(UtilError::ChipError);
+        }
+        let out = circuit_builder.create_ext_cell();
+        let items = [value.mul(F::BaseField::from(1 << (RANGE_CHIP_BIT_WIDTH - bit_width)))];
+        circuit_builder.rlc_mixed(&out, &items, self.challenge.record_rlc);
+        self.records.push(out);
+        Ok(())
+    }
+}
+
+impl<Ext: SmallField> ROMHandler<Ext> {
+    pub fn add_pc_const(
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        pc: &PCUInt,
+        constant: i64,
+        witness: &[CellId],
+    ) -> Result<PCUInt, UtilError> {
+        let carry = UIntAddSub::<PCUInt>::extract_unsafe_carry(witness);
+        UIntAddSub::<PCUInt>::add_const_unsafe(
+            circuit_builder,
+            &pc,
+            i64_to_base_field::<Ext>(constant),
+            carry,
+        )
+    }
+
+    pub fn add_ts_with_const(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        ts: &TSUInt,
+        constant: i64,
+        witness: &[CellId],
+    ) -> Result<TSUInt, UtilError> {
+        let carry = UIntAddSub::<TSUInt>::extract_unsafe_carry(witness);
+        UIntAddSub::<TSUInt>::add_const(
+            circuit_builder,
+            self,
+            &ts,
+            i64_to_base_field::<Ext>(constant),
+            carry,
+        )
+    }
+
+    pub fn non_zero(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        val: CellId,
+        wit: CellId,
+    ) -> Result<CellId, UtilError> {
+        let prod = circuit_builder.create_cell();
+        circuit_builder.mul2(prod, val, wit, Ext::BaseField::ONE);
+        self.small_range_check(circuit_builder, prod.into(), 1)?;
+
+        let statement = circuit_builder.create_cell();
+        // If val != 0, then prod = 1. => assert!( val (prod - 1) = 0 )
+        circuit_builder.mul2(statement, val, prod, Ext::BaseField::ONE);
+        circuit_builder.add(statement, val, -Ext::BaseField::ONE);
+        circuit_builder.assert_const(statement, 0);
+        Ok(prod)
+    }
+}
+
+fn i64_to_base_field<F: SmallField>(x: i64) -> F::BaseField {
+    if x >= 0 {
+        F::BaseField::from(x as u64)
+    } else {
+        -F::BaseField::from((-x) as u64)
+    }
+}

--- a/singer-utils/src/chip_handler/rom_handler.rs
+++ b/singer-utils/src/chip_handler/rom_handler.rs
@@ -1,0 +1,60 @@
+use ff::Field;
+use goldilocks::SmallField;
+use simple_frontend::structs::{CellId, CircuitBuilder, MixedCell, WitnessId};
+
+use crate::structs::{ChipChallenges, ROMHandler};
+
+use super::ROMOperations;
+
+impl<Ext: SmallField> ROMHandler<Ext> {
+    pub fn new(challenge: &ChipChallenges) -> Self {
+        Self {
+            records: Vec::new(),
+            challenge: challenge.clone(),
+        }
+    }
+}
+
+impl<Ext: SmallField> ROMOperations<Ext> for ROMHandler<Ext> {
+    fn rom_load(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        key: &[CellId],
+        value: &[CellId],
+    ) {
+        let out = circuit_builder.create_ext_cell();
+        let items = [key.to_vec(), value.to_vec()].concat();
+        circuit_builder.rlc(&out, &items, self.challenge.record_rlc);
+        self.records.push(out);
+    }
+
+    fn rom_load_mixed(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        key: &[MixedCell<Ext>],
+        value: &[MixedCell<Ext>],
+    ) {
+        let out = circuit_builder.create_ext_cell();
+        let items = [key.to_vec(), value.to_vec()].concat();
+        circuit_builder.rlc_mixed(&out, &items, self.challenge.record_rlc);
+        self.records.push(out);
+    }
+
+    fn finalize(self, circuit_builder: &mut CircuitBuilder<Ext>) -> Option<(WitnessId, usize)> {
+        if self.records.len() == 0 {
+            return None;
+        }
+        let count = self.records.len().next_power_of_two() - self.records.len();
+        let last = self.records[self.records.len() - 1].clone();
+        let mut records = self.records;
+        for _ in 0..count {
+            let out = circuit_builder.create_ext_cell();
+            circuit_builder.add_ext(&out, &last, Ext::BaseField::ONE);
+            records.push(out);
+        }
+        Some((
+            circuit_builder.create_witness_out_from_exts(&records),
+            records.len(),
+        ))
+    }
+}

--- a/singer-utils/src/chip_handler/stack.rs
+++ b/singer-utils/src/chip_handler/stack.rs
@@ -1,0 +1,41 @@
+use goldilocks::SmallField;
+use itertools::Itertools;
+use simple_frontend::structs::{CellId, CircuitBuilder, MixedCell};
+
+use crate::structs::{RAMHandler, RAMType};
+
+use super::{OAMOperations, StackChipOperations};
+
+impl<Ext: SmallField> StackChipOperations<Ext> for RAMHandler<Ext> {
+    fn stack_push(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        stack_top: MixedCell<Ext>,
+        stack_ts: &[CellId],
+        values: &[CellId],
+    ) {
+        let key = [
+            MixedCell::Constant(Ext::BaseField::from(RAMType::Stack as u64)),
+            stack_top,
+        ];
+        let stack_ts = stack_ts.iter().map(|&x| MixedCell::Cell(x)).collect_vec();
+        let values = values.iter().map(|&x| MixedCell::Cell(x)).collect_vec();
+        self.oam_store_mixed(circuit_builder, &stack_ts, &key, &values);
+    }
+
+    fn stack_pop(
+        &mut self,
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        stack_top: MixedCell<Ext>,
+        stack_ts: &[CellId],
+        values: &[CellId],
+    ) {
+        let key = [
+            MixedCell::Constant(Ext::BaseField::from(RAMType::Stack as u64)),
+            stack_top,
+        ];
+        let stack_ts = stack_ts.iter().map(|&x| MixedCell::Cell(x)).collect_vec();
+        let values = values.iter().map(|&x| MixedCell::Cell(x)).collect_vec();
+        self.oam_load_mixed(circuit_builder, &stack_ts, &key, &values);
+    }
+}

--- a/singer-utils/src/constants.rs
+++ b/singer-utils/src/constants.rs
@@ -1,0 +1,26 @@
+pub const STACK_TOP_BIT_WIDTH: usize = 10;
+
+pub const RANGE_CHIP_BIT_WIDTH: usize = 16;
+pub const VALUE_BIT_WIDTH: usize = 32;
+pub const EVM_STACK_BIT_WIDTH: usize = 256;
+pub const EVM_STACK_BYTE_WIDTH: usize = EVM_STACK_BIT_WIDTH / 8;
+
+// opcode bytecode
+pub enum OpcodeType {
+    ADD = 0x01,
+    GT = 0x11,
+    CALLDATALOAD = 0x35,
+    POP = 0x50,
+    MSTORE = 0x52,
+    JUMP = 0x56,
+    JUMPI = 0x57,
+    JUMPDEST = 0x5b,
+    PUSH0 = 0x5F,
+    PUSH1 = 0x60,
+    DUP1 = 0x80,
+    DUP2 = 0x81,
+    SWAP1 = 0x90,
+    SWAP2 = 0x91,
+    SWAP4 = 0x93,
+    RETURN = 0xf3,
+}

--- a/singer-utils/src/error.rs
+++ b/singer-utils/src/error.rs
@@ -1,0 +1,5 @@
+#[derive(Clone, Debug)]
+pub enum UtilError {
+    ChipError,
+    UIntError,
+}

--- a/singer-utils/src/lib.rs
+++ b/singer-utils/src/lib.rs
@@ -1,0 +1,7 @@
+#![feature(generic_const_exprs)]
+
+pub mod chip_handler;
+pub mod constants;
+pub mod error;
+pub mod structs;
+pub mod uint;

--- a/singer-utils/src/structs.rs
+++ b/singer-utils/src/structs.rs
@@ -1,0 +1,48 @@
+use goldilocks::SmallField;
+use simple_frontend::structs::{CellId, ChallengeId, ExtCellId};
+
+use crate::constants::{EVM_STACK_BIT_WIDTH, VALUE_BIT_WIDTH};
+
+pub enum RAMType {
+    Stack,
+    Memory,
+    GlobalState,
+}
+
+pub enum ROMType {
+    Bytecode,
+    Calldata,
+    Range,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ChipChallenges {
+    // Challenges for multiple-tuple chip records
+    pub record_rlc: ChallengeId,
+    // Challenges for multiple-cell values
+    pub record_item_rlc: ChallengeId,
+}
+
+#[derive(Clone, Debug)]
+pub struct RAMHandler<Ext: SmallField> {
+    pub(crate) rd_records: Vec<ExtCellId<Ext>>,
+    pub(crate) wt_records: Vec<ExtCellId<Ext>>,
+    pub(crate) challenge: ChipChallenges,
+}
+
+#[derive(Clone, Debug)]
+pub struct ROMHandler<Ext: SmallField> {
+    pub(crate) records: Vec<ExtCellId<Ext>>,
+    pub(crate) challenge: ChipChallenges,
+}
+
+/// Unsigned integer with `M` bits. C denotes the cell bit width.
+#[derive(Clone, Debug)]
+pub struct UInt<const M: usize, const C: usize> {
+    pub(crate) values: Vec<CellId>,
+}
+
+pub type UInt64 = UInt<64, VALUE_BIT_WIDTH>;
+pub type PCUInt = UInt64;
+pub type TSUInt = UInt<56, 56>;
+pub type StackUInt = UInt<{ EVM_STACK_BIT_WIDTH as usize }, { VALUE_BIT_WIDTH as usize }>;

--- a/singer-utils/src/uint.rs
+++ b/singer-utils/src/uint.rs
@@ -1,0 +1,212 @@
+use ff::Field;
+use gkr::utils::ceil_log2;
+use goldilocks::SmallField;
+use itertools::Itertools;
+use simple_frontend::structs::{CellId, CircuitBuilder};
+use std::marker::PhantomData;
+
+use crate::{constants::RANGE_CHIP_BIT_WIDTH, error::UtilError, structs::UInt};
+
+pub mod add_sub;
+pub mod cmp;
+
+impl<const M: usize, const C: usize> TryFrom<&[usize]> for UInt<M, C> {
+    type Error = UtilError;
+    fn try_from(values: &[usize]) -> Result<Self, Self::Error> {
+        if values.len() != Self::N_OPRAND_CELLS {
+            return Err(UtilError::UIntError);
+        }
+        Ok(Self {
+            values: values.to_vec(),
+        })
+    }
+}
+
+impl<const M: usize, const C: usize> TryFrom<Vec<usize>> for UInt<M, C> {
+    type Error = UtilError;
+    fn try_from(values: Vec<usize>) -> Result<Self, Self::Error> {
+        let values = values.as_slice().try_into()?;
+        Ok(values)
+    }
+}
+
+impl<const M: usize, const C: usize> UInt<M, C> {
+    pub const N_OPRAND_CELLS: usize = (M + C - 1) / C;
+
+    const N_CARRY_CELLS: usize = Self::N_OPRAND_CELLS;
+    const N_CARRY_NO_OVERFLOW_CELLS: usize = Self::N_OPRAND_CELLS - 1;
+    pub const N_RANGE_CHECK_CELLS: usize =
+        Self::N_OPRAND_CELLS * (C + RANGE_CHIP_BIT_WIDTH - 1) / RANGE_CHIP_BIT_WIDTH;
+    pub const N_RANGE_CHECK_NO_OVERFLOW_CELLS: usize =
+        (Self::N_OPRAND_CELLS - 1) * (C + RANGE_CHIP_BIT_WIDTH - 1) / RANGE_CHIP_BIT_WIDTH;
+
+    pub fn values(&self) -> &[CellId] {
+        &self.values
+    }
+
+    pub fn from_range_values<F: SmallField>(
+        circuit_builder: &mut CircuitBuilder<F>,
+        range_values: &[CellId],
+    ) -> Result<Self, UtilError> {
+        let mut values = if C <= M {
+            convert_decomp(circuit_builder, range_values, RANGE_CHIP_BIT_WIDTH, C, true)
+        } else {
+            convert_decomp(circuit_builder, range_values, RANGE_CHIP_BIT_WIDTH, M, true)
+        };
+        while values.len() < Self::N_OPRAND_CELLS {
+            values.push(circuit_builder.create_cell());
+        }
+        Self::try_from(values)
+    }
+
+    pub fn from_bytes_big_endien<F: SmallField>(
+        circuit_builder: &mut CircuitBuilder<F>,
+        bytes: &[CellId],
+    ) -> Result<Self, UtilError> {
+        if C <= M {
+            convert_decomp(circuit_builder, bytes, 8, C, true).try_into()
+        } else {
+            convert_decomp(circuit_builder, bytes, 8, M, true).try_into()
+        }
+    }
+
+    pub fn assert_eq<F: SmallField>(&self, circuit_builder: &mut CircuitBuilder<F>, other: &Self) {
+        for i in 0..self.values.len() {
+            let diff = circuit_builder.create_cell();
+            circuit_builder.add(diff, self.values[i], F::BaseField::ONE);
+            circuit_builder.add(diff, other.values[i], -F::BaseField::ONE);
+            circuit_builder.assert_const(diff, 0);
+        }
+    }
+
+    pub fn assert_eq_range_values<F: SmallField>(
+        &self,
+        circuit_builder: &mut CircuitBuilder<F>,
+        range_values: &[CellId],
+    ) {
+        let values = if C <= M {
+            convert_decomp(circuit_builder, range_values, RANGE_CHIP_BIT_WIDTH, C, true)
+        } else {
+            convert_decomp(circuit_builder, range_values, RANGE_CHIP_BIT_WIDTH, M, true)
+        };
+        let length = self.values.len().min(values.len());
+        for i in 0..length {
+            let diff = circuit_builder.create_cell();
+            circuit_builder.add(diff, self.values[i], F::BaseField::ONE);
+            circuit_builder.add(diff, values[i], -F::BaseField::ONE);
+            circuit_builder.assert_const(diff, 0);
+        }
+        for i in length..values.len() {
+            circuit_builder.assert_const(values[i], 0);
+        }
+        for i in length..self.values.len() {
+            circuit_builder.assert_const(self.values[i], 0);
+        }
+    }
+
+    /// Generate (0, 1, ...,  size)
+    pub fn counter_vector<F: SmallField>(size: usize) -> Vec<F> {
+        let num_vars = ceil_log2(size);
+        let tensor = |a: &[F], b: Vec<F>| {
+            let mut res = vec![F::ZERO; a.len() * b.len()];
+            for i in 0..b.len() {
+                for j in 0..a.len() {
+                    res[i * a.len() + j] = b[i] * a[j];
+                }
+            }
+            res
+        };
+        let counter = (0..(1 << C)).map(|x| F::from(x as u64)).collect_vec();
+        let (di, mo) = (num_vars / C, num_vars % C);
+        let mut res = (0..(1 << mo)).map(|x| F::from(x as u64)).collect_vec();
+        for _ in 0..di {
+            res = tensor(&counter, res);
+        }
+        res
+    }
+}
+
+pub struct UIntAddSub<UInt> {
+    _phantom: PhantomData<UInt>,
+}
+pub struct UIntCmp<UInt> {
+    _phantom: PhantomData<UInt>,
+}
+
+/// Big-endian bytes to little-endien field values. We don't require
+/// `BIG_BIT_WIDTH` % `SMALL_BIT_WIDTH` == 0 because we assume `small_values`
+/// can be splitted into chunks with size ceil(BIG_BIT_WIDTH / SMALL_BIT_WIDTH).
+/// Each chunk is converted to a value with BIG_BIT_WIDTH bits.
+fn convert_decomp<F: SmallField>(
+    circuit_builder: &mut CircuitBuilder<F>,
+    small_values: &[CellId],
+    small_bit_width: usize,
+    big_bit_width: usize,
+    is_little_endian: bool,
+) -> Vec<CellId> {
+    let small_values = if is_little_endian {
+        small_values.to_vec()
+    } else {
+        small_values.iter().rev().map(|x: &usize| *x).collect_vec()
+    };
+    let chunk_size = (big_bit_width + small_bit_width - 1) / small_bit_width;
+    let small_len = small_values.len();
+    let values = (0..small_len)
+        .step_by(chunk_size)
+        .map(|j| {
+            let tmp = circuit_builder.create_cell();
+            for k in j..(j + chunk_size).min(small_len) {
+                let k = k as usize;
+                circuit_builder.add(
+                    tmp,
+                    small_values[k],
+                    F::BaseField::from((1 as u64) << j * small_bit_width),
+                );
+            }
+            tmp
+        })
+        .collect_vec();
+    values
+}
+
+#[cfg(test)]
+mod test {
+    use crate::uint::convert_decomp;
+
+    use super::UInt;
+    use goldilocks::Goldilocks;
+    use simple_frontend::structs::CircuitBuilder;
+
+    #[test]
+    fn test_uint() {
+        // M = 256 is the number of bits for unsigned integer
+        // C = 63 is the cell bit width
+        type Uint256_63 = UInt<256, 63>;
+        assert_eq!(Uint256_63::N_OPRAND_CELLS, 5);
+        assert_eq!(Uint256_63::N_CARRY_CELLS, 5);
+        assert_eq!(Uint256_63::N_CARRY_NO_OVERFLOW_CELLS, 4);
+        assert_eq!(Uint256_63::N_RANGE_CHECK_CELLS, 24);
+        assert_eq!(Uint256_63::N_RANGE_CHECK_NO_OVERFLOW_CELLS, 19);
+        let u_int = Uint256_63::try_from(vec![1, 2, 3, 4, 5]);
+        assert_eq!(u_int.unwrap().values, vec![1, 2, 3, 4, 5]);
+        // TODO: implement tests for methods in UInt
+        // they mostly depend on convert_decomp which will be tested separately
+    }
+
+    #[test]
+    fn test_convert_decomp() {
+        let mut circuit_builder = CircuitBuilder::<Goldilocks>::new();
+        let small_values: Vec<usize> = vec![1; 64];
+        let values = convert_decomp(&mut circuit_builder, &small_values, 1, 2, true);
+        let vec: Vec<usize> = (0..=31).collect();
+        assert_eq!(values, vec);
+        // this test will fail if small_len * small_bit_width exceeds
+        //      the field's max bit size
+        // e.g.
+        // let values = convert_decomp(&mut circuit_builder,
+        //                                 &small_values,
+        //                                 2,
+        //                                 2,
+        //                                 true);
+    }
+}

--- a/singer-utils/src/uint/add_sub.rs
+++ b/singer-utils/src/uint/add_sub.rs
@@ -1,0 +1,341 @@
+use ff::Field;
+use goldilocks::SmallField;
+use simple_frontend::structs::{CellId, CircuitBuilder};
+
+use crate::{chip_handler::RangeChipOperations, error::UtilError, structs::UInt};
+
+use super::UIntAddSub;
+
+impl<const M: usize, const C: usize> UIntAddSub<UInt<M, C>> {
+    pub const N_NO_OVERFLOW_WITNESS_CELLS: usize =
+        UInt::<M, C>::N_RANGE_CHECK_CELLS + UInt::<M, C>::N_CARRY_NO_OVERFLOW_CELLS;
+    pub const N_NO_OVERFLOW_WITNESS_UNSAFE_CELLS: usize = UInt::<M, C>::N_CARRY_NO_OVERFLOW_CELLS;
+
+    pub const N_WITNESS_UNSAFE_CELLS: usize = UInt::<M, C>::N_CARRY_CELLS;
+    pub const N_WITNESS_CELLS: usize =
+        UInt::<M, C>::N_RANGE_CHECK_CELLS + UInt::<M, C>::N_CARRY_CELLS;
+
+    pub fn extract_range_values(witness: &[CellId]) -> &[CellId] {
+        &witness[..UInt::<M, C>::N_RANGE_CHECK_CELLS]
+    }
+
+    pub fn extract_range_values_no_overflow(witness: &[CellId]) -> &[CellId] {
+        &witness[..UInt::<M, C>::N_RANGE_CHECK_NO_OVERFLOW_CELLS]
+    }
+
+    pub fn extract_carry_no_overflow(witness: &[CellId]) -> &[CellId] {
+        &witness[UInt::<M, C>::N_RANGE_CHECK_NO_OVERFLOW_CELLS..]
+    }
+
+    pub fn extract_carry(witness: &[CellId]) -> &[CellId] {
+        &witness[UInt::<M, C>::N_RANGE_CHECK_CELLS..]
+    }
+
+    pub fn extract_unsafe_carry(witness: &[CellId]) -> &[CellId] {
+        witness
+    }
+
+    /// Little-endian addition. Assume users to check the correct range of the
+    /// result by themselves.
+    pub fn add_unsafe<Ext: SmallField>(
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        addend_0: &UInt<M, C>,
+        addend_1: &UInt<M, C>,
+        carry: &[CellId],
+    ) -> Result<UInt<M, C>, UtilError> {
+        let result: UInt<M, C> = circuit_builder
+            .create_cells(UInt::<M, C>::N_OPRAND_CELLS)
+            .try_into()?;
+        for i in 0..UInt::<M, C>::N_OPRAND_CELLS {
+            let (a, b, result) = (addend_0.values[i], addend_1.values[i], result.values[i]);
+            // result = addend_0 + addend_1 + last_carry - carry * (1 << VALUE_BIT_WIDTH)
+            circuit_builder.add(result, a, Ext::BaseField::ONE);
+            circuit_builder.add(result, b, Ext::BaseField::ONE);
+            // It is equivalent to pad carry with 0s.
+            if i < carry.len() {
+                circuit_builder.add(result, carry[i], -Ext::BaseField::from(1 << C));
+            }
+            if i > 0 && i - 1 < carry.len() {
+                circuit_builder.add(result, carry[i - 1], Ext::BaseField::ONE);
+            }
+        }
+        Ok(result)
+    }
+
+    /// Little-endian addition.
+    pub fn add<Ext: SmallField, H: RangeChipOperations<Ext>>(
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        range_chip_handler: &mut H,
+        addend_0: &UInt<M, C>,
+        addend_1: &UInt<M, C>,
+        witness: &[CellId],
+    ) -> Result<UInt<M, C>, UtilError> {
+        let carry = Self::extract_carry(witness);
+        let range_values = Self::extract_range_values(witness);
+        let computed_result = Self::add_unsafe(circuit_builder, addend_0, addend_1, carry)?;
+        range_chip_handler.range_check_uint(circuit_builder, &computed_result, Some(range_values))
+    }
+
+    /// Little-endian addition with a constant. Assume users to check the
+    /// correct range of the result by themselves.
+    pub fn add_const_unsafe<Ext: SmallField>(
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        addend_0: &UInt<M, C>,
+        constant: Ext::BaseField,
+        carry: &[CellId],
+    ) -> Result<UInt<M, C>, UtilError> {
+        let result: UInt<M, C> = circuit_builder
+            .create_cells(UInt::<M, C>::N_OPRAND_CELLS)
+            .try_into()?;
+        for i in 0..result.values.len() {
+            let (a, result) = (addend_0.values[i], result.values[i]);
+            // result = addend_0 + addend_1 + last_carry - carry * (256 << BYTE_WIDTH)
+            circuit_builder.add(result, a, Ext::BaseField::ONE);
+            circuit_builder.add_const(result, constant);
+            // It is equivalent to pad carry with 0s.
+            if i < carry.len() {
+                circuit_builder.add(result, carry[i], -Ext::BaseField::from(1 << C));
+            }
+            if i > 0 && i - 1 < carry.len() {
+                circuit_builder.add(result, carry[i - 1], Ext::BaseField::ONE);
+            }
+        }
+        Ok(result)
+    }
+
+    /// Little-endian addition with a constant.
+    pub fn add_const<Ext: SmallField, H: RangeChipOperations<Ext>>(
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        range_chip_handler: &mut H,
+        addend_0: &UInt<M, C>,
+        constant: Ext::BaseField,
+        witness: &[CellId],
+    ) -> Result<UInt<M, C>, UtilError> {
+        let carry = Self::extract_carry(witness);
+        let range_values = Self::extract_range_values(witness);
+        let computed_result = Self::add_const_unsafe(circuit_builder, addend_0, constant, carry)?;
+        range_chip_handler.range_check_uint(circuit_builder, &computed_result, Some(range_values))
+    }
+
+    /// Little-endian addition with a constant, guaranteed no overflow.
+    pub fn add_const_no_overflow<Ext: SmallField, H: RangeChipOperations<Ext>>(
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        range_chip_handler: &mut H,
+        addend_0: &UInt<M, C>,
+        constant: Ext::BaseField,
+        witness: &[CellId],
+    ) -> Result<UInt<M, C>, UtilError> {
+        let carry = Self::extract_carry_no_overflow(witness);
+        let range_values = Self::extract_range_values_no_overflow(witness);
+        let computed_result = Self::add_const_unsafe(circuit_builder, addend_0, constant, carry)?;
+        range_chip_handler.range_check_uint(circuit_builder, &computed_result, Some(range_values))
+    }
+
+    /// Little-endian addition with a small number. Notice that the user should
+    /// guarantee addend_1 < 1 << C.
+    pub fn add_small_unsafe<F: SmallField>(
+        circuit_builder: &mut CircuitBuilder<F>,
+        addend_0: &UInt<M, C>,
+        addend_1: CellId,
+        carry: &[CellId],
+    ) -> Result<UInt<M, C>, UtilError> {
+        let result: UInt<M, C> = circuit_builder
+            .create_cells(UInt::<M, C>::N_OPRAND_CELLS)
+            .try_into()?;
+        for i in 0..result.values.len() {
+            let (a, result) = (addend_0.values[i], result.values[i]);
+            // result = addend_0 + addend_1 + last_carry - carry * (256 << BYTE_WIDTH)
+            circuit_builder.add(result, a, F::BaseField::ONE);
+            circuit_builder.add(result, addend_1, F::BaseField::ONE);
+            // It is equivalent to pad carry with 0s.
+            if i < carry.len() {
+                circuit_builder.add(result, carry[i], -F::BaseField::from(1 << C));
+            }
+            if i > 0 && i - 1 < carry.len() {
+                circuit_builder.add(result, carry[i - 1], F::BaseField::ONE);
+            }
+        }
+        Ok(result)
+    }
+
+    /// Little-endian addition with a small number. Notice that the user should
+    /// guarantee addend_1 < 1 << C.
+    pub fn add_small<Ext: SmallField, H: RangeChipOperations<Ext>>(
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        range_chip_handler: &mut H,
+        addend_0: &UInt<M, C>,
+        addend_1: CellId,
+        witness: &[CellId],
+    ) -> Result<UInt<M, C>, UtilError> {
+        let carry = Self::extract_carry(witness);
+        let range_values = Self::extract_range_values(witness);
+        let computed_result = Self::add_small_unsafe(circuit_builder, addend_0, addend_1, carry)?;
+        range_chip_handler.range_check_uint(circuit_builder, &computed_result, Some(range_values))
+    }
+
+    /// Little-endian addition with a small number, guaranteed no overflow.
+    /// Notice that the user should guarantee addend_1 < 1 << C.
+    pub fn add_small_no_overflow<Ext: SmallField, H: RangeChipOperations<Ext>>(
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        range_chip_handler: &mut H,
+        addend_0: &UInt<M, C>,
+        addend_1: CellId,
+        witness: &[CellId],
+    ) -> Result<UInt<M, C>, UtilError> {
+        let carry = Self::extract_carry_no_overflow(witness);
+        let range_values = Self::extract_range_values_no_overflow(witness);
+        let computed_result = Self::add_small_unsafe(circuit_builder, addend_0, addend_1, carry)?;
+        range_chip_handler.range_check_uint(circuit_builder, &computed_result, Some(range_values))
+    }
+
+    /// Little-endian subtraction. Assume users to check the correct range of
+    /// the result by themselves.
+    pub fn sub_unsafe<F: SmallField>(
+        circuit_builder: &mut CircuitBuilder<F>,
+        minuend: &UInt<M, C>,
+        subtrahend: &UInt<M, C>,
+        borrow: &[CellId],
+    ) -> Result<UInt<M, C>, UtilError> {
+        let result: UInt<M, C> = circuit_builder
+            .create_cells(UInt::<M, C>::N_OPRAND_CELLS)
+            .try_into()?;
+        // result = minuend - subtrahend + borrow * (1 << BIT_WIDTH) - last_borrow
+        for i in 0..result.values.len() {
+            let (minuend, subtrahend, result) =
+                (minuend.values[i], subtrahend.values[i], result.values[i]);
+            circuit_builder.add(result, minuend, F::BaseField::ONE);
+            circuit_builder.add(result, subtrahend, -F::BaseField::ONE);
+            if i < borrow.len() {
+                circuit_builder.add(result, borrow[i], F::BaseField::from(1 << C));
+            }
+            if i > 0 && i - 1 < borrow.len() {
+                circuit_builder.add(result, borrow[i - 1], -F::BaseField::ONE);
+            }
+        }
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{UInt, UIntAddSub};
+    use gkr::structs::{Circuit, CircuitWitness};
+    use goldilocks::Goldilocks;
+    use simple_frontend::structs::CircuitBuilder;
+
+    #[test]
+    fn test_add_unsafe() {
+        type Uint256_8 = UInt<256, 8>;
+        assert_eq!(Uint256_8::N_OPRAND_CELLS, 32);
+        let mut circuit_builder = CircuitBuilder::new();
+
+        // configure circuit with cells for addend_0, addend_1 and carry as wire_in
+        let (addend_0_wire_in_id, addend_0_wire_in_cells) =
+            circuit_builder.create_witness_in(Uint256_8::N_OPRAND_CELLS);
+        let (addend_1_wire_in_id, addend_1_wire_in_cells) =
+            circuit_builder.create_witness_in(Uint256_8::N_OPRAND_CELLS);
+        let (carry_wire_in_id, carry_wire_in_cells) =
+            circuit_builder.create_witness_in(Uint256_8::N_OPRAND_CELLS);
+        let addend_0 = Uint256_8::try_from(addend_0_wire_in_cells);
+        let addend_1 = Uint256_8::try_from(addend_1_wire_in_cells);
+        let result = UIntAddSub::<Uint256_8>::add_unsafe(
+            &mut circuit_builder,
+            &addend_0.unwrap(),
+            &addend_1.unwrap(),
+            &carry_wire_in_cells,
+        );
+        assert_eq!(result.unwrap().values(), (96..128).collect::<Vec<usize>>());
+        circuit_builder.configure();
+        let circuit = Circuit::new(&circuit_builder);
+        //println!("add unsafe circuit {:?}", circuit);
+
+        // generate witnesses for addend_0, addend_1 and carry
+        // must pad each witness to the size of N_OPERAND_CELLS
+        let n_witness_in = circuit.n_witness_in;
+        let mut wires_in = vec![vec![]; n_witness_in];
+        wires_in[addend_0_wire_in_id as usize] =
+            vec![Goldilocks::from(255u64), Goldilocks::from(255u64)];
+        wires_in[addend_0_wire_in_id as usize]
+            .extend(vec![Goldilocks::from(0u64); Uint256_8::N_OPRAND_CELLS - 2]);
+        wires_in[addend_1_wire_in_id as usize] =
+            vec![Goldilocks::from(255u64), Goldilocks::from(254u64)];
+        wires_in[addend_1_wire_in_id as usize]
+            .extend(vec![Goldilocks::from(0u64); Uint256_8::N_OPRAND_CELLS - 2]);
+        wires_in[carry_wire_in_id as usize] = vec![Goldilocks::from(1u64), Goldilocks::from(1u64)];
+        wires_in[carry_wire_in_id as usize]
+            .extend(vec![Goldilocks::from(0u64); Uint256_8::N_OPRAND_CELLS - 2]);
+        let circuit_witness = {
+            let challenges = vec![Goldilocks::from(2)];
+            let mut circuit_witness = CircuitWitness::new(&circuit, challenges);
+            circuit_witness.add_instance(&circuit, wires_in);
+            circuit_witness
+        };
+        //println!("{:?}", circuit_witness);
+        circuit_witness.check_correctness(&circuit);
+
+        // check the result
+        let result_values = circuit_witness.output_layer_witness_ref();
+        //println!("{:?}", result_values[0]);
+        assert_eq!(result_values.instances[0][0], Goldilocks::from(254u64));
+        assert_eq!(result_values.instances[0][1], Goldilocks::from(254u64));
+        assert_eq!(result_values.instances[0][2], Goldilocks::from(1u64));
+    }
+
+    #[test]
+    fn test_sub_unsafe() {
+        type Uint256_8 = UInt<256, 8>;
+        assert_eq!(Uint256_8::N_OPRAND_CELLS, 32);
+        let mut circuit_builder = CircuitBuilder::<Goldilocks>::new();
+
+        // configure circuit with cells for minuend, subtrend and borrow as wire_in
+        let (minuend_wire_in_id, minuend_wire_in_cells) =
+            circuit_builder.create_witness_in(Uint256_8::N_OPRAND_CELLS);
+        let (subtrend_wire_in_id, subtrend_wire_in_cells) =
+            circuit_builder.create_witness_in(Uint256_8::N_OPRAND_CELLS);
+        let (borrow_wire_in_id, borrow_wire_in_cells) =
+            circuit_builder.create_witness_in(Uint256_8::N_OPRAND_CELLS);
+        let minuend = Uint256_8::try_from(minuend_wire_in_cells);
+        let subtrend = Uint256_8::try_from(subtrend_wire_in_cells);
+        let result = UIntAddSub::<Uint256_8>::sub_unsafe(
+            &mut circuit_builder,
+            &minuend.unwrap(),
+            &subtrend.unwrap(),
+            &borrow_wire_in_cells,
+        );
+        assert_eq!(result.unwrap().values(), (96..128).collect::<Vec<usize>>());
+        circuit_builder.configure();
+        let circuit = Circuit::new(&circuit_builder);
+        //println!("add unsafe circuit {:?}", circuit);
+
+        // generate witnesses for addend_0, addend_1 and carry
+        // must pad each witness to the size of N_OPERAND_CELLS
+        let n_witness_in = circuit.n_witness_in;
+        let mut wires_in = vec![vec![]; n_witness_in];
+        wires_in[minuend_wire_in_id as usize] =
+            vec![Goldilocks::from(1u64), Goldilocks::from(1u64)];
+        wires_in[minuend_wire_in_id as usize]
+            .extend(vec![Goldilocks::from(0u64); Uint256_8::N_OPRAND_CELLS - 2]);
+        wires_in[subtrend_wire_in_id as usize] =
+            vec![Goldilocks::from(255u64), Goldilocks::from(254u64)];
+        wires_in[subtrend_wire_in_id as usize]
+            .extend(vec![Goldilocks::from(0u64); Uint256_8::N_OPRAND_CELLS - 2]);
+        wires_in[borrow_wire_in_id as usize] = vec![Goldilocks::from(1u64), Goldilocks::from(1u64)];
+        wires_in[borrow_wire_in_id as usize]
+            .extend(vec![Goldilocks::from(0u64); Uint256_8::N_OPRAND_CELLS - 2]);
+        let circuit_witness = {
+            let challenges = vec![Goldilocks::from(2)];
+            let mut circuit_witness = CircuitWitness::new(&circuit, challenges);
+            circuit_witness.add_instance(&circuit, wires_in);
+            circuit_witness
+        };
+        //println!("{:?}", circuit_witness);
+        circuit_witness.check_correctness(&circuit);
+
+        // check the result
+        let result_values = circuit_witness.output_layer_witness_ref();
+        //println!("{:?}", result_values[0]);
+        assert_eq!(result_values.instances[0][0], Goldilocks::from(2u64));
+        assert_eq!(result_values.instances[0][1], Goldilocks::from(2u64));
+        assert_eq!(result_values.instances[0][2], -Goldilocks::from(1u64));
+    }
+}

--- a/singer-utils/src/uint/cmp.rs
+++ b/singer-utils/src/uint/cmp.rs
@@ -1,0 +1,149 @@
+use ff::Field;
+use goldilocks::SmallField;
+use simple_frontend::structs::{CellId, CircuitBuilder, MixedCell};
+
+use crate::{chip_handler::RangeChipOperations, error::UtilError, structs::UInt};
+
+use super::{UIntAddSub, UIntCmp};
+
+impl<const M: usize, const C: usize> UIntCmp<UInt<M, C>> {
+    pub const N_NO_OVERFLOW_WITNESS_CELLS: usize =
+        UIntAddSub::<UInt<M, C>>::N_NO_OVERFLOW_WITNESS_CELLS;
+
+    pub const N_WITNESS_CELLS: usize = UIntAddSub::<UInt<M, C>>::N_WITNESS_CELLS;
+
+    pub fn extract_range_values(witness: &[CellId]) -> &[CellId] {
+        &witness[..UInt::<M, C>::N_RANGE_CHECK_CELLS]
+    }
+
+    pub fn extract_borrow(witness: &[CellId]) -> &[CellId] {
+        &UIntAddSub::<UInt<M, C>>::extract_carry(witness)
+    }
+
+    pub fn extract_unsafe_borrow(witness: &[CellId]) -> &[CellId] {
+        &UIntAddSub::<UInt<M, C>>::extract_unsafe_carry(witness)
+    }
+
+    /// Greater than implemented by little-endian subtraction.
+    pub fn lt<Ext: SmallField, H: RangeChipOperations<Ext>>(
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        range_chip_handler: &mut H,
+        oprand_0: &UInt<M, C>,
+        oprand_1: &UInt<M, C>,
+        witness: &[CellId],
+    ) -> Result<(CellId, UInt<M, C>), UtilError> {
+        let borrow = Self::extract_borrow(witness);
+        let range_values = Self::extract_range_values(witness);
+        let computed_diff =
+            UIntAddSub::<UInt<M, C>>::sub_unsafe(circuit_builder, oprand_0, oprand_1, borrow)?;
+        let diff = range_chip_handler.range_check_uint(
+            circuit_builder,
+            &computed_diff,
+            Some(&range_values),
+        )?;
+        if borrow.len() == UInt::<M, C>::N_CARRY_CELLS {
+            Ok((borrow[UInt::<M, C>::N_CARRY_CELLS - 1], diff))
+        } else {
+            Ok((circuit_builder.create_cell(), diff))
+        }
+    }
+
+    pub fn assert_lt<Ext: SmallField, H: RangeChipOperations<Ext>>(
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        range_chip_handler: &mut H,
+        oprand_0: &UInt<M, C>,
+        oprand_1: &UInt<M, C>,
+        witness: &[CellId],
+    ) -> Result<(), UtilError> {
+        let (borrow, _) = Self::lt(
+            circuit_builder,
+            range_chip_handler,
+            oprand_0,
+            oprand_1,
+            witness,
+        )?;
+        circuit_builder.assert_const(borrow, 1);
+        Ok(())
+    }
+
+    /// Greater or equal than implemented by little-endian subtraction.
+    pub fn assert_leq<Ext: SmallField, H: RangeChipOperations<Ext>>(
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        range_chip_handler: &mut H,
+        oprand_0: &UInt<M, C>,
+        oprand_1: &UInt<M, C>,
+        witness: &[CellId],
+    ) -> Result<(), UtilError> {
+        let (borrow, diff) = Self::lt(
+            circuit_builder,
+            range_chip_handler,
+            oprand_0,
+            oprand_1,
+            witness,
+        )?;
+        let diff_values = diff.values();
+        for d in diff_values.iter() {
+            let s = circuit_builder.create_cell();
+            // assert_zero({borrow ? 0 : diff})
+            circuit_builder.sel_mixed(
+                s,
+                (*d).into(),
+                MixedCell::Constant(Ext::BaseField::ZERO),
+                borrow,
+            );
+            circuit_builder.assert_const(s, 0);
+        }
+        Ok(())
+    }
+
+    pub fn assert_eq<Ext: SmallField>(
+        circuit_builder: &mut CircuitBuilder<Ext>,
+        oprand_0: &UInt<M, C>,
+        oprand_1: &UInt<M, C>,
+    ) -> Result<(), UtilError> {
+        let diff = circuit_builder.create_cells(oprand_0.values().len());
+        let opr_0 = oprand_0.values();
+        let opr_1 = oprand_1.values();
+        for i in 0..diff.len() {
+            circuit_builder.add(diff[i], opr_0[i], Ext::BaseField::ONE);
+            circuit_builder.add(diff[i], opr_1[i], -Ext::BaseField::ONE);
+            circuit_builder.assert_const(diff[i], 0);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::structs::{ChipChallenges, ROMHandler};
+
+    use super::{UInt, UIntCmp};
+    use goldilocks::Goldilocks;
+    use simple_frontend::structs::CircuitBuilder;
+
+    #[test]
+    fn test_lt() {
+        // TODO: this test yet cannot pass due to the same reason
+        // as happened in add tests
+        // this test fails at singer/src/instructions/utils/uint.rs:168:49:
+        // attempt to shift left with overflow
+        type Uint256_63 = UInt<256, 63>;
+        let mut circuit_builder = CircuitBuilder::<Goldilocks>::new();
+        // create cells for operand_0, operand_1 and witness
+        let _operand_0_cells = circuit_builder.create_cells(Uint256_63::N_OPRAND_CELLS);
+        let _operand_1_cells = circuit_builder.create_cells(Uint256_63::N_OPRAND_CELLS);
+        let _witness_cells = circuit_builder.create_cells(Uint256_63::N_OPRAND_CELLS);
+        let operand_0 = Uint256_63::try_from(vec![0, 1, 2, 3, 4]);
+        let operand_1 = Uint256_63::try_from(vec![5, 6, 7, 8, 9]);
+        let witness: Vec<usize> = (10..35).collect();
+        let mut range_chip_handler = ROMHandler::new(&ChipChallenges::default());
+        let result = UIntCmp::<Uint256_63>::lt(
+            &mut circuit_builder,
+            &mut range_chip_handler,
+            &operand_0.unwrap(),
+            &operand_1.unwrap(),
+            &witness,
+        );
+        println!("{:?}", result);
+    }
+}


### PR DESCRIPTION
Need merging after #49 .

This PR is to merge all vm tables into two tables RAM and ROM, this is to reduce the number tables, therefore the number of circuits to prove is reduced.