### PR TITLE
Use global lookup table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,7 @@ dependencies = [
  "goldilocks",
  "itertools 0.12.1",
  "multilinear_extensions",
+ "once_cell",
  "paste",
  "pprof",
  "rand",

--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -29,6 +29,7 @@ tracing = "0.1.40"
 
 rand = "0.8"
 thread_local = "1.1.8"
+once_cell = "1.19.0"
 
 [dev-dependencies]
 pprof = { version = "0.13", features = ["flamegraph"]}

--- a/ceno_zkvm/src/chip_handler/general.rs
+++ b/ceno_zkvm/src/chip_handler/general.rs
@@ -80,24 +80,11 @@ impl<'a, E: ExtensionField> CircuitBuilder<'a, E> {
     }
 
     pub fn rlc_chip_record(&self, records: Vec<Expression<E>>) -> Expression<E> {
-        assert!(!records.is_empty());
-        let beta_pows = {
-            let mut beta_pows = Vec::with_capacity(records.len());
-            beta_pows.push(Expression::Constant(E::BaseField::ONE));
-            (0..records.len() - 1).for_each(|_| {
-                beta_pows.push(self.cs.chip_record_beta.clone() * beta_pows.last().unwrap().clone())
-            });
-            beta_pows
-        };
-
-        let item_rlc = beta_pows
-            .into_iter()
-            .zip(records.iter())
-            .map(|(beta, record)| beta * record.clone())
-            .reduce(|a, b| a + b)
-            .expect("reduce error");
-
-        item_rlc + self.cs.chip_record_alpha.clone()
+        rlc_chip_record(
+            records,
+            self.cs.chip_record_alpha.clone(),
+            self.cs.chip_record_beta.clone(),
+        )
     }
 
     pub fn require_zero<NR, N>(
@@ -284,4 +271,29 @@ impl<'a, E: ExtensionField> CircuitBuilder<'a, E> {
 
         Ok((is_eq, diff_inverse))
     }
+}
+
+pub fn rlc_chip_record<E: ExtensionField>(
+    records: Vec<Expression<E>>,
+    chip_record_alpha: Expression<E>,
+    chip_record_beta: Expression<E>,
+) -> Expression<E> {
+    assert!(!records.is_empty());
+    let beta_pows = {
+        let mut beta_pows = Vec::with_capacity(records.len());
+        beta_pows.push(Expression::Constant(E::BaseField::ONE));
+        (0..records.len() - 1).for_each(|_| {
+            beta_pows.push(chip_record_beta.clone() * beta_pows.last().unwrap().clone())
+        });
+        beta_pows
+    };
+
+    let item_rlc = beta_pows
+        .into_iter()
+        .zip(records.iter())
+        .map(|(beta, record)| beta * record.clone())
+        .reduce(|a, b| a + b)
+        .expect("reduce error");
+
+    item_rlc + chip_record_alpha.clone()
 }

--- a/ceno_zkvm/src/instructions/riscv/addsub.rs
+++ b/ceno_zkvm/src/instructions/riscv/addsub.rs
@@ -293,7 +293,6 @@ mod test {
                 .into_iter()
                 .map(|v| v.into())
                 .collect_vec(),
-            None,
         );
     }
 
@@ -340,7 +339,6 @@ mod test {
                 .into_iter()
                 .map(|v| v.into())
                 .collect_vec(),
-            None,
         );
     }
 }

--- a/ceno_zkvm/src/instructions/riscv/blt.rs
+++ b/ceno_zkvm/src/instructions/riscv/blt.rs
@@ -267,7 +267,6 @@ mod test {
                 .into_iter()
                 .map(|v| v.into())
                 .collect_vec(),
-            None,
         )
         .expect_err("lookup will fail");
         Ok(())


### PR DESCRIPTION
Multiple test cases load lookup tables separately. This causes tests to run longer due to duplicate work. This PR enables to load the lookup tables once and reuse them in all the test cases.

## Before / Master branch

```sh
$ time RUST_TEST_THREADS=1 cargo test

7.904 seconds

```

## After / This PR

```sh
$ time RUST_TEST_THREADS=1 cargo test

1.964 seconds
```