### PR TITLE
Run benchmarks in CI/CD and fix them

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,4 +63,10 @@ jobs:
       - name: run test
         env:
           TARGET: ${{ matrix.target }}
-        run: cargo make tests
+        run: |
+          cargo make tests
+      - name: run benchmarks
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          cargo bench --workspace --exclude ceno_rt --exclude singer-pro

--- a/mpcs/benches/hashing.rs
+++ b/mpcs/benches/hashing.rs
@@ -2,13 +2,12 @@ use ark_std::test_rng;
 use criterion::{criterion_group, criterion_main, Criterion};
 use ff::Field;
 use goldilocks::Goldilocks;
-use mpcs::util::hash::{hash_two_digests, new_hasher, Digest, DIGEST_WIDTH};
+use mpcs::util::hash::{hash_two_digests, Digest};
 
 fn random_ceno_goldy() -> Goldilocks {
     Goldilocks::random(&mut test_rng())
 }
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let hasher = new_hasher();
     let left = Digest(
         vec![Goldilocks::random(&mut test_rng()); 4]
             .try_into()
@@ -20,10 +19,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             .unwrap(),
     );
     c.bench_function("ceno hash 2 to 1", |bencher| {
-        bencher.iter(|| hash_two_digests(&left, &right, &hasher))
+        bencher.iter(|| hash_two_digests(&left, &right))
     });
 
-    let mut hasher = new_hasher();
     let values = (0..60)
         .map(|_| Goldilocks::random(&mut test_rng()))
         .collect::<Vec<_>>();

--- a/mpcs/benches/hashing.rs
+++ b/mpcs/benches/hashing.rs
@@ -3,10 +3,8 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use ff::Field;
 use goldilocks::Goldilocks;
 use mpcs::util::hash::{hash_two_digests, Digest};
+use poseidon::poseidon_hash::PoseidonHash;
 
-fn random_ceno_goldy() -> Goldilocks {
-    Goldilocks::random(&mut test_rng())
-}
 pub fn criterion_benchmark(c: &mut Criterion) {
     let left = Digest(
         vec![Goldilocks::random(&mut test_rng()); 4]
@@ -27,8 +25,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         .collect::<Vec<_>>();
     c.bench_function("ceno hash 60 to 1", |bencher| {
         bencher.iter(|| {
-            hasher.update(values.as_slice());
-            let result = &hasher.squeeze_vec()[0..DIGEST_WIDTH];
+            PoseidonHash::hash_or_noop(&values);
         })
     });
 }


### PR DESCRIPTION
https://github.com/scroll-tech/ceno/pull/325 broke `mpcs/benches/hashing.rs` as far as I can tell.  Here is the start of an attempt to fix it.

@dreamATD @yczhangsjtu Please take over as you worked on the PR I mentioned and I'm not quite sure how to actually fix that benchmark.  Thanks!  Feel free to push to this PR's git branch.

For an alternative that just reverts the offending commit for now, see https://github.com/scroll-tech/ceno/pull/375.