### PR TITLE
[part4] general improvement: inline and parallisms on DP level

### DIFF
--- a/ff_ext/Cargo.toml
+++ b/ff_ext/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ff_ext"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde.workspace = true
+goldilocks.workspace = true
+ff.workspace = true

--- a/ff_ext/src/lib.rs
+++ b/ff_ext/src/lib.rs
@@ -1,0 +1,59 @@
+pub use ff;
+use ff::FromUniformBytes;
+use goldilocks::SmallField;
+use serde::Serialize;
+use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
+
+pub trait ExtensionField:
+    Serialize
+    + FromUniformBytes<64>
+    + From<Self::BaseField>
+    + Add<Self::BaseField, Output = Self>
+    + Sub<Self::BaseField, Output = Self>
+    + Mul<Self::BaseField, Output = Self>
+    + for<'a> Add<&'a Self::BaseField, Output = Self>
+    + for<'a> Sub<&'a Self::BaseField, Output = Self>
+    + for<'a> Mul<&'a Self::BaseField, Output = Self>
+    + AddAssign<Self::BaseField>
+    + SubAssign<Self::BaseField>
+    + MulAssign<Self::BaseField>
+    + for<'a> AddAssign<&'a Self::BaseField>
+    + for<'a> SubAssign<&'a Self::BaseField>
+    + for<'a> MulAssign<&'a Self::BaseField>
+{
+    const DEGREE: usize;
+
+    type BaseField: SmallField + FromUniformBytes<64>;
+
+    fn from_bases(bases: &[Self::BaseField]) -> Self;
+
+    fn as_bases(&self) -> &[Self::BaseField];
+
+    /// Convert limbs into self
+    fn from_limbs(limbs: &[Self::BaseField]) -> Self;
+}
+
+mod impl_goldilocks {
+    use crate::ExtensionField;
+    use goldilocks::{Goldilocks, GoldilocksExt2};
+
+    impl ExtensionField for GoldilocksExt2 {
+        const DEGREE: usize = 2;
+
+        type BaseField = Goldilocks;
+
+        fn from_bases(bases: &[Goldilocks]) -> Self {
+            debug_assert_eq!(bases.len(), 2);
+            Self([bases[0], bases[1]])
+        }
+
+        fn as_bases(&self) -> &[Goldilocks] {
+            self.0.as_slice()
+        }
+
+        /// Convert limbs into self
+        fn from_limbs(limbs: &[Self::BaseField]) -> Self {
+            Self([limbs[0], limbs[1]])
+        }
+    }
+}

--- a/gkr/src/circuit.rs
+++ b/gkr/src/circuit.rs
@@ -154,6 +154,7 @@ pub(crate) trait EvaluateConstant<E: ExtensionField> {
 }
 
 impl<E: ExtensionField> EvaluateConstant<E> for ConstantType<E> {
+    #[inline(always)]
     fn eval(&self, challenges: &HashMap<ChallengeConst, Vec<E::BaseField>>) -> E::BaseField {
         match self {
             ConstantType::Challenge(c, j) => challenges[&c][*j],

--- a/gkr/src/prover/phase1.rs
+++ b/gkr/src/prover/phase1.rs
@@ -164,7 +164,7 @@ impl<E: ExtensionField> IOPProverState<E> {
 
         let span = entered_span!("f2_fix_variables");
         // f2(t) = layers[i](t || ry)
-        let f2 = self.phase1_layer_polys[self.layer_id as usize]
+        let f2 = mem::take(&mut self.phase1_layer_polys[self.layer_id as usize])
             .fix_variables(&self.to_next_step_point)
             .into();
         exit_span!(span);

--- a/gkr/src/unsafe_utils.rs
+++ b/gkr/src/unsafe_utils.rs
@@ -18,6 +18,7 @@ impl<'a, T> UnsafeSlice<'a, T> {
 
     /// SAFETY: It is undefined-behavior if two threads write to the same index without
     /// synchronization.
+    #[inline(always)]
     pub unsafe fn write(&self, i: usize, value: T) {
         let ptr = self.slice[i].get();
         *ptr = value;

--- a/sumcheck/src/prover.rs
+++ b/sumcheck/src/prover.rs
@@ -244,12 +244,10 @@ impl<E: ExtensionField> IOPProverState<E> {
                             extrapolate(points, weights, &sum, &at)
                         })
                         .collect::<Vec<_>>();
+                    sum.extend(extrapolation);
                     exit_span!(span);
                     let span = entered_span!("extend_extrapolate");
-                    products_sum
-                        .iter_mut()
-                        .zip(sum.iter().chain(extrapolation.iter()))
-                        .for_each(|(products_sum, sum)| *products_sum += sum);
+                    products_sum += AdditiveVec(sum);
                     exit_span!(span);
                     products_sum
                 },


### PR DESCRIPTION
### optimisation type
- [x] `same memory consumption`, `+ throughtput` 


### changed scope
- fix build failed: missing commitment new package `ff_ext`
- parallel `g` on data parallel, less thread cross-synchronization. This improve the performance when `#number of data parallel instance >= CPU cores`.  It also help to clean up `phase2.rs` code.
- chores optimisation: `inline` of arithmetics function

### benchmark results on keccak256 [^1]

> benchmark run on 16 cores server, so it's expected that for #instance < 2^4  it will be slow, while >2^5 it got perf boost
```
| #instance | time spending                   | speedup (with p < 0.05)      | note        |
|-----------|---------------------------------|------------------------------|-------------|
| 1         | [410.05 ms 410.96 ms 411.93 ms] | [+41.863% +42.217% +42.594%] | 1.4x slow   |
| 2         | [472.05 ms 473.45 ms 474.87 ms] | [+31.091% +31.519% +31.909%] | 1.3x slow   |
| 4         | [551.12 ms 553.37 ms 555.87 ms] | [+17.318% +17.860% +18.459%] | 1.17x slow  |
| 8         | [689.72 ms 693.65 ms 697.76 ms] | [+6.2314% +6.8459% +7.5059%] | 1.06x slow  |
| 16        | [907.55 ms 909.89 ms 912.18 ms] | [-5.1167% -4.7571% -4.3846%] | 1.04x boost |
| 32        | [1.4038 s 1.4072 s 1.4104 s]    | [-6.3321% -5.9762% -5.6334%] | 1.06x boost |
| 64        | [2.3235 s 2.3288 s 2.3345 s]    | [-7.5569% -7.2698% -7.0109%] | 1.06x boost |
| 128       | [4.0730 s 4.0921 s 4.1110 s]    | [-8.3402% -7.7544% -7.1984%] | 1.06x boost |
| 256       | [8.0212 s 8.1539 s 8.2784 s]    | [-12.207% -10.595% -9.0188%] | 1.11x boost |
| 512       | [17.143 s 17.273 s 17.431 s]    | [-15.673% -14.385% -13.082%] | 1.16x boost |
```


[^1]: AMD EPYC 9R14 (16 cores) + 32GB memory
