### PR TITLE
Refactor RISC-V instruction base types

### DIFF
--- a/ceno_zkvm/src/instructions/riscv.rs
+++ b/ceno_zkvm/src/instructions/riscv.rs
@@ -6,13 +6,14 @@ pub mod branch;
 pub mod config;
 pub mod constants;
 pub mod divu;
-mod i_insn;
 pub mod logic;
+pub mod shift_imm;
 pub mod sltu;
 
 mod b_insn;
+mod i_insn;
+mod insn_base;
 mod r_insn;
-pub mod shift_imm;
 
 #[cfg(test)]
 mod test;

--- a/ceno_zkvm/src/instructions/riscv/branch/beq_circuit.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch/beq_circuit.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 pub struct BeqConfig<E: ExtensionField> {
-    b_insn: BInstructionConfig,
+    b_insn: BInstructionConfig<E>,
 
     // TODO: Limb decomposition is not necessary. Replace with a single witness.
     rs1_read: UInt<E>,
@@ -78,7 +78,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BeqCircuit<E, I> {
     ) -> Result<(), ZKVMError> {
         config
             .b_insn
-            .assign_instance::<E>(instance, lk_multiplicity, step)?;
+            .assign_instance(instance, lk_multiplicity, step)?;
 
         let rs1_read = step.rs1().unwrap().value;
         config

--- a/ceno_zkvm/src/instructions/riscv/branch/blt.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch/blt.rs
@@ -20,7 +20,7 @@ use ceno_emul::InsnKind;
 pub struct BltCircuit<I>(PhantomData<I>);
 
 pub struct InstructionConfig<E: ExtensionField> {
-    pub b_insn: BInstructionConfig,
+    pub b_insn: BInstructionConfig<E>,
     pub read_rs1: UInt<E>,
     pub read_rs2: UInt<E>,
     pub is_lt: UIntLtSignedConfig,
@@ -90,7 +90,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BltCircuit<I> {
 
         config
             .b_insn
-            .assign_instance::<E>(instance, lk_multiplicity, step)?;
+            .assign_instance(instance, lk_multiplicity, step)?;
 
         Ok(())
     }

--- a/ceno_zkvm/src/instructions/riscv/branch/bltu.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch/bltu.rs
@@ -23,7 +23,7 @@ use ceno_emul::InsnKind;
 pub struct BltuCircuit<I>(PhantomData<I>);
 
 pub struct InstructionConfig<E: ExtensionField> {
-    pub b_insn: BInstructionConfig,
+    pub b_insn: BInstructionConfig<E>,
     pub read_rs1: UInt<E>,
     pub read_rs2: UInt<E>,
     pub is_lt: IsLtConfig,
@@ -93,7 +93,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BltuCircuit<I> {
 
         config
             .b_insn
-            .assign_instance::<E>(instance, lk_multiplicity, step)?;
+            .assign_instance(instance, lk_multiplicity, step)?;
 
         Ok(())
     }

--- a/ceno_zkvm/src/instructions/riscv/insn_base.rs
+++ b/ceno_zkvm/src/instructions/riscv/insn_base.rs
@@ -1,0 +1,242 @@
+use ceno_emul::StepRecord;
+use ff_ext::ExtensionField;
+
+use super::constants::{UInt, PC_STEP_SIZE};
+use crate::{
+    chip_handler::{
+        GlobalStateRegisterMachineChipOperations, RegisterChipOperations, RegisterExpr,
+    },
+    circuit_builder::CircuitBuilder,
+    error::ZKVMError,
+    expression::{ToExpr, WitIn},
+    gadgets::IsLtConfig,
+    set_val,
+    uint::Value,
+    witness::LkMultiplicity,
+};
+use ceno_emul::Tracer;
+use core::mem::MaybeUninit;
+use std::marker::PhantomData;
+
+#[derive(Debug)]
+pub struct StateInOut<E: ExtensionField> {
+    pub pc: WitIn,
+    pub next_pc: Option<WitIn>,
+    pub ts: WitIn,
+    _field_type: PhantomData<E>,
+}
+
+impl<E: ExtensionField> StateInOut<E> {
+    /// If circuit is branching, leave witness for next_pc free and return in
+    /// configuration so that calling circuit can constrain its value.
+    /// Otherwise, internally increment by PC_STEP_SIZE
+    pub fn construct_circuit(
+        circuit_builder: &mut CircuitBuilder<E>,
+        branching: bool,
+    ) -> Result<Self, ZKVMError> {
+        let pc = circuit_builder.create_witin(|| "pc")?;
+        let (next_pc_opt, next_pc_expr) = if branching {
+            let next_pc = circuit_builder.create_witin(|| "next_pc")?;
+            (Some(next_pc), next_pc.expr())
+        } else {
+            (None, pc.expr() + PC_STEP_SIZE.into())
+        };
+        let ts = circuit_builder.create_witin(|| "ts")?;
+        let next_ts = ts.expr() + (Tracer::SUBCYCLES_PER_INSN as usize).into();
+        circuit_builder.state_in(pc.expr(), ts.expr())?;
+        circuit_builder.state_out(next_pc_expr, next_ts)?;
+
+        Ok(StateInOut {
+            pc,
+            next_pc: next_pc_opt,
+            ts,
+            _field_type: PhantomData,
+        })
+    }
+
+    pub fn assign_instance(
+        &self,
+        instance: &mut [MaybeUninit<<E as ExtensionField>::BaseField>],
+        // lk_multiplicity: &mut LkMultiplicity,
+        step: &StepRecord,
+    ) -> Result<(), ZKVMError> {
+        set_val!(instance, self.pc, step.pc().before.0 as u64);
+        if let Some(n_pc) = self.next_pc {
+            set_val!(instance, n_pc, step.pc().after.0 as u64);
+        }
+        set_val!(instance, self.ts, step.cycle());
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct ReadRS1<E: ExtensionField> {
+    pub id: WitIn,
+    pub prev_ts: WitIn,
+    pub lt_cfg: IsLtConfig,
+    _field_type: PhantomData<E>,
+}
+
+impl<E: ExtensionField> ReadRS1<E> {
+    pub fn construct_circuit(
+        circuit_builder: &mut CircuitBuilder<E>,
+        rs1_read: RegisterExpr<E>,
+        cur_ts: WitIn,
+    ) -> Result<Self, ZKVMError> {
+        let id = circuit_builder.create_witin(|| "rs1_id")?;
+        let prev_ts = circuit_builder.create_witin(|| "prev_rs1_ts")?;
+        let (_, lt_cfg) = circuit_builder.register_read(
+            || "read_rs1",
+            &id,
+            prev_ts.expr(),
+            cur_ts.expr() + (Tracer::SUBCYCLE_RS1 as usize).into(),
+            rs1_read,
+        )?;
+
+        Ok(ReadRS1 {
+            id,
+            prev_ts,
+            lt_cfg,
+            _field_type: PhantomData,
+        })
+    }
+
+    pub fn assign_instance(
+        &self,
+        instance: &mut [MaybeUninit<<E as ExtensionField>::BaseField>],
+        lk_multiplicity: &mut LkMultiplicity,
+        step: &StepRecord,
+    ) -> Result<(), ZKVMError> {
+        set_val!(instance, self.id, step.insn().rs1() as u64);
+
+        // Register state
+        set_val!(instance, self.prev_ts, step.rs1().unwrap().previous_cycle);
+
+        // Register read
+        self.lt_cfg.assign_instance(
+            instance,
+            lk_multiplicity,
+            step.rs1().unwrap().previous_cycle,
+            step.cycle() + Tracer::SUBCYCLE_RS1,
+        )?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct ReadRS2<E: ExtensionField> {
+    pub id: WitIn,
+    pub prev_ts: WitIn,
+    pub lt_cfg: IsLtConfig,
+    _field_type: PhantomData<E>,
+}
+
+impl<E: ExtensionField> ReadRS2<E> {
+    pub fn construct_circuit(
+        circuit_builder: &mut CircuitBuilder<E>,
+        rs2_read: RegisterExpr<E>,
+        cur_ts: WitIn,
+    ) -> Result<Self, ZKVMError> {
+        let id = circuit_builder.create_witin(|| "rs2_id")?;
+        let prev_ts = circuit_builder.create_witin(|| "prev_rs2_ts")?;
+        let (_, lt_cfg) = circuit_builder.register_read(
+            || "read_rs2",
+            &id,
+            prev_ts.expr(),
+            cur_ts.expr() + (Tracer::SUBCYCLE_RS2 as usize).into(),
+            rs2_read,
+        )?;
+
+        Ok(ReadRS2 {
+            id,
+            prev_ts,
+            lt_cfg,
+            _field_type: PhantomData,
+        })
+    }
+
+    pub fn assign_instance(
+        &self,
+        instance: &mut [MaybeUninit<<E as ExtensionField>::BaseField>],
+        lk_multiplicity: &mut LkMultiplicity,
+        step: &StepRecord,
+    ) -> Result<(), ZKVMError> {
+        set_val!(instance, self.id, step.insn().rs2() as u64);
+
+        // Register state
+        set_val!(instance, self.prev_ts, step.rs2().unwrap().previous_cycle);
+
+        // Register read
+        self.lt_cfg.assign_instance(
+            instance,
+            lk_multiplicity,
+            step.rs2().unwrap().previous_cycle,
+            step.cycle() + Tracer::SUBCYCLE_RS2,
+        )?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct WriteRD<E: ExtensionField> {
+    pub id: WitIn,
+    pub prev_ts: WitIn,
+    pub prev_value: UInt<E>,
+    pub lt_cfg: IsLtConfig,
+}
+
+impl<E: ExtensionField> WriteRD<E> {
+    pub fn construct_circuit(
+        circuit_builder: &mut CircuitBuilder<E>,
+        rd_written: RegisterExpr<E>,
+        cur_ts: WitIn,
+    ) -> Result<Self, ZKVMError> {
+        let id = circuit_builder.create_witin(|| "rd_id")?;
+        let prev_ts = circuit_builder.create_witin(|| "prev_rd_ts")?;
+        let prev_value = UInt::new_unchecked(|| "prev_rd_value", circuit_builder)?;
+        let (_, lt_cfg) = circuit_builder.register_write(
+            || "write_rd",
+            &id,
+            prev_ts.expr(),
+            cur_ts.expr() + (Tracer::SUBCYCLE_RD as usize).into(),
+            prev_value.register_expr(),
+            rd_written,
+        )?;
+
+        Ok(WriteRD {
+            id,
+            prev_ts,
+            prev_value,
+            lt_cfg,
+        })
+    }
+
+    pub fn assign_instance(
+        &self,
+        instance: &mut [MaybeUninit<<E as ExtensionField>::BaseField>],
+        lk_multiplicity: &mut LkMultiplicity,
+        step: &StepRecord,
+    ) -> Result<(), ZKVMError> {
+        set_val!(instance, self.id, step.insn().rd() as u64);
+        set_val!(instance, self.prev_ts, step.rd().unwrap().previous_cycle);
+
+        // Register state
+        self.prev_value.assign_limbs(
+            instance,
+            Value::new_unchecked(step.rd().unwrap().value.before).as_u16_limbs(),
+        );
+
+        // Register write
+        self.lt_cfg.assign_instance(
+            instance,
+            lk_multiplicity,
+            step.rd().unwrap().previous_cycle,
+            step.cycle() + Tracer::SUBCYCLE_RD,
+        )?;
+
+        Ok(())
+    }
+}

--- a/ceno_zkvm/src/instructions/riscv/r_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/r_insn.rs
@@ -1,18 +1,13 @@
 use ceno_emul::{InsnKind, StepRecord};
 use ff_ext::ExtensionField;
 
-use super::constants::{UInt, PC_STEP_SIZE};
 use crate::{
-    chip_handler::{
-        GlobalStateRegisterMachineChipOperations, RegisterChipOperations, RegisterExpr,
-    },
+    chip_handler::RegisterExpr,
     circuit_builder::CircuitBuilder,
     error::ZKVMError,
-    expression::{ToExpr, WitIn},
-    gadgets::IsLtConfig,
-    set_val,
+    expression::ToExpr,
+    instructions::riscv::insn_base::{ReadRS1, ReadRS2, StateInOut, WriteRD},
     tables::InsnRecord,
-    uint::Value,
     witness::LkMultiplicity,
 };
 use core::mem::MaybeUninit;
@@ -24,18 +19,10 @@ use core::mem::MaybeUninit;
 /// It does not witness of the register values, nor the actual function (e.g. add, sub, etc).
 #[derive(Debug)]
 pub struct RInstructionConfig<E: ExtensionField> {
-    pc: WitIn,
-    ts: WitIn,
-    rs1_id: WitIn,
-    rs2_id: WitIn,
-    rd_id: WitIn,
-    prev_rd_value: UInt<E>,
-    prev_rs1_ts: WitIn,
-    prev_rs2_ts: WitIn,
-    prev_rd_ts: WitIn,
-    lt_rs1_cfg: IsLtConfig,
-    lt_rs2_cfg: IsLtConfig,
-    lt_prev_ts_cfg: IsLtConfig,
+    pub vm_state: StateInOut<E>,
+    pub rs1: ReadRS1<E>,
+    pub rs2: ReadRS2<E>,
+    pub rd: WriteRD<E>,
 }
 
 impl<E: ExtensionField> RInstructionConfig<E> {
@@ -46,74 +33,30 @@ impl<E: ExtensionField> RInstructionConfig<E> {
         rs2_read: RegisterExpr<E>,
         rd_written: RegisterExpr<E>,
     ) -> Result<Self, ZKVMError> {
-        // State in.
-        let pc = circuit_builder.create_witin(|| "pc")?;
-        let cur_ts = circuit_builder.create_witin(|| "cur_ts")?;
-        circuit_builder.state_in(pc.expr(), cur_ts.expr())?;
+        // State in and out
+        let vm_state = StateInOut::construct_circuit(circuit_builder, false)?;
 
-        // Register indexes.
-        let rs1_id = circuit_builder.create_witin(|| "rs1_id")?;
-        let rs2_id = circuit_builder.create_witin(|| "rs2_id")?;
-        let rd_id = circuit_builder.create_witin(|| "rd_id")?;
+        // Registers
+        let rs1 = ReadRS1::construct_circuit(circuit_builder, rs1_read, vm_state.ts)?;
+        let rs2 = ReadRS2::construct_circuit(circuit_builder, rs2_read, vm_state.ts)?;
+        let rd = WriteRD::construct_circuit(circuit_builder, rd_written, vm_state.ts)?;
 
-        // Fetch the instruction.
+        // Fetch instruction
         circuit_builder.lk_fetch(&InsnRecord::new(
-            pc.expr(),
+            vm_state.pc.expr(),
             (insn_kind.codes().opcode as usize).into(),
-            rd_id.expr(),
+            rd.id.expr(),
             (insn_kind.codes().func3 as usize).into(),
-            rs1_id.expr(),
-            rs2_id.expr(),
+            rs1.id.expr(),
+            rs2.id.expr(),
             (insn_kind.codes().func7 as usize).into(),
         ))?;
 
-        // Register state.
-        let prev_rs1_ts = circuit_builder.create_witin(|| "prev_rs1_ts")?;
-        let prev_rs2_ts = circuit_builder.create_witin(|| "prev_rs2_ts")?;
-        let prev_rd_ts = circuit_builder.create_witin(|| "prev_rd_ts")?;
-        let prev_rd_value = UInt::new_unchecked(|| "prev_rd_value", circuit_builder)?;
-
-        // Register read and write.
-        let (next_ts, lt_rs1_cfg) = circuit_builder.register_read(
-            || "read_rs1",
-            &rs1_id,
-            prev_rs1_ts.expr(),
-            cur_ts.expr(),
-            rs1_read,
-        )?;
-        let (next_ts, lt_rs2_cfg) = circuit_builder.register_read(
-            || "read_rs2",
-            &rs2_id,
-            prev_rs2_ts.expr(),
-            next_ts,
-            rs2_read,
-        )?;
-        let (next_ts, lt_prev_ts_cfg) = circuit_builder.register_write(
-            || "write_rd",
-            &rd_id,
-            prev_rd_ts.expr(),
-            next_ts,
-            prev_rd_value.register_expr(),
-            rd_written,
-        )?;
-
-        // State out.
-        let next_pc = pc.expr() + PC_STEP_SIZE.into();
-        circuit_builder.state_out(next_pc, next_ts)?;
-
         Ok(RInstructionConfig {
-            pc,
-            ts: cur_ts,
-            rs1_id,
-            rs2_id,
-            rd_id,
-            prev_rd_value,
-            prev_rs1_ts,
-            prev_rs2_ts,
-            prev_rd_ts,
-            lt_rs1_cfg,
-            lt_rs2_cfg,
-            lt_prev_ts_cfg,
+            vm_state,
+            rs1,
+            rs2,
+            rd,
         })
     }
 
@@ -123,54 +66,13 @@ impl<E: ExtensionField> RInstructionConfig<E> {
         lk_multiplicity: &mut LkMultiplicity,
         step: &StepRecord,
     ) -> Result<(), ZKVMError> {
-        // State in.
-        set_val!(instance, self.pc, step.pc().before.0 as u64);
-        set_val!(instance, self.ts, step.cycle());
+        self.vm_state.assign_instance(instance, step)?;
+        self.rs1.assign_instance(instance, lk_multiplicity, step)?;
+        self.rs2.assign_instance(instance, lk_multiplicity, step)?;
+        self.rd.assign_instance(instance, lk_multiplicity, step)?;
 
-        // Register indexes.
-        set_val!(instance, self.rs1_id, step.insn().rs1() as u64);
-        set_val!(instance, self.rs2_id, step.insn().rs2() as u64);
-        set_val!(instance, self.rd_id, step.insn().rd() as u64);
-
-        // Fetch the instruction.
+        // Fetch instruction
         lk_multiplicity.fetch(step.pc().before.0);
-
-        // Register state.
-        set_val!(
-            instance,
-            self.prev_rs1_ts,
-            step.rs1().unwrap().previous_cycle
-        );
-        set_val!(
-            instance,
-            self.prev_rs2_ts,
-            step.rs2().unwrap().previous_cycle
-        );
-        set_val!(instance, self.prev_rd_ts, step.rd().unwrap().previous_cycle);
-        self.prev_rd_value.assign_limbs(
-            instance,
-            Value::new_unchecked(step.rd().unwrap().value.before).as_u16_limbs(),
-        );
-
-        // Register read and write.
-        self.lt_rs1_cfg.assign_instance(
-            instance,
-            lk_multiplicity,
-            step.rs1().unwrap().previous_cycle,
-            step.cycle(),
-        )?;
-        self.lt_rs2_cfg.assign_instance(
-            instance,
-            lk_multiplicity,
-            step.rs2().unwrap().previous_cycle,
-            step.cycle() + 1,
-        )?;
-        self.lt_prev_ts_cfg.assign_instance(
-            instance,
-            lk_multiplicity,
-            step.rd().unwrap().previous_cycle,
-            step.cycle() + 2,
-        )?;
 
         Ok(())
     }


### PR DESCRIPTION
Implementations of the R-type, I-type, and B-type instruction gadgets previously included a lot of repeated code for setting up vm state and register access. This PR refactors those parts into smaller self-contained gadgets, which simplifies and unifies the presentation of the instruction base types.