### PR TITLE
Decode all instruction types

### DIFF
--- a/ceno_emul/src/lib.rs
+++ b/ceno_emul/src/lib.rs
@@ -11,7 +11,7 @@ mod vm_state;
 pub use vm_state::VMState;
 
 mod rv32im;
-pub use rv32im::{DecodedInstruction, EmuContext, InsnCodes, InsnCategory, InsnKind};
+pub use rv32im::{DecodedInstruction, EmuContext, InsnCategory, InsnCodes, InsnKind};
 
 mod elf;
 pub use elf::Program;

--- a/ceno_zkvm/src/tables/program.rs
+++ b/ceno_zkvm/src/tables/program.rs
@@ -35,19 +35,19 @@ impl<T> InsnRecord<T> {
         &self.0[1]
     }
 
-    pub fn rd(&self) -> &T {
+    pub fn rd_or_zero(&self) -> &T {
         &self.0[2]
     }
 
-    pub fn funct3(&self) -> &T {
+    pub fn funct3_or_zero(&self) -> &T {
         &self.0[3]
     }
 
-    pub fn rs1(&self) -> &T {
+    pub fn rs1_or_zero(&self) -> &T {
         &self.0[4]
     }
 
-    pub fn rs2(&self) -> &T {
+    pub fn rs2_or_zero(&self) -> &T {
         &self.0[5]
     }
 
@@ -63,11 +63,11 @@ impl InsnRecord<u32> {
         InsnRecord::new(
             pc,
             insn.opcode(),
-            insn.rd(),
-            insn.funct3(),
-            insn.rs1(),
-            insn.rs2(),
-            insn.funct7(), // TODO: get immediate for all types.
+            insn.rd_or_zero(),
+            insn.funct3_or_zero(),
+            insn.rs1_or_zero(),
+            insn.rs2_or_zero(),
+            insn.imm_or_funct7(),
         )
     }
 }


### PR DESCRIPTION
This PR populates the program table with fully decoded values for all instruction types:
- Unused variables get a constant 0.
- The immediate variable gets the fully decoded value.