### PR TITLE
18x speed up for `cargo make fmt` and others

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "ceno_zkvm",
     "poseidon"
 ]
+resolver = "2"
 
 [workspace.package]
 version = "0.1.0"


### PR DESCRIPTION
The old `Makefile.toml` unnecessarily ran your commands once for each sub-crate.  [According to the docs](https://github.com/sagiegurari/cargo-make?tab=readme-ov-file#disabling-workspace-support) we can fix this behaviour by adding `workspace = false` to the relevant tasks.

On my machine that transforms:

```console
$ time cargo make fmt
[cargo-make] INFO - cargo make 0.37.19
[cargo-make] INFO - Calling cargo metadata to extract project info
[cargo-make] INFO - Cargo metadata done
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: fmt
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: workspace
/home/matthias/scroll/prog/ceno3
[cargo-make][1] INFO - Calling cargo metadata to extract project info
[cargo-make][1] INFO - Cargo metadata done
[cargo-make][1] INFO - Project: ceno_emul
[cargo-make][1] INFO - Build File: Makefile.toml
[cargo-make][1] INFO - Task: fmt
[cargo-make][1] INFO - Profile: development
[cargo-make][1] INFO - Execute Command: "cargo" "fmt" "-p" "ceno_zkvm" "--" "--check"
Warning: Unknown configuration option `style_edition`
Warning: Unknown configuration option `style_edition`
Warning: Unknown configuration option `style_edition`
Warning: Unknown configuration option `style_edition`
[cargo-make][1] INFO - Build Done in 0.67 seconds.
[cargo-make][1] INFO - Calling cargo metadata to extract project info
[... snip ...]
[cargo-make][1] INFO - Task: fmt
[cargo-make][1] INFO - Profile: development
[cargo-make][1] INFO - Execute Command: "cargo" "fmt" "-p" "ceno_zkvm" "--" "--check"
Warning: Unknown configuration option `style_edition`
Warning: Unknown configuration option `style_edition`
Warning: Unknown configuration option `style_edition`
Warning: Unknown configuration option `style_edition`
[cargo-make][1] INFO - Build Done in 0.64 seconds.
[cargo-make][1] INFO - Calling cargo metadata to extract project info
[cargo-make][1] INFO - Cargo metadata done
[cargo-make][1] INFO - Project: poseidon
[cargo-make][1] INFO - Build File: Makefile.toml
[cargo-make][1] INFO - Task: fmt
[cargo-make][1] INFO - Profile: development
[cargo-make][1] INFO - Execute Command: "cargo" "fmt" "-p" "ceno_zkvm" "--" "--check"
Warning: Unknown configuration option `style_edition`
Warning: Unknown configuration option `style_edition`
Warning: Unknown configuration option `style_edition`
Warning: Unknown configuration option `style_edition`
[cargo-make][1] INFO - Build Done in 0.70 seconds.
[cargo-make] INFO - Build Done in 9.92 seconds.

real    0m9.961s
user    0m7.309s
sys     0m2.481s
```

into

```console
$ time cargo make fmt
[cargo-make] INFO - cargo make 0.37.19
[cargo-make] INFO - Calling cargo metadata to extract project info
[cargo-make] INFO - Cargo metadata done
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: fmt
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Execute Command: "cargo" "fmt" "-p" "ceno_zkvm" "--" "--check"
Warning: Unknown configuration option `style_edition`
Warning: Unknown configuration option `style_edition`
Warning: Unknown configuration option `style_edition`
Warning: Unknown configuration option `style_edition`
[cargo-make] INFO - Build Done in 0.52 seconds.

real    0m0.550s
user    0m0.423s
sys     0m0.123s
```

We gain similar speedups for most other tasks.