### PR TITLE
refactor opcode enum

### DIFF
--- a/ceno_zkvm/src/instructions/riscv.rs
+++ b/ceno_zkvm/src/instructions/riscv.rs
@@ -1,4 +1,4 @@
-use constants::OpcodeType;
+use constants::RvInstruction;
 use ff_ext::ExtensionField;
 
 use super::Instruction;
@@ -12,5 +12,5 @@ pub mod constants;
 mod test;
 
 pub trait RIVInstruction<E: ExtensionField>: Instruction<E> {
-    const OPCODE_TYPE: OpcodeType;
+    const OPCODE_TYPE: RvInstruction;
 }

--- a/ceno_zkvm/src/instructions/riscv/blt.rs
+++ b/ceno_zkvm/src/instructions/riscv/blt.rs
@@ -20,7 +20,7 @@ use crate::{
 
 use super::{
     config::ExprLtConfig,
-    constants::{OPType, OpcodeType, RegUInt, RegUInt8, PC_STEP_SIZE},
+    constants::{RegUInt, RegUInt8, RvInstruction, PC_STEP_SIZE},
     RIVInstruction,
 };
 
@@ -141,7 +141,7 @@ impl BltInput {
 }
 
 impl<E: ExtensionField> RIVInstruction<E> for BltInstruction {
-    const OPCODE_TYPE: OpcodeType = OpcodeType::BType(OPType::Branch, 0x004);
+    const OPCODE_TYPE: RvInstruction = RvInstruction::BLT;
 }
 
 /// if (rs1 < rs2) PC += sext(imm)
@@ -210,7 +210,6 @@ fn blt_gadget<E: ExtensionField>(
 }
 
 impl<E: ExtensionField> Instruction<E> for BltInstruction {
-    // const NAME: &'static str = "BLT";
     fn name() -> String {
         "BLT".into()
     }

--- a/ceno_zkvm/src/instructions/riscv/constants.rs
+++ b/ceno_zkvm/src/instructions/riscv/constants.rs
@@ -1,30 +1,122 @@
 use std::fmt;
+use strum_macros::EnumIter;
 
 use crate::uint::UInt;
 pub use ceno_emul::PC_STEP_SIZE;
 
-pub const OPCODE_OP: usize = 0x33;
-pub const FUNCT3_ADD_SUB: usize = 0;
-pub const FUNCT7_ADD: usize = 0;
-pub const FUNCT7_SUB: usize = 0x20;
+/// This struct is used to define the opcode format for RISC-V instructions,
+/// containing three main components: the opcode, funct3, and funct7 fields.
+/// These fields are crucial for specifying the
+/// exact operation and variants in the RISC-V instruction set architecture.
+#[derive(Default, Clone, Debug)]
+pub struct RvOpcode {
+    pub opcode: OPType,
+    pub funct3: Option<u8>,
+    pub funct7: Option<u8>,
+}
 
-#[allow(clippy::upper_case_acronyms)]
+impl From<RvOpcode> for u64 {
+    fn from(opcode: RvOpcode) -> Self {
+        let mut result: u64 = 0;
+        result |= (opcode.opcode as u64) & 0xFF;
+        result |= ((opcode.funct3.unwrap() as u64) & 0xFF) << 8;
+        result |= ((opcode.funct7.unwrap() as u64) & 0xFF) << 16;
+        result
+    }
+}
+
+#[allow(dead_code, non_camel_case_types)]
+/// List all RISC-V base instruction formats:
+/// R-Type, I-Type, S-Type, B-Type, U-Type, J-Type and special type.
 #[derive(Debug, Clone, Copy)]
 pub enum OPType {
-    Op,
-    Opimm,
-    Jal,
-    Jalr,
-    Branch,
+    UNKNOWN = 0x00,
+
+    R = 0x33,
+    I_LOAD = 0x03,
+    I_ARITH = 0x13,
+    S = 0x63,
+    B = 0x23,
+    U_LUI = 0x37,
+    U_AUIPC = 0x7,
+    J = 0x6F,
+    JAR = 0x67,
+    SYS = 0x73,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum OpcodeType {
-    RType(OPType, usize, usize), // (OP, func3, func7)
-    BType(OPType, usize),        // (OP, func3)
+impl Default for OPType {
+    fn default() -> Self {
+        OPType::UNKNOWN
+    }
 }
 
-impl fmt::Display for OpcodeType {
+impl From<OPType> for u8 {
+    fn from(opcode: OPType) -> Self {
+        opcode as u8
+    }
+}
+
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Debug, Clone, Copy, EnumIter)]
+pub enum RvInstruction {
+    // Type R
+    ADD = 0,
+    SUB,
+
+    // Type M
+    MUL,
+    DIV,
+    DIVU,
+
+    // Type B
+    BLT,
+}
+
+impl From<RvInstruction> for RvOpcode {
+    fn from(ins: RvInstruction) -> Self {
+        // Find the instruction format here:
+        // https://fraserinnovations.com/risc-v/risc-v-instruction-set-explanation/
+        match ins {
+            // Type R
+            RvInstruction::ADD => RvOpcode {
+                opcode: OPType::R,
+                funct3: Some(0b000 as u8),
+                funct7: Some(0),
+            },
+            RvInstruction::SUB => RvOpcode {
+                opcode: OPType::R,
+                funct3: Some(0b000 as u8),
+                funct7: Some(0b010_0000),
+            },
+
+            // Type M
+            RvInstruction::MUL => RvOpcode {
+                opcode: OPType::R,
+                funct3: Some(0b000 as u8),
+                funct7: Some(0b0000_0001),
+            },
+            RvInstruction::DIV => RvOpcode {
+                opcode: OPType::R,
+                funct3: Some(0b100 as u8),
+                funct7: Some(0b0000_0001),
+            },
+            RvInstruction::DIVU => RvOpcode {
+                opcode: OPType::R,
+                funct3: Some(0b101 as u8),
+                funct7: Some(0b0000_0001),
+            },
+
+            // Type B
+            RvInstruction::BLT => RvOpcode {
+                opcode: OPType::B,
+                funct3: Some(0b100 as u8),
+                funct7: None,
+            },
+        }
+    }
+}
+
+impl fmt::Display for RvInstruction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
     }


### PR DESCRIPTION
refactoring `enum OpcodeType` and `enum OpType` to `struct RvOpcode` and `enum RvInstruction`.
1. manage opcode, funct3, funct7 at the same place (constants.rs)
2. each opcode implementation can get necesary info through `OPCODE_TYPE` directly (see addsub.rs as example)

cc @hero78119 and @kunxian-xia for more feedback