### PR TITLE
Singer scheme

### DIFF
--- a/gkr-graph/src/circuit_builder.rs
+++ b/gkr-graph/src/circuit_builder.rs
@@ -1,0 +1,37 @@
+use gkr::{
+    structs::{Point, PointAndEval},
+    utils::MultilinearExtensionFromVectors,
+};
+use goldilocks::SmallField;
+use itertools::Itertools;
+
+use crate::structs::{CircuitGraph, CircuitGraphWitness, NodeOutputType, TargetEvaluations};
+
+impl<F: SmallField> CircuitGraph<F> {
+    pub fn target_evals(
+        &self,
+        witness: &CircuitGraphWitness<F::BaseField>,
+        point: &Point<F>,
+    ) -> TargetEvaluations<F> {
+        let target_evals = self
+            .targets
+            .iter()
+            .map(|target| {
+                let poly = match target {
+                    NodeOutputType::OutputLayer(node_id) => witness.node_witnesses[*node_id]
+                        .output_layer_witness_ref()
+                        .instances
+                        .as_slice()
+                        .original_mle(),
+                    NodeOutputType::WireOut(node_id, wit_id) => witness.node_witnesses[*node_id]
+                        .witness_out_ref()[*wit_id as usize]
+                        .instances
+                        .as_slice()
+                        .original_mle(),
+                };
+                PointAndEval::new(point[..poly.num_vars].to_vec(), poly.evaluate(point))
+            })
+            .collect_vec();
+        TargetEvaluations(target_evals)
+    }
+}

--- a/singer-utils/src/chips.rs
+++ b/singer-utils/src/chips.rs
@@ -1,0 +1,425 @@
+use std::{mem, sync::Arc};
+
+use gkr::{
+    structs::{Circuit, LayerWitness},
+    utils::ceil_log2,
+};
+use gkr_graph::structs::{CircuitGraphBuilder, NodeOutputType, PredType};
+use goldilocks::SmallField;
+use simple_frontend::structs::WitnessId;
+pub use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
+
+use crate::{
+    constants::RANGE_CHIP_BIT_WIDTH,
+    error::UtilError,
+    structs::{ChipChallenges, InstOutChipType},
+};
+
+use self::{
+    bytecode::{construct_bytecode_table, construct_bytecode_table_and_witness},
+    calldata::{construct_calldata_table, construct_calldata_table_and_witness},
+    circuit_gadgets::{LeafCircuit, LeafFracSumCircuit, LeafFracSumNoSelectorCircuit},
+    range::{construct_range_table, construct_range_table_and_witness},
+};
+
+mod bytecode;
+mod calldata;
+mod range;
+
+pub mod circuit_gadgets;
+
+#[derive(Clone, Debug)]
+pub struct SingerChipBuilder<F: SmallField> {
+    pub chip_circuit_gadgets: ChipCircuitGadgets<F>,
+    pub output_wires_id: Vec<Vec<NodeOutputType>>,
+}
+
+impl<F: SmallField> SingerChipBuilder<F> {
+    pub fn new() -> Self {
+        let chip_circuit_gadgets = ChipCircuitGadgets::new();
+        Self {
+            chip_circuit_gadgets,
+            output_wires_id: vec![vec![]; InstOutChipType::iter().count()],
+        }
+    }
+
+    /// Construct the product of frac sum circuits for to chips of each circuit
+    /// and witnesses. This includes computing the LHS and RHS of the set
+    /// equality check, and the input of lookup arguments.
+    pub fn construct_chip_check_graph_and_witness(
+        &mut self,
+        graph_builder: &mut CircuitGraphBuilder<F>,
+        node_id: usize,
+        to_chip_ids: &[Option<(WitnessId, usize)>],
+        real_challenges: &[F],
+        real_n_instances: usize,
+    ) -> Result<(), UtilError> {
+        let mut build = |real_n_instances: usize,
+                         num: usize,
+                         input_wit_id: WitnessId,
+                         leaf: &LeafCircuit<F>,
+                         inner: &Arc<Circuit<F>>|
+         -> Result<NodeOutputType, UtilError> {
+            let selector = ChipCircuitGadgets::construct_prefix_selector(real_n_instances, num);
+            let selector_node_id = graph_builder.add_node_with_witness(
+                "selector circuit",
+                &selector.circuit,
+                vec![],
+                real_challenges.to_vec(),
+                vec![],
+                real_n_instances.next_power_of_two(),
+            )?;
+            let mut preds = vec![PredType::Source; 2];
+            preds[leaf.input_id as usize] =
+                PredType::PredWire(NodeOutputType::WireOut(node_id, input_wit_id));
+            preds[leaf.cond_id as usize] =
+                PredType::PredWire(NodeOutputType::OutputLayer(selector_node_id));
+
+            let instance_num_vars = ceil_log2(real_n_instances * num) - 1;
+            build_tree_graph_and_witness(
+                graph_builder,
+                preds,
+                &leaf.circuit,
+                inner,
+                vec![],
+                real_challenges,
+                instance_num_vars,
+            )
+        };
+
+        // Set equality argument
+        for output_type in [InstOutChipType::RAMLoad, InstOutChipType::RAMStore] {
+            if let Some((id, num)) = to_chip_ids[output_type as usize] {
+                let out = build(
+                    real_n_instances,
+                    num,
+                    id,
+                    &self.chip_circuit_gadgets.product_leaf,
+                    &self.chip_circuit_gadgets.product_inner,
+                )?;
+                self.output_wires_id[output_type as usize].push(out);
+            }
+        }
+
+        // Lookup argument
+        for output_type in [InstOutChipType::ROMInput] {
+            if let Some((id, num)) = to_chip_ids[output_type as usize] {
+                let out = build(
+                    real_n_instances,
+                    num,
+                    id,
+                    &self.chip_circuit_gadgets.inv_sum,
+                    &self.chip_circuit_gadgets.frac_sum_inner,
+                )?;
+                self.output_wires_id[output_type as usize].push(out);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Construct the product of frac sum circuits for to chips of each circuit.
+    /// This includes computing the LHS and RHS of the set equality check, and
+    /// the input of lookup arguments.
+    pub fn construct_chip_check_graph(
+        &mut self,
+        graph_builder: &mut CircuitGraphBuilder<F>,
+        node_id: usize,
+        to_chip_ids: &[Option<(WitnessId, usize)>],
+        real_n_instances: usize,
+    ) -> Result<(), UtilError> {
+        let mut build = |n_instances: usize,
+                         num: usize,
+                         input_wit_id: WitnessId,
+                         leaf: &LeafCircuit<F>,
+                         inner: &Arc<Circuit<F>>|
+         -> Result<NodeOutputType, UtilError> {
+            let selector = ChipCircuitGadgets::construct_prefix_selector(n_instances, num);
+            let selector_node_id =
+                graph_builder.add_node("selector circuit", &selector.circuit, vec![])?;
+            let mut preds = vec![PredType::Source; 2];
+            preds[leaf.input_id as usize] =
+                PredType::PredWire(NodeOutputType::WireOut(node_id, input_wit_id));
+            preds[leaf.cond_id as usize] =
+                PredType::PredWire(NodeOutputType::OutputLayer(selector_node_id));
+
+            let instance_num_vars = ceil_log2(real_n_instances) - 1;
+            build_tree_graph(
+                graph_builder,
+                preds,
+                &leaf.circuit,
+                inner,
+                instance_num_vars,
+            )
+        };
+
+        // Set equality argument
+        for output_type in [InstOutChipType::RAMLoad, InstOutChipType::RAMStore] {
+            if let Some((id, num)) = to_chip_ids[output_type as usize] {
+                let out = build(
+                    real_n_instances,
+                    num,
+                    id,
+                    &self.chip_circuit_gadgets.product_leaf,
+                    &self.chip_circuit_gadgets.product_inner,
+                )?;
+                self.output_wires_id[output_type as usize].push(out);
+            }
+        }
+
+        // Lookup argument
+        for output_type in [InstOutChipType::ROMInput] {
+            if let Some((id, num)) = to_chip_ids[output_type as usize] {
+                let out = build(
+                    real_n_instances,
+                    num,
+                    id,
+                    &self.chip_circuit_gadgets.inv_sum,
+                    &self.chip_circuit_gadgets.frac_sum_inner,
+                )?;
+                self.output_wires_id[output_type as usize].push(out);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Construct circuits and witnesses to generate the lookup table for each
+    /// table, including bytecode, range and calldata. Also generate the
+    /// tree-structured circuits to fold the summation.
+    pub fn construct_lookup_table_graph_and_witness(
+        &self,
+        graph_builder: &mut CircuitGraphBuilder<F>,
+        bytecode: &[u8],
+        program_input: &[u8],
+        mut table_count_witness: Vec<LayerWitness<F::BaseField>>,
+        challenges: &ChipChallenges,
+        real_challenges: &[F],
+    ) -> Result<Vec<NodeOutputType>, UtilError> {
+        let mut tables_out = vec![NodeOutputType::OutputLayer(0); LookupChipType::iter().count()];
+
+        let leaf = &self.chip_circuit_gadgets.frac_sum_leaf;
+        let inner = &self.chip_circuit_gadgets.frac_sum_inner;
+        let mut pred_source = |table_type, table_pred, selector_pred| {
+            let mut preds = vec![PredType::Source; 3];
+            preds[leaf.input_den_id as usize] = table_pred;
+            preds[leaf.cond_id as usize] = selector_pred;
+            let mut sources = vec![LayerWitness::default(); 3];
+            sources[leaf.input_num_id as usize].instances =
+                mem::take(&mut table_count_witness[table_type as usize].instances);
+            (preds, sources)
+        };
+
+        let (input_pred, selector_pred, instance_num_vars) = construct_bytecode_table_and_witness(
+            graph_builder,
+            bytecode,
+            challenges,
+            real_challenges,
+        )?;
+        let (preds, sources) = pred_source(
+            LookupChipType::BytecodeChip as usize,
+            input_pred,
+            selector_pred,
+        );
+        tables_out[LookupChipType::BytecodeChip as usize] = build_tree_graph_and_witness(
+            graph_builder,
+            preds,
+            &leaf.circuit,
+            inner,
+            sources,
+            real_challenges,
+            instance_num_vars,
+        )?;
+
+        let (input_pred, selector_pred, instance_num_vars) = construct_calldata_table_and_witness(
+            graph_builder,
+            program_input,
+            challenges,
+            real_challenges,
+        )?;
+        let (preds, sources) = pred_source(
+            LookupChipType::CalldataChip as usize,
+            input_pred,
+            selector_pred,
+        );
+        tables_out[LookupChipType::CalldataChip as usize] = build_tree_graph_and_witness(
+            graph_builder,
+            preds,
+            &leaf.circuit,
+            inner,
+            sources,
+            real_challenges,
+            instance_num_vars,
+        )?;
+
+        let leaf = &self.chip_circuit_gadgets.frac_sum_leaf_no_selector;
+        let mut preds_no_selector = |table_type, table_pred| {
+            let mut preds = vec![PredType::Source; 2];
+            preds[leaf.input_den_id as usize] = table_pred;
+            let mut sources = vec![LayerWitness::default(); 3];
+            sources[leaf.input_num_id as usize].instances =
+                mem::take(&mut table_count_witness[table_type as usize].instances);
+            (preds, sources)
+        };
+        let (input_pred, instance_num_vars) = construct_range_table_and_witness(
+            graph_builder,
+            RANGE_CHIP_BIT_WIDTH,
+            challenges,
+            real_challenges,
+        )?;
+        let (preds, sources) = preds_no_selector(LookupChipType::RangeChip as usize, input_pred);
+        tables_out[LookupChipType::RangeChip as usize] = build_tree_graph_and_witness(
+            graph_builder,
+            preds,
+            &leaf.circuit,
+            inner,
+            sources,
+            real_challenges,
+            instance_num_vars,
+        )?;
+        Ok(tables_out)
+    }
+
+    /// Construct circuits to generate the lookup table for each table, including
+    /// bytecode, range and calldata. Also generate the tree-structured circuits to
+    /// fold the summation.
+    pub fn construct_lookup_table_graph(
+        &self,
+        graph_builder: &mut CircuitGraphBuilder<F>,
+        byte_code_len: usize,
+        program_input_len: usize,
+        challenges: &ChipChallenges,
+    ) -> Result<Vec<NodeOutputType>, UtilError> {
+        let mut tables_out = vec![NodeOutputType::OutputLayer(0); LookupChipType::iter().count()];
+
+        let leaf = &self.chip_circuit_gadgets.frac_sum_leaf;
+        let inner = &self.chip_circuit_gadgets.frac_sum_inner;
+        let compute_preds = |table_pred, selector_pred| {
+            let mut preds = vec![PredType::Source; 3];
+            preds[leaf.input_den_id as usize] = table_pred;
+            preds[leaf.cond_id as usize] = selector_pred;
+            preds
+        };
+
+        let (input_pred, selector_pred, instance_num_vars) =
+            construct_bytecode_table(graph_builder, byte_code_len, challenges)?;
+        let preds = compute_preds(input_pred, selector_pred);
+        tables_out[LookupChipType::BytecodeChip as usize] = build_tree_graph(
+            graph_builder,
+            preds,
+            &leaf.circuit,
+            inner,
+            instance_num_vars,
+        )?;
+
+        let (input_pred, selector_pred, instance_num_vars) =
+            construct_calldata_table(graph_builder, program_input_len, challenges)?;
+        let preds = compute_preds(input_pred, selector_pred);
+        tables_out[LookupChipType::CalldataChip as usize] = build_tree_graph(
+            graph_builder,
+            preds,
+            &leaf.circuit,
+            inner,
+            instance_num_vars,
+        )?;
+
+        let leaf = &self.chip_circuit_gadgets.frac_sum_leaf_no_selector;
+        let compute_preds_no_selector = |table_pred| {
+            let mut preds = vec![PredType::Source; 2];
+            preds[leaf.input_den_id as usize] = table_pred;
+            preds
+        };
+        let (input_pred, instance_num_vars) =
+            construct_range_table(graph_builder, RANGE_CHIP_BIT_WIDTH, challenges)?;
+        let preds = compute_preds_no_selector(input_pred);
+        tables_out[LookupChipType::RangeChip as usize] = build_tree_graph(
+            graph_builder,
+            preds,
+            &leaf.circuit,
+            inner,
+            instance_num_vars,
+        )?;
+        Ok(tables_out)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ChipCircuitGadgets<F: SmallField> {
+    inv_sum: LeafCircuit<F>,
+    frac_sum_inner: Arc<Circuit<F>>,
+    frac_sum_leaf: LeafFracSumCircuit<F>,
+    frac_sum_leaf_no_selector: LeafFracSumNoSelectorCircuit<F>,
+    product_inner: Arc<Circuit<F>>,
+    product_leaf: LeafCircuit<F>,
+}
+
+#[derive(Clone, Copy, Debug, EnumIter)]
+pub enum LookupChipType {
+    BytecodeChip,
+    RangeChip,
+    CalldataChip,
+}
+
+/// Generate the tree-structured circuit and witness to compute the product or
+/// summation. `instance_num_vars` is corresponding to the leaves.
+fn build_tree_graph_and_witness<F: SmallField>(
+    graph_builder: &mut CircuitGraphBuilder<F>,
+    first_pred: Vec<PredType>,
+    leaf: &Arc<Circuit<F>>,
+    inner: &Arc<Circuit<F>>,
+    first_source: Vec<LayerWitness<F::BaseField>>,
+    real_challenges: &[F],
+    instance_num_vars: usize,
+) -> Result<NodeOutputType, UtilError> {
+    let (last_pred, _) =
+        (0..=instance_num_vars).fold(Ok((first_pred, first_source)), |prev, i| {
+            let circuit = if i == 0 { leaf } else { inner };
+            match prev {
+                Ok((pred, source)) => graph_builder
+                    .add_node_with_witness(
+                        "tree inner node",
+                        circuit,
+                        pred,
+                        real_challenges.to_vec(),
+                        source,
+                        1 << (instance_num_vars - i),
+                    )
+                    .map(|id| {
+                        (
+                            vec![PredType::PredWire(NodeOutputType::OutputLayer(id))],
+                            vec![LayerWitness { instances: vec![] }],
+                        )
+                    }),
+                Err(err) => Err(err),
+            }
+        })?;
+    match last_pred[0] {
+        PredType::PredWire(out) => Ok(out),
+        _ => unreachable!(),
+    }
+}
+
+/// Generate the tree-structured circuit to compute the product or summation.
+/// `instance_num_vars` is corresponding to the leaves.
+fn build_tree_graph<F: SmallField>(
+    graph_builder: &mut CircuitGraphBuilder<F>,
+    first_pred: Vec<PredType>,
+    leaf: &Arc<Circuit<F>>,
+    inner: &Arc<Circuit<F>>,
+    instance_num_vars: usize,
+) -> Result<NodeOutputType, UtilError> {
+    let last_pred = (0..=instance_num_vars).fold(Ok(first_pred), |prev, i| {
+        let circuit = if i == 0 { leaf } else { inner };
+        match prev {
+            Ok(pred) => graph_builder
+                .add_node("tree inner node", circuit, pred)
+                .map(|id| vec![PredType::PredWire(NodeOutputType::OutputLayer(id))]),
+            Err(err) => Err(err),
+        }
+    })?;
+    match last_pred[0] {
+        PredType::PredWire(out) => Ok(out),
+        _ => unreachable!(),
+    }
+}

--- a/singer-utils/src/chips/bytecode.rs
+++ b/singer-utils/src/chips/bytecode.rs
@@ -1,0 +1,130 @@
+use std::sync::Arc;
+
+use gkr::{
+    structs::{Circuit, LayerWitness},
+    utils::ceil_log2,
+};
+use gkr_graph::structs::{CircuitGraphBuilder, NodeOutputType, PredType};
+use goldilocks::SmallField;
+use itertools::Itertools;
+use simple_frontend::structs::{CircuitBuilder, MixedCell};
+
+use crate::{
+    error::UtilError,
+    structs::{ChipChallenges, PCUInt, ROMType},
+};
+
+use super::ChipCircuitGadgets;
+
+/// Add bytecode table circuit and witness to the circuit graph. Return node id
+/// and lookup instance log size.
+pub(crate) fn construct_bytecode_table_and_witness<F: SmallField>(
+    builder: &mut CircuitGraphBuilder<F>,
+    bytecode: &[u8],
+    challenges: &ChipChallenges,
+    real_challenges: &[F],
+) -> Result<(PredType, PredType, usize), UtilError> {
+    let mut circuit_builder = CircuitBuilder::<F>::new();
+    let (_, pc_cells) = circuit_builder.create_witness_in(PCUInt::N_OPRAND_CELLS);
+    let (_, bytecode_cells) = circuit_builder.create_witness_in(1);
+
+    let rlc = circuit_builder.create_ext_cell();
+    let mut items = vec![MixedCell::Constant(F::BaseField::from(
+        ROMType::Bytecode as u64,
+    ))];
+    items.extend(pc_cells.iter().map(|x| MixedCell::Cell(*x)).collect_vec());
+    items.extend(
+        bytecode_cells
+            .iter()
+            .map(|x| MixedCell::Cell(*x))
+            .collect_vec(),
+    );
+    circuit_builder.rlc_mixed(&rlc, &items, challenges.bytecode());
+
+    circuit_builder.configure();
+    let bytecode_circuit = Arc::new(Circuit::new(&circuit_builder));
+    let selector = ChipCircuitGadgets::construct_prefix_selector(bytecode.len(), 1);
+
+    let selector_node_id = builder.add_node_with_witness(
+        "bytecode selector circuit",
+        &selector.circuit,
+        vec![],
+        real_challenges.to_vec(),
+        vec![],
+        bytecode.len().next_power_of_two(),
+    )?;
+
+    let wits_in = vec![
+        LayerWitness {
+            instances: PCUInt::counter_vector::<F::BaseField>(bytecode.len().next_power_of_two())
+                .into_iter()
+                .map(|x| vec![x])
+                .collect_vec(),
+        },
+        LayerWitness {
+            instances: bytecode
+                .iter()
+                .map(|x| vec![F::BaseField::from(*x as u64)])
+                .collect_vec(),
+        },
+    ];
+
+    let table_node_id = builder.add_node_with_witness(
+        "bytecode table circuit",
+        &bytecode_circuit,
+        vec![PredType::Source; 2],
+        real_challenges.to_vec(),
+        wits_in,
+        bytecode.len().next_power_of_two(),
+    )?;
+
+    Ok((
+        PredType::PredWire(NodeOutputType::OutputLayer(table_node_id)),
+        PredType::PredWire(NodeOutputType::OutputLayer(selector_node_id)),
+        ceil_log2(bytecode.len()) - 1,
+    ))
+}
+
+/// Add bytecode table circuit to the circuit graph. Return node id and lookup
+/// instance log size.
+pub(crate) fn construct_bytecode_table<F: SmallField>(
+    builder: &mut CircuitGraphBuilder<F>,
+    bytecode_len: usize,
+    challenges: &ChipChallenges,
+) -> Result<(PredType, PredType, usize), UtilError> {
+    let mut circuit_builder = CircuitBuilder::<F>::new();
+    let (_, pc_cells) = circuit_builder.create_witness_in(PCUInt::N_OPRAND_CELLS);
+    let (_, bytecode_cells) = circuit_builder.create_witness_in(1);
+
+    let rlc = circuit_builder.create_ext_cell();
+    let mut items = vec![MixedCell::Constant(F::BaseField::from(
+        ROMType::Bytecode as u64,
+    ))];
+    items.extend(pc_cells.iter().map(|x| MixedCell::Cell(*x)).collect_vec());
+    items.extend(
+        bytecode_cells
+            .iter()
+            .map(|x| MixedCell::Cell(*x))
+            .collect_vec(),
+    );
+    circuit_builder.rlc_mixed(&rlc, &items, challenges.bytecode());
+
+    circuit_builder.configure();
+    let bytecode_circuit = Arc::new(Circuit::new(&circuit_builder));
+    let selector = ChipCircuitGadgets::construct_prefix_selector(bytecode_len, 1);
+
+    let selector_node_id =
+        builder.add_node("bytecode selector circuit", &selector.circuit, vec![])?;
+
+    let table_node_id = builder.add_node(
+        "bytecode table circuit",
+        &bytecode_circuit,
+        vec![PredType::Source; 2],
+    )?;
+
+    Ok((
+        PredType::PredWire(NodeOutputType::OutputLayer(table_node_id)),
+        PredType::PredWire(NodeOutputType::OutputLayer(selector_node_id)),
+        ceil_log2(bytecode_len) - 1,
+    ))
+}

--- a/singer-utils/src/chips/calldata.rs
+++ b/singer-utils/src/chips/calldata.rs
@@ -1,0 +1,138 @@
+use std::sync::Arc;
+
+use crate::{
+    error::UtilError,
+    structs::{ChipChallenges, ROMType, StackUInt},
+};
+
+use super::ChipCircuitGadgets;
+use gkr::{
+    structs::{Circuit, LayerWitness},
+    utils::ceil_log2,
+};
+use gkr_graph::structs::{CircuitGraphBuilder, NodeOutputType, PredType};
+use goldilocks::SmallField;
+use itertools::Itertools;
+use simple_frontend::structs::{CircuitBuilder, MixedCell};
+
+/// Add calldata table circuit and witness to the circuit graph. Return node id
+/// and lookup instance log size.
+pub(crate) fn construct_calldata_table_and_witness<F: SmallField>(
+    builder: &mut CircuitGraphBuilder<F>,
+    program_input: &[u8],
+    challenges: &ChipChallenges,
+    real_challenges: &[F],
+) -> Result<(PredType, PredType, usize), UtilError> {
+    let mut circuit_builder = CircuitBuilder::<F>::new();
+    let (_, id_cells) = circuit_builder.create_witness_in(1);
+    let (_, calldata_cells) = circuit_builder.create_witness_in(StackUInt::N_OPRAND_CELLS);
+
+    let rlc = circuit_builder.create_ext_cell();
+    let mut items = vec![MixedCell::Constant(F::BaseField::from(
+        ROMType::Calldata as u64,
+    ))];
+    items.extend(id_cells.iter().map(|x| MixedCell::Cell(*x)).collect_vec());
+    items.extend(
+        calldata_cells
+            .iter()
+            .map(|x| MixedCell::Cell(*x))
+            .collect_vec(),
+    );
+    circuit_builder.rlc_mixed(&rlc, &items, challenges.calldata());
+
+    circuit_builder.configure();
+    let calldata_circuit = Arc::new(Circuit::new(&circuit_builder));
+    let selector = ChipCircuitGadgets::construct_prefix_selector(program_input.len(), 1);
+
+    let selector_node_id = builder.add_node_with_witness(
+        "calldata selector circuit",
+        &selector.circuit,
+        vec![],
+        real_challenges.to_vec(),
+        vec![],
+        program_input.len().next_power_of_two(),
+    )?;
+
+    let calldata = program_input
+        .iter()
+        .map(|x| F::BaseField::from(*x as u64))
+        .collect_vec();
+    let wits_in = vec![
+        LayerWitness {
+            instances: (0..calldata.len())
+                .map(|x| vec![F::BaseField::from(x as u64)])
+                .collect_vec(),
+        },
+        LayerWitness {
+            instances: (0..calldata.len())
+                .step_by(StackUInt::N_OPRAND_CELLS)
+                .map(|i| {
+                    calldata[i..(i + StackUInt::N_OPRAND_CELLS).min(calldata.len())]
+                        .iter()
+                        .cloned()
+                        .rev()
+                        .collect_vec()
+                })
+                .collect_vec(),
+        },
+    ];
+
+    let table_node_id = builder.add_node_with_witness(
+        "calldata table circuit",
+        &calldata_circuit,
+        vec![PredType::Source; 2],
+        real_challenges.to_vec(),
+        wits_in,
+        program_input.len().next_power_of_two(),
+    )?;
+
+    Ok((
+        PredType::PredWire(NodeOutputType::OutputLayer(table_node_id)),
+        PredType::PredWire(NodeOutputType::OutputLayer(selector_node_id)),
+        ceil_log2(program_input.len()) - 1,
+    ))
+}
+
+/// Add calldata table circuit to the circuit graph. Return node id and lookup
+/// instance log size.
+pub(crate) fn construct_calldata_table<F: SmallField>(
+    builder: &mut CircuitGraphBuilder<F>,
+    program_input_len: usize,
+    challenges: &ChipChallenges,
+) -> Result<(PredType, PredType, usize), UtilError> {
+    let mut circuit_builder = CircuitBuilder::<F>::new();
+    let (_, id_cells) = circuit_builder.create_witness_in(1);
+    let (_, calldata_cells) = circuit_builder.create_witness_in(StackUInt::N_OPRAND_CELLS);
+
+    let rlc = circuit_builder.create_ext_cell();
+    let mut items = vec![MixedCell::Constant(F::BaseField::from(
+        ROMType::Calldata as u64,
+    ))];
+    items.extend(id_cells.iter().map(|x| MixedCell::Cell(*x)).collect_vec());
+    items.extend(
+        calldata_cells
+            .iter()
+            .map(|x| MixedCell::Cell(*x))
+            .collect_vec(),
+    );
+    circuit_builder.rlc_mixed(&rlc, &items, challenges.calldata());
+
+    circuit_builder.configure();
+    let calldata_circuit = Arc::new(Circuit::new(&circuit_builder));
+    let selector = ChipCircuitGadgets::construct_prefix_selector(program_input_len, 1);
+
+    let selector_node_id =
+        builder.add_node("calldata selector circuit", &selector.circuit, vec![])?;
+
+    let table_node_id = builder.add_node(
+        "calldata table circuit",
+        &calldata_circuit,
+        vec![PredType::Source; 2],
+    )?;
+
+    Ok((
+        PredType::PredWire(NodeOutputType::OutputLayer(table_node_id)),
+        PredType::PredWire(NodeOutputType::OutputLayer(selector_node_id)),
+        ceil_log2(program_input_len) - 1,
+    ))
+}

--- a/singer-utils/src/chips/circuit_gadgets.rs
+++ b/singer-utils/src/chips/circuit_gadgets.rs
@@ -1,0 +1,259 @@
+use ff::Field;
+use std::sync::Arc;
+
+use gkr::structs::Circuit;
+use goldilocks::SmallField;
+use simple_frontend::structs::{CircuitBuilder, MixedCell, WitnessId};
+
+use super::ChipCircuitGadgets;
+
+#[derive(Clone, Debug)]
+pub(crate) struct PrefixSelectorCircuit<F: SmallField> {
+    pub(crate) circuit: Arc<Circuit<F>>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LeafFracSumCircuit<F: SmallField> {
+    pub(crate) circuit: Arc<Circuit<F>>,
+    pub(crate) input_den_id: WitnessId,
+    pub(crate) input_num_id: WitnessId,
+    pub(crate) cond_id: WitnessId,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LeafFracSumNoSelectorCircuit<F: SmallField> {
+    pub(crate) circuit: Arc<Circuit<F>>,
+    pub(crate) input_den_id: WitnessId,
+    pub(crate) input_num_id: WitnessId,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LeafCircuit<F: SmallField> {
+    pub(crate) circuit: Arc<Circuit<F>>,
+    pub(crate) input_id: WitnessId,
+    pub(crate) cond_id: WitnessId,
+}
+
+impl<F: SmallField> ChipCircuitGadgets<F> {
+    pub(crate) fn new() -> Self {
+        Self {
+            inv_sum: Self::construct_inv_sum(),
+            frac_sum_inner: Self::construct_frac_sum_inner(),
+            frac_sum_leaf: Self::construct_frac_sum_leaf(),
+            frac_sum_leaf_no_selector: Self::construct_frac_sum_leaf_no_selector(),
+            product_inner: Self::construct_product_inner(),
+            product_leaf: Self::construct_product_leaf(),
+        }
+    }
+
+    /// Construct a selector for n_instances and each instance contains `num`
+    /// items. `num` must be a power of 2.
+    pub(crate) fn construct_prefix_selector(
+        n_instances: usize,
+        num: usize,
+    ) -> PrefixSelectorCircuit<F> {
+        assert_eq!(num, num.next_power_of_two());
+        let mut circuit_builder = CircuitBuilder::<F>::new();
+        let _ = circuit_builder.create_constant_in(n_instances * num, 1);
+        circuit_builder.configure();
+        PrefixSelectorCircuit {
+            circuit: Arc::new(Circuit::new(&circuit_builder)),
+        }
+    }
+
+    /// Construct a circuit to compute the inverse sum of two extension field
+    /// elements.
+    /// Wire in 0: 2 extension field elements.
+    /// Wire in 1: 2-bit selector.
+    /// output layer: the denominator and the numerator.
+    pub(crate) fn construct_inv_sum() -> LeafCircuit<F> {
+        let mut circuit_builder = CircuitBuilder::<F>::new();
+        let (input_id, input) = circuit_builder.create_ext_witness_in(2);
+        let (cond_id, cond) = circuit_builder.create_witness_in(2);
+        let (_, output) = circuit_builder.create_ext_witness_out(2);
+        // selector denominator 1 or input[0] or input[0] * input[1]
+        let den_mul = circuit_builder.create_ext_cell();
+        circuit_builder.mul2_ext(&den_mul, &input[0], &input[1], F::BaseField::ONE);
+        let tmp = circuit_builder.create_ext_cell();
+        circuit_builder.sel_mixed_and_ext(
+            &tmp,
+            &MixedCell::Constant(F::BaseField::ONE),
+            &input[0],
+            cond[0],
+        );
+        circuit_builder.sel_ext(&output[0], &tmp, &den_mul, cond[1]);
+
+        // select the numerator 0 or 1 or input[0] + input[1]
+        let den_add = circuit_builder.create_ext_cell();
+        circuit_builder.add_ext(&den_add, &input[0], F::BaseField::ONE);
+        circuit_builder.add_ext(&den_add, &input[0], F::BaseField::ONE);
+        circuit_builder.sel_mixed_and_ext(&output[1], &cond[0].into(), &den_add, cond[1]);
+
+        circuit_builder.configure();
+        LeafCircuit {
+            circuit: Arc::new(Circuit::new(&circuit_builder)),
+            input_id,
+            cond_id,
+        }
+    }
+
+    /// Construct a circuit to compute the sum of two fractions. The
+    /// denominators are on the extension field. The numerators are on the base
+    /// field.
+    /// Wire in 0: denominators, 2 extension field elements.
+    /// Wire in 1: numerators, 2 base field elements.
+    /// Wire in 2: 2-bit selector.
+    /// output layer: the denominator and the numerator.
+    pub(crate) fn construct_frac_sum_leaf() -> LeafFracSumCircuit<F> {
+        let mut circuit_builder = CircuitBuilder::<F>::new();
+        let (input_den_id, input_den) = circuit_builder.create_ext_witness_in(2);
+        let (input_num_id, input_num) = circuit_builder.create_witness_in(2);
+        let (cond_id, cond) = circuit_builder.create_witness_in(2);
+        let (_, output) = circuit_builder.create_ext_witness_out(2);
+        // selector denominator, 1 or input_den[0] or input_den[0] * input_den[1]
+        let den_mul = circuit_builder.create_ext_cell();
+        circuit_builder.mul2_ext(&den_mul, &input_den[0], &input_den[1], F::BaseField::ONE);
+        let tmp = circuit_builder.create_ext_cell();
+        circuit_builder.sel_mixed_and_ext(
+            &tmp,
+            &MixedCell::Constant(F::BaseField::ONE),
+            &input_den[0],
+            cond[0],
+        );
+        circuit_builder.sel_ext(&output[0], &tmp, &den_mul, cond[1]);
+
+        // select the numerator, 0 or input_num[0] or input_den[0] * input_num[1] + input_num[0] * input_den[1]
+        let num = circuit_builder.create_ext_cell();
+        circuit_builder.mul_ext_base(&num, &input_den[0], input_num[1], F::BaseField::ONE);
+        circuit_builder.mul_ext_base(&num, &input_den[1], input_num[0], F::BaseField::ONE);
+        let tmp = circuit_builder.create_cell();
+        circuit_builder.sel_mixed(
+            tmp,
+            MixedCell::Constant(F::BaseField::ZERO),
+            input_num[0].into(),
+            cond[0],
+        );
+        circuit_builder.sel_mixed_and_ext(&output[1], &tmp.into(), &num, cond[1]);
+
+        circuit_builder.configure();
+        LeafFracSumCircuit {
+            circuit: Arc::new(Circuit::new(&circuit_builder)),
+            input_den_id,
+            input_num_id,
+            cond_id,
+        }
+    }
+
+    /// Construct a circuit to compute the sum of two fractions. The
+    /// denominators are on the extension field. The numerators are on the base
+    /// field.
+    /// Wire in 0: denominators, 2 extension field elements.
+    /// Wire in 1: numerators, 2 base field elements.
+    /// output layer: the denominator and the numerator.
+    pub(crate) fn construct_frac_sum_leaf_no_selector() -> LeafFracSumNoSelectorCircuit<F> {
+        let mut circuit_builder = CircuitBuilder::<F>::new();
+        let (input_den_id, input_den) = circuit_builder.create_ext_witness_in(2);
+        let (input_num_id, input_num) = circuit_builder.create_witness_in(2);
+        let (_, output) = circuit_builder.create_ext_witness_out(2);
+        // denominator
+        circuit_builder.mul2_ext(
+            &output[0], // output_den
+            &input_den[0],
+            &input_den[1],
+            F::BaseField::ONE,
+        );
+
+        // numerator
+        circuit_builder.mul_ext_base(
+            &output[1], // output_num
+            &input_den[0],
+            input_num[1],
+            F::BaseField::ONE,
+        );
+        circuit_builder.mul_ext_base(
+            &output[1], // output_num
+            &input_den[1],
+            input_num[0],
+            F::BaseField::ONE,
+        );
+
+        circuit_builder.configure();
+        LeafFracSumNoSelectorCircuit {
+            circuit: Arc::new(Circuit::new(&circuit_builder)),
+            input_den_id,
+            input_num_id,
+        }
+    }
+
+    /// Construct a circuit to compute the sum of two fractions. The
+    /// denominators and numerators are on the extension field
+    /// Wire in 0: denominators, 2 extension field elements.
+    /// Wire in 1: numerators, 2 extensuin field elements.
+    /// Wire out 0: the denominator.
+    /// Wire out 1: the numerator.
+    pub(crate) fn construct_frac_sum_inner() -> Arc<Circuit<F>> {
+        let mut circuit_builder = CircuitBuilder::<F>::new();
+        let (_, input) = circuit_builder.create_ext_witness_in(4);
+        let (_, output) = circuit_builder.create_ext_witness_out(2);
+        // denominator
+        circuit_builder.mul2_ext(
+            &output[0], // output_den
+            &input[0],  // input_den[0]
+            &input[2],  // input_den[1]
+            F::BaseField::ONE,
+        );
+
+        // numerator
+        circuit_builder.mul2_ext(
+            &output[1], // output_num
+            &input[0],  // input_den[0]
+            &input[3],  // input_num[1]
+            F::BaseField::ONE,
+        );
+        circuit_builder.mul2_ext(
+            &output[1], // output_num
+            &input[2],  // input_den[1]
+            &input[1],  // input_num[0]
+            F::BaseField::ONE,
+        );
+
+        circuit_builder.configure();
+        Arc::new(Circuit::new(&circuit_builder))
+    }
+
+    /// Construct a circuit to compute the product of two extension field elements.
+    pub(crate) fn construct_product_leaf() -> LeafCircuit<F> {
+        let mut circuit_builder = CircuitBuilder::<F>::new();
+        let (input_id, input) = circuit_builder.create_ext_witness_in(2);
+        let (cond_id, sel) = circuit_builder.create_witness_in(2);
+        let (_, output) = circuit_builder.create_ext_witness_out(1);
+        // selector elements, 1 or input[0] or input[0] * input[1]
+        let mul = circuit_builder.create_ext_cell();
+        circuit_builder.mul2_ext(&mul, &input[0], &input[1], F::BaseField::ONE);
+        let tmp = circuit_builder.create_ext_cell();
+        circuit_builder.sel_mixed_and_ext(
+            &tmp,
+            &MixedCell::Constant(F::BaseField::ONE),
+            &input[0],
+            sel[0],
+        );
+        circuit_builder.sel_ext(&output[0], &tmp, &mul, sel[1]);
+
+        circuit_builder.configure();
+        LeafCircuit {
+            circuit: Arc::new(Circuit::new(&circuit_builder)),
+            input_id,
+            cond_id,
+        }
+    }
+
+    /// Construct a circuit to compute the product of two extension field elements.
+    pub(crate) fn construct_product_inner() -> Arc<Circuit<F>> {
+        let mut circuit_builder = CircuitBuilder::<F>::new();
+        let (_, input) = circuit_builder.create_ext_witness_in(2);
+        let (_, output) = circuit_builder.create_ext_witness_out(1);
+        circuit_builder.mul2_ext(&output[0], &input[0], &input[1], F::BaseField::ONE);
+
+        Arc::new(Circuit::new(&circuit_builder))
+    }
+}

--- a/singer-utils/src/chips/range.rs
+++ b/singer-utils/src/chips/range.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+
+use gkr::structs::Circuit;
+use gkr_graph::structs::{CircuitGraphBuilder, NodeOutputType, PredType};
+use goldilocks::SmallField;
+use simple_frontend::structs::{CircuitBuilder, MixedCell};
+
+use crate::{
+    error::UtilError,
+    structs::{ChipChallenges, ROMType},
+};
+
+/// Add range table circuit and witness to the circuit graph. Return node id and
+/// lookup instance log size.
+pub(crate) fn construct_range_table_and_witness<F: SmallField>(
+    builder: &mut CircuitGraphBuilder<F>,
+    bit_width: usize,
+    challenges: &ChipChallenges,
+    real_challenges: &[F],
+) -> Result<(PredType, usize), UtilError> {
+    let mut circuit_builder = CircuitBuilder::<F>::new();
+    let cells = circuit_builder.create_counter_in(0);
+    let items = [
+        MixedCell::Constant(F::BaseField::from(ROMType::Range as u64)),
+        MixedCell::Cell(cells[0]),
+    ];
+    let rlc = circuit_builder.create_ext_cell();
+    circuit_builder.rlc_mixed(&rlc, &items, challenges.range());
+    circuit_builder.configure();
+    let range_circuit = Arc::new(Circuit::new(&circuit_builder));
+
+    let table_node_id = builder.add_node_with_witness(
+        "range table circuit",
+        &range_circuit,
+        vec![],
+        real_challenges.to_vec(),
+        vec![],
+        1 << bit_width,
+    )?;
+    Ok((
+        PredType::PredWire(NodeOutputType::OutputLayer(table_node_id)),
+        bit_width - 1,
+    ))
+}
+
+/// Add range table circuit to the circuit graph. Return node id and lookup
+/// instance log size.
+pub(crate) fn construct_range_table<F: SmallField>(
+    builder: &mut CircuitGraphBuilder<F>,
+    bit_width: usize,
+    challenges: &ChipChallenges,
+) -> Result<(PredType, usize), UtilError> {
+    let mut circuit_builder = CircuitBuilder::<F>::new();
+    let cells = circuit_builder.create_counter_in(0);
+    let items = [
+        MixedCell::Constant(F::BaseField::from(ROMType::Range as u64)),
+        MixedCell::Cell(cells[0]),
+    ];
+    let rlc = circuit_builder.create_ext_cell();
+    circuit_builder.rlc_mixed(&rlc, &items, challenges.range());
+    circuit_builder.configure();
+    let range_circuit = Arc::new(Circuit::new(&circuit_builder));
+
+    let table_node_id = builder.add_node("range table circuit", &range_circuit, vec![])?;
+    Ok((
+        PredType::PredWire(NodeOutputType::OutputLayer(table_node_id)),
+        bit_width - 1,
+    ))
+}

--- a/singer-utils/src/macros.rs
+++ b/singer-utils/src/macros.rs
@@ -1,0 +1,95 @@
+#[macro_export]
+macro_rules! register_witness {
+    ($struct_name:ident, $($wire_name:ident { $($slice_name:ident => $length:expr),* }),*) => {
+        paste! {
+            impl $struct_name {
+                $(
+                    #[inline]
+                    pub fn [<$wire_name _ size>]() -> usize {
+                        (0 $(+ $length)* as usize).next_power_of_two()
+                    }
+
+                    register_witness!(@internal $wire_name, 0usize; $($slice_name => $length),*);
+                )*
+            }
+        }
+    };
+
+    ($struct_name:ident<N>, $($wire_name:ident { $($slice_name:ident => $length:expr),* }),*) => {
+        paste! {
+            impl<const N: usize> $struct_name<N> {
+                $(
+                    #[inline]
+                    pub fn [<$wire_name _ size>]() -> usize {
+                        (0 $(+ $length)* as usize).next_power_of_two()
+                    }
+
+                    register_witness!(@internal $wire_name, 0usize; $($slice_name => $length),*);
+                )*
+            }
+        }
+    };
+
+    (@internal $wire_name:ident, $offset:expr; $name:ident => $length:expr $(, $rest:ident => $rest_length:expr)*) => {
+        paste! {
+            fn [<$wire_name _ $name>]() -> std::ops::Range<usize> {
+                $offset..$offset + $length
+            }
+            register_witness!(@internal $wire_name, $offset + $length; $($rest => $rest_length),*);
+        }
+    };
+
+    (@internal $wire_name:ident, $offset:expr;) => {};
+}
+
+#[macro_export]
+macro_rules! register_multi_witness {
+    ($struct_name:ident, $($wire_name:ident($($wire_param:ident)*) { $($slice_name:ident$(($num:expr))? => $length:expr),* }),*) => {
+        paste! {
+            impl $struct_name {
+                $(
+                    register_multi_witness!(@internal $wire_name($($wire_param)*), 0usize; $($slice_name$(($num))? => $length),*);
+                )*
+            }
+        }
+    };
+
+    ($struct_name:ident<N>, $($wire_name:ident($($wire_param:ident)*) { $($slice_name:ident$(($num:expr))? => $length:expr),* }),*) => {
+        paste! {
+            impl<const N: usize> $struct_name<N> {
+                $(
+                    register_multi_witness!(@internal $wire_name($($wire_param)*), 0usize; $($slice_name$(($num))? => $length),*);
+                )*
+            }
+        }
+    };
+
+    (@internal $wire_name:ident($($wire_param:ident)*), $offset:expr; $name:ident($num:expr) => $length:expr $(, $rest:ident$(($rest_num:expr))? => $rest_length:expr)*) => {
+        paste! {
+            #[inline]
+            fn [<$wire_name _ $name>](idx: usize$(, $wire_param: usize)*) -> std::ops::Range<usize> {
+                $offset + $length * (idx - 1)..$offset + $length * idx
+            }
+            register_multi_witness!(@internal $wire_name($($wire_param)*), $offset + $length * $num; $($rest$(($rest_num))? => $rest_length),*);
+        }
+    };
+
+    (@internal $wire_name:ident($($wire_param:ident)*), $offset:expr; $name:ident => $length:expr $(, $rest:ident$(($rest_num:expr))? => $rest_length:expr)*) => {
+        paste! {
+            #[inline]
+            fn [<$wire_name _ $name>]($($wire_param: usize)*) -> std::ops::Range<usize> {
+                $offset..$offset + $length
+            }
+            register_multi_witness!(@internal $wire_name($($wire_param)*), $offset + $length; $($rest$(($rest_num))? => $rest_length),*);
+        }
+    };
+
+    (@internal $wire_name:ident($($wire_param:ident)*), $offset:expr;) => {
+        paste! {
+            #[inline]
+            fn [<$wire_name _ size>]($($wire_param: usize)*) -> usize {
+                $offset.next_power_of_two()
+            }
+        }
+    };
+}


### PR DESCRIPTION
Need merging after #49 and #53 

Updates in this PR:
1. For each prover's function, i.e. `construct_graph_and_witness`, add a verifier's version, i.e. `construct_graph`.
2. Add `prove` and `verify` functions.
3. Move some structures used both in singer and singer pro to singer-utils, such as `SingerChipBuilder`, chip handlers, some macros and so on.