### PR TITLE
Dummy Circuit - Basic ECALL

### DIFF
--- a/ceno_emul/src/lib.rs
+++ b/ceno_emul/src/lib.rs
@@ -11,7 +11,7 @@ mod vm_state;
 pub use vm_state::VMState;
 
 mod rv32im;
-pub use rv32im::{DecodedInstruction, EmuContext, InsnCodes, InsnFormat, InsnKind};
+pub use rv32im::{DecodedInstruction, EmuContext, InsnCategory, InsnCodes, InsnFormat, InsnKind};
 
 mod elf;
 pub use elf::Program;

--- a/ceno_emul/src/platform.rs
+++ b/ceno_emul/src/platform.rs
@@ -11,6 +11,8 @@ pub struct Platform {
     pub rom_end: Addr,
     pub ram_start: Addr,
     pub ram_end: Addr,
+    /// If true, ecall instructions are no-op instead of trap. Testing only.
+    pub unsafe_ecall_nop: bool,
 }
 
 pub const CENO_PLATFORM: Platform = Platform {
@@ -18,6 +20,7 @@ pub const CENO_PLATFORM: Platform = Platform {
     rom_end: 0x3000_0000 - 1,
     ram_start: 0x8000_0000,
     ram_end: 0xFFFF_FFFF,
+    unsafe_ecall_nop: false,
 };
 
 impl Platform {

--- a/ceno_emul/src/rv32im.rs
+++ b/ceno_emul/src/rv32im.rs
@@ -111,7 +111,7 @@ pub struct DecodedInstruction {
 }
 
 #[derive(Clone, Copy, Debug)]
-enum InsnCategory {
+pub enum InsnCategory {
     Compute,
     Branch,
     Load,
@@ -196,7 +196,7 @@ impl InsnKind {
 pub struct InsnCodes {
     pub format: InsnFormat,
     pub kind: InsnKind,
-    category: InsnCategory,
+    pub category: InsnCategory,
     pub(crate) opcode: u32,
     pub(crate) func3: u32,
     pub(crate) func7: u32,

--- a/ceno_emul/src/tracer.rs
+++ b/ceno_emul/src/tracer.rs
@@ -188,26 +188,26 @@ impl StepRecord {
         )
     }
 
-    /// Create a test record for an ECALL instruction that does NOP.
-    pub fn new_ecall_nop(
-        cycle: Cycle,
-        pc: ByteAddr,
-        ecall_id: Word,
-        previous_cycle: Cycle,
-    ) -> StepRecord {
-        StepRecord {
+    /// Create a test record for an ECALL instruction that can do anything.
+    pub fn new_ecall_any(cycle: Cycle, pc: ByteAddr) -> StepRecord {
+        let value = 1234;
+        Self::new_insn(
             cycle,
-            pc: Change::new(pc, pc + PC_STEP_SIZE),
-            insn_code: encode_rv32(InsnKind::EANY, 0, 0, 0, 0),
-            rs1: Some(ReadOp {
-                addr: CENO_PLATFORM.register_vma(CENO_PLATFORM.reg_ecall()).into(),
-                value: ecall_id,
-                previous_cycle,
+            Change::new(pc, pc + PC_STEP_SIZE),
+            encode_rv32(InsnKind::EANY, 0, 0, 0, 0),
+            Some(value),
+            Some(value),
+            Some(Change::new(value, value)),
+            Some(WriteOp {
+                addr: CENO_PLATFORM.ram_start().into(),
+                value: Change {
+                    before: value,
+                    after: value,
+                },
+                previous_cycle: 0,
             }),
-            rs2: None,
-            rd: None,
-            memory_op: None,
-        }
+            0,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/ceno_emul/src/tracer.rs
+++ b/ceno_emul/src/tracer.rs
@@ -188,28 +188,23 @@ impl StepRecord {
         )
     }
 
-    pub fn new_ecall_instruction(
+    /// Create a test record for an ECALL instruction that does NOP.
+    pub fn new_ecall_nop(
         cycle: Cycle,
         pc: ByteAddr,
         ecall_id: Word,
-        ecall_arg: Word,
         previous_cycle: Cycle,
     ) -> StepRecord {
-        let insn = DecodedInstruction::new(encode_rv32(InsnKind::EANY, 0, 0, 0, 0));
         StepRecord {
             cycle,
             pc: Change::new(pc, pc + PC_STEP_SIZE),
-            insn_code: insn.encoded(),
+            insn_code: encode_rv32(InsnKind::EANY, 0, 0, 0, 0),
             rs1: Some(ReadOp {
                 addr: CENO_PLATFORM.register_vma(CENO_PLATFORM.reg_ecall()).into(),
                 value: ecall_id,
                 previous_cycle,
             }),
-            rs2: Some(ReadOp {
-                addr: CENO_PLATFORM.register_vma(CENO_PLATFORM.reg_arg0()).into(),
-                value: ecall_arg,
-                previous_cycle,
-            }),
+            rs2: None,
             rd: None,
             memory_op: None,
         }

--- a/ceno_emul/src/vm_state.rs
+++ b/ceno_emul/src/vm_state.rs
@@ -117,15 +117,19 @@ impl EmuContext for VMState {
     // Expect an ecall to terminate the program: function HALT with argument exit_code.
     fn ecall(&mut self) -> Result<bool> {
         let function = self.load_register(self.platform.reg_ecall())?;
+        let arg0 = self.load_register(self.platform.reg_arg0())?;
         if function == self.platform.ecall_halt() {
-            let exit_code = self.load_register(self.platform.reg_arg0())?;
-            tracing::debug!("halt with exit_code={}", exit_code);
+            tracing::debug!("halt with exit_code={}", arg0);
 
             self.halt();
             Ok(true)
         } else if self.platform.unsafe_ecall_nop {
-            // Treat unknown ecalls as NOP.
+            // Treat unknown ecalls as all powerful instructions:
+            // Read two registers, write one register, write one memory word, and branch.
             tracing::warn!("ecall ignored: syscall_id={}", function);
+            self.store_register(DecodedInstruction::RD_NULL as RegIdx, 0)?;
+            let addr = self.platform.ram_start().into();
+            self.store_memory(addr, self.peek_memory(addr))?;
             self.set_pc(ByteAddr(self.pc) + PC_STEP_SIZE);
             Ok(true)
         } else {

--- a/ceno_emul/src/vm_state.rs
+++ b/ceno_emul/src/vm_state.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use super::rv32im::EmuContext;
 use crate::{
-    Program,
+    PC_STEP_SIZE, Program,
     addr::{ByteAddr, RegIdx, Word, WordAddr},
     platform::Platform,
     rv32im::{DecodedInstruction, Emulator, TrapCause},
@@ -122,6 +122,11 @@ impl EmuContext for VMState {
             tracing::debug!("halt with exit_code={}", exit_code);
 
             self.halt();
+            Ok(true)
+        } else if self.platform.unsafe_ecall_nop {
+            // Treat unknown ecalls as NOP.
+            tracing::warn!("ecall ignored: syscall_id={}", function);
+            self.set_pc(ByteAddr(self.pc) + PC_STEP_SIZE);
             Ok(true)
         } else {
             self.trap(TrapCause::EcallError)

--- a/ceno_zkvm/src/instructions/riscv.rs
+++ b/ceno_zkvm/src/instructions/riscv.rs
@@ -9,6 +9,7 @@ pub mod branch;
 pub mod config;
 pub mod constants;
 pub mod divu;
+pub mod dummy;
 pub mod ecall;
 pub mod jump;
 pub mod logic;

--- a/ceno_zkvm/src/instructions/riscv/divu.rs
+++ b/ceno_zkvm/src/instructions/riscv/divu.rs
@@ -4,6 +4,7 @@ use ff_ext::ExtensionField;
 use super::{
     RIVInstruction,
     constants::{UINT_LIMBS, UInt},
+    dummy::DummyInstruction,
     r_insn::RInstructionConfig,
 };
 use crate::{
@@ -33,11 +34,29 @@ pub struct ArithConfig<E: ExtensionField> {
 
 pub struct ArithInstruction<E, I>(PhantomData<(E, I)>);
 
+pub struct DivOp;
+impl RIVInstruction for DivOp {
+    const INST_KIND: InsnKind = InsnKind::DIV;
+}
+pub type DivDummy<E> = DummyInstruction<E, DivOp>; // TODO: implement DivInstruction.
+
 pub struct DivUOp;
 impl RIVInstruction for DivUOp {
     const INST_KIND: InsnKind = InsnKind::DIVU;
 }
 pub type DivUInstruction<E> = ArithInstruction<E, DivUOp>;
+
+pub struct RemOp;
+impl RIVInstruction for RemOp {
+    const INST_KIND: InsnKind = InsnKind::REM;
+}
+pub type RemDummy<E> = DummyInstruction<E, RemOp>; // TODO: implement RemInstruction.
+
+pub struct RemuOp;
+impl RIVInstruction for RemuOp {
+    const INST_KIND: InsnKind = InsnKind::REMU;
+}
+pub type RemuDummy<E> = DummyInstruction<E, RemuOp>; // TODO: implement RemuInstruction.
 
 impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ArithInstruction<E, I> {
     type InstructionConfig = ArithConfig<E>;

--- a/ceno_zkvm/src/instructions/riscv/dummy/dummy_circuit.rs
+++ b/ceno_zkvm/src/instructions/riscv/dummy/dummy_circuit.rs
@@ -67,19 +67,18 @@ impl<E: ExtensionField> DummyConfig<E> {
         circuit_builder: &mut CircuitBuilder<E>,
         codes: InsnCodes,
     ) -> Result<Self, ZKVMError> {
-        let (with_rs1, with_rs2, with_rd) = match (codes.format, codes.kind) {
-            (_, InsnKind::EANY) => (true, true, false),
-            (InsnFormat::R, _) => (true, true, true),
-            (InsnFormat::I, _) => (true, false, true),
-            (InsnFormat::S, _) => (true, true, false),
-            (InsnFormat::B, _) => (true, true, false),
-            (InsnFormat::U, _) => (false, false, true),
-            (InsnFormat::J, _) => (false, false, true),
+        let (with_rs1, with_rs2, with_rd) = match codes.format {
+            InsnFormat::R => (true, true, true),
+            InsnFormat::I => (true, false, true),
+            InsnFormat::S => (true, true, false),
+            InsnFormat::B => (true, true, false),
+            InsnFormat::U => (false, false, true),
+            InsnFormat::J => (false, false, true),
         };
         let with_mem_write = matches!(codes.category, InsnCategory::Store);
         let with_mem_read = matches!(codes.category, InsnCategory::Load);
         let branching = matches!(codes.category, InsnCategory::Branch)
-            || matches!(codes.kind, InsnKind::JAL | InsnKind::JALR | InsnKind::EANY);
+            || matches!(codes.kind, InsnKind::JAL | InsnKind::JALR);
 
         // State in and out
         let vm_state = StateInOut::construct_circuit(circuit_builder, branching)?;

--- a/ceno_zkvm/src/instructions/riscv/dummy/dummy_circuit.rs
+++ b/ceno_zkvm/src/instructions/riscv/dummy/dummy_circuit.rs
@@ -1,0 +1,238 @@
+use std::marker::PhantomData;
+
+use ceno_emul::{InsnCategory, InsnCodes, InsnFormat, InsnKind, StepRecord};
+use ff_ext::ExtensionField;
+
+use super::super::{
+    RIVInstruction,
+    constants::UInt,
+    insn_base::{ReadMEM, ReadRS1, ReadRS2, StateInOut, WriteMEM, WriteRD},
+};
+use crate::{
+    circuit_builder::CircuitBuilder,
+    error::ZKVMError,
+    expression::{ToExpr, WitIn},
+    instructions::Instruction,
+    set_val,
+    tables::InsnRecord,
+    uint::Value,
+    utils::i64_to_base,
+    witness::LkMultiplicity,
+};
+use core::mem::MaybeUninit;
+
+/// DummyInstruction can handle any instruction and produce its side-effects.
+pub struct DummyInstruction<E, I>(PhantomData<(E, I)>);
+
+impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for DummyInstruction<E, I> {
+    type InstructionConfig = DummyConfig<E>;
+
+    fn name() -> String {
+        format!("{:?}_DUMMY", I::INST_KIND)
+    }
+
+    fn construct_circuit(
+        circuit_builder: &mut CircuitBuilder<E>,
+    ) -> Result<Self::InstructionConfig, ZKVMError> {
+        DummyConfig::construct_circuit(circuit_builder, I::INST_KIND.codes())
+    }
+
+    fn assign_instance(
+        config: &Self::InstructionConfig,
+        instance: &mut [MaybeUninit<<E as ExtensionField>::BaseField>],
+        lk_multiplicity: &mut LkMultiplicity,
+        step: &StepRecord,
+    ) -> Result<(), ZKVMError> {
+        config.assign_instance(instance, lk_multiplicity, step)
+    }
+}
+
+#[derive(Debug)]
+pub struct DummyConfig<E: ExtensionField> {
+    vm_state: StateInOut<E>,
+
+    rs1: Option<(ReadRS1<E>, UInt<E>)>,
+    rs2: Option<(ReadRS2<E>, UInt<E>)>,
+    rd: Option<(WriteRD<E>, UInt<E>)>,
+
+    mem_addr_val: Option<[WitIn; 3]>,
+    mem_read: Option<ReadMEM<E>>,
+    mem_write: Option<WriteMEM>,
+
+    imm: WitIn,
+}
+
+impl<E: ExtensionField> DummyConfig<E> {
+    fn construct_circuit(
+        circuit_builder: &mut CircuitBuilder<E>,
+        codes: InsnCodes,
+    ) -> Result<Self, ZKVMError> {
+        let (with_rs1, with_rs2, with_rd) = match (codes.format, codes.kind) {
+            (_, InsnKind::EANY) => (true, true, false),
+            (InsnFormat::R, _) => (true, true, true),
+            (InsnFormat::I, _) => (true, false, true),
+            (InsnFormat::S, _) => (true, true, false),
+            (InsnFormat::B, _) => (true, true, false),
+            (InsnFormat::U, _) => (false, false, true),
+            (InsnFormat::J, _) => (false, false, true),
+        };
+        let with_mem_write = matches!(codes.category, InsnCategory::Store);
+        let with_mem_read = matches!(codes.category, InsnCategory::Load);
+        let branching = matches!(codes.category, InsnCategory::Branch)
+            || matches!(codes.kind, InsnKind::JAL | InsnKind::JALR | InsnKind::EANY);
+
+        // State in and out
+        let vm_state = StateInOut::construct_circuit(circuit_builder, branching)?;
+
+        // Registers
+        let rs1 = if with_rs1 {
+            let rs1_read = UInt::new_unchecked(|| "rs1_read", circuit_builder)?;
+            let rs1_op =
+                ReadRS1::construct_circuit(circuit_builder, rs1_read.register_expr(), vm_state.ts)?;
+            Some((rs1_op, rs1_read))
+        } else {
+            None
+        };
+
+        let rs2 = if with_rs2 {
+            let rs2_read = UInt::new_unchecked(|| "rs2_read", circuit_builder)?;
+            let rs2_op =
+                ReadRS2::construct_circuit(circuit_builder, rs2_read.register_expr(), vm_state.ts)?;
+            Some((rs2_op, rs2_read))
+        } else {
+            None
+        };
+
+        let rd = if with_rd {
+            let rd_written = UInt::new_unchecked(|| "rd_written", circuit_builder)?;
+            let rd_op = WriteRD::construct_circuit(
+                circuit_builder,
+                rd_written.register_expr(),
+                vm_state.ts,
+            )?;
+            Some((rd_op, rd_written))
+        } else {
+            None
+        };
+
+        // Memory
+        let mem_addr_val = if with_mem_read || with_mem_write {
+            Some([
+                circuit_builder.create_witin(|| "mem_addr"),
+                circuit_builder.create_witin(|| "mem_before"),
+                circuit_builder.create_witin(|| "mem_after"),
+            ])
+        } else {
+            None
+        };
+
+        let mem_read = if with_mem_read {
+            Some(ReadMEM::construct_circuit(
+                circuit_builder,
+                mem_addr_val.as_ref().unwrap()[0].expr(),
+                mem_addr_val.as_ref().unwrap()[1].expr(),
+                vm_state.ts,
+            )?)
+        } else {
+            None
+        };
+
+        let mem_write = if with_mem_write {
+            Some(WriteMEM::construct_circuit(
+                circuit_builder,
+                mem_addr_val.as_ref().unwrap()[0].expr(),
+                mem_addr_val.as_ref().unwrap()[1].expr(),
+                mem_addr_val.as_ref().unwrap()[2].expr(),
+                vm_state.ts,
+            )?)
+        } else {
+            None
+        };
+
+        // Fetch instruction
+
+        // Encode the register IDs
+        let rs1_id = match (&rs1, codes.kind) {
+            (None, _) | (_, InsnKind::EANY) => 0.into(),
+            (Some((r, _)), _) => r.id.expr(),
+        };
+        let rs2_id = match (&rs2, codes.kind) {
+            (None, _) | (_, InsnKind::EANY) => 0.into(),
+            (Some((r, _)), _) => r.id.expr(),
+        };
+
+        let imm = circuit_builder.create_witin(|| "imm");
+
+        circuit_builder.lk_fetch(&InsnRecord::new(
+            vm_state.pc.expr(),
+            codes.kind.into(),
+            rd.as_ref().map(|(r, _)| r.id.expr()),
+            rs1_id,
+            rs2_id,
+            imm.expr(),
+        ))?;
+
+        Ok(DummyConfig {
+            vm_state,
+            rs1,
+            rs2,
+            rd,
+            mem_addr_val,
+            mem_read,
+            mem_write,
+            imm,
+        })
+    }
+
+    fn assign_instance(
+        &self,
+        instance: &mut [MaybeUninit<<E as ExtensionField>::BaseField>],
+        lk_multiplicity: &mut LkMultiplicity,
+        step: &StepRecord,
+    ) -> Result<(), ZKVMError> {
+        // State in and out
+        self.vm_state.assign_instance(instance, step)?;
+
+        // Fetch instruction
+        lk_multiplicity.fetch(step.pc().before.0);
+
+        // Registers
+        if let Some((rs1_op, rs1_read)) = &self.rs1 {
+            rs1_op.assign_instance(instance, lk_multiplicity, step)?;
+
+            let rs1_val = Value::new_unchecked(step.rs1().expect("rs1 value").value);
+            rs1_read.assign_value(instance, rs1_val);
+        }
+        if let Some((rs2_op, rs2_read)) = &self.rs2 {
+            rs2_op.assign_instance(instance, lk_multiplicity, step)?;
+
+            let rs2_val = Value::new_unchecked(step.rs2().expect("rs2 value").value);
+            rs2_read.assign_value(instance, rs2_val);
+        }
+        if let Some((rd_op, rd_written)) = &self.rd {
+            rd_op.assign_instance(instance, lk_multiplicity, step)?;
+
+            let rd_val = Value::new_unchecked(step.rd().expect("rd value").value.after);
+            rd_written.assign_value(instance, rd_val);
+        }
+
+        // Memory
+        if let Some([mem_addr, mem_before, mem_after]) = &self.mem_addr_val {
+            let mem_op = step.memory_op().expect("memory operation");
+            set_val!(instance, mem_addr, u64::from(mem_op.addr));
+            set_val!(instance, mem_before, mem_op.value.before as u64);
+            set_val!(instance, mem_after, mem_op.value.after as u64);
+        }
+        if let Some(mem_read) = &self.mem_read {
+            mem_read.assign_instance(instance, lk_multiplicity, step)?;
+        }
+        if let Some(mem_write) = &self.mem_write {
+            mem_write.assign_instance::<E>(instance, lk_multiplicity, step)?;
+        }
+
+        let imm = i64_to_base::<E::BaseField>(InsnRecord::imm_internal(&step.insn()));
+        set_val!(instance, self.imm, imm);
+
+        Ok(())
+    }
+}

--- a/ceno_zkvm/src/instructions/riscv/dummy/mod.rs
+++ b/ceno_zkvm/src/instructions/riscv/dummy/mod.rs
@@ -1,0 +1,16 @@
+//! Dummy instruction circuits for testing.
+//! Support instructions that don’t have a complete implementation yet.
+//! It connects all the state together (register writes, etc), but does not verify the values.
+//!
+//! Usage:
+//! Specify an instruction with `trait RIVInstruction` and define a `DummyInstruction` like so:
+//!
+//!     use ceno_zkvm::instructions::riscv::{arith::AddOp, dummy::DummyInstruction};
+//!
+//!     type AddDummy<E> = DummyInstruction<E, AddOp>;
+
+mod dummy_circuit;
+pub use dummy_circuit::DummyInstruction;
+
+#[cfg(test)]
+mod test;

--- a/ceno_zkvm/src/instructions/riscv/dummy/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/dummy/test.rs
@@ -1,0 +1,101 @@
+use ceno_emul::{Change, InsnKind, StepRecord, encode_rv32};
+use goldilocks::GoldilocksExt2;
+
+use super::*;
+use crate::{
+    circuit_builder::{CircuitBuilder, ConstraintSystem},
+    instructions::{
+        Instruction,
+        riscv::{arith::AddOp, branch::BeqOp, ecall::EcallDummy},
+    },
+    scheme::mock_prover::{MOCK_PC_START, MockProver},
+};
+
+type AddDummy<E> = DummyInstruction<E, AddOp>;
+type BeqDummy<E> = DummyInstruction<E, BeqOp>;
+
+#[test]
+fn test_dummy_ecall() {
+    let mut cs = ConstraintSystem::<GoldilocksExt2>::new(|| "riscv");
+    let mut cb = CircuitBuilder::new(&mut cs);
+    let config = cb
+        .namespace(
+            || "ecall_dummy",
+            |cb| {
+                let config = EcallDummy::construct_circuit(cb);
+                Ok(config)
+            },
+        )
+        .unwrap()
+        .unwrap();
+
+    let step = StepRecord::new_ecall_instruction(4, MOCK_PC_START, 123, 456, 0);
+    let insn_code = step.insn_code();
+    let (raw_witin, lkm) =
+        EcallDummy::assign_instances(&config, cb.cs.num_witin as usize, vec![step]).unwrap();
+
+    MockProver::assert_satisfied_raw(&cb, raw_witin, &[insn_code], None, Some(lkm));
+}
+
+#[test]
+fn test_dummy_r() {
+    let mut cs = ConstraintSystem::<GoldilocksExt2>::new(|| "riscv");
+    let mut cb = CircuitBuilder::new(&mut cs);
+    let config = cb
+        .namespace(
+            || "add_dummy",
+            |cb| {
+                let config = AddDummy::construct_circuit(cb);
+                Ok(config)
+            },
+        )
+        .unwrap()
+        .unwrap();
+
+    let insn_code = encode_rv32(InsnKind::ADD, 2, 3, 4, 0);
+    let (raw_witin, lkm) = AddDummy::assign_instances(&config, cb.cs.num_witin as usize, vec![
+        StepRecord::new_r_instruction(
+            3,
+            MOCK_PC_START,
+            insn_code,
+            11,
+            0xfffffffe,
+            Change::new(0, 11_u32.wrapping_add(0xfffffffe)),
+            0,
+        ),
+    ])
+    .unwrap();
+
+    MockProver::assert_satisfied_raw(&cb, raw_witin, &[insn_code], None, Some(lkm));
+}
+
+#[test]
+fn test_dummy_b() {
+    let mut cs = ConstraintSystem::<GoldilocksExt2>::new(|| "riscv");
+    let mut cb = CircuitBuilder::new(&mut cs);
+    let config = cb
+        .namespace(
+            || "beq_dummy",
+            |cb| {
+                let config = BeqDummy::construct_circuit(cb);
+                Ok(config)
+            },
+        )
+        .unwrap()
+        .unwrap();
+
+    let insn_code = encode_rv32(InsnKind::BEQ, 2, 3, 0, 8);
+    let (raw_witin, lkm) = BeqDummy::assign_instances(&config, cb.cs.num_witin as usize, vec![
+        StepRecord::new_b_instruction(
+            3,
+            Change::new(MOCK_PC_START, MOCK_PC_START + 8_usize),
+            insn_code,
+            0xbead1010,
+            0xbead1010,
+            0,
+        ),
+    ])
+    .unwrap();
+
+    MockProver::assert_satisfied_raw(&cb, raw_witin, &[insn_code], None, Some(lkm));
+}

--- a/ceno_zkvm/src/instructions/riscv/dummy/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/dummy/test.rs
@@ -29,7 +29,7 @@ fn test_dummy_ecall() {
         .unwrap()
         .unwrap();
 
-    let step = StepRecord::new_ecall_instruction(4, MOCK_PC_START, 123, 456, 0);
+    let step = StepRecord::new_ecall_nop(4, MOCK_PC_START, 1234, 0);
     let insn_code = step.insn_code();
     let (raw_witin, lkm) =
         EcallDummy::assign_instances(&config, cb.cs.num_witin as usize, vec![step]).unwrap();

--- a/ceno_zkvm/src/instructions/riscv/dummy/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/dummy/test.rs
@@ -29,7 +29,7 @@ fn test_dummy_ecall() {
         .unwrap()
         .unwrap();
 
-    let step = StepRecord::new_ecall_nop(4, MOCK_PC_START, 1234, 0);
+    let step = StepRecord::new_ecall_any(4, MOCK_PC_START);
     let insn_code = step.insn_code();
     let (raw_witin, lkm) =
         EcallDummy::assign_instances(&config, cb.cs.num_witin as usize, vec![step]).unwrap();

--- a/ceno_zkvm/src/instructions/riscv/ecall.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall.rs
@@ -1,3 +1,13 @@
 mod halt;
 
+use ceno_emul::InsnKind;
 pub use halt::HaltInstruction;
+
+use super::{RIVInstruction, dummy::DummyInstruction};
+
+pub struct EcallOp;
+impl RIVInstruction for EcallOp {
+    const INST_KIND: InsnKind = InsnKind::EANY;
+}
+/// Unsafe. A dummy ecall circuit that ignores unimplemented functions.
+pub type EcallDummy<E> = DummyInstruction<E, EcallOp>;

--- a/ceno_zkvm/src/instructions/riscv/insn_base.rs
+++ b/ceno_zkvm/src/instructions/riscv/insn_base.rs
@@ -111,16 +111,15 @@ impl<E: ExtensionField> ReadRS1<E> {
         lk_multiplicity: &mut LkMultiplicity,
         step: &StepRecord,
     ) -> Result<(), ZKVMError> {
-        set_val!(instance, self.id, step.insn().rs1() as u64);
-
-        // Register state
-        set_val!(instance, self.prev_ts, step.rs1().unwrap().previous_cycle);
+        let op = step.rs1().expect("rs1 op");
+        set_val!(instance, self.id, op.register_index() as u64);
+        set_val!(instance, self.prev_ts, op.previous_cycle);
 
         // Register read
         self.lt_cfg.assign_instance(
             instance,
             lk_multiplicity,
-            step.rs1().unwrap().previous_cycle,
+            op.previous_cycle,
             step.cycle() + Tracer::SUBCYCLE_RS1,
         )?;
 
@@ -166,16 +165,15 @@ impl<E: ExtensionField> ReadRS2<E> {
         lk_multiplicity: &mut LkMultiplicity,
         step: &StepRecord,
     ) -> Result<(), ZKVMError> {
-        set_val!(instance, self.id, step.insn().rs2() as u64);
-
-        // Register state
-        set_val!(instance, self.prev_ts, step.rs2().unwrap().previous_cycle);
+        let op = step.rs2().expect("rs2 op");
+        set_val!(instance, self.id, op.register_index() as u64);
+        set_val!(instance, self.prev_ts, op.previous_cycle);
 
         // Register read
         self.lt_cfg.assign_instance(
             instance,
             lk_multiplicity,
-            step.rs2().unwrap().previous_cycle,
+            op.previous_cycle,
             step.cycle() + Tracer::SUBCYCLE_RS2,
         )?;
 
@@ -223,20 +221,21 @@ impl<E: ExtensionField> WriteRD<E> {
         lk_multiplicity: &mut LkMultiplicity,
         step: &StepRecord,
     ) -> Result<(), ZKVMError> {
-        set_val!(instance, self.id, step.insn().rd_internal() as u64);
-        set_val!(instance, self.prev_ts, step.rd().unwrap().previous_cycle);
+        let op = step.rd().expect("rd op");
+        set_val!(instance, self.id, op.register_index() as u64);
+        set_val!(instance, self.prev_ts, op.previous_cycle);
 
         // Register state
         self.prev_value.assign_limbs(
             instance,
-            Value::new_unchecked(step.rd().unwrap().value.before).as_u16_limbs(),
+            Value::new_unchecked(op.value.before).as_u16_limbs(),
         );
 
         // Register write
         self.lt_cfg.assign_instance(
             instance,
             lk_multiplicity,
-            step.rd().unwrap().previous_cycle,
+            op.previous_cycle,
             step.cycle() + Tracer::SUBCYCLE_RD,
         )?;
 


### PR DESCRIPTION
_Issue #359 and #567_

* The `DummyInstruction` implements all the communications of a step: state, fetch, registers, memory. But it does not verify calculations: any value can be written out.

* Placeholder circuits for missing implementations, including unknown ecalls.

* More precise register op assignment, see #570.