### PR TITLE
refactor/rename UInt

### DIFF
--- a/ceno_zkvm/src/instructions/riscv/blt.rs
+++ b/ceno_zkvm/src/instructions/riscv/blt.rs
@@ -21,7 +21,7 @@ use crate::{
 
 use super::{
     config::ExprLtConfig,
-    constants::{RegUInt, RegUInt8, PC_STEP_SIZE},
+    constants::{UInt, UInt8, PC_STEP_SIZE},
     RIVInstruction,
 };
 
@@ -32,8 +32,8 @@ pub struct InstructionConfig<E: ExtensionField> {
     pub next_pc: WitIn,
     pub ts: WitIn,
     pub imm: WitIn,
-    pub lhs_limb8: RegUInt8<E>,
-    pub rhs_limb8: RegUInt8<E>,
+    pub lhs_limb8: UInt8<E>,
+    pub rhs_limb8: UInt8<E>,
     pub rs1_id: WitIn,
     pub rs2_id: WitIn,
     pub prev_rs1_ts: WitIn,
@@ -159,8 +159,8 @@ fn blt_gadget<E: ExtensionField>(
     let rs1_id = circuit_builder.create_witin(|| "rs1_id")?;
     let rs2_id = circuit_builder.create_witin(|| "rs2_id")?;
 
-    let lhs_limb8 = RegUInt8::new(|| "lhs_limb8", circuit_builder)?;
-    let rhs_limb8 = RegUInt8::new(|| "rhs_limb8", circuit_builder)?;
+    let lhs_limb8 = UInt8::new(|| "lhs_limb8", circuit_builder)?;
+    let rhs_limb8 = UInt8::new(|| "rhs_limb8", circuit_builder)?;
 
     let is_lt = lhs_limb8.lt_limb8(circuit_builder, &rhs_limb8)?;
 
@@ -171,8 +171,8 @@ fn blt_gadget<E: ExtensionField>(
     // update ts
     let prev_rs1_ts = circuit_builder.create_witin(|| "prev_rs1_ts")?;
     let prev_rs2_ts = circuit_builder.create_witin(|| "prev_rs2_ts")?;
-    let lhs = RegUInt::from_u8_limbs(&lhs_limb8)?;
-    let rhs = RegUInt::from_u8_limbs(&rhs_limb8)?;
+    let lhs = UInt::from_u8_limbs(&lhs_limb8)?;
+    let rhs = UInt::from_u8_limbs(&rhs_limb8)?;
 
     let (ts, lt_rs1_cfg) = circuit_builder.register_read(
         || "read ts for rs1",

--- a/ceno_zkvm/src/instructions/riscv/constants.rs
+++ b/ceno_zkvm/src/instructions/riscv/constants.rs
@@ -1,15 +1,15 @@
-use crate::uint::UInt;
+use crate::uint::UIntLimbs;
 pub use ceno_emul::PC_STEP_SIZE;
 
 pub const VALUE_BIT_WIDTH: usize = 16;
 
 #[cfg(feature = "riv32")]
-pub type RegUInt<E> = UInt<32, VALUE_BIT_WIDTH, E>;
+pub type UInt<E> = UIntLimbs<32, VALUE_BIT_WIDTH, E>;
 #[cfg(feature = "riv32")]
-/// use RegUInt<x> for x bits limb size
-pub type RegUInt8<E> = UInt<32, 8, E>;
+/// use UInt<x> for x bits limb size
+pub type UInt8<E> = UIntLimbs<32, 8, E>;
 
 #[cfg(feature = "riv64")]
-pub type RegUInt<E> = UInt<64, VALUE_BIT_WIDTH, E>;
+pub type UInt<E> = UIntLimbs<64, VALUE_BIT_WIDTH, E>;
 #[cfg(feature = "riv64")]
-pub type RegUInt8<E> = UInt<64, 8, E>;
+pub type UInt8<E> = UIntLimbs<64, 8, E>;

--- a/ceno_zkvm/src/instructions/riscv/mul.rs
+++ b/ceno_zkvm/src/instructions/riscv/mul.rs
@@ -2,9 +2,9 @@ use ceno_emul::{InsnKind, StepRecord};
 use ff_ext::ExtensionField;
 use itertools::Itertools;
 
-use super::{constants::RegUInt, r_insn::RInstructionConfig, RIVInstruction};
+use super::{constants::UInt, r_insn::RInstructionConfig, RIVInstruction};
 use crate::{
-    circuit_builder::CircuitBuilder, error::ZKVMError, instructions::Instruction, uint::UIntValue,
+    circuit_builder::CircuitBuilder, error::ZKVMError, instructions::Instruction, uint::Value,
     witness::LkMultiplicity,
 };
 use core::mem::MaybeUninit;
@@ -14,9 +14,9 @@ use std::marker::PhantomData;
 pub struct ArithConfig<E: ExtensionField> {
     r_insn: RInstructionConfig<E>,
 
-    multiplier_1: RegUInt<E>,
-    multiplier_2: RegUInt<E>,
-    outcome: RegUInt<E>,
+    multiplier_1: UInt<E>,
+    multiplier_2: UInt<E>,
+    outcome: UInt<E>,
 }
 
 pub struct ArithInstruction<E, I>(PhantomData<(E, I)>);
@@ -37,8 +37,8 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ArithInstruction<E
     fn construct_circuit(
         circuit_builder: &mut CircuitBuilder<E>,
     ) -> Result<Self::InstructionConfig, ZKVMError> {
-        let mut multiplier_1 = RegUInt::new_unchecked(|| "multiplier_1", circuit_builder)?;
-        let mut multiplier_2 = RegUInt::new_unchecked(|| "multiplier_2", circuit_builder)?;
+        let mut multiplier_1 = UInt::new_unchecked(|| "multiplier_1", circuit_builder)?;
+        let mut multiplier_2 = UInt::new_unchecked(|| "multiplier_2", circuit_builder)?;
         let outcome = multiplier_1.mul(|| "outcome", circuit_builder, &mut multiplier_2, true)?;
 
         let r_insn = RInstructionConfig::<E>::construct_circuit(
@@ -65,9 +65,9 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ArithInstruction<E
     ) -> Result<(), ZKVMError> {
         config.r_insn.assign_instance(instance, lkm, step)?;
 
-        let multiplier_1 = UIntValue::new_unchecked(step.rs1().unwrap().value);
-        let multiplier_2 = UIntValue::new_unchecked(step.rs2().unwrap().value);
-        let outcome = UIntValue::new_unchecked(step.rd().unwrap().value.after);
+        let multiplier_1 = Value::new_unchecked(step.rs1().unwrap().value);
+        let multiplier_2 = Value::new_unchecked(step.rs2().unwrap().value);
+        let outcome = Value::new_unchecked(step.rd().unwrap().value.after);
 
         config
             .multiplier_1

--- a/ceno_zkvm/src/instructions/riscv/r_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/r_insn.rs
@@ -3,7 +3,7 @@ use ff_ext::ExtensionField;
 
 use super::{
     config::ExprLtConfig,
-    constants::{RegUInt, PC_STEP_SIZE},
+    constants::{UInt, PC_STEP_SIZE},
 };
 use crate::{
     chip_handler::{GlobalStateRegisterMachineChipOperations, RegisterChipOperations},
@@ -13,7 +13,7 @@ use crate::{
     instructions::riscv::config::ExprLtInput,
     set_val,
     tables::InsnRecord,
-    uint::UIntValue,
+    uint::Value,
     witness::LkMultiplicity,
 };
 use core::mem::MaybeUninit;
@@ -30,7 +30,7 @@ pub struct RInstructionConfig<E: ExtensionField> {
     rs1_id: WitIn,
     rs2_id: WitIn,
     rd_id: WitIn,
-    prev_rd_value: RegUInt<E>,
+    prev_rd_value: UInt<E>,
     prev_rs1_ts: WitIn,
     prev_rs2_ts: WitIn,
     prev_rd_ts: WitIn,
@@ -72,7 +72,7 @@ impl<E: ExtensionField> RInstructionConfig<E> {
         let prev_rs1_ts = circuit_builder.create_witin(|| "prev_rs1_ts")?;
         let prev_rs2_ts = circuit_builder.create_witin(|| "prev_rs2_ts")?;
         let prev_rd_ts = circuit_builder.create_witin(|| "prev_rd_ts")?;
-        let prev_rd_value = RegUInt::new_unchecked(|| "prev_rd_value", circuit_builder)?;
+        let prev_rd_value = UInt::new_unchecked(|| "prev_rd_value", circuit_builder)?;
 
         // Register read and write.
         let (ts, lt_rs1_cfg) = circuit_builder.register_read(
@@ -151,7 +151,7 @@ impl<E: ExtensionField> RInstructionConfig<E> {
         set_val!(instance, self.prev_rd_ts, step.rd().unwrap().previous_cycle);
         self.prev_rd_value.assign_limbs(
             instance,
-            UIntValue::new_unchecked(step.rd().unwrap().value.before).u16_fields(),
+            Value::new_unchecked(step.rd().unwrap().value.before).u16_fields(),
         );
 
         // Register read and write.

--- a/ceno_zkvm/src/lib.rs
+++ b/ceno_zkvm/src/lib.rs
@@ -18,4 +18,4 @@ mod virtual_polys;
 mod witness;
 
 pub use structs::ROMType;
-pub use uint::UIntValue;
+pub use uint::Value;

--- a/ceno_zkvm/src/uint/constants.rs
+++ b/ceno_zkvm/src/uint/constants.rs
@@ -1,13 +1,13 @@
 use crate::utils::const_min;
 
-use super::UInt;
+use super::UIntLimbs;
 
 pub const RANGE_CHIP_BIT_WIDTH: usize = 16;
 pub const BYTE_BIT_WIDTH: usize = 8;
 
 use ff_ext::ExtensionField;
 
-impl<const M: usize, const C: usize, E: ExtensionField> UInt<M, C, E> {
+impl<const M: usize, const C: usize, E: ExtensionField> UIntLimbs<M, C, E> {
     pub const M: usize = M;
     pub const C: usize = C;
 
@@ -25,6 +25,6 @@ impl<const M: usize, const C: usize, E: ExtensionField> UInt<M, C, E> {
     /// The number of `RANGE_CHIP_BIT_WIDTH` cells needed to represent one cell of size `C`
     const N_RANGE_CELLS_PER_CELL: usize = (C + RANGE_CHIP_BIT_WIDTH - 1) / RANGE_CHIP_BIT_WIDTH;
 
-    /// The number of `RANGE_CHIP_BIT_WIDTH` cells needed to represent the entire `UInt<M, C>`
+    /// The number of `RANGE_CHIP_BIT_WIDTH` cells needed to represent the entire `UIntLimbs<M, C>`
     pub const N_RANGE_CELLS: usize = Self::NUM_CELLS * Self::N_RANGE_CELLS_PER_CELL;
 }


### PR DESCRIPTION
A quick PR, just rename the following 3 structues
- UInt --> UIntLimbs
- RegUInt --> UInt
- UIntValue --> Value

`RegUInt` is designed for constraint system and I think `UInt` is enough to represent it. `UIntValue` is designed for witness assignment and looks similiar with `RegUInt`. To avoid being confused for new comers, rename to `Vaule` (follow zkEVM's naming). After `RegUInt` being renamed, the original `UInt` conflicts with it so renaming the original `UInt` to `UIntLimbs`.

cc @hero78119 and @kunxian-xia 