### PR TITLE
general latency optimisation under gkr/sumcheck/mle package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,6 +488,9 @@ dependencies = [
  "simple-frontend",
  "sumcheck",
  "tiny-keccak",
+ "tracing",
+ "tracing-flame",
+ "tracing-subscriber",
  "transcript",
 ]
 
@@ -688,6 +691,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +743,7 @@ dependencies = [
  "goldilocks",
  "rayon",
  "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -742,6 +755,16 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -805,6 +828,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +876,12 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "plotters"
@@ -1013,8 +1048,17 @@ checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.3",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -1025,8 +1069,14 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.3",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1133,6 +1183,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1288,6 +1347,7 @@ dependencies = [
  "multilinear_extensions",
  "rayon",
  "serde",
+ "tracing",
  "transcript",
 ]
 
@@ -1375,6 +1435,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,6 +1461,78 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.49",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-flame"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
+dependencies = [
+ "lazy_static",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1423,6 +1565,12 @@ name = "uuid"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,7 @@
+[env]
+CORE = { script = ["grep ^cpu\\scores /proc/cpuinfo | uniq |  awk '{print $4}'"] }
+RAYON_NUM_THREADS = "${CORE}"
+
+[tasks.test]
+command = "cargo"
+args = ["test", "--release", "--all", "--all-features"]

--- a/gkr-graph/Cargo.toml
+++ b/gkr-graph/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 [dependencies]
 ark-std.workspace = true
 ff.workspace = true
-gkr = { path = "../gkr" }
+gkr = { path = "../gkr", features = ["parallel"] }
 goldilocks.workspace = true
 itertools = "0.12.0"
 multilinear_extensions = { version = "0.1.0", path = "../multilinear_extensions" }

--- a/gkr/Cargo.toml
+++ b/gkr/Cargo.toml
@@ -19,15 +19,20 @@ itertools = "0.12.0"
 serde.workspace = true
 serde_json = "1.0.108"
 rayon.workspace = true
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+tracing-flame = "0.2.0"
+tracing = "0.1.40"
 
 [dev-dependencies]
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
-pprof = { version = "0.13" }
+pprof = { version = "0.13", features = ["flamegraph"]}
 criterion = { version = "0.5", features = ["html_reports"] }
 cfg-if = "1.0.0"
 
 [features]
+default = [ ]
 flamegraph = ["pprof/flamegraph", "pprof/criterion"]
+parallel = [ ]
 
 [[bench]]
 name = "keccak256"

--- a/gkr/Makefile.toml
+++ b/gkr/Makefile.toml
@@ -1,0 +1,17 @@
+[env]
+CORE = { script = ["grep ^cpu\\scores /proc/cpuinfo | uniq |  awk '{print $4}'"] }
+RAYON_NUM_THREADS = "${CORE}"
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
+[tasks.gkr_bench]
+command = "cargo"
+args = ["bench", "--bench", "keccak256", "--features", "flamegraph", "--package", "gkr"]
+
+[tasks.gkr_example]
+command = "cargo"
+args = ["run", "--package", "gkr", "--release", "--example", "keccak256"]
+
+[tasks.gkr_example_flamegraph]
+env = { "RUST_LOG" = "debug"}
+command = "cargo"
+args = ["run", "--package", "gkr", "--release", "--example", "keccak256"]

--- a/gkr/benches/README.md
+++ b/gkr/benches/README.md
@@ -1,0 +1,24 @@
+benchmark
+=======
+
+rust benchmark powered by [criterion.rs](https://bheisler.github.io/criterion.rs/book/criterion_rs.html)
+
+- [x] keccak256
+
+
+
+### command
+benchmark and save as `bashline`
+```
+cargo bench --bench <benchmark name> --features parallel --package gkr -- --save-baseline baseline
+```
+
+comparing with `baseline`
+```
+cargo bench --bench <benchmark name> --features parallel [--features <features to comparing with baseline> ...] --package gkr -- --baseline baseline
+```
+
+flamegraph
+```
+cargo bench --bench <benchmark name> --features parallel --features flamegraph --package gkr -- --profile-time <profile time in secs>
+```

--- a/gkr/src/lib.rs
+++ b/gkr/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod circuit;
 pub mod error;
+pub mod macros;
 mod prover;
 pub mod structs;
 pub mod utils;

--- a/gkr/src/macros.rs
+++ b/gkr/src/macros.rs
@@ -1,0 +1,64 @@
+#[macro_export]
+macro_rules! entered_span {
+    ($first:expr $(,)*) => {
+        $crate::tracing_span!($first).entered()
+    };
+}
+
+#[macro_export]
+macro_rules! tracing_span {
+    ($first:expr $(,)*) => {
+        tracing::span!(tracing::Level::DEBUG, $first)
+    };
+}
+
+#[macro_export]
+macro_rules! exit_span {
+    ($first:expr $(,)*) => {
+        $first.exit();
+    };
+}
+
+#[macro_export]
+#[cfg(feature = "parallel")]
+macro_rules! izip_parallizable {
+    (@closure $p:pat => $tup:expr) => {
+        |$p| $tup
+    };
+    (@closure $p:pat => ($($tup:tt)*) , $_iter:expr $(, $tail:expr)*) => {
+        $crate::izip_parallizable!(@closure ($p, b) => ($($tup)*, b) $(, $tail)*)
+    };
+    ($first:expr $(,)*) => {
+        rayon::iter::IntoParallelIterator::into_par_iter($first)
+    };
+    ($first:expr, $second:expr $(,)*) => {
+        $crate::izip_parallizable!($first).zip($second)
+    };
+    ($first:expr $(, $rest:expr)* $(,)*) => {
+        $crate::izip_parallizable!($first)
+            $(.zip($rest))*
+            .map($crate::izip_parallizable!(@closure a => (a) $(, $rest)*))
+    };
+}
+
+#[macro_export]
+#[cfg(not(feature = "parallel"))]
+macro_rules! izip_parallizable {
+    (@closure $p:pat => $tup:expr) => {
+        |$p| $tup
+    };
+    (@closure $p:pat => ($($tup:tt)*) , $_iter:expr $(, $tail:expr)*) => {
+        $crate::izip_parallizable!(@closure ($p, b) => ($($tup)*, b) $(, $tail)*)
+    };
+    ($first:expr $(,)*) => {
+        $first.into_iter()
+    };
+    ($first:expr, $second:expr $(,)*) => {
+        $crate::izip_parallizable!($first).zip($second)
+    };
+    ($first:expr $(, $rest:expr)* $(,)*) => {
+        $crate::izip_parallizable!($first)
+            $(.zip($rest))*
+            .map($crate::izip_parallizable!(@closure a => (a) $(, $rest)*))
+    };
+}

--- a/gkr/src/utils.rs
+++ b/gkr/src/utils.rs
@@ -1,4 +1,5 @@
 use ff::Field;
+
 use std::{iter, sync::Arc};
 
 use ark_std::{end_timer, start_timer};
@@ -154,33 +155,6 @@ pub fn counter_eval<F: SmallField>(num_vars: usize, x: &[F]) -> F {
     ans
 }
 
-/// Reduce the number of variables of `self` by fixing the
-/// `partial_point.len()` variables at `partial_point`.
-pub fn fix_high_variables<F: SmallField>(
-    poly: &ArcDenseMultilinearExtension<F>,
-    partial_point: &[F],
-) -> DenseMultilinearExtension<F> {
-    // TODO: return error.
-    assert!(
-        partial_point.len() <= poly.num_vars,
-        "invalid size of partial point"
-    );
-    let nv = poly.num_vars;
-    let new_len = 1 << (nv - partial_point.len());
-    let mut poly = poly.evaluations.to_vec();
-
-    for i in 0..new_len {
-        let partial_poly = DenseMultilinearExtension::from_evaluations_vec(
-            partial_point.len(),
-            poly[i..].iter().step_by(new_len).map(|x| *x).collect_vec(),
-        );
-        poly[i] = partial_poly.evaluate(&partial_point);
-    }
-
-    poly.resize(new_len, F::ZERO);
-    DenseMultilinearExtension::from_evaluations_vec(nv - partial_point.len(), poly)
-}
-
 /// Evaluate eq polynomial for 3 random points.
 pub fn eq3_eval<F: SmallField>(x: &[F], y: &[F], z: &[F]) -> F {
     assert_eq!(x.len(), y.len(), "x and y have different length");
@@ -224,14 +198,13 @@ pub trait MultilinearExtensionFromVectors<F: SmallField> {
 
 impl<F: SmallField> MultilinearExtensionFromVectors<F> for &[Vec<F::BaseField>] {
     fn mle(&self, lo_num_vars: usize, hi_num_vars: usize) -> ArcDenseMultilinearExtension<F> {
-        let vecs = self.to_vec();
-
         Arc::new(DenseMultilinearExtension::from_evaluations_vec(
             lo_num_vars + hi_num_vars,
-            vecs.into_iter()
+            self.iter()
                 .flat_map(|instance| {
                     instance
-                        .into_iter()
+                        .iter()
+                        .cloned()
                         .chain(iter::repeat(F::BaseField::ZERO))
                         .take(1 << lo_num_vars)
                 })
@@ -449,45 +422,6 @@ mod test {
                 DenseMultilinearExtension::from_evaluations_vec(n, partial_eq_vec).evaluate(&b);
             assert_eq!(expected_ans, eq_eval_less_or_equal_than(max_idx, &a, &b));
         }
-    }
-
-    #[test]
-    fn test_fix_high_variables() {
-        let poly = DenseMultilinearExtension::from_evaluations_vec(
-            3,
-            vec![
-                Goldilocks::from(13),
-                Goldilocks::from(97),
-                Goldilocks::from(11),
-                Goldilocks::from(101),
-                Goldilocks::from(7),
-                Goldilocks::from(103),
-                Goldilocks::from(5),
-                Goldilocks::from(107),
-            ],
-        );
-        let poly = Arc::new(poly);
-
-        let partial_point = vec![Goldilocks::from(3), Goldilocks::from(5)];
-
-        let expected1 = DenseMultilinearExtension::from_evaluations_vec(
-            2,
-            vec![
-                -Goldilocks::from(17),
-                Goldilocks::from(127),
-                -Goldilocks::from(19),
-                Goldilocks::from(131),
-            ],
-        );
-        let got1 = fix_high_variables(&poly, &partial_point[1..]);
-        assert_eq!(got1, expected1);
-
-        let expected2 = DenseMultilinearExtension::from_evaluations_vec(
-            1,
-            vec![-Goldilocks::from(23), Goldilocks::from(139)],
-        );
-        let got2: DenseMultilinearExtension<Goldilocks> = fix_high_variables(&poly, &partial_point);
-        assert_eq!(got2, expected2);
     }
 
     #[test]

--- a/multilinear_extensions/Cargo.toml
+++ b/multilinear_extensions/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+tracing = "0.1.40"
 ark-std.workspace = true
 ff.workspace = true
 goldilocks.workspace = true

--- a/multilinear_extensions/src/mle.rs
+++ b/multilinear_extensions/src/mle.rs
@@ -1,7 +1,8 @@
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use ark_std::{end_timer, rand::RngCore, start_timer};
 use goldilocks::SmallField;
+use rayon::iter::IntoParallelRefIterator;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "parallel")]
@@ -53,17 +54,44 @@ impl<F: SmallField> DenseMultilinearExtension<F> {
             point.len(),
             "MLE size does not match the point"
         );
-
-        // TODO evaluate without clone?
-        let mut to_bind_poly = self.clone();
-        to_bind_poly.fix_variables(point);
-        assert!(to_bind_poly.evaluations.len() == 1);
-        to_bind_poly.evaluations[0]
+        self.fix_variables(point).evaluations[0]
     }
 
     /// Reduce the number of variables of `self` by fixing the
     /// `partial_point.len()` variables at `partial_point`.
-    pub fn fix_variables(&mut self, partial_point: &[F]) {
+    pub fn fix_variables(&self, partial_point: &[F]) -> DenseMultilinearExtension<F> {
+        // TODO: return error.
+        assert!(
+            partial_point.len() <= self.num_vars,
+            "invalid size of partial point"
+        );
+        let mut poly = Cow::Borrowed(self);
+
+        // evaluate single variable of partial point from left to right
+        // `Cow` type here to skip first evaluation vector copy
+        for point in partial_point.iter() {
+            match &mut poly {
+                poly @ Cow::Borrowed(_) => {
+                    *poly = Cow::Owned(DenseMultilinearExtension::from_evaluations_vec(
+                        self.num_vars - 1,
+                        self.evaluations
+                            .par_iter()
+                            .chunks(2)
+                            .with_min_len(64)
+                            .map(|buf| *buf[0] + (*buf[1] - *buf[0]) * point)
+                            .collect(),
+                    ));
+                }
+                Cow::Owned(poly) => poly.fix_variables_in_place(&[*point]),
+            }
+        }
+        assert!(poly.num_vars == self.num_vars - partial_point.len(),);
+        poly.into_owned()
+    }
+
+    /// Reduce the number of variables of `self` by fixing the
+    /// `partial_point.len()` variables at `partial_point` in place
+    pub fn fix_variables_in_place(&mut self, partial_point: &[F]) {
         // TODO: return error.
         assert!(
             partial_point.len() <= self.num_vars,
@@ -73,25 +101,77 @@ impl<F: SmallField> DenseMultilinearExtension<F> {
         let poly = &mut self.evaluations;
         // evaluate single variable of partial point from left to right
         for (i, point) in partial_point.iter().enumerate() {
-            Self::fix_one_variable_helper(poly, nv - i, point);
+            let max_log2_size = nv - i;
+            // override buf[b1, b2,..bt, 0] = (1-point) * buf[b1, b2,..bt, 0] + point * buf[b1, b2,..bt, 1] in parallel
+            poly.par_iter_mut()
+                .chunks(2)
+                .with_min_len(64)
+                .for_each(|mut buf| *buf[0] = *buf[0] + (*buf[1] - *buf[0]) * point);
+
+            // sequentially update buf[b1, b2,..bt] = buf[b1, b2,..bt, 0]
+            for index in 0..1 << (max_log2_size - 1) {
+                poly[index] = poly[index << 1];
+            }
         }
-        let dim = partial_point.len();
-        poly.resize(1 << (nv - dim), F::ZERO);
-        self.num_vars = nv - dim;
+        poly.truncate(1 << (nv - partial_point.len()));
+        self.num_vars = nv - partial_point.len();
     }
 
-    /// Helper function. Fix 1 variable.
-    fn fix_one_variable_helper(data: &mut Vec<F>, max_log2_size: usize, point: &F) {
-        // override buf[b1, b2,..bt, 0] = (1-point) * buf[b1, b2,..bt, 0] + point * buf[b1, b2,..bt, 1] in parallel
-        data.par_iter_mut()
-            .chunks(2)
-            .with_min_len(64)
-            .for_each(|mut buf| *buf[0] = *buf[0] + (*buf[1] - *buf[0]) * point);
-
-        // sequentially update buf[b1, b2,..bt] = buf[b1, b2,..bt, 0]
-        for index in 0..1 << (max_log2_size - 1) {
-            data[index] = data[index << 1];
+    /// Reduce the number of variables of `self` by fixing the
+    /// `partial_point.len()` variables at `partial_point` from high position
+    pub fn fix_high_variables(&self, partial_point: &[F]) -> DenseMultilinearExtension<F> {
+        // TODO: return error.
+        assert!(
+            partial_point.len() <= self.num_vars,
+            "invalid size of partial point"
+        );
+        let mut poly = Cow::Borrowed(self);
+        let current_eval_size = poly.evaluations.len();
+        // `Cow` type here to skip first evaluation vector copy
+        for point in partial_point.iter().rev() {
+            match &mut poly {
+                poly @ Cow::Borrowed(_) => {
+                    let half_size = current_eval_size >> 1;
+                    *poly = Cow::Owned(DenseMultilinearExtension::from_evaluations_vec(
+                        self.num_vars - 1,
+                        {
+                            let (lo, hi) = self.evaluations.split_at(half_size);
+                            lo.par_iter()
+                                .zip(hi)
+                                .with_min_len(64)
+                                .map(|(lo, hi)| *lo + (*hi - *lo) * point)
+                                .collect()
+                        },
+                    ));
+                }
+                Cow::Owned(poly) => poly.fix_high_variables_in_place(&[*point]),
+            }
         }
+        assert!(poly.num_vars == self.num_vars - partial_point.len(),);
+        poly.into_owned()
+    }
+
+    /// Reduce the number of variables of `self` by fixing the
+    /// `partial_point.len()` variables at `partial_point` from high position in place
+    pub fn fix_high_variables_in_place(&mut self, partial_point: &[F]) {
+        // TODO: return error.
+        assert!(
+            partial_point.len() <= self.num_vars,
+            "invalid size of partial point"
+        );
+        let nv = self.num_vars;
+        let mut current_eval_size = self.evaluations.len();
+        for point in partial_point.iter().rev() {
+            let half_size = current_eval_size >> 1;
+            let (lo, hi) = self.evaluations.split_at_mut(half_size);
+            lo.par_iter_mut()
+                .zip(hi)
+                .with_min_len(64)
+                .for_each(|(lo, hi)| *lo += (*hi - *lo) * point);
+            current_eval_size = half_size;
+        }
+        self.evaluations.truncate(current_eval_size);
+        self.num_vars = nv - partial_point.len()
     }
 
     /// Generate a random evaluation of a multilinear poly

--- a/multilinear_extensions/src/test.rs
+++ b/multilinear_extensions/src/test.rs
@@ -64,6 +64,37 @@ fn test_eq_xr() {
     }
 }
 
+#[test]
+fn test_fix_high_variables() {
+    let poly = DenseMultilinearExtension::from_evaluations_vec(
+        3,
+        vec![
+            F::from(13),
+            F::from(97),
+            F::from(11),
+            F::from(101),
+            F::from(7),
+            F::from(103),
+            F::from(5),
+            F::from(107),
+        ],
+    );
+
+    let partial_point = vec![F::from(3), F::from(5)];
+
+    let expected1 = DenseMultilinearExtension::from_evaluations_vec(
+        2,
+        vec![-F::from(17), F::from(127), -F::from(19), F::from(131)],
+    );
+    let result1 = poly.fix_high_variables(&partial_point[1..]);
+    assert_eq!(result1, expected1);
+
+    let expected2 =
+        DenseMultilinearExtension::from_evaluations_vec(1, vec![-F::from(23), F::from(139)]);
+    let result2 = poly.fix_high_variables(&partial_point);
+    assert_eq!(result2, expected2);
+}
+
 /// Naive method to build eq(x, r).
 /// Only used for testing purpose.
 // Evaluate

--- a/multilinear_extensions/src/virtual_poly.rs
+++ b/multilinear_extensions/src/virtual_poly.rs
@@ -382,6 +382,8 @@ pub fn build_eq_x_r<F: SmallField>(r: &[F]) -> ArcDenseMultilinearExtension<F> {
 ///      eq(x,y) = \prod_i=1^num_var (x_i * y_i + (1-x_i)*(1-y_i))
 /// over r, which is
 ///      eq(x,y) = \prod_i=1^num_var (x_i * r_i + (1-x_i)*(1-r_i))
+
+#[tracing::instrument(skip_all, name = "multilinear_extensions::build_eq_x_r_vec")]
 pub fn build_eq_x_r_vec<F: PrimeField>(r: &[F]) -> Vec<F> {
     // we build eq(x,r) from its evaluations
     // we want to evaluate eq(x,r) over x \in {0, 1}^num_vars

--- a/singer-pro/Cargo.toml
+++ b/singer-pro/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 [dependencies]
 ark-std.workspace = true
 ff.workspace = true
-gkr = { version = "0.1.0", path = "../gkr" }
+gkr = { version = "0.1.0", path = "../gkr", features = ["parallel"] }
 gkr-graph = { version = "0.1.0", path = "../gkr-graph" }
 goldilocks.workspace = true
 itertools = "0.12.0"

--- a/singer-utils/Cargo.toml
+++ b/singer-utils/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 ff.workspace = true
 goldilocks.workspace = true
 
-gkr = { path = "../gkr" }
+gkr = { path = "../gkr", features = ["parallel"] }
 itertools = "0.12.0"
 simple-frontend = { version = "0.1.0", path = "../simple-frontend" }
 gkr-graph = { version = "0.1.0", path = "../gkr-graph" }

--- a/singer/Cargo.toml
+++ b/singer/Cargo.toml
@@ -13,7 +13,7 @@ goldilocks.workspace = true
 rayon.workspace = true
 serde.workspace = true
 
-gkr = { path = "../gkr" }
+gkr = { path = "../gkr", features = ["parallel"] }
 transcript = { path = "../transcript" }
 mpcs = { path = "../mpcs" }
 gkr-graph = { version = "0.1.0", path = "../gkr-graph" }

--- a/sumcheck/Cargo.toml
+++ b/sumcheck/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 
 [dependencies]
 ark-ff = "0.4.0"
+tracing = "0.1.40"
 ark-std.workspace = true
 ff.workspace = true
 goldilocks.workspace = true

--- a/sumcheck/src/lib.rs
+++ b/sumcheck/src/lib.rs
@@ -1,3 +1,4 @@
+mod macros;
 mod prover;
 pub mod structs;
 mod util;

--- a/sumcheck/src/macros.rs
+++ b/sumcheck/src/macros.rs
@@ -1,0 +1,20 @@
+#[macro_export]
+macro_rules! entered_span {
+    ($first:expr $(,)*) => {
+        $crate::tracing_span!($first).entered()
+    };
+}
+
+#[macro_export]
+macro_rules! tracing_span {
+    ($first:expr $(,)*) => {
+        tracing::span!(tracing::Level::DEBUG, $first)
+    };
+}
+
+#[macro_export]
+macro_rules! exit_span {
+    ($first:expr $(,)*) => {
+        $first.exit();
+    };
+}

--- a/sumcheck/src/test.rs
+++ b/sumcheck/src/test.rs
@@ -62,7 +62,6 @@ fn test_sumcheck_internal<F: SmallField>(
         num_products,
         &mut rng,
     );
-    // let poly_bak = poly.clone();
     let (poly_info, num_variables) = (poly.aux_info.clone(), poly.aux_info.num_variables);
     let mut prover_state = IOPProverState::prover_init(poly.clone());
     let mut verifier_state = IOPVerifierState::verifier_init(&poly_info);
@@ -91,7 +90,7 @@ fn test_sumcheck_internal<F: SmallField>(
             .flattened_ml_extensions
             .par_iter_mut()
             .for_each(|mle| {
-                Arc::get_mut(mle).unwrap().fix_variables(&[p.elements]);
+                Arc::make_mut(mle).fix_variables_in_place(&[p.elements]);
             });
     };
     let subclaim = IOPVerifierState::check_and_generate_subclaim(&verifier_state, &asserted_sum);

--- a/sumcheck/src/util.rs
+++ b/sumcheck/src/util.rs
@@ -84,10 +84,12 @@ pub(crate) fn extrapolate<F: PrimeField>(points: &[F], weights: &[F], evals: &[F
     let (coeffs, sum_inv) = {
         let mut coeffs = points.iter().map(|point| *at - point).collect::<Vec<_>>();
         batch_inversion(&mut coeffs);
+        let mut sum = F::ZERO;
         coeffs.iter_mut().zip(weights).for_each(|(coeff, weight)| {
             *coeff *= weight;
+            sum += *coeff
         });
-        let sum_inv = coeffs.iter().sum::<F>().invert().unwrap_or(F::ZERO);
+        let sum_inv = sum.invert().unwrap_or(F::ZERO);
         (coeffs, sum_inv)
     };
     coeffs


### PR DESCRIPTION
### changes
This PR majorly focus on latency optimisations under gkr/sumcheck/mle packages.

This change majorly touch below 3 packages: `gkr`/`sumcheck`/`mle`

- [x] gkr sumcheck phase inner step parallel processing with new features "parallel"
- [x] fixed unittest error due to previous change: return valid prover state when passing with constant polynomial
- [x] add readme and [cargo-make](https://sagiegurari.github.io/cargo-make/)
- [x] gkr/sumcheck performance optimisation
- [x] use tracing-span to generate user-friendly flamegraph

### tracing_flame
Integrate [rust tracing_flame](https://docs.rs/tracing-flame/latest/tracing_flame/) to merge call stack and generating user-friendly flamegraph, which makes shared steps across multi gkr layers to be aggregated so the real bottleneck can be catch up visually. 

### benchmark results
keccak256 Benchmark [^1] results shows > 3-4x latency speedup, and trending shows more performance gain when getting more keccak256 instances. 

```
| #instance | master branch                | pull-request                    | speedup (with p < 0.05)      |
|-----------|------------------------------|---------------------------------|------------------------------|
| 2         | [1.2970 s 1.3015 s 1.3076 s] | [550.77 ms 552.17 ms 553.63 ms] | [-57.800% -57.575% -57.378%] |
| 4         | [1.9132 s 1.9213 s 1.9318 s] | [779.22 ms 781.05 ms 783.01 ms] | [-59.585% -59.349% -59.142%] |
| 8         | [3.4717 s 3.6375 s 3.8360 s] | [1.2111 s 1.2132 s 1.2152 s]    | [-68.368% -66.648% -65.058%] |
| 16        | [6.6745 s 6.6855 s 6.6961 s] | [2.0469 s 2.0559 s 2.0685 s]    | [-69.393% -69.248% -69.045%] |
| 32        | [13.893 s 13.915 s 13.938 s] | [3.7090 s 3.7152 s 3.7222 s]    | [-73.364% -73.300% -73.235%] |
```

[^1]: AMD 5800X (8 cores) + 32GB memory

### probably next steps
- re-design keccak circuit layers to consume less layers
- adapt [sumcheck over smaller field](https://people.cs.georgetown.edu/jthaler/small-sumcheck.pdf) methodology to trade more base field with less ext-field arithmetics

### flamegraph example
![tracing-flamegraph_new](https://github.com/scroll-tech/singer/assets/3962077/ff29e142-e59d-4de1-bbe2-94304b3f55ea)

