### PR TITLE
fix(blt): fix github test error

### DIFF
--- a/ceno_zkvm/src/instructions/riscv/config.rs
+++ b/ceno_zkvm/src/instructions/riscv/config.rs
@@ -77,6 +77,9 @@ impl UIntLtuInput<'_> {
                 break;
             }
         }
+        config.indexes.iter().for_each(|witin| {
+            set_val!(instance, witin, { i64_to_base::<F>(0) });
+        });
         set_val!(instance, config.indexes[idx], {
             i64_to_base::<F>(flag as i64)
         });

--- a/ceno_zkvm/src/scheme/tests.rs
+++ b/ceno_zkvm/src/scheme/tests.rs
@@ -111,7 +111,7 @@ fn test_rw_lk_expression_combination() {
             .collect_vec();
         let proof = prover
             .create_opcode_proof(
-                &prover.pk.circuit_pks.get(&name).unwrap(),
+                prover.pk.circuit_pks.get(&name).unwrap(),
                 wits_in,
                 num_instances,
                 1,


### PR DESCRIPTION
## Description

The issue is due to some of the witness input are not assigned, but because the use of MaybeUninit, they may not default to zero, refer:  [comment](https://github.com/scroll-tech/ceno/pull/187#issuecomment-2328456095)

We could add checking for unassigned witness due to the use of MaybeUninit.