### PR TITLE
fix challenge mul scalar and improve printing

### DIFF
--- a/ceno_zkvm/src/expression.rs
+++ b/ceno_zkvm/src/expression.rs
@@ -341,31 +341,42 @@ impl<E: ExtensionField> Mul for Expression<E> {
                 if challenge_id1 == challenge_id2 {
                     // (s1 * s2 * c1^(pow1 + pow2) + offset2 * s1 * c1^(pow1) + offset1 * s2 * c2^(pow2))
                     // + offset1 * offset2
-                    Expression::Sum(
-                        Box::new(Expression::Sum(
-                            // (s1 * s2 * c1^(pow1 + pow2) + offset1 * offset2
-                            Box::new(Expression::Challenge(
-                                *challenge_id1,
-                                pow1 + pow2,
-                                *s1 * s2,
-                                *offset1 * offset2,
-                            )),
-                            // offset2 * s1 * c1^(pow1)
+
+                    // (s1 * s2 * c1^(pow1 + pow2) + offset1 * offset2
+                    let mut result = Expression::Challenge(
+                        *challenge_id1,
+                        pow1 + pow2,
+                        *s1 * s2,
+                        *offset1 * offset2,
+                    );
+
+                    // offset2 * s1 * c1^(pow1)
+                    if *s1 != E::ZERO && *offset2 != E::ZERO {
+                        result = Expression::Sum(
+                            Box::new(result),
                             Box::new(Expression::Challenge(
                                 *challenge_id1,
                                 *pow1,
                                 *offset2 * *s1,
                                 E::ZERO,
                             )),
-                        )),
-                        // offset1 * s2 * c2^(pow2))
-                        Box::new(Expression::Challenge(
-                            *challenge_id1,
-                            *pow2,
-                            *offset1 * *s2,
-                            E::ZERO,
-                        )),
-                    )
+                        );
+                    }
+
+                    // offset1 * s2 * c2^(pow2))
+                    if *s2 != E::ZERO && *offset1 != E::ZERO {
+                        result = Expression::Sum(
+                            Box::new(result),
+                            Box::new(Expression::Challenge(
+                                *challenge_id1,
+                                *pow2,
+                                *offset1 * *s2,
+                                E::ZERO,
+                            )),
+                        );
+                    }
+
+                    result
                 } else {
                     Expression::Product(Box::new(self), Box::new(rhs))
                 }


### PR DESCRIPTION
## Bug

Bug fix suggested by @hero78119 

## Printing

Expression involving challenge printed not making sense due to missing details about scalar power and offset. And expression included redundant `0*Challenge` (scalar is zero).

### Before

```
Expression: Challenge(1) * WitIn(6) + 7 + (Challenge(1) + Challenge(1) + Challenge(1)) * 19 + Challenge(1) * (Challenge(1) 
+ Challenge(1) + Challenge(1)) * WitIn(9) + Challenge(1) * Challenge(1) * (Challenge(1) + Challenge(1) + Challenge(1)) * 0 
+ Challenge(1) * Challenge(1) * Challenge(1) * (Challenge(1) + Challenge(1) + Challenge(1)) * WitIn(8) + Challenge(1) * 
Challenge(1) * Challenge(1) * Challenge(1) * (Challenge(1) + Challenge(1) + Challenge(1)) * (1 * WitIn(2) + 0 + 0x10000 * 
WitIn(3) + 0) + Challenge(1) * Challenge(1) * Challenge(1) * Challenge(1) * Challenge(1) * (Challenge(1) + Challenge(1) + 
Challenge(1)) * 0xffffffff + Challenge(0)
```

### After

```
Expression: Challenge(1) * WitIn(6) + 19*Challenge(1)^2+7 + Challenge(1)^3 * WitIn(9) + 0 + 0*Challenge(1)^4 + 
Challenge(1)^5 * WitIn(8) + 0 + Challenge(1)^6 * (1 * WitIn(2) + 0 + 0x10000 * WitIn(3) + 0) + 0xffffffff*Challenge(1)^7 + 
Challenge(0)
```