### PR TITLE
impl Display for Expression

### DIFF
--- a/ceno_zkvm/src/expression.rs
+++ b/ceno_zkvm/src/expression.rs
@@ -11,6 +11,9 @@ use ff::Field;
 use ff_ext::ExtensionField;
 use goldilocks::SmallField;
 
+#[cfg(test)]
+use multilinear_extensions::virtual_poly_v2::ArcMultilinearExtension;
+
 use crate::{
     circuit_builder::CircuitBuilder,
     error::ZKVMError,
@@ -601,6 +604,32 @@ pub mod fmt {
 
     pub fn prn(s: String, add_prn: bool) -> String {
         if add_prn { format!("({})", s) } else { s }
+    }
+
+    #[cfg(test)]
+    pub fn wtns<E: ExtensionField>(
+        wtns: &[WitnessId],
+        wits_in: &[ArcMultilinearExtension<E>],
+        inst_id: usize,
+        wits_in_name: &[String],
+    ) -> String {
+        use itertools::Itertools;
+
+        wtns.iter()
+            .sorted()
+            .map(|wt_id| {
+                let wit = &wits_in[*wt_id as usize];
+                let name = &wits_in_name[*wt_id as usize];
+                let value_fmt = if let Some(e) = wit.get_ext_field_vec_optn() {
+                    field(&e[inst_id])
+                } else if let Some(bf) = wit.get_base_field_vec_optn() {
+                    base_field::<E>(&bf[inst_id], true)
+                } else {
+                    "Unknown".to_string()
+                };
+                format!("  WitIn({wt_id})={value_fmt} {name:?}")
+            })
+            .join("\n")
     }
 }
 

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -3,7 +3,6 @@ use crate::{
     circuit_builder::{CircuitBuilder, ConstraintSystem},
     expression::{fmt, Expression},
     scheme::utils::eval_by_expr_with_fixed,
-    structs::WitnessId,
     tables::{
         AndTable, LtuTable, OpsTable, OrTable, ProgramTableCircuit, RangeTable, TableCircuit,
         U16Table, U5Table, U8Table, XorTable,
@@ -138,7 +137,7 @@ impl<E: ExtensionField> MockProverError<E> {
                 inst_id,
             } => {
                 let expression_fmt = fmt::expr(expression, &mut wtns, false);
-                let wtns_fmt = fmt_wtns(&wtns, wits_in, *inst_id, wits_in_name);
+                let wtns_fmt = fmt::wtns(&wtns, wits_in, *inst_id, wits_in_name);
                 let eval_fmt = fmt::field(evaluated);
                 println!(
                     "\nAssertZeroError {name:?}: Evaluated expression is not zero\n\
@@ -157,7 +156,7 @@ impl<E: ExtensionField> MockProverError<E> {
             } => {
                 let left_expression_fmt = fmt::expr(left_expression, &mut wtns, false);
                 let right_expression_fmt = fmt::expr(right_expression, &mut wtns, false);
-                let wtns_fmt = fmt_wtns(&wtns, wits_in, *inst_id, wits_in_name);
+                let wtns_fmt = fmt::wtns(&wtns, wits_in, *inst_id, wits_in_name);
                 let left_eval_fmt = fmt::field(left);
                 let right_eval_fmt = fmt::field(right);
                 println!(
@@ -175,7 +174,7 @@ impl<E: ExtensionField> MockProverError<E> {
                 inst_id,
             } => {
                 let expression_fmt = fmt::expr(expression, &mut wtns, false);
-                let wtns_fmt = fmt_wtns(&wtns, wits_in, *inst_id, wits_in_name);
+                let wtns_fmt = fmt::wtns(&wtns, wits_in, *inst_id, wits_in_name);
                 let eval_fmt = fmt::field(evaluated);
                 println!(
                     "\nLookupError {name:#?}: Evaluated expression does not exist in T vector\n\
@@ -186,29 +185,6 @@ impl<E: ExtensionField> MockProverError<E> {
             }
         }
     }
-}
-
-pub fn fmt_wtns<E: ExtensionField>(
-    wtns: &[WitnessId],
-    wits_in: &[ArcMultilinearExtension<E>],
-    inst_id: usize,
-    wits_in_name: &[String],
-) -> String {
-    wtns.iter()
-        .sorted()
-        .map(|wt_id| {
-            let wit = &wits_in[*wt_id as usize];
-            let name = &wits_in_name[*wt_id as usize];
-            let value_fmt = if let Some(e) = wit.get_ext_field_vec_optn() {
-                fmt::field(&e[inst_id])
-            } else if let Some(bf) = wit.get_base_field_vec_optn() {
-                fmt::base_field::<E>(&bf[inst_id], true)
-            } else {
-                "Unknown".to_string()
-            };
-            format!("  WitIn({wt_id})={value_fmt} {name:?}")
-        })
-        .join("\n")
 }
 
 pub(crate) struct MockProver<E: ExtensionField> {


### PR DESCRIPTION
1. move fmt expr utils to expression module
2. impl Display for Expression

For a complex Expression, `println("{:?}", expr)` prints a lot of stuff and it is difficult to comprehend. 

This PR enables `println("{}", expr)` which uses fmt_expr that is implemented originally in mock prover.