### PR TITLE
Fix a concurrency bug in the `mock_prover`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,6 +358,7 @@ dependencies = [
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "sumcheck",
+ "tempfile",
  "thread_local",
  "tracing",
  "tracing-flame",
@@ -708,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "ff"
@@ -1099,15 +1100,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -1738,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -2069,14 +2070,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2418,7 +2420,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2438,17 +2449,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2459,9 +2471,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2471,9 +2483,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2483,9 +2495,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2495,9 +2513,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2507,9 +2525,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2519,9 +2537,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2531,9 +2549,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wyz"

--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -33,6 +33,7 @@ rand = "0.8"
 thread_local = "1.1.8"
 generic_static = "0.2.0"
 clap = { version = "4.5.17", features = ["derive"] }
+tempfile = "3.13.0"
 
 [dev-dependencies]
 pprof = { version = "0.13", features = ["flamegraph"]}


### PR DESCRIPTION
While investigating our tests, I got occasional failures like the following:

```
        FAIL [   0.003s] ceno_zkvm scheme::mock_prover::tests::test_assert_zero_1

--- STDOUT:              ceno_zkvm scheme::mock_prover::tests::test_assert_zero_1 ---

running 1 test
test scheme::mock_prover::tests::test_assert_zero_1 ... FAILED

failures:

failures:
    scheme::mock_prover::tests::test_assert_zero_1

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 84 filtered out; finished in 0.00s

--- STDERR:              ceno_zkvm scheme::mock_prover::tests::test_assert_zero_1 ---
thread 'scheme::mock_prover::tests::test_assert_zero_1' panicked at ceno_zkvm/src/scheme/mock_prover.rs:291:49:
called `Result::unwrap()` on an `Err` value: Error("expected value", line: 1, column: 5713)
stack backtrace:
   0:     0x5b31b75639c5 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h83a98f6d5617789b
   1:     0x5b31b758a8ab - core::fmt::write::h880ae86840cfb66d
   2:     0x5b31b75612af - std::io::Write::write_fmt::h39b30cd087522a51
   3:     0x5b31b756379e - std::sys_common::backtrace::print::h5e0016a491d84c1d
   4:     0x5b31b7565119 - std::panicking::default_hook::{{closure}}::h0c2f75f7a65b5547
   5:     0x5b31b7564e5d - std::panicking::default_hook::h1284229a24b71c4c
   6:     0x5b31b75655b3 - std::panicking::rust_panic_with_hook::hca3ced3c46879131
   7:     0x5b31b7565494 - std::panicking::begin_panic_handler::{{closure}}::h4ff95bfaaee639b6
   8:     0x5b31b7563e89 - std::sys_common::backtrace::__rust_end_short_backtrace::h9ea6903d337d4498
   9:     0x5b31b75651c7 - rust_begin_unwind
  10:     0x5b31b728dd33 - core::panicking::panic_fmt::h766125e319de443c
  11:     0x5b31b728e1c6 - core::result::unwrap_failed::h942a9268418bbe17
  12:     0x5b31b7423e88 - once_cell::imp::OnceCell<T>::initialize::{{closure}}::hc1ee21766f98f3fc
  13:     0x5b31b753395c - once_cell::imp::initialize_or_wait::hdd8bf699e4c89212
  14:     0x5b31b7283792 - once_cell::imp::OnceCell<T>::initialize::hf44c7193bf21f43a
  15:     0x5b31b7477a67 - ceno_zkvm::scheme::mock_prover::MockProver<E>::run_maybe_challenge::hb12fdfee9f40754d
  16:     0x5b31b747a609 - ceno_zkvm::scheme::mock_prover::MockProver<E>::assert_satisfied::hcf9209e11d042a19
  17:     0x5b31b7480a22 - ceno_zkvm::scheme::mock_prover::tests::test_assert_zero_1::h1bb14ba97e93e8f6
  18:     0x5b31b749c809 - core::ops::function::FnOnce::call_once::he8a4303862ce2ecc
  19:     0x5b31b752688b - test::__rust_begin_short_backtrace::h0ba1545d31830bb8
  20:     0x5b31b7525f91 - test::run_test::{{closure}}::h4eaafd5cb0f565b7
  21:     0x5b31b74eeb64 - std::sys_common::backtrace::__rust_begin_short_backtrace::hb0fbd81a33fa2097
  22:     0x5b31b74f3532 - core::ops::function::FnOnce::call_once{{vtable.shim}}::h1b2e25513f007c23
  23:     0x5b31b7569a9b - std::sys::pal::unix::thread::Thread::new::thread_start::haf9a58ee26566211
  24:     0x714a9d82639d - <unknown>
  25:     0x714a9d8ab49c - <unknown>
  26:                0x0 - <unknown>
  ```

As far as I can tell, this was caused by a [time-of-check to time-of-use (TOCTOU)](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use)
issue in our code.  This PR fixes this.