### PR TITLE
Explicit trait for register values

### DIFF
--- a/ceno_zkvm/src/chip_handler.rs
+++ b/ceno_zkvm/src/chip_handler.rs
@@ -2,7 +2,7 @@ use ff_ext::ExtensionField;
 
 use crate::{
     error::ZKVMError,
-    expression::{Expression, ToExpr, WitIn},
+    expression::{Expression, WitIn},
     instructions::riscv::config::ExprLtConfig,
 };
 
@@ -17,11 +17,10 @@ pub trait GlobalStateRegisterMachineChipOperations<E: ExtensionField> {
     fn state_out(&mut self, pc: Expression<E>, ts: Expression<E>) -> Result<(), ZKVMError>;
 }
 
-/// Return a common representation of a register value.
-/// Format: `2 * u16`, least-significant first.
-pub trait RegisterExpr<E: ExtensionField> {
-    fn register_expr(&self) -> Vec<Expression<E>>;
-}
+/// The common representation of a register value.
+/// Format: `[u16; 2]`, least-significant-first.
+#[derive(Debug, Clone)]
+pub struct RegisterExpr<E: ExtensionField>(pub [Expression<E>; 2]);
 
 pub trait RegisterChipOperations<E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> {
     fn register_read(
@@ -30,7 +29,7 @@ pub trait RegisterChipOperations<E: ExtensionField, NR: Into<String>, N: FnOnce(
         register_id: &WitIn,
         prev_ts: Expression<E>,
         ts: Expression<E>,
-        value: &impl RegisterExpr<E>,
+        value: RegisterExpr<E>,
     ) -> Result<(Expression<E>, ExprLtConfig), ZKVMError>;
 
     #[allow(clippy::too_many_arguments)]
@@ -40,7 +39,7 @@ pub trait RegisterChipOperations<E: ExtensionField, NR: Into<String>, N: FnOnce(
         register_id: &WitIn,
         prev_ts: Expression<E>,
         ts: Expression<E>,
-        prev_values: &impl ToExpr<E, Output = Vec<Expression<E>>>,
-        value: &impl RegisterExpr<E>,
+        prev_values: RegisterExpr<E>,
+        value: RegisterExpr<E>,
     ) -> Result<(Expression<E>, ExprLtConfig), ZKVMError>;
 }

--- a/ceno_zkvm/src/chip_handler/register.rs
+++ b/ceno_zkvm/src/chip_handler/register.rs
@@ -19,7 +19,7 @@ impl<'a, E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> RegisterChipOpe
         register_id: &WitIn,
         prev_ts: Expression<E>,
         ts: Expression<E>,
-        value: &impl RegisterExpr<E>,
+        value: RegisterExpr<E>,
     ) -> Result<(Expression<E>, ExprLtConfig), ZKVMError> {
         self.namespace(name_fn, |cb| {
             // READ (a, v, t)
@@ -29,7 +29,7 @@ impl<'a, E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> RegisterChipOpe
                         RAMType::Register as u64,
                     ))],
                     vec![register_id.expr()],
-                    value.register_expr(),
+                    value.0.to_vec(),
                     vec![prev_ts.clone()],
                 ]
                 .concat(),
@@ -41,7 +41,7 @@ impl<'a, E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> RegisterChipOpe
                         RAMType::Register as u64,
                     ))],
                     vec![register_id.expr()],
-                    value.register_expr(),
+                    value.0.to_vec(),
                     vec![ts.clone()],
                 ]
                 .concat(),
@@ -64,8 +64,8 @@ impl<'a, E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> RegisterChipOpe
         register_id: &WitIn,
         prev_ts: Expression<E>,
         ts: Expression<E>,
-        prev_values: &impl ToExpr<E, Output = Vec<Expression<E>>>,
-        value: &impl RegisterExpr<E>,
+        prev_values: RegisterExpr<E>,
+        value: RegisterExpr<E>,
     ) -> Result<(Expression<E>, ExprLtConfig), ZKVMError> {
         self.namespace(name_fn, |cb| {
             // READ (a, v, t)
@@ -75,7 +75,7 @@ impl<'a, E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> RegisterChipOpe
                         RAMType::Register as u64,
                     ))],
                     vec![register_id.expr()],
-                    prev_values.expr(),
+                    prev_values.0.to_vec(),
                     vec![prev_ts.clone()],
                 ]
                 .concat(),
@@ -87,7 +87,7 @@ impl<'a, E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> RegisterChipOpe
                         RAMType::Register as u64,
                     ))],
                     vec![register_id.expr()],
-                    value.register_expr(),
+                    value.0.to_vec(),
                     vec![ts.clone()],
                 ]
                 .concat(),

--- a/ceno_zkvm/src/instructions/riscv/arith.rs
+++ b/ceno_zkvm/src/instructions/riscv/arith.rs
@@ -89,9 +89,9 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ArithInstruction<E
         let r_insn = RInstructionConfig::<E>::construct_circuit(
             circuit_builder,
             I::INST_KIND,
-            &rs1_read,
-            &rs2_read,
-            &rd_written,
+            rs1_read.register_expr(),
+            rs2_read.register_expr(),
+            rd_written.register_expr(),
         )?;
 
         Ok(ArithConfig {

--- a/ceno_zkvm/src/instructions/riscv/b_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/b_insn.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)] // TODO: remove after BLT, BEQ, …
+
 use ceno_emul::{InsnKind, StepRecord};
 use ff_ext::ExtensionField;
 
@@ -50,8 +52,8 @@ impl BInstructionConfig {
     pub fn construct_circuit<E: ExtensionField>(
         circuit_builder: &mut CircuitBuilder<E>,
         insn_kind: InsnKind,
-        rs1_read: &impl RegisterExpr<E>,
-        rs2_read: &impl RegisterExpr<E>,
+        rs1_read: RegisterExpr<E>,
+        rs2_read: RegisterExpr<E>,
         branch_taken_bit: Expression<E>,
     ) -> Result<Self, ZKVMError> {
         // State in.

--- a/ceno_zkvm/src/instructions/riscv/blt.rs
+++ b/ceno_zkvm/src/instructions/riscv/blt.rs
@@ -179,14 +179,14 @@ fn blt_gadget<E: ExtensionField>(
         &rs1_id,
         prev_rs1_ts.expr(),
         cur_ts.expr(),
-        &lhs,
+        lhs.register_expr(),
     )?;
     let (ts, lt_rs2_cfg) = circuit_builder.register_read(
         || "read ts for rs2",
         &rs2_id,
         prev_rs2_ts.expr(),
         ts,
-        &rhs,
+        rhs.register_expr(),
     )?;
 
     let next_pc = create_witin_from_expr!(|| "next_pc", circuit_builder, false, next_pc)?;

--- a/ceno_zkvm/src/instructions/riscv/logic/logic_circuit.rs
+++ b/ceno_zkvm/src/instructions/riscv/logic/logic_circuit.rs
@@ -86,9 +86,9 @@ impl<E: ExtensionField> LogicConfig<E> {
         let r_insn = RInstructionConfig::<E>::construct_circuit(
             cb,
             insn_kind,
-            &rs1_read,
-            &rs2_read,
-            &rd_written,
+            rs1_read.register_expr(),
+            rs2_read.register_expr(),
+            rd_written.register_expr(),
         )?;
 
         Ok(Self {

--- a/ceno_zkvm/src/instructions/riscv/r_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/r_insn.rs
@@ -45,9 +45,9 @@ impl<E: ExtensionField> RInstructionConfig<E> {
     pub fn construct_circuit(
         circuit_builder: &mut CircuitBuilder<E>,
         insn_kind: InsnKind,
-        rs1_read: &impl RegisterExpr<E>,
-        rs2_read: &impl RegisterExpr<E>,
-        rd_written: &impl RegisterExpr<E>,
+        rs1_read: RegisterExpr<E>,
+        rs2_read: RegisterExpr<E>,
+        rd_written: RegisterExpr<E>,
     ) -> Result<Self, ZKVMError> {
         // State in.
         let pc = circuit_builder.create_witin(|| "pc")?;
@@ -96,7 +96,7 @@ impl<E: ExtensionField> RInstructionConfig<E> {
             &rd_id,
             prev_rd_ts.expr(),
             ts,
-            &prev_rd_value,
+            prev_rd_value.register_expr(),
             rd_written,
         )?;
 

--- a/ceno_zkvm/src/uint.rs
+++ b/ceno_zkvm/src/uint.rs
@@ -465,22 +465,26 @@ impl<E: ExtensionField, const M: usize, const C: usize> ToExpr<E> for UIntLimbs<
     }
 }
 
-impl<E: ExtensionField, const M: usize> RegisterExpr<E> for UIntLimbs<M, 16, E> {
-    fn register_expr(&self) -> Vec<Expression<E>> {
-        self.expr()
+impl<E: ExtensionField> UIntLimbs<32, 16, E> {
+    /// Return a value suitable for register read/write. From [u16; 2] limbs.
+    pub fn register_expr(&self) -> RegisterExpr<E> {
+        let u16_limbs = self.expr();
+        RegisterExpr(u16_limbs.try_into().expect("two limbs with M=32 and C=16"))
     }
 }
 
-impl<E: ExtensionField, const M: usize> RegisterExpr<E> for UIntLimbs<M, 8, E> {
-    fn register_expr(&self) -> Vec<Expression<E>> {
+impl<E: ExtensionField> UIntLimbs<32, 8, E> {
+    /// Return a value suitable for register read/write. From [u8; 4] limbs.
+    pub fn register_expr(&self) -> RegisterExpr<E> {
         let u8_limbs = self.expr();
-        u8_limbs
+        let u16_limbs = u8_limbs
             .chunks(2)
             .map(|chunk| {
                 let (a, b) = (chunk[0].clone(), chunk[1].clone());
-                a + (b * 256.into())
+                a + b * 256.into()
             })
-            .collect_vec()
+            .collect_vec();
+        RegisterExpr(u16_limbs.try_into().expect("four limbs with M=32 and C=8"))
     }
 }
 


### PR DESCRIPTION
The issue is that different instructions need different register representations. The values must be connected through a common format.

Currently, that format is quasi invisible when looking at `trait ToExpr`. In fact, the types `Uint` and `Uint8` both appear to work but their values are incompatible (`2 * u16` vs `4 * u8`).

In this PR:
- Introduce a trait specifically for the register format.
- Implement both `Uint` and `Uint8` such that they are compatible with each other.

Besides, after that we have the option of changing this format. In particular, it should be the common denominator which is just one expression of `u32`.