### PR TITLE
add namespace for mul and add

### DIFF
--- a/ceno_zkvm/src/uint/arithmetic.rs
+++ b/ceno_zkvm/src/uint/arithmetic.rs
@@ -270,8 +270,15 @@ impl<const M: usize, const C: usize, E: ExtensionField> UIntLimbs<M, C, E> {
         is_hi_limb: bool,
     ) -> Result<(UIntLimbs<M, C, E>, UIntLimbs<M, C, E>), ZKVMError> {
         circuit_builder.namespace(name_fn, |cb| {
-            let c = self.internal_mul(cb, multiplier, with_overflow, is_hi_limb)?;
-            Ok((c.internal_add(cb, &addend.expr(), with_overflow)?, c))
+            let mul = cb.namespace(
+                || "mul",
+                |cb| self.internal_mul(cb, multiplier, with_overflow, is_hi_limb),
+            )?;
+            let add = cb.namespace(
+                || "add",
+                |cb| mul.internal_add(cb, &addend.expr(), with_overflow),
+            )?;
+            Ok((add, mul))
         })
     }
 


### PR DESCRIPTION
When looking at the constraint failure resulting from a `mul_add` for e.g. following:

```
AssertEqualError "riscv/srl/rs1_read = rd_written * pow2_rs2_low5 + remainder/require_equal/c_expr0"
Left: 33 != Right: 32
Left Expression: WitIn(11)
Right Expression: (1 * WitIn(7) + 0) * WitIn(3) + (-0x10000) * WitIn(13) + 0
Inst[1]:
  WitIn(3)=8 "riscv/srl/pow2_rs2_low5/limb_0"
  WitIn(7)=4 "riscv/srl/rd_written/limb_0"
  WitIn(11)=33 "riscv/srl/rs1_read = rd_written * pow2_rs2_low5 + remainder/c/limb_0"
  WitIn(13)=0 "riscv/srl/rs1_read = rd_written * pow2_rs2_low5 + remainder/mul_carry/carry_0"
```

This probably occurs due to incorrect assignment. However, it would be great if it also includes if it occurred in mul or add to easily locate the problem.