### PR TITLE
chore: consistent notation

### DIFF
--- a/ceno_emul/src/platform.rs
+++ b/ceno_emul/src/platform.rs
@@ -36,14 +36,15 @@ impl Platform {
     }
 
     pub const fn ram_end(&self) -> Addr {
-        if cfg!(feature = "forbid_overflow") {
-            // (1<<11) - 1 == 0x7ff is the largest positive 'immediate'
-            // offset we can have in memory instructions.
-            // So if we stay away from it, we are safe.
-            u32::MAX - 0x7FF
-        } else {
-            0xFFFF_FFFF
-        }
+        0xFFFF_FFFF
+            - if cfg!(feature = "forbid_overflow") {
+                // (1<<11) - 1 == 0x7ff is the largest positive 'immediate'
+                // offset we can have in memory instructions.
+                // So if we stay away from it, we are safe.
+                0x7FF
+            } else {
+                0
+            }
     }
 
     pub fn is_ram(&self, addr: Addr) -> bool {


### PR DESCRIPTION
A very small cosmetic fix.

Previously, we spelled the same number in two different ways: either as `u32::MAX` or as `0xFFFF_FFFF` just next to each other.