### PR TITLE
hide-fast-decode: rename and privatize specialized instruction form

### DIFF
--- a/ceno_emul/src/tracer.rs
+++ b/ceno_emul/src/tracer.rs
@@ -5,7 +5,6 @@ use crate::{
     rv32im::DecodedInstruction,
     CENO_PLATFORM,
 };
-use crate::rv32im::Instruction;
 
 /// An instruction and its context in an execution trace. That is concrete values of registers and memory.
 ///
@@ -23,7 +22,6 @@ pub struct StepRecord {
     pub cycle: Cycle,
     pub pc: Change<ByteAddr>,
     pub insn_code: Word,
-    pub insn: Instruction,
 
     pub rs1: Option<ReadOp>,
     pub rs2: Option<ReadOp>,
@@ -63,16 +61,14 @@ impl StepRecord {
         self.pc
     }
 
+    /// The instruction as a raw code.
     pub fn insn_code(&self) -> Word {
         self.insn_code
     }
 
-    pub fn insn_decoded(&self) -> DecodedInstruction {
+    /// The instruction as a decoded structure.
+    pub fn insn(&self) -> DecodedInstruction {
         DecodedInstruction::new(self.insn_code)
-    }
-
-    pub fn insn(&self) -> Instruction {
-        self.insn
     }
 
     pub fn rs1(&self) -> Option<ReadOp> {
@@ -145,10 +141,6 @@ impl Tracer {
     pub fn fetch(&mut self, pc: WordAddr, value: Word) {
         self.record.pc.before = pc.baddr();
         self.record.insn_code = value;
-    }
-
-    pub fn store_insn(&mut self, insn: Instruction) {
-        self.record.insn = insn;
     }
 
     pub fn load_register(&mut self, idx: RegIdx, value: Word) {

--- a/ceno_emul/src/vm_state.rs
+++ b/ceno_emul/src/vm_state.rs
@@ -4,7 +4,7 @@ use super::rv32im::EmuContext;
 use crate::{
     addr::{ByteAddr, RegIdx, Word, WordAddr},
     platform::Platform,
-    rv32im::{DecodedInstruction, Emulator, Instruction, TrapCause},
+    rv32im::{DecodedInstruction, Emulator, TrapCause},
     tracer::{Change, StepRecord, Tracer},
     Program,
 };
@@ -113,11 +113,7 @@ impl EmuContext for VMState {
         Err(anyhow!("Trap {:?}", cause)) // Crash.
     }
 
-    fn on_insn_decoded(&mut self, insn: &Instruction, _decoded: &DecodedInstruction) {
-        self.tracer.store_insn(*insn);
-    }
-
-    fn on_normal_end(&mut self, _kind: &Instruction, _decoded: &DecodedInstruction) {
+    fn on_normal_end(&mut self, _decoded: &DecodedInstruction) {
         self.tracer.store_pc(ByteAddr(self.pc));
     }
 

--- a/ceno_emul/tests/test_vm_trace.rs
+++ b/ceno_emul/tests/test_vm_trace.rs
@@ -21,10 +21,7 @@ fn test_vm_trace() -> Result<()> {
     assert_eq!(ctx.peek_register(2), x2);
     assert_eq!(ctx.peek_register(3), x3);
 
-    let ops: Vec<InsnKind> = steps
-        .iter()
-        .map(|step| step.insn_decoded().kind().1)
-        .collect();
+    let ops: Vec<InsnKind> = steps.iter().map(|step| step.insn().kind().1).collect();
     assert_eq!(ops, expected_ops_fibonacci_20());
 
     assert_eq!(

--- a/ceno_zkvm/examples/riscv_add.rs
+++ b/ceno_zkvm/examples/riscv_add.rs
@@ -108,7 +108,7 @@ fn main() {
             .collect::<Result<Vec<StepRecord>, _>>()
             .expect("vm exec failed")
             .into_iter()
-            .filter(|record| record.insn().kind == ADD)
+            .filter(|record| record.insn().kind().1 == ADD)
             .collect::<Vec<_>>();
         tracing::info!("tracer generated {} ADD records", records.len());
 


### PR DESCRIPTION
_Follow-up to https://github.com/scroll-tech/ceno/pull/188._

The above PR started to depend on a special internal type, originally and confusingly named `Instruction`.

This PR uses the intended public type `DecodedInstruction` and makes the weird one private.