### PR TITLE
Revert "feat: integrate poseidon port into mpcs + transcript (#325)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,6 @@ version = "0.1.0"
 dependencies = [
  "ff",
  "goldilocks",
- "poseidon",
  "serde",
 ]
 
@@ -1196,7 +1195,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "plonky2",
- "poseidon",
+ "poseidon 0.2.0",
  "rand",
  "rand_chacha",
  "rayon",
@@ -1504,6 +1503,15 @@ dependencies = [
  "rand",
  "serde",
  "unroll",
+]
+
+[[package]]
+name = "poseidon"
+version = "0.2.0"
+source = "git+https://github.com/zhenfeizhang/poseidon#e32c0c18a70a4e00644e81e86b5729fe176831c8"
+dependencies = [
+ "halo2curves 0.1.0",
+ "subtle",
 ]
 
 [[package]]
@@ -2236,7 +2244,7 @@ dependencies = [
  "ff_ext",
  "goldilocks",
  "halo2curves 0.1.0",
- "poseidon",
+ "poseidon 0.2.0",
  "rayon",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 ff = "0.13"
 goldilocks = { git = "https://github.com/zhenfeizhang/Goldilocks" }
 halo2curves = "0.1.0"
-poseidon = { path = "./poseidon" }
+poseidon = { git = "https://github.com/zhenfeizhang/poseidon" }
 serde = { version = "1.0", features = ["derive"] }
 subtle = "2.6.1"
 rand_core = "0.6.4"

--- a/ff_ext/Cargo.toml
+++ b/ff_ext/Cargo.toml
@@ -10,4 +10,3 @@ license.workspace = true
 serde.workspace = true
 goldilocks.workspace = true
 ff.workspace = true
-poseidon.workspace = true

--- a/ff_ext/src/lib.rs
+++ b/ff_ext/src/lib.rs
@@ -3,7 +3,6 @@ use ff::FromUniformBytes;
 use goldilocks::SmallField;
 use serde::Serialize;
 use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
-use poseidon::poseidon::Poseidon;
 
 pub trait ExtensionField:
     Serialize
@@ -24,7 +23,7 @@ pub trait ExtensionField:
 {
     const DEGREE: usize;
 
-    type BaseField: SmallField + FromUniformBytes<64> + Poseidon;
+    type BaseField: SmallField + FromUniformBytes<64>;
 
     fn from_bases(bases: &[Self::BaseField]) -> Self;
 

--- a/mpcs/src/basefold.rs
+++ b/mpcs/src/basefold.rs
@@ -10,7 +10,7 @@ use crate::{
         },
         expression::{Expression, Query, Rotation},
         ext_to_usize,
-        hash::{write_digest_to_transcript, Digest},
+        hash::{new_hasher, write_digest_to_transcript, Digest},
         log2_strict,
         merkle_tree::MerkleTree,
         multiply_poly,
@@ -318,13 +318,14 @@ where
         };
 
         // 2. Compute and store all the layers of the Merkle tree
+        let hasher = new_hasher::<E::BaseField>();
 
         // 1. Encode the polynomials. Simultaneously get:
         //  (1) The evaluations over the hypercube (just a clone of the input)
         //  (2) The encoding of the coefficient vector (need an interpolation)
         let ret = match Self::get_poly_bh_evals_and_codeword(pp, poly) {
             PolyEvalsCodeword::Normal((bh_evals, codeword)) => {
-                let codeword_tree = MerkleTree::<E>::from_leaves(codeword);
+                let codeword_tree = MerkleTree::<E>::from_leaves(codeword, &hasher);
 
                 // All these values are stored in the `CommitmentWithData` because
                 // they are useful in opening, and we don't want to recompute them.
@@ -337,7 +338,7 @@ where
                 })
             }
             PolyEvalsCodeword::TooSmall(evals) => {
-                let codeword_tree = MerkleTree::<E>::from_leaves(evals.clone());
+                let codeword_tree = MerkleTree::<E>::from_leaves(evals.clone(), &hasher);
 
                 // All these values are stored in the `CommitmentWithData` because
                 // they are useful in opening, and we don't want to recompute them.
@@ -399,6 +400,8 @@ where
         end_timer!(encode_timer);
 
         // build merkle tree from leaves
+        let hasher = new_hasher::<E::BaseField>();
+
         let ret = match evals_codewords[0] {
             PolyEvalsCodeword::Normal(_) => {
                 let (bh_evals, codewords) = evals_codewords
@@ -413,7 +416,7 @@ where
                         }
                     })
                     .collect::<(Vec<_>, Vec<_>)>();
-                let codeword_tree = MerkleTree::<E>::from_batch_leaves(codewords);
+                let codeword_tree = MerkleTree::<E>::from_batch_leaves(codewords, &hasher);
                 Self::CommitmentWithData {
                     codeword_tree,
                     polynomials_bh_evals: bh_evals,
@@ -433,7 +436,7 @@ where
                         }
                     })
                     .collect::<Vec<_>>();
-                let codeword_tree = MerkleTree::<E>::from_batch_leaves(bh_evals.clone());
+                let codeword_tree = MerkleTree::<E>::from_batch_leaves(bh_evals.clone(), &hasher);
                 Self::CommitmentWithData {
                     codeword_tree,
                     polynomials_bh_evals: bh_evals,
@@ -473,6 +476,7 @@ where
         _eval: &E, // Opening does not need eval, except for sanity check
         transcript: &mut Transcript<E>,
     ) -> Result<Self::Proof, Error> {
+        let hasher = new_hasher::<E::BaseField>();
         let timer = start_timer!(|| "Basefold::open");
 
         // The encoded polynomial should at least have the number of
@@ -502,6 +506,7 @@ where
             transcript,
             poly.num_vars,
             poly.num_vars - Spec::get_basecode_msg_size_log(),
+            &hasher,
         );
 
         // 2. Query phase. ---------------------------------------
@@ -553,6 +558,7 @@ where
         evals: &[Evaluation<E>],
         transcript: &mut Transcript<E>,
     ) -> Result<Self::Proof, Error> {
+        let hasher = new_hasher::<E::BaseField>();
         let timer = start_timer!(|| "Basefold::batch_open");
         let num_vars = polys.iter().map(|poly| poly.num_vars).max().unwrap();
         let min_num_vars = polys.iter().map(|p| p.num_vars).min().unwrap();
@@ -728,6 +734,7 @@ where
             num_vars,
             num_vars - Spec::get_basecode_msg_size_log(),
             coeffs.as_slice(),
+            &hasher,
         );
 
         let query_timer = start_timer!(|| "Basefold::batch_open query phase");
@@ -775,6 +782,7 @@ where
         evals: &[E],
         transcript: &mut Transcript<E>,
     ) -> Result<Self::Proof, Error> {
+        let hasher = new_hasher::<E::BaseField>();
         let timer = start_timer!(|| "Basefold::batch_open");
         let num_vars = polys[0].num_vars();
 
@@ -824,6 +832,7 @@ where
             transcript,
             num_vars,
             num_vars - Spec::get_basecode_msg_size_log(),
+            &hasher,
         );
 
         let query_timer = start_timer!(|| "Basefold::open::query_phase");
@@ -862,10 +871,11 @@ where
         transcript: &mut Transcript<E>,
     ) -> Result<(), Error> {
         let timer = start_timer!(|| "Basefold::verify");
+        let hasher = new_hasher::<E::BaseField>();
 
         if proof.is_trivial() {
             let trivial_proof = &proof.trivial_proof;
-            let merkle_tree = MerkleTree::from_batch_leaves(trivial_proof.clone());
+            let merkle_tree = MerkleTree::from_batch_leaves(trivial_proof.clone(), &hasher);
             if comm.root() == merkle_tree.root() {
                 return Ok(());
             } else {
@@ -933,6 +943,7 @@ where
             comm,
             eq.as_slice(),
             eval,
+            &hasher,
         );
         end_timer!(timer);
 
@@ -950,6 +961,7 @@ where
         let timer = start_timer!(|| "Basefold::batch_verify");
         // 	let key = "RAYON_NUM_THREADS";
         // 	env::set_var(key, "32");
+        let hasher = new_hasher::<E::BaseField>();
         let comms = comms.iter().collect_vec();
         let num_vars = points.iter().map(|point| point.len()).max().unwrap();
         let num_rounds = num_vars - Spec::get_basecode_msg_size_log();
@@ -1061,6 +1073,7 @@ where
             &coeffs,
             eq.as_slice(),
             &new_target_sum,
+            &hasher,
         );
         end_timer!(timer);
         Ok(())
@@ -1079,10 +1092,11 @@ where
         if let Some(num_polys) = comm.num_polys {
             assert_eq!(num_polys, batch_size);
         }
+        let hasher = new_hasher::<E::BaseField>();
 
         if proof.is_trivial() {
             let trivial_proof = &proof.trivial_proof;
-            let merkle_tree = MerkleTree::from_batch_leaves(trivial_proof.clone());
+            let merkle_tree = MerkleTree::from_batch_leaves(trivial_proof.clone(), &hasher);
             if comm.root() == merkle_tree.root() {
                 return Ok(());
             } else {
@@ -1161,6 +1175,7 @@ where
             comm,
             eq.as_slice(),
             evals,
+            &hasher,
         );
         end_timer!(timer);
 

--- a/mpcs/src/util/hash.rs
+++ b/mpcs/src/util/hash.rs
@@ -1,11 +1,16 @@
+// use std::iter::repeat;
+
 use ff_ext::ExtensionField;
 use goldilocks::SmallField;
-use poseidon::poseidon_hash::PoseidonHash;
+use poseidon::Poseidon;
 
+use serde::{Deserialize, Serialize};
 use transcript::Transcript;
 
-pub use poseidon::digest::Digest;
-use poseidon::poseidon::Poseidon;
+pub const DIGEST_WIDTH: usize = transcript::basic::OUTPUT_WIDTH;
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Digest<F: SmallField + Serialize>(pub [F; DIGEST_WIDTH]);
+pub type Hasher<F> = Poseidon<F, 12, 11>;
 
 pub fn write_digest_to_transcript<E: ExtensionField>(
     digest: &Digest<E::BaseField>,
@@ -17,33 +22,129 @@ pub fn write_digest_to_transcript<E: ExtensionField>(
         .for_each(|x| transcript.append_field_element(x));
 }
 
-pub fn hash_two_leaves_ext<E: ExtensionField>(a: &E, b: &E) -> Digest<E::BaseField> {
-    let input = [a.as_bases(), b.as_bases()].concat();
-    PoseidonHash::hash_or_noop(&input)
+pub fn new_hasher<F: SmallField>() -> Hasher<F> {
+    // FIXME: Change to the right parameter
+    Hasher::<F>::new(8, 22)
+}
+
+pub fn hash_two_leaves_ext<E: ExtensionField>(
+    a: &E,
+    b: &E,
+    hasher: &Hasher<E::BaseField>,
+) -> Digest<E::BaseField> {
+    let mut hasher = hasher.clone();
+    hasher.update(a.as_bases());
+    hasher.update(b.as_bases());
+    let result = hasher.squeeze_vec()[0..DIGEST_WIDTH].try_into().unwrap();
+    Digest(result)
 }
 
 pub fn hash_two_leaves_base<E: ExtensionField>(
     a: &E::BaseField,
     b: &E::BaseField,
+    hasher: &Hasher<E::BaseField>,
 ) -> Digest<E::BaseField> {
-    PoseidonHash::hash_or_noop(&[*a, *b])
+    let mut hasher = hasher.clone();
+    hasher.update(&[*a]);
+    hasher.update(&[*b]);
+    let result = hasher.squeeze_vec()[0..DIGEST_WIDTH].try_into().unwrap();
+    Digest(result)
 }
 
-pub fn hash_two_leaves_batch_ext<E: ExtensionField>(a: &[E], b: &[E]) -> Digest<E::BaseField> {
-    let a_m_to_1_hash = PoseidonHash::hash_or_noop_iter(a.iter().flat_map(|v| v.as_bases()));
-    let b_m_to_1_hash = PoseidonHash::hash_or_noop_iter(b.iter().flat_map(|v| v.as_bases()));
-    hash_two_digests(&a_m_to_1_hash, &b_m_to_1_hash)
+pub fn hash_two_leaves_batch_ext<E: ExtensionField>(
+    a: &[E],
+    b: &[E],
+    hasher: &Hasher<E::BaseField>,
+) -> Digest<E::BaseField> {
+    let mut left_hasher = hasher.clone();
+    a.iter().for_each(|a| left_hasher.update(a.as_bases()));
+    let left = Digest(
+        left_hasher.squeeze_vec()[0..DIGEST_WIDTH]
+            .try_into()
+            .unwrap(),
+    );
+
+    let mut right_hasher = hasher.clone();
+    b.iter().for_each(|b| right_hasher.update(b.as_bases()));
+    let right = Digest(
+        right_hasher.squeeze_vec()[0..DIGEST_WIDTH]
+            .try_into()
+            .unwrap(),
+    );
+
+    hash_two_digests(&left, &right, hasher)
 }
 
 pub fn hash_two_leaves_batch_base<E: ExtensionField>(
     a: &[E::BaseField],
     b: &[E::BaseField],
+    hasher: &Hasher<E::BaseField>,
 ) -> Digest<E::BaseField> {
-    let a_m_to_1_hash = PoseidonHash::hash_or_noop_iter(a.iter());
-    let b_m_to_1_hash = PoseidonHash::hash_or_noop_iter(b.iter());
-    hash_two_digests(&a_m_to_1_hash, &b_m_to_1_hash)
+    let mut left_hasher = hasher.clone();
+    left_hasher.update(a);
+    let left = Digest(
+        left_hasher.squeeze_vec()[0..DIGEST_WIDTH]
+            .try_into()
+            .unwrap(),
+    );
+
+    let mut right_hasher = hasher.clone();
+    right_hasher.update(b);
+    let right = Digest(
+        right_hasher.squeeze_vec()[0..DIGEST_WIDTH]
+            .try_into()
+            .unwrap(),
+    );
+
+    hash_two_digests(&left, &right, hasher)
 }
 
-pub fn hash_two_digests<F: SmallField + Poseidon>(a: &Digest<F>, b: &Digest<F>) -> Digest<F> {
-    PoseidonHash::two_to_one(a, b)
+pub fn hash_two_digests<F: SmallField>(
+    a: &Digest<F>,
+    b: &Digest<F>,
+    hasher: &Hasher<F>,
+) -> Digest<F> {
+    let mut hasher = hasher.clone();
+    hasher.update(a.0.as_slice());
+    hasher.update(b.0.as_slice());
+    let result = hasher.squeeze_vec()[0..DIGEST_WIDTH].try_into().unwrap();
+    Digest(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_std::{end_timer, start_timer, test_rng};
+    use ff::Field;
+    use goldilocks::Goldilocks;
+
+    use super::*;
+
+    #[test]
+    fn benchmark_hashing() {
+        let rng = test_rng();
+        let timer = start_timer!(|| "Timing hash initialization");
+        let mut hasher = new_hasher::<Goldilocks>();
+        end_timer!(timer);
+
+        let element = Goldilocks::random(rng);
+
+        let timer = start_timer!(|| "Timing hash update");
+        for _ in 0..10000 {
+            hasher.update(&[element]);
+        }
+        end_timer!(timer);
+
+        let timer = start_timer!(|| "Timing hash squeeze");
+        for _ in 0..10000 {
+            hasher.squeeze_vec();
+        }
+        end_timer!(timer);
+
+        let timer = start_timer!(|| "Timing hash update squeeze");
+        for _ in 0..10000 {
+            hasher.update(&[element]);
+            hasher.squeeze_vec();
+        }
+        end_timer!(timer);
+    }
 }

--- a/poseidon/src/digest.rs
+++ b/poseidon/src/digest.rs
@@ -1,8 +1,7 @@
 use crate::constants::DIGEST_WIDTH;
 use goldilocks::SmallField;
-use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct Digest<F: SmallField>(pub [F; DIGEST_WIDTH]);
 
 impl<F: SmallField> TryFrom<Vec<F>> for Digest<F> {

--- a/poseidon/src/lib.rs
+++ b/poseidon/src/lib.rs
@@ -1,8 +1,6 @@
-extern crate core;
-
 pub(crate) mod constants;
 pub mod digest;
-pub mod poseidon;
+pub(crate) mod poseidon;
 mod poseidon_goldilocks;
 pub mod poseidon_hash;
 pub mod poseidon_permutation;

--- a/poseidon/src/poseidon_hash.rs
+++ b/poseidon/src/poseidon_hash.rs
@@ -1,50 +1,25 @@
 use crate::{
-    constants::{DIGEST_WIDTH, SPONGE_RATE},
+    constants::{DIGEST_WIDTH, SPONGE_RATE, SPONGE_WIDTH},
     digest::Digest,
-    poseidon::Poseidon,
+    poseidon::{AdaptedField, Poseidon},
     poseidon_permutation::PoseidonPermutation,
 };
 
 pub struct PoseidonHash;
 
 impl PoseidonHash {
-    pub fn two_to_one<F: Poseidon>(left: &Digest<F>, right: &Digest<F>) -> Digest<F> {
+    pub fn two_to_one<F: Poseidon + AdaptedField>(
+        left: &Digest<F>,
+        right: &Digest<F>,
+    ) -> Digest<F> {
         compress(left, right)
     }
 
-    pub fn hash_or_noop<F: Poseidon>(inputs: &[F]) -> Digest<F> {
+    pub fn hash_or_noop<F: Poseidon + AdaptedField>(inputs: &[F]) -> Digest<F> {
         if inputs.len() <= DIGEST_WIDTH {
             Digest::from_partial(inputs)
         } else {
             hash_n_to_hash_no_pad(inputs)
-        }
-    }
-
-    pub fn hash_or_noop_iter<'a, F: Poseidon, I: Iterator<Item = &'a F>>(
-        mut input_iter: I,
-    ) -> Digest<F> {
-        let mut initial_elements = Vec::with_capacity(DIGEST_WIDTH);
-
-        for _ in 0..DIGEST_WIDTH + 1 {
-            match input_iter.next() {
-                Some(value) => initial_elements.push(value),
-                None => break,
-            }
-        }
-
-        if initial_elements.len() <= DIGEST_WIDTH {
-            Digest::from_partial(
-                initial_elements
-                    .into_iter()
-                    .copied()
-                    .collect::<Vec<F>>()
-                    .as_slice(),
-            )
-        } else {
-            let iter = initial_elements.into_iter().chain(input_iter);
-            hash_n_to_m_no_pad_iter(iter, DIGEST_WIDTH)
-                .try_into()
-                .unwrap()
         }
     }
 }
@@ -74,43 +49,16 @@ pub fn hash_n_to_m_no_pad<F: Poseidon>(inputs: &[F], num_outputs: usize) -> Vec<
     }
 }
 
-pub fn hash_n_to_m_no_pad_iter<'a, F: Poseidon, I: Iterator<Item = &'a F>>(
-    mut input_iter: I,
-    num_outputs: usize,
-) -> Vec<F> {
-    let mut perm = PoseidonPermutation::new(core::iter::repeat(F::ZERO));
-
-    // Absorb all input chunks.
-    loop {
-        let chunk = input_iter.by_ref().take(SPONGE_RATE).collect::<Vec<_>>();
-        if chunk.is_empty() {
-            break;
-        }
-        // Overwrite the first r elements with the inputs. This differs from a standard sponge,
-        // where we would xor or add in the inputs. This is a well-known variant, though,
-        // sometimes called "overwrite mode".
-        perm.set_from_slice(chunk.into_iter().copied().collect::<Vec<F>>().as_slice(), 0);
-        perm.permute();
-    }
-
-    // Squeeze until we have the desired number of outputs
-    let mut outputs = Vec::with_capacity(num_outputs);
-    loop {
-        for &item in perm.squeeze() {
-            outputs.push(item);
-            if outputs.len() == num_outputs {
-                return outputs;
-            }
-        }
-        perm.permute();
-    }
-}
-
 pub fn hash_n_to_hash_no_pad<F: Poseidon>(inputs: &[F]) -> Digest<F> {
     hash_n_to_m_no_pad(inputs, DIGEST_WIDTH).try_into().unwrap()
 }
 
 pub fn compress<F: Poseidon>(x: &Digest<F>, y: &Digest<F>) -> Digest<F> {
+    debug_assert!(SPONGE_RATE >= DIGEST_WIDTH);
+    debug_assert!(SPONGE_WIDTH >= 2 * DIGEST_WIDTH);
+    debug_assert_eq!(x.elements().len(), DIGEST_WIDTH);
+    debug_assert_eq!(y.elements().len(), DIGEST_WIDTH);
+
     let mut perm = PoseidonPermutation::new(core::iter::repeat(F::ZERO));
     perm.set_from_slice(x.elements(), 0);
     perm.set_from_slice(y.elements(), DIGEST_WIDTH);
@@ -179,9 +127,7 @@ mod tests {
             let (plonky_elems, ceno_elems) = test_vector_pair(n);
             let plonky_out = PlonkyPoseidonHash::hash_or_noop(plonky_elems.as_slice());
             let ceno_out = PoseidonHash::hash_or_noop(ceno_elems.as_slice());
-            let ceno_iter = PoseidonHash::hash_or_noop_iter(ceno_elems.iter());
             assert!(compare_hash_output(plonky_out, ceno_out));
-            assert!(compare_hash_output(plonky_out, ceno_iter));
         }
     }
 
@@ -193,9 +139,7 @@ mod tests {
             let (plonky_elems, ceno_elems) = test_vector_pair(n);
             let plonky_out = PlonkyPoseidonHash::hash_or_noop(plonky_elems.as_slice());
             let ceno_out = PoseidonHash::hash_or_noop(ceno_elems.as_slice());
-            let ceno_iter = PoseidonHash::hash_or_noop_iter(ceno_elems.iter());
             assert!(compare_hash_output(plonky_out, ceno_out));
-            assert!(compare_hash_output(plonky_out, ceno_iter));
         }
     }
 

--- a/poseidon/src/poseidon_permutation.rs
+++ b/poseidon/src/poseidon_permutation.rs
@@ -3,7 +3,6 @@ use crate::{
     poseidon::Poseidon,
 };
 
-#[derive(Clone)]
 pub struct PoseidonPermutation<T: Poseidon> {
     state: [T; SPONGE_WIDTH],
 }
@@ -27,7 +26,7 @@ impl<T: Poseidon> PoseidonPermutation<T> {
     /// Set state element `i` to be `elts[i] for i =
     /// start_idx..start_idx + n` where `n = min(elts.len(),
     /// WIDTH-start_idx)`. Panics if `start_idx > SPONGE_WIDTH`.
-    pub fn set_from_slice(&mut self, elts: &[T], start_idx: usize) {
+    pub(crate) fn set_from_slice(&mut self, elts: &[T], start_idx: usize) {
         let begin = start_idx;
         let end = start_idx + elts.len();
         self.state[begin..end].copy_from_slice(elts)

--- a/transcript/Cargo.toml
+++ b/transcript/Cargo.toml
@@ -13,6 +13,6 @@ ark-std.workspace = true
 ff.workspace = true
 goldilocks.workspace = true
 halo2curves.workspace = true
+poseidon.workspace = true
 rayon.workspace = true
 serde.workspace = true
-poseidon.workspace = true


### PR DESCRIPTION
This reverts commit a9cd14361c8729a39cc52626d3151598358b0c29 from https://github.com/scroll-tech/ceno/pull/325, because that commit/PR broke `mpcs/benches/hashing.rs`.

Please feel free to re-submit a fixed version of that PR.

This is an alternative to https://github.com/scroll-tech/ceno/pull/374