### PR TITLE
unittest assertion on register value

### DIFF
--- a/ceno_zkvm/src/instructions/riscv/arith.rs
+++ b/ceno_zkvm/src/instructions/riscv/arith.rs
@@ -182,7 +182,6 @@ mod test {
     };
 
     #[test]
-    #[allow(clippy::option_map_unit_fn)]
     fn test_opcode_add() {
         let mut cs = ConstraintSystem::<GoldilocksExt2>::new(|| "riscv");
         let mut cb = CircuitBuilder::new(&mut cs);
@@ -212,6 +211,17 @@ mod test {
         )
         .unwrap();
 
+        let expected_rd_written = UInt::from_const_unchecked(
+            Value::new_unchecked(11_u32.wrapping_add(0xfffffffe))
+                .as_u16_limbs()
+                .to_vec(),
+        );
+
+        config
+            .rd_written
+            .require_equal(|| "assert_rd_written", &mut cb, &expected_rd_written)
+            .unwrap();
+
         MockProver::assert_satisfied(
             &mut cb,
             &raw_witin
@@ -225,7 +235,6 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::option_map_unit_fn)]
     fn test_opcode_add_overflow() {
         let mut cs = ConstraintSystem::<GoldilocksExt2>::new(|| "riscv");
         let mut cb = CircuitBuilder::new(&mut cs);
@@ -255,6 +264,17 @@ mod test {
         )
         .unwrap();
 
+        let expected_rd_written = UInt::from_const_unchecked(
+            Value::new_unchecked((u32::MAX - 1).wrapping_add(u32::MAX - 1))
+                .as_u16_limbs()
+                .to_vec(),
+        );
+
+        config
+            .rd_written
+            .require_equal(|| "assert_rd_written", &mut cb, &expected_rd_written)
+            .unwrap();
+
         MockProver::assert_satisfied(
             &mut cb,
             &raw_witin
@@ -268,7 +288,6 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::option_map_unit_fn)]
     fn test_opcode_sub() {
         let mut cs = ConstraintSystem::<GoldilocksExt2>::new(|| "riscv");
         let mut cb = CircuitBuilder::new(&mut cs);
@@ -298,6 +317,17 @@ mod test {
         )
         .unwrap();
 
+        let expected_rd_written = UInt::from_const_unchecked(
+            Value::new_unchecked(11_u32.wrapping_sub(2))
+                .as_u16_limbs()
+                .to_vec(),
+        );
+
+        config
+            .rd_written
+            .require_equal(|| "assert_rd_written", &mut cb, &expected_rd_written)
+            .unwrap();
+
         MockProver::assert_satisfied(
             &mut cb,
             &raw_witin
@@ -311,7 +341,6 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::option_map_unit_fn)]
     fn test_opcode_sub_underflow() {
         let mut cs = ConstraintSystem::<GoldilocksExt2>::new(|| "riscv");
         let mut cb = CircuitBuilder::new(&mut cs);
@@ -340,6 +369,17 @@ mod test {
             )],
         )
         .unwrap();
+
+        let expected_rd_written = UInt::from_const_unchecked(
+            Value::new_unchecked(3_u32.wrapping_sub(11))
+                .as_u16_limbs()
+                .to_vec(),
+        );
+
+        config
+            .rd_written
+            .require_equal(|| "assert_rd_written", &mut cb, &expected_rd_written)
+            .unwrap();
 
         MockProver::assert_satisfied(
             &mut cb,
@@ -378,6 +418,14 @@ mod test {
         )
         .unwrap();
 
+        let expected_rd_written =
+            UInt::from_const_unchecked(Value::new_unchecked(22u32).as_u16_limbs().to_vec());
+
+        config
+            .rd_written
+            .require_equal(|| "assert_rd_written", &mut cb, &expected_rd_written)
+            .unwrap();
+
         MockProver::assert_satisfied(
             &mut cb,
             &raw_witin
@@ -415,6 +463,13 @@ mod test {
         )
         .unwrap();
 
+        let expected_rd_written = UInt::from_const_unchecked(vec![0u64, 0]);
+
+        config
+            .rd_written
+            .require_equal(|| "assert_rd_written", &mut cb, &expected_rd_written)
+            .unwrap();
+
         MockProver::assert_satisfied(
             &mut cb,
             &raw_witin
@@ -450,11 +505,21 @@ mod test {
                 MOCK_PROGRAM[2],
                 a.as_u64() as u32,
                 b.as_u64() as u32,
-                Change::new(0, Value::<u32>::from_limb_unchecked(c_limb).as_u64() as u32),
+                Change::new(
+                    0,
+                    Value::<u32>::from_limb_unchecked(c_limb.clone()).as_u64() as u32,
+                ),
                 0,
             )],
         )
         .unwrap();
+
+        let expected_rd_written = UInt::from_const_unchecked(c_limb.clone());
+
+        config
+            .rd_written
+            .require_equal(|| "assert_rd_written", &mut cb, &expected_rd_written)
+            .unwrap();
 
         MockProver::assert_satisfied(
             &mut cb,

--- a/ceno_zkvm/src/instructions/riscv/divu.rs
+++ b/ceno_zkvm/src/instructions/riscv/divu.rs
@@ -14,7 +14,7 @@ pub struct ArithConfig<E: ExtensionField> {
 
     dividend: UInt<E>,
     divisor: UInt<E>,
-    outcome: UInt<E>,
+    pub(crate) outcome: UInt<E>,
 
     remainder: UInt<E>,
     inter_mul_value: UInt<E>,
@@ -145,8 +145,12 @@ mod test {
 
         use crate::{
             circuit_builder::{CircuitBuilder, ConstraintSystem},
-            instructions::{riscv::divu::DivUInstruction, Instruction},
+            instructions::{
+                riscv::{constants::UInt, divu::DivUInstruction},
+                Instruction,
+            },
             scheme::mock_prover::{MockProver, MOCK_PC_DIVU, MOCK_PROGRAM},
+            Value,
         };
 
         fn verify(name: &'static str, dividend: Word, divisor: Word, outcome: Word) {
@@ -175,6 +179,14 @@ mod test {
                 )],
             )
             .unwrap();
+
+            let expected_rd_written =
+                UInt::from_const_unchecked(Value::new_unchecked(outcome).as_u16_limbs().to_vec());
+
+            config
+                .outcome
+                .require_equal(|| "assert_outcome", &mut cb, &expected_rd_written)
+                .unwrap();
 
             MockProver::assert_satisfied(
                 &mut cb,

--- a/ceno_zkvm/src/instructions/riscv/logic/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/logic/test.rs
@@ -5,8 +5,9 @@ use multilinear_extensions::mle::IntoMLEs;
 
 use crate::{
     circuit_builder::{CircuitBuilder, ConstraintSystem},
-    instructions::Instruction,
+    instructions::{riscv::constants::UInt8, Instruction},
     scheme::mock_prover::{MockProver, MOCK_PC_AND, MOCK_PC_OR, MOCK_PC_XOR, MOCK_PROGRAM},
+    utils::split_to_u8,
     ROMType,
 };
 
@@ -49,6 +50,13 @@ fn test_opcode_and() {
 
     let lkm = lkm.into_finalize_result()[ROMType::And as usize].clone();
     assert_eq!(&lkm.into_iter().sorted().collect_vec(), LOOKUPS);
+
+    let expected_rd_written = UInt8::from_const_unchecked(split_to_u8::<u64>((A & B) as u32));
+
+    config
+        .rd_written
+        .require_equal(|| "assert_rd_written", &mut cb, &expected_rd_written)
+        .unwrap();
 
     MockProver::assert_satisfied(
         &mut cb,
@@ -95,6 +103,13 @@ fn test_opcode_or() {
     let lkm = lkm.into_finalize_result()[ROMType::Or as usize].clone();
     assert_eq!(&lkm.into_iter().sorted().collect_vec(), LOOKUPS);
 
+    let expected_rd_written = UInt8::from_const_unchecked(split_to_u8::<u64>((A | B) as u32));
+
+    config
+        .rd_written
+        .require_equal(|| "assert_rd_written", &mut cb, &expected_rd_written)
+        .unwrap();
+
     MockProver::assert_satisfied(
         &mut cb,
         &raw_witin
@@ -139,6 +154,13 @@ fn test_opcode_xor() {
 
     let lkm = lkm.into_finalize_result()[ROMType::Xor as usize].clone();
     assert_eq!(&lkm.into_iter().sorted().collect_vec(), LOOKUPS);
+
+    let expected_rd_written = UInt8::from_const_unchecked(split_to_u8::<u64>((A ^ B) as u32));
+
+    config
+        .rd_written
+        .require_equal(|| "assert_rd_written", &mut cb, &expected_rd_written)
+        .unwrap();
 
     MockProver::assert_satisfied(
         &mut cb,

--- a/ceno_zkvm/src/instructions/riscv/shift_imm/shift_imm_circuit.rs
+++ b/ceno_zkvm/src/instructions/riscv/shift_imm/shift_imm_circuit.rs
@@ -21,7 +21,7 @@ pub struct InstructionConfig<E: ExtensionField> {
 
     rs1: UInt<E>,
     imm: UInt<E>,
-    rd_written: UInt<E>,
+    pub(crate) rd_written: UInt<E>,
     remainder: UInt<E>,
     rd_imm_mul: UInt<E>,
 }

--- a/ceno_zkvm/src/instructions/riscv/shift_imm/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/shift_imm/test.rs
@@ -5,8 +5,9 @@ use multilinear_extensions::mle::IntoMLEs;
 
 use crate::{
     circuit_builder::{CircuitBuilder, ConstraintSystem},
-    instructions::Instruction,
+    instructions::{riscv::constants::UInt, Instruction},
     scheme::mock_prover::{MockProver, MOCK_PC_SRLI, MOCK_PC_SRLI_31, MOCK_PROGRAM},
+    Value,
 };
 
 use super::{shift_imm_circuit::ShiftImmInstruction, SrliOp};
@@ -39,6 +40,14 @@ fn test_opcode_srli_1() {
         )],
     )
     .unwrap();
+
+    let expected_rd_written =
+        UInt::from_const_unchecked(Value::new_unchecked(32u32 >> 3).as_u16_limbs().to_vec());
+
+    config
+        .rd_written
+        .require_equal(|| "assert_rd_written", &mut cb, &expected_rd_written)
+        .unwrap();
 
     MockProver::assert_satisfied(
         &cb,

--- a/ceno_zkvm/src/instructions/riscv/sltu.rs
+++ b/ceno_zkvm/src/instructions/riscv/sltu.rs
@@ -150,6 +150,14 @@ mod test {
         )
         .unwrap();
 
+        let expected_rd_written =
+            UInt::from_const_unchecked(Value::new_unchecked(rd).as_u16_limbs().to_vec());
+
+        config
+            .rd_written
+            .require_equal(|| "assert_rd_written", &mut cb, &expected_rd_written)
+            .unwrap();
+
         MockProver::assert_satisfied(
             &mut cb,
             &raw_witin

--- a/ceno_zkvm/src/uint.rs
+++ b/ceno_zkvm/src/uint.rs
@@ -119,6 +119,22 @@ impl<const M: usize, const C: usize, E: ExtensionField> UIntLimbs<M, C, E> {
         }
     }
 
+    /// this fn does not create new witness
+    pub fn from_const_unchecked<T: Into<u64>>(limbs: Vec<T>) -> Self {
+        assert!(limbs.len() == Self::NUM_CELLS);
+        UIntLimbs {
+            limbs: UintLimb::Expression(
+                limbs
+                    .into_iter()
+                    .take(Self::NUM_CELLS)
+                    .map(|limb| Expression::Constant(E::BaseField::from(limb.into())))
+                    .collect::<Vec<Expression<E>>>(),
+            ),
+            carries: None,
+            carries_auxiliary_lt_config: None,
+        }
+    }
+
     /// expr_limbs is little endian order
     pub fn new_as_empty() -> Self {
         Self {

--- a/ceno_zkvm/src/utils.rs
+++ b/ceno_zkvm/src/utils.rs
@@ -33,11 +33,10 @@ pub fn limb_u8_to_u16(input: &[u8]) -> Vec<u16> {
         .collect()
 }
 
-#[allow(dead_code)]
-pub fn split_to_u8(value: u32) -> Vec<u8> {
+pub fn split_to_u8<T: From<u8>>(value: u32) -> Vec<T> {
     (0..(u32::BITS / 8))
         .scan(value, |acc, _| {
-            let limb = (*acc & 0xFF) as u8;
+            let limb = ((*acc & 0xFF) as u8).into();
             *acc >>= 8;
             Some(limb)
         })


### PR DESCRIPTION
Previously in unittest, we are stuck on how to assertion on rd value especially when it's limb represented as expression. Without checking this, a potiential under-constrain can't be detect correctly

I figure out a pretty simple and beautiful way 😛   to capture this: simply adding testing equality constrain 

