### PR TITLE
Fix: avoid running benchmark unit test in the debug model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 *.log
 log.txt
+logs/

--- a/singer-pro/src/basic_block.rs
+++ b/singer-pro/src/basic_block.rs
@@ -503,6 +503,7 @@ mod test {
     use transcript::Transcript;
 
     // A benchmark containing `n_adds_in_bb` ADD instructions in a basic block.
+    #[cfg(not(debug_assertions))]
     fn bench_bb_helper<E: ExtensionField>(instance_num_vars: usize, n_adds_in_bb: usize) {
         let chip_challenges = ChipChallenges::default();
         let circuit_builder =
@@ -612,6 +613,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(debug_assertions))]
     fn bench_bb() {
         bench_bb_helper::<GoldilocksExt2>(10, 5);
     }

--- a/singer-utils/src/structs.rs
+++ b/singer-utils/src/structs.rs
@@ -1,10 +1,12 @@
 use ff_ext::ExtensionField;
-use simple_frontend::structs::{CellId, ChallengeId, ExtCellId};
+use simple_frontend::structs::{ChallengeId, ExtCellId};
 use strum_macros::EnumIter;
 use uint::UInt;
 
-use crate::constants::{EVM_STACK_BIT_WIDTH, VALUE_BIT_WIDTH};
-use crate::uint;
+use crate::{
+    constants::{EVM_STACK_BIT_WIDTH, VALUE_BIT_WIDTH},
+    uint,
+};
 
 #[derive(Clone, Debug, Copy, EnumIter)]
 pub enum RAMType {

--- a/singer-utils/src/uint/arithmetic.rs
+++ b/singer-utils/src/uint/arithmetic.rs
@@ -1,7 +1,7 @@
 use crate::{chip_handler::RangeChipOperations, error::UtilError, uint::uint::UInt};
 use ff::Field;
 use ff_ext::ExtensionField;
-use simple_frontend::structs::{Cell, CellId, CircuitBuilder};
+use simple_frontend::structs::{CellId, CircuitBuilder};
 
 impl<const M: usize, const C: usize> UInt<M, C> {
     /// Little-endian addition.
@@ -332,7 +332,7 @@ mod tests {
         let addend_1 = UInt20::try_from(addend_1_cells).expect("should build uint");
 
         // update circuit builder with circuit instructions
-        let result =
+        let _ =
             UInt20::add_unsafe(&mut circuit_builder, &addend_0, &addend_1, &carry_cells).unwrap();
         circuit_builder.configure();
         let circuit = Circuit::new(&circuit_builder);
@@ -406,7 +406,7 @@ mod tests {
         let addend_0 = UInt20::try_from(addend_0_cells).expect("should build uint");
 
         // update circuit builder
-        let result = UInt20::add_const_unsafe(
+        let _ = UInt20::add_const_unsafe(
             &mut circuit_builder,
             &addend_0,
             Goldilocks::from(200),
@@ -480,7 +480,7 @@ mod tests {
         let addend_0 = UInt20::try_from(addend_0_cells).expect("should build uint");
 
         // update circuit builder
-        let result = UInt20::add_cell_unsafe(
+        let _ = UInt20::add_cell_unsafe(
             &mut circuit_builder,
             &addend_0,
             small_value_cell[0],
@@ -559,7 +559,7 @@ mod tests {
         let subtrahend = UInt20::try_from(subtrahend_cells).expect("should build uint");
 
         // update the circuit builder
-        let result =
+        let _ =
             UInt20::sub_unsafe(&mut circuit_builder, &minuend, &subtrahend, &borrow_cells).unwrap();
         circuit_builder.configure();
         let circuit = Circuit::new(&circuit_builder);

--- a/singer-utils/src/uint/constants.rs
+++ b/singer-utils/src/uint/constants.rs
@@ -1,9 +1,10 @@
 use super::uint::UInt;
-use crate::constants::RANGE_CHIP_BIT_WIDTH;
-use crate::uint::util::const_min;
+use crate::{constants::RANGE_CHIP_BIT_WIDTH, uint::util::const_min};
 use std::marker::PhantomData;
 
 impl<const M: usize, const C: usize> UInt<M, C> {
+    pub const C: usize = C;
+    pub const M: usize = M;
     /// Determines the maximum number of bits that should be represented in each cell
     /// independent of the cell capacity `C`.
     /// If M < C i.e. total bit < cell capacity, the maximum_usable_cell_capacity

--- a/singer-utils/src/uint/uint.rs
+++ b/singer-utils/src/uint/uint.rs
@@ -5,7 +5,6 @@ use crate::{
 };
 use ff_ext::ExtensionField;
 use goldilocks::SmallField;
-use itertools::Itertools;
 use simple_frontend::structs::{CellId, CircuitBuilder};
 use sumcheck::util::ceil_log2;
 
@@ -154,7 +153,7 @@ mod tests {
         let mut circuit_builder = CircuitBuilder::<GoldilocksExt2>::new();
         let (_, small_values) = circuit_builder.create_witness_in(8);
         type UInt30 = UInt<30, 6>;
-        let uint_instance =
+        let _ =
             UInt30::from_different_sized_cell_values(&mut circuit_builder, &small_values, 2, true)
                 .unwrap();
         circuit_builder.configure();

--- a/singer-utils/src/uint/util.rs
+++ b/singer-utils/src/uint/util.rs
@@ -1,8 +1,7 @@
-use ff::PrimeField;
 use crate::error::UtilError;
+use ff::PrimeField;
 use ff_ext::ExtensionField;
 use goldilocks::SmallField;
-use itertools::Itertools;
 use simple_frontend::structs::{CellId, CircuitBuilder};
 
 /// Given some data represented by n small cells of size s
@@ -120,7 +119,7 @@ mod tests {
         let (_, big_values) = circuit_builder.create_witness_in(5);
         let big_bit_width = 5;
         let small_bit_width = 2;
-        let cell_packing_result = convert_decomp(
+        let _ = convert_decomp(
             &mut circuit_builder,
             &big_values,
             big_bit_width,

--- a/singer/examples/add.rs
+++ b/singer/examples/add.rs
@@ -63,14 +63,13 @@ fn get_single_instance_values_map() -> BTreeMap<&'static str, Vec<Goldilocks>> {
         vec![Goldilocks::from(2u64)],
     );
     let m: u64 = (1 << TSUInt::C) - 1;
-    let range_values = u64vec::<{ TSUInt::N_RANGE_CHECK_CELLS }, RANGE_CHIP_BIT_WIDTH>(m);
+    let range_values = u64vec::<{ TSUInt::N_RANGE_CELLS }, RANGE_CHIP_BIT_WIDTH>(m);
     phase0_values_map.insert(
         AddInstruction::phase0_old_stack_ts_lt0_str(),
         vec![
             Goldilocks::from(range_values[0]),
             Goldilocks::from(range_values[1]),
             Goldilocks::from(range_values[2]),
-            Goldilocks::from(range_values[3]),
             Goldilocks::from(1u64), // borrow
         ],
     );
@@ -79,14 +78,13 @@ fn get_single_instance_values_map() -> BTreeMap<&'static str, Vec<Goldilocks>> {
         vec![Goldilocks::from(1u64)],
     );
     let m: u64 = (1 << TSUInt::C) - 2;
-    let range_values = u64vec::<{ TSUInt::N_RANGE_CHECK_CELLS }, RANGE_CHIP_BIT_WIDTH>(m);
+    let range_values = u64vec::<{ TSUInt::N_RANGE_CELLS }, RANGE_CHIP_BIT_WIDTH>(m);
     phase0_values_map.insert(
         AddInstruction::phase0_old_stack_ts_lt1_str(),
         vec![
             Goldilocks::from(range_values[0]),
             Goldilocks::from(range_values[1]),
             Goldilocks::from(range_values[2]),
-            Goldilocks::from(range_values[3]),
             Goldilocks::from(1u64), // borrow
         ],
     );
@@ -99,7 +97,7 @@ fn get_single_instance_values_map() -> BTreeMap<&'static str, Vec<Goldilocks>> {
         AddInstruction::phase0_addend_1_str(),
         vec![Goldilocks::from(1u64)],
     );
-    let range_values = u64vec::<{ StackUInt::N_RANGE_CHECK_CELLS }, RANGE_CHIP_BIT_WIDTH>(m + 1);
+    let range_values = u64vec::<{ StackUInt::N_RANGE_CELLS }, RANGE_CHIP_BIT_WIDTH>(m + 1);
     let mut wit_phase0_instruction_add: Vec<Goldilocks> = vec![];
     for i in 0..16 {
         wit_phase0_instruction_add.push(Goldilocks::from(range_values[i]))

--- a/singer/src/instructions/add.rs
+++ b/singer/src/instructions/add.rs
@@ -323,6 +323,7 @@ mod test {
         );
     }
 
+    #[cfg(not(debug_assertions))]
     fn bench_add_instruction_helper<E: ExtensionField>(instance_num_vars: usize) {
         let chip_challenges = ChipChallenges::default();
         let circuit_builder =
@@ -380,6 +381,8 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(debug_assertions))]
+
     fn bench_add_instruction() {
         bench_add_instruction_helper::<GoldilocksExt2>(10);
     }

--- a/singer/src/instructions/calldataload.rs
+++ b/singer/src/instructions/calldataload.rs
@@ -261,6 +261,7 @@ mod test {
         );
     }
 
+    #[cfg(not(debug_assertions))]
     fn bench_calldataload_instruction_helper<E: ExtensionField>(instance_num_vars: usize) {
         let chip_challenges = ChipChallenges::default();
         let circuit_builder =
@@ -319,6 +320,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(debug_assertions))]
     fn bench_calldataload_instruction() {
         bench_calldataload_instruction_helper::<GoldilocksExt2>(10);
     }

--- a/singer/src/instructions/dup.rs
+++ b/singer/src/instructions/dup.rs
@@ -268,6 +268,7 @@ mod test {
         );
     }
 
+    #[cfg(not(debug_assertions))]
     fn bench_dup_instruction_helper<E: ExtensionField, const N: usize>(instance_num_vars: usize) {
         let chip_challenges = ChipChallenges::default();
         let circuit_builder =
@@ -327,11 +328,13 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(debug_assertions))]
     fn bench_dup1_instruction() {
         bench_dup_instruction_helper::<GoldilocksExt2, 1>(10);
     }
 
     #[test]
+    #[cfg(not(debug_assertions))]
     fn bench_dup2_instruction() {
         bench_dup_instruction_helper::<GoldilocksExt2, 2>(10);
     }

--- a/singer/src/instructions/gt.rs
+++ b/singer/src/instructions/gt.rs
@@ -296,6 +296,7 @@ mod test {
         );
     }
 
+    #[cfg(not(debug_assertions))]
     fn bench_gt_instruction_helper<E: ExtensionField>(instance_num_vars: usize) {
         let chip_challenges = ChipChallenges::default();
         let circuit_builder =
@@ -353,6 +354,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(debug_assertions))]
     fn bench_gt_instruction() {
         bench_gt_instruction_helper::<GoldilocksExt2>(10);
     }

--- a/singer/src/instructions/jump.rs
+++ b/singer/src/instructions/jump.rs
@@ -211,6 +211,7 @@ mod test {
         );
     }
 
+    #[cfg(not(debug_assertions))]
     fn bench_jump_instruction_helper<E: ExtensionField>(instance_num_vars: usize) {
         let chip_challenges = ChipChallenges::default();
         let circuit_builder =
@@ -268,6 +269,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(debug_assertions))]
     fn bench_jump_instruction() {
         bench_jump_instruction_helper::<GoldilocksExt2>(10);
     }

--- a/singer/src/instructions/jumpdest.rs
+++ b/singer/src/instructions/jumpdest.rs
@@ -3,7 +3,6 @@ use ff_ext::ExtensionField;
 use gkr::structs::Circuit;
 use paste::paste;
 use simple_frontend::structs::{CircuitBuilder, MixedCell};
-use singer_utils::uint::constants::AddSubConstants;
 use singer_utils::{
     chip_handler::{
         BytecodeChipOperations, GlobalStateChipOperations, OAMOperations, ROMOperations,
@@ -11,6 +10,7 @@ use singer_utils::{
     constants::OpcodeType,
     register_witness,
     structs::{PCUInt, RAMHandler, ROMHandler, TSUInt},
+    uint::constants::AddSubConstants,
 };
 use std::{collections::BTreeMap, sync::Arc};
 
@@ -166,6 +166,7 @@ mod test {
         );
     }
 
+    #[cfg(not(debug_assertions))]
     fn bench_jumpdest_instruction_helper<E: ExtensionField>(instance_num_vars: usize) {
         let chip_challenges = ChipChallenges::default();
         let circuit_builder =
@@ -224,6 +225,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(debug_assertions))]
     fn bench_jumpdest_instruction() {
         bench_jumpdest_instruction_helper::<GoldilocksExt2>(10);
     }

--- a/singer/src/instructions/mstore.rs
+++ b/singer/src/instructions/mstore.rs
@@ -500,6 +500,7 @@ mod test {
         );
     }
 
+    #[cfg(not(debug_assertions))]
     fn bench_mstore_instruction_helper<E: ExtensionField>(instance_num_vars: usize) {
         let chip_challenges = ChipChallenges::default();
         let circuit_builder =
@@ -571,6 +572,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(debug_assertions))]
     fn bench_mstore_instruction() {
         bench_mstore_instruction_helper::<GoldilocksExt2>(5);
     }

--- a/singer/src/instructions/pop.rs
+++ b/singer/src/instructions/pop.rs
@@ -225,6 +225,7 @@ mod test {
         );
     }
 
+    #[cfg(not(debug_assertions))]
     fn bench_pop_instruction_helper<E: ExtensionField>(instance_num_vars: usize) {
         let chip_challenges = ChipChallenges::default();
         let circuit_builder =
@@ -282,6 +283,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(debug_assertions))]
     fn bench_pop_instruction() {
         bench_pop_instruction_helper::<GoldilocksExt2>(10);
     }

--- a/singer/src/instructions/push.rs
+++ b/singer/src/instructions/push.rs
@@ -234,6 +234,7 @@ mod test {
         );
     }
 
+    #[cfg(not(debug_assertions))]
     fn bench_push_instruction_helper<E: ExtensionField, const N: usize>(instance_num_vars: usize) {
         let chip_challenges = ChipChallenges::default();
         let circuit_builder =
@@ -294,6 +295,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(debug_assertions))]
     fn bench_push1_instruction() {
         bench_push_instruction_helper::<GoldilocksExt2, 1>(10);
     }

--- a/singer/src/instructions/swap.rs
+++ b/singer/src/instructions/swap.rs
@@ -315,6 +315,7 @@ mod test {
         );
     }
 
+    #[cfg(not(debug_assertions))]
     fn bench_swap_instruction_helper<E: ExtensionField, const N: usize>(instance_num_vars: usize) {
         let chip_challenges = ChipChallenges::default();
         let circuit_builder =
@@ -375,11 +376,13 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(debug_assertions))]
     fn bench_swap2_instruction() {
         bench_swap_instruction_helper::<GoldilocksExt2, 2>(10);
     }
 
     #[test]
+    #[cfg(not(debug_assertions))]
     fn bench_swap4_instruction() {
         bench_swap_instruction_helper::<GoldilocksExt2, 4>(10);
     }


### PR DESCRIPTION
The benchmark unit tests generates random vector as the witness in, therefore can't pass the circuit's correctness check, which will result in a test fail.