### PR TITLE
refactor instruction config structs

### DIFF
--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -105,7 +105,7 @@ fn main() {
     let mut zkvm_cs = ZKVMConstraintSystem::default();
     // opcode circuits
     let add_config = zkvm_cs.register_opcode_circuit::<AddInstruction<E>>();
-    let bltu_config = zkvm_cs.register_opcode_circuit::<BltuInstruction>();
+    let bltu_config = zkvm_cs.register_opcode_circuit::<BltuInstruction<E>>();
     let jal_config = zkvm_cs.register_opcode_circuit::<JalInstruction<E>>();
     let halt_config = zkvm_cs.register_opcode_circuit::<HaltInstruction<E>>();
     // tables
@@ -122,7 +122,7 @@ fn main() {
         .collect();
     let mut zkvm_fixed_traces = ZKVMFixedTraces::default();
     zkvm_fixed_traces.register_opcode_circuit::<AddInstruction<E>>(&zkvm_cs);
-    zkvm_fixed_traces.register_opcode_circuit::<BltuInstruction>(&zkvm_cs);
+    zkvm_fixed_traces.register_opcode_circuit::<BltuInstruction<E>>(&zkvm_cs);
     zkvm_fixed_traces.register_opcode_circuit::<JalInstruction<E>>(&zkvm_cs);
     zkvm_fixed_traces.register_opcode_circuit::<HaltInstruction<E>>(&zkvm_cs);
 
@@ -213,7 +213,7 @@ fn main() {
             .assign_opcode_circuit::<AddInstruction<E>>(&zkvm_cs, &add_config, add_records)
             .unwrap();
         zkvm_witness
-            .assign_opcode_circuit::<BltuInstruction>(&zkvm_cs, &bltu_config, bltu_records)
+            .assign_opcode_circuit::<BltuInstruction<E>>(&zkvm_cs, &bltu_config, bltu_records)
             .unwrap();
         zkvm_witness
             .assign_opcode_circuit::<JalInstruction<E>>(&zkvm_cs, &jal_config, jal_records)

--- a/ceno_zkvm/src/instructions/riscv.rs
+++ b/ceno_zkvm/src/instructions/riscv.rs
@@ -29,6 +29,6 @@ mod s_insn;
 #[cfg(test)]
 mod test;
 
-pub trait RIVInstruction {
+pub trait RIVInstruction: Send + Sync {
     const INST_KIND: InsnKind;
 }

--- a/ceno_zkvm/src/instructions/riscv/arith.rs
+++ b/ceno_zkvm/src/instructions/riscv/arith.rs
@@ -15,15 +15,15 @@ use core::mem::MaybeUninit;
 
 /// This config handles R-Instructions that represent registers values as 2 * u16.
 #[derive(Debug)]
-pub struct ArithConfig<E: ExtensionField> {
+pub struct ArithInstruction<E: ExtensionField, I: RIVInstruction> {
     r_insn: RInstructionConfig<E>,
 
     rs1_read: UInt<E>,
     rs2_read: UInt<E>,
     rd_written: UInt<E>,
-}
 
-pub struct ArithInstruction<E, I>(PhantomData<(E, I)>);
+    _phantom: PhantomData<I>,
+}
 
 pub struct AddOp;
 impl RIVInstruction for AddOp {
@@ -44,15 +44,11 @@ impl RIVInstruction for MulOp {
 pub type MulInstruction<E> = ArithInstruction<E, MulOp>;
 
 impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ArithInstruction<E, I> {
-    type InstructionConfig = ArithConfig<E>;
-
     fn name() -> String {
         format!("{:?}", I::INST_KIND)
     }
 
-    fn construct_circuit(
-        circuit_builder: &mut CircuitBuilder<E>,
-    ) -> Result<Self::InstructionConfig, ZKVMError> {
+    fn construct_circuit(circuit_builder: &mut CircuitBuilder<E>) -> Result<Self, ZKVMError> {
         let (rs1_read, rs2_read, rd_written) = match I::INST_KIND {
             InsnKind::ADD => {
                 // rd_written = rs1_read + rs2_read
@@ -96,48 +92,45 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ArithInstruction<E
             rd_written.register_expr(),
         )?;
 
-        Ok(ArithConfig {
+        Ok(Self {
             r_insn,
             rs1_read,
             rs2_read,
             rd_written,
+            _phantom: PhantomData,
         })
     }
 
     fn assign_instance(
-        config: &Self::InstructionConfig,
+        &self,
         instance: &mut [MaybeUninit<<E as ExtensionField>::BaseField>],
         lk_multiplicity: &mut LkMultiplicity,
         step: &StepRecord,
     ) -> Result<(), ZKVMError> {
-        config
-            .r_insn
+        self.r_insn
             .assign_instance(instance, lk_multiplicity, step)?;
 
         let rs2_read = Value::new_unchecked(step.rs2().unwrap().value);
-        config
-            .rs2_read
+        self.rs2_read
             .assign_limbs(instance, rs2_read.as_u16_limbs());
 
         match I::INST_KIND {
             InsnKind::ADD => {
                 // rs1_read + rs2_read = rd_written
                 let rs1_read = Value::new_unchecked(step.rs1().unwrap().value);
-                config
-                    .rs1_read
+                self.rs1_read
                     .assign_limbs(instance, rs1_read.as_u16_limbs());
                 let result = rs1_read.add(&rs2_read, lk_multiplicity, true);
-                config.rd_written.assign_carries(instance, &result.carries);
+                self.rd_written.assign_carries(instance, &result.carries);
             }
 
             InsnKind::SUB => {
                 // rs1_read = rd_written + rs2_read
                 let rd_written = Value::new(step.rd().unwrap().value.after, lk_multiplicity);
-                config
-                    .rd_written
+                self.rd_written
                     .assign_limbs(instance, rd_written.as_u16_limbs());
                 let result = rs2_read.add(&rd_written, lk_multiplicity, true);
-                config.rs1_read.assign_carries(instance, &result.carries);
+                self.rs1_read.assign_carries(instance, &result.carries);
             }
 
             InsnKind::MUL => {
@@ -145,13 +138,12 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ArithInstruction<E
                 let rs1_read = Value::new_unchecked(step.rs1().unwrap().value);
                 let rd_written = Value::new_unchecked(step.rd().unwrap().value.after);
 
-                config
-                    .rs1_read
+                self.rs1_read
                     .assign_limbs(instance, rs1_read.as_u16_limbs());
 
                 let result = rs1_read.mul(&rs2_read, lk_multiplicity, true);
 
-                config.rd_written.assign_mul_outcome(
+                self.rd_written.assign_mul_outcome(
                     instance,
                     lk_multiplicity,
                     &ValueMul {

--- a/ceno_zkvm/src/instructions/riscv/branch.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch.rs
@@ -25,22 +25,22 @@ pub struct BltuOp;
 impl RIVInstruction for BltuOp {
     const INST_KIND: InsnKind = InsnKind::BLTU;
 }
-pub type BltuInstruction = bltu::BltuCircuit<BltuOp>;
+pub type BltuInstruction<E> = bltu::BltuCircuit<E, BltuOp>;
 
 pub struct BgeuOp;
 impl RIVInstruction for BgeuOp {
     const INST_KIND: InsnKind = InsnKind::BGEU;
 }
-pub type BgeuInstruction = bltu::BltuCircuit<BgeuOp>;
+pub type BgeuInstruction<E> = bltu::BltuCircuit<E, BgeuOp>;
 
 pub struct BltOp;
 impl RIVInstruction for BltOp {
     const INST_KIND: InsnKind = InsnKind::BLT;
 }
-pub type BltInstruction = blt::BltCircuit<BltOp>;
+pub type BltInstruction<E> = blt::BltCircuit<E, BltOp>;
 
 pub struct BgeOp;
 impl RIVInstruction for BgeOp {
     const INST_KIND: InsnKind = InsnKind::BGE;
 }
-pub type BgeInstruction = blt::BltCircuit<BgeOp>;
+pub type BgeInstruction<E> = blt::BltCircuit<E, BgeOp>;

--- a/ceno_zkvm/src/instructions/riscv/branch/blt.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch/blt.rs
@@ -17,25 +17,20 @@ use crate::{
 };
 use ceno_emul::{InsnKind, SWord};
 
-pub struct BltCircuit<I>(PhantomData<I>);
-
-pub struct InstructionConfig<E: ExtensionField> {
+pub struct BltCircuit<E: ExtensionField, I: RIVInstruction> {
     pub b_insn: BInstructionConfig<E>,
     pub read_rs1: UInt<E>,
     pub read_rs2: UInt<E>,
     pub signed_lt: SignedLtConfig,
+    _phantom: PhantomData<I>,
 }
 
-impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BltCircuit<I> {
+impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BltCircuit<E, I> {
     fn name() -> String {
         format!("{:?}", I::INST_KIND)
     }
 
-    type InstructionConfig = InstructionConfig<E>;
-
-    fn construct_circuit(
-        circuit_builder: &mut CircuitBuilder<E>,
-    ) -> Result<InstructionConfig<E>, ZKVMError> {
+    fn construct_circuit(circuit_builder: &mut CircuitBuilder<E>) -> Result<Self, ZKVMError> {
         let read_rs1 = UInt::new_unchecked(|| "rs1_limbs", circuit_builder)?;
         let read_rs2 = UInt::new_unchecked(|| "rs2_limbs", circuit_builder)?;
 
@@ -57,33 +52,33 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BltCircuit<I> {
             branch_taken_bit,
         )?;
 
-        Ok(InstructionConfig {
+        Ok(Self {
             b_insn,
             read_rs1,
             read_rs2,
             signed_lt: is_lt,
+            _phantom: PhantomData,
         })
     }
 
     fn assign_instance(
-        config: &Self::InstructionConfig,
+        &self,
         instance: &mut [MaybeUninit<E::BaseField>],
         lk_multiplicity: &mut LkMultiplicity,
         step: &ceno_emul::StepRecord,
     ) -> Result<(), ZKVMError> {
         let rs1 = Value::new_unchecked(step.rs1().unwrap().value);
         let rs2 = Value::new_unchecked(step.rs2().unwrap().value);
-        config.read_rs1.assign_limbs(instance, rs1.as_u16_limbs());
-        config.read_rs2.assign_limbs(instance, rs2.as_u16_limbs());
-        config.signed_lt.assign_instance::<E>(
+        self.read_rs1.assign_limbs(instance, rs1.as_u16_limbs());
+        self.read_rs2.assign_limbs(instance, rs2.as_u16_limbs());
+        self.signed_lt.assign_instance::<E>(
             instance,
             lk_multiplicity,
             step.rs1().unwrap().value as SWord,
             step.rs2().unwrap().value as SWord,
         )?;
 
-        config
-            .b_insn
+        self.b_insn
             .assign_instance(instance, lk_multiplicity, step)?;
 
         Ok(())

--- a/ceno_zkvm/src/instructions/riscv/branch/bltu.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch/bltu.rs
@@ -20,25 +20,20 @@ use crate::{
 };
 use ceno_emul::InsnKind;
 
-pub struct BltuCircuit<I>(PhantomData<I>);
-
-pub struct InstructionConfig<E: ExtensionField> {
+pub struct BltuCircuit<E: ExtensionField, I: RIVInstruction> {
     pub b_insn: BInstructionConfig<E>,
     pub read_rs1: UInt<E>,
     pub read_rs2: UInt<E>,
     pub is_lt: IsLtConfig,
+    _phantom: PhantomData<I>,
 }
 
-impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BltuCircuit<I> {
+impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BltuCircuit<E, I> {
     fn name() -> String {
         format!("{:?}", I::INST_KIND)
     }
 
-    type InstructionConfig = InstructionConfig<E>;
-
-    fn construct_circuit(
-        circuit_builder: &mut CircuitBuilder<E>,
-    ) -> Result<InstructionConfig<E>, ZKVMError> {
+    fn construct_circuit(circuit_builder: &mut CircuitBuilder<E>) -> Result<Self, ZKVMError> {
         let read_rs1 = UInt::new_unchecked(|| "rs1_limbs", circuit_builder)?;
         let read_rs2 = UInt::new_unchecked(|| "rs2_limbs", circuit_builder)?;
 
@@ -65,33 +60,33 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BltuCircuit<I> {
             branch_taken_bit,
         )?;
 
-        Ok(InstructionConfig {
+        Ok(Self {
             b_insn,
             read_rs1,
             read_rs2,
             is_lt,
+            _phantom: PhantomData,
         })
     }
 
     fn assign_instance(
-        config: &Self::InstructionConfig,
+        &self,
         instance: &mut [std::mem::MaybeUninit<E::BaseField>],
         lk_multiplicity: &mut LkMultiplicity,
         step: &ceno_emul::StepRecord,
     ) -> Result<(), ZKVMError> {
         let rs1 = Value::new_unchecked(step.rs1().unwrap().value);
         let rs2 = Value::new_unchecked(step.rs2().unwrap().value);
-        config.read_rs1.assign_limbs(instance, rs1.as_u16_limbs());
-        config.read_rs2.assign_limbs(instance, rs2.as_u16_limbs());
-        config.is_lt.assign_instance(
+        self.read_rs1.assign_limbs(instance, rs1.as_u16_limbs());
+        self.read_rs2.assign_limbs(instance, rs2.as_u16_limbs());
+        self.is_lt.assign_instance(
             instance,
             lk_multiplicity,
             step.rs1().unwrap().value as u64,
             step.rs2().unwrap().value as u64,
         )?;
 
-        config
-            .b_insn
+        self.b_insn
             .assign_instance(instance, lk_multiplicity, step)?;
 
         Ok(())

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -127,7 +127,7 @@ pub struct ZKVMConstraintSystem<E: ExtensionField> {
 }
 
 impl<E: ExtensionField> ZKVMConstraintSystem<E> {
-    pub fn register_opcode_circuit<OC: Instruction<E>>(&mut self) -> OC::InstructionConfig {
+    pub fn register_opcode_circuit<OC: Instruction<E>>(&mut self) -> OC {
         let mut cs = ConstraintSystem::new(|| format!("riscv_opcode/{}", OC::name()));
         let mut circuit_builder = CircuitBuilder::<E>::new(&mut cs);
         let config = OC::construct_circuit(&mut circuit_builder).unwrap();
@@ -189,7 +189,7 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
     pub fn assign_opcode_circuit<OC: Instruction<E>>(
         &mut self,
         cs: &ZKVMConstraintSystem<E>,
-        config: &OC::InstructionConfig,
+        config: &OC,
         records: Vec<StepRecord>,
     ) -> Result<(), ZKVMError> {
         assert!(self.combined_lk_mlt.is_none());


### PR DESCRIPTION
Simplifies opcode implementation by combining the config and circuit structs into a single one that implements `Instruction`. This style can be useful to derive some function on the config by including it in Instruction trait.

All the tests pass without any modification to them.

## Before

```rs
struct OpConfig<E> {
    witin_a: Uint<E>
    ..
}

struct OpInstruction<E, I>(PhantomData<(E, I)>);

impl Instruction for OpInstruction {
  ...
}
```

## After

```rs
struct OpInstruction <E, I> {
    witin_a: Uint<E>
    ..
    _phantom: PhantomData<I>
}

impl Instruction for OpInstruction {
  ...
}
```