### PR TITLE
standardize witness assignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,7 @@ name = "ceno_zkvm"
 version = "0.1.0"
 dependencies = [
  "ark-std",
+ "ceno_emul",
  "cfg-if",
  "const_env",
  "criterion",

--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -17,6 +17,7 @@ transcript = { path = "../transcript" }
 sumcheck = { version = "0.1.0", path = "../sumcheck" }
 multilinear_extensions = { version = "0.1.0", path = "../multilinear_extensions" }
 ff_ext = { path = "../ff_ext" }
+ceno_emul = { path = "../ceno_emul" }
 
 itertools = "0.12.0"
 strum = "0.25.0"

--- a/ceno_zkvm/src/instructions.rs
+++ b/ceno_zkvm/src/instructions.rs
@@ -1,12 +1,39 @@
-use ff_ext::ExtensionField;
+use std::mem::MaybeUninit;
 
-use crate::{circuit_builder::CircuitBuilder, error::ZKVMError};
+use ceno_emul::StepRecord;
+use ff_ext::ExtensionField;
+use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+
+use crate::{circuit_builder::CircuitBuilder, error::ZKVMError, witness::RowMajorMatrix};
 
 pub mod riscv;
 
 pub trait Instruction<E: ExtensionField> {
-    type InstructionConfig;
+    type InstructionConfig: Send + Sync;
     fn construct_circuit(
         circuit_builder: &mut CircuitBuilder<E>,
     ) -> Result<Self::InstructionConfig, ZKVMError>;
+
+    // assign single instance giving step from trace
+    fn assign_instance(
+        config: &Self::InstructionConfig,
+        instance: &mut [MaybeUninit<E>],
+        step: StepRecord,
+    ) -> Result<(), ZKVMError>;
+
+    fn assign_instances(
+        config: &Self::InstructionConfig,
+        num_witin: usize,
+        steps: Vec<StepRecord>,
+    ) -> Result<RowMajorMatrix<E>, ZKVMError> {
+        let mut raw_witin = RowMajorMatrix::<E>::new(steps.len(), num_witin);
+        let raw_witin_iter = raw_witin.par_iter_mut();
+
+        raw_witin_iter
+            .zip_eq(steps.into_par_iter())
+            .map(|(instance, step)| Self::assign_instance(config, instance, step))
+            .collect::<Result<(), ZKVMError>>()?;
+
+        Ok(raw_witin)
+    }
 }

--- a/ceno_zkvm/src/lib.rs
+++ b/ceno_zkvm/src/lib.rs
@@ -4,7 +4,6 @@ pub mod error;
 pub mod instructions;
 pub mod scheme;
 pub mod tables;
-// #[cfg(test)]
 pub use utils::u64vec;
 mod chip_handler;
 pub mod circuit_builder;
@@ -13,3 +12,4 @@ mod structs;
 mod uint;
 mod utils;
 mod virtual_polys;
+mod witness;

--- a/ceno_zkvm/src/witness.rs
+++ b/ceno_zkvm/src/witness.rs
@@ -1,0 +1,53 @@
+use std::{
+    mem::{self, MaybeUninit},
+    slice::ChunksMut,
+};
+
+use multilinear_extensions::util::create_uninit_vec;
+use rayon::{
+    iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator},
+    slice::ParallelSliceMut,
+};
+
+#[macro_export]
+macro_rules! set_val {
+    ($ins:ident, $field:expr, $val:expr) => {
+        $ins[$field.id as usize] = MaybeUninit::new($val.into());
+    };
+}
+
+pub struct RowMajorMatrix<T: Sized + Sync + Clone + Send> {
+    // represent 2D in 1D linear memory and avoid double indirection by Vec<Vec<T>> to improve performance
+    values: Vec<MaybeUninit<T>>,
+    num_col: usize,
+}
+
+impl<T: Sized + Sync + Clone + Send> RowMajorMatrix<T> {
+    pub fn new(num_row: usize, num_col: usize) -> Self {
+        RowMajorMatrix {
+            values: create_uninit_vec(num_row * num_col),
+            num_col,
+        }
+    }
+
+    pub fn iter_mut(&mut self) -> ChunksMut<MaybeUninit<T>> {
+        self.values.chunks_mut(self.num_col)
+    }
+
+    pub fn par_iter_mut(&mut self) -> rayon::slice::ChunksMut<MaybeUninit<T>> {
+        self.values.par_chunks_mut(self.num_col)
+    }
+
+    pub fn de_interleaving(mut self) -> Vec<Vec<T>> {
+        (0..self.num_col)
+            .map(|i| {
+                self.values
+                    .par_iter_mut()
+                    .skip(i)
+                    .step_by(self.num_col)
+                    .map(|v| unsafe { mem::replace(v, mem::MaybeUninit::uninit()).assume_init() })
+                    .collect::<Vec<T>>()
+            })
+            .collect()
+    }
+}

--- a/multilinear_extensions/src/mle.rs
+++ b/multilinear_extensions/src/mle.rs
@@ -109,6 +109,16 @@ impl<F: Field, E: ExtensionField> IntoMLE<DenseMultilinearExtension<E>> for Vec<
         DenseMultilinearExtension::from_evaluation_vec_smart::<F>(ceil_log2(next_pow2), self)
     }
 }
+pub trait IntoMLEs<T>: Sized {
+    /// Converts this type into the (usually inferred) input type.
+    fn into_mles(self) -> Vec<T>;
+}
+
+impl<F: Field, E: ExtensionField> IntoMLEs<DenseMultilinearExtension<E>> for Vec<Vec<F>> {
+    fn into_mles(self) -> Vec<DenseMultilinearExtension<E>> {
+        self.into_iter().map(|v| v.into_mle()).collect()
+    }
+}
 
 #[derive(Clone, PartialEq, Eq, Hash, Default, Debug, Serialize, Deserialize)]
 #[serde(untagged)]

--- a/multilinear_extensions/src/util.rs
+++ b/multilinear_extensions/src/util.rs
@@ -20,7 +20,7 @@ pub fn ceil_log2(x: usize) -> usize {
     usize_bits - (x - 1).leading_zeros() as usize
 }
 
-pub(crate) fn create_uninit_vec<T: Sized>(len: usize) -> Vec<MaybeUninit<T>> {
+pub fn create_uninit_vec<T: Sized>(len: usize) -> Vec<MaybeUninit<T>> {
     let mut vec: Vec<MaybeUninit<T>> = Vec::with_capacity(len);
     unsafe { vec.set_len(len) };
     vec


### PR DESCRIPTION
Related to #177 

Change scopes:
- [x] introduce `RowMajorMatrix` as row-oriented witness holder
- [x] standardize opcode witness assignment interface & mechanism

