### PR TITLE
fix main-sel sumcheck degree and wrong dedup issue

### DIFF
--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -374,7 +374,7 @@ impl<E: ExtensionField> ZKVMProver<E> {
                 + if cs.assert_zero_sumcheck_expressions.is_empty() {
                     0
                 } else {
-                    distrinct_zerocheck_terms_set.len() + 1 // 1 from sel_non_lc_zero_sumcheck
+                    distrinct_zerocheck_terms_set.len() + 1 // +1 from sel_non_lc_zero_sumcheck
                 }
         ); // 3 from [sel_r, sel_w, sel_lk]
         let mut main_sel_evals_iter = main_sel_evals.into_iter();

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -116,6 +116,7 @@ impl<E: ExtensionField> ZKVMVerifier<E> {
         let claim_sum = *alpha_read * (record_evals[0].eval - E::ONE)
             + *alpha_write * (record_evals[1].eval - E::ONE)
             + *alpha_lk * (logup_q_evals[0].eval - chip_record_alpha);
+
         let main_sel_subclaim = IOPVerifierState::verify(
             claim_sum,
             &IOPProof {
@@ -123,7 +124,8 @@ impl<E: ExtensionField> ZKVMVerifier<E> {
                 proofs: proof.main_sel_sumcheck_proofs.clone(),
             },
             &VPAuxInfo {
-                max_degree: SEL_DEGREE.max(cs.max_non_lc_degree),
+                // + 1 from sel_non_lc_zero_sumcheck
+                max_degree: SEL_DEGREE.max(cs.max_non_lc_degree + 1),
                 num_variables: log2_num_instances,
                 phantom: PhantomData,
             },


### PR DESCRIPTION
### change scope
- To address TODO support constant in monomial term, quoted in comment https://github.com/scroll-tech/ceno/pull/169#issuecomment-2316798685 cc @chaosma 
- wrongly degree in verifier main-sel sumcheck: degree should plus 1 to include degree > 1 zero_sumcheck selector
- wrongly deduplication of term in expr -> virtual_poly convertion. For example $w1(x) * w1(x) * w1(x)$ should be viewed as degree 3, while before bug fix it will be deduplication as `1`
