### PR TITLE
Fix: the transcript should not depend on the proving order

### DIFF
--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -52,6 +52,8 @@ impl<E: ExtensionField> ZKVMProver<E> {
     ) -> Result<ZKVMProof<E>, ZKVMError> {
         let mut vm_proof = ZKVMProof::default();
         for (circuit_name, pk) in self.pk.circuit_pks.iter() {
+            // each circuit should be proved independently
+            let mut transcript = transcript.clone();
             let witness = witnesses
                 .witnesses
                 .remove(circuit_name)
@@ -84,7 +86,7 @@ impl<E: ExtensionField> ZKVMProver<E> {
                         .collect_vec(),
                     num_instances,
                     max_threads,
-                    transcript,
+                    &mut transcript,
                     challenges,
                 )?;
                 tracing::info!(
@@ -106,7 +108,7 @@ impl<E: ExtensionField> ZKVMProver<E> {
                         .collect_vec(),
                     num_instances,
                     max_threads,
-                    transcript,
+                    &mut transcript,
                     challenges,
                 )?;
                 tracing::info!(

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -49,6 +49,7 @@ impl<E: ExtensionField> ZKVMVerifier<E> {
         let point_eval = PointAndEval::default();
         let mut dummy_table_item_multiplicity = 0;
         for (name, opcode_proof) in vm_proof.opcode_proofs {
+            let mut transcript = transcript.clone();
             let circuit_vk = self
                 .vk
                 .circuit_vks
@@ -57,7 +58,7 @@ impl<E: ExtensionField> ZKVMVerifier<E> {
             let _rand_point = self.verify_opcode_proof(
                 circuit_vk,
                 &opcode_proof,
-                transcript,
+                &mut transcript,
                 NUM_FANIN,
                 &point_eval,
                 challenges,
@@ -83,6 +84,7 @@ impl<E: ExtensionField> ZKVMVerifier<E> {
         }
 
         for (name, table_proof) in vm_proof.table_proofs {
+            let mut transcript = transcript.clone();
             let circuit_vk = self
                 .vk
                 .circuit_vks
@@ -91,7 +93,7 @@ impl<E: ExtensionField> ZKVMVerifier<E> {
             let _rand_point = self.verify_table_proof(
                 circuit_vk,
                 &table_proof,
-                transcript,
+                &mut transcript,
                 NUM_FANIN_LOGUP,
                 &point_eval,
                 challenges,


### PR DESCRIPTION
The input transcript to opcode circuits and table circuits should be the same.

This will fix #222 and also resolve the failure in #210.