### PR TITLE
add `build.rs` to hint rebuild binary once environment variable change

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-env-changed=RAYON_NUM_THREADS");
+}


### PR DESCRIPTION
env variable change will not trigger re-build by default

For example

https://github.com/scroll-tech/ceno/blob/10566f56ad5744b73c254edb2694be97e2596e8e/singer/benches/add.rs#L35-L36

Environment variable will only be fetch when first time compilation (e.g. cargo run/cargo bench...). Once it first time pass, changing environment variable will not refresh constant definition in binary.

Need to have "build.rs" to hints `cargo` tool.