### PR TITLE
Make `witin_namespace_map` more robust

### DIFF
--- a/ceno_zkvm/benches/riscv_add.rs
+++ b/ceno_zkvm/benches/riscv_add.rs
@@ -98,7 +98,7 @@ fn bench_add(c: &mut Criterion) {
                         // generate mock witness
                         let mut rng = test_rng();
                         let num_instances = 1 << instance_num_vars;
-                        (0..num_witin as usize)
+                        (0..num_witin)
                             .map(|_| {
                                 (0..num_instances)
                                     .map(|_| Goldilocks::random(&mut rng))

--- a/ceno_zkvm/benches/riscv_add.rs
+++ b/ceno_zkvm/benches/riscv_add.rs
@@ -80,7 +80,7 @@ fn bench_add(c: &mut Criterion) {
         .get(&AddInstruction::<E>::name())
         .unwrap()
         .clone();
-    let num_witin = circuit_pk.get_cs().num_witin_fnord;
+    let num_witin = circuit_pk.get_cs().num_witin();
 
     let prover = ZKVMProver::new(pk);
 

--- a/ceno_zkvm/benches/riscv_add.rs
+++ b/ceno_zkvm/benches/riscv_add.rs
@@ -80,7 +80,7 @@ fn bench_add(c: &mut Criterion) {
         .get(&AddInstruction::<E>::name())
         .unwrap()
         .clone();
-    let num_witin = circuit_pk.get_cs().num_witin;
+    let num_witin = circuit_pk.get_cs().num_witin_fnord;
 
     let prover = ZKVMProver::new(pk);
 

--- a/ceno_zkvm/src/circuit_builder.rs
+++ b/ceno_zkvm/src/circuit_builder.rs
@@ -82,7 +82,6 @@ pub struct SetTableExpression<E: ExtensionField> {
 pub struct ConstraintSystem<E: ExtensionField> {
     pub(crate) ns: NameSpace,
 
-    pub num_witin_fnord: WitnessId,
     pub witin_namespace_map: Vec<String>,
 
     pub num_fixed: usize,
@@ -132,9 +131,12 @@ pub struct ConstraintSystem<E: ExtensionField> {
 }
 
 impl<E: ExtensionField> ConstraintSystem<E> {
+    pub fn num_witin(&self) -> usize {
+        self.witin_namespace_map.len()
+    }
+
     pub fn new<NR: Into<String>, N: FnOnce() -> NR>(root_name_fn: N) -> Self {
         Self {
-            num_witin_fnord: 0,
             witin_namespace_map: vec![],
             num_fixed: 0,
             fixed_namespace_map: vec![],
@@ -199,11 +201,7 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         n: N,
     ) -> Result<WitIn, ZKVMError> {
         let wit_in = WitIn {
-            id: {
-                let id = self.num_witin_fnord;
-                self.num_witin_fnord += 1;
-                id
-            },
+            id: WitnessId::try_from(self.num_witin()).unwrap(),
         };
 
         let path = self.ns.compute_path(n().into());

--- a/ceno_zkvm/src/circuit_builder.rs
+++ b/ceno_zkvm/src/circuit_builder.rs
@@ -131,10 +131,6 @@ pub struct ConstraintSystem<E: ExtensionField> {
 }
 
 impl<E: ExtensionField> ConstraintSystem<E> {
-    pub fn num_witin(&self) -> usize {
-        self.witin_namespace_map.len()
-    }
-
     pub fn new<NR: Into<String>, N: FnOnce() -> NR>(root_name_fn: N) -> Self {
         Self {
             witin_namespace_map: vec![],
@@ -194,6 +190,10 @@ impl<E: ExtensionField> ConstraintSystem<E> {
                 fixed_commit,
             },
         }
+    }
+
+    pub fn num_witin(&self) -> usize {
+        self.witin_namespace_map.len()
     }
 
     pub fn create_witin<NR: Into<String>, N: FnOnce() -> NR>(

--- a/ceno_zkvm/src/circuit_builder.rs
+++ b/ceno_zkvm/src/circuit_builder.rs
@@ -85,7 +85,7 @@ pub struct ConstraintSystem<E: ExtensionField> {
     pub num_witin: WitnessId,
     pub witin_namespace_map: Vec<String>,
 
-    pub num_fixed: usize,
+    pub num_fixed_fnord: usize,
     pub fixed_namespace_map: Vec<String>,
 
     pub instance_name_map: HashMap<Instance, String>,
@@ -136,7 +136,7 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         Self {
             num_witin: 0,
             witin_namespace_map: vec![],
-            num_fixed: 0,
+            num_fixed_fnord: 0,
             fixed_namespace_map: vec![],
             ns: NameSpace::new(root_name_fn),
             instance_name_map: HashMap::new(),
@@ -216,8 +216,8 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         &mut self,
         n: N,
     ) -> Result<Fixed, ZKVMError> {
-        let f = Fixed(self.num_fixed);
-        self.num_fixed += 1;
+        let f = Fixed(self.num_fixed_fnord);
+        self.num_fixed_fnord += 1;
 
         let path = self.ns.compute_path(n().into());
         self.fixed_namespace_map.push(path);

--- a/ceno_zkvm/src/circuit_builder.rs
+++ b/ceno_zkvm/src/circuit_builder.rs
@@ -85,7 +85,6 @@ pub struct ConstraintSystem<E: ExtensionField> {
     pub num_witin: WitnessId,
     pub witin_namespace_map: Vec<String>,
 
-    pub num_fixed_fnord: usize,
     pub fixed_namespace_map: Vec<String>,
 
     pub instance_name_map: HashMap<Instance, String>,
@@ -136,7 +135,6 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         Self {
             num_witin: 0,
             witin_namespace_map: vec![],
-            num_fixed_fnord: 0,
             fixed_namespace_map: vec![],
             ns: NameSpace::new(root_name_fn),
             instance_name_map: HashMap::new(),
@@ -212,12 +210,15 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         Ok(wit_in)
     }
 
+    pub fn num_fixed(&self) -> usize {
+        self.fixed_namespace_map.len()
+    }
+
     pub fn create_fixed<NR: Into<String>, N: FnOnce() -> NR>(
         &mut self,
         n: N,
     ) -> Result<Fixed, ZKVMError> {
-        let f = Fixed(self.num_fixed_fnord);
-        self.num_fixed_fnord += 1;
+        let f = Fixed(self.num_fixed());
 
         let path = self.ns.compute_path(n().into());
         self.fixed_namespace_map.push(path);

--- a/ceno_zkvm/src/circuit_builder.rs
+++ b/ceno_zkvm/src/circuit_builder.rs
@@ -196,14 +196,12 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         &mut self,
         n: N,
     ) -> Result<WitIn, ZKVMError> {
-        let wit_in = WitIn {
-            id: WitnessId::try_from(self.num_witin()).unwrap(),
-        };
+        let id = WitnessId::try_from(self.num_witin()).unwrap();
 
         let path = self.ns.compute_path(n().into());
         self.witin_namespace_map.push(path);
 
-        Ok(wit_in)
+        Ok(WitIn { id })
     }
 
     pub fn num_fixed(&self) -> usize {

--- a/ceno_zkvm/src/circuit_builder.rs
+++ b/ceno_zkvm/src/circuit_builder.rs
@@ -83,9 +83,7 @@ pub struct ConstraintSystem<E: ExtensionField> {
     pub(crate) ns: NameSpace,
 
     pub witin_namespace_map: Vec<String>,
-
     pub fixed_namespace_map: Vec<String>,
-
     pub instance_name_map: HashMap<Instance, String>,
 
     pub r_expressions: Vec<Expression<E>>,

--- a/ceno_zkvm/src/circuit_builder.rs
+++ b/ceno_zkvm/src/circuit_builder.rs
@@ -82,7 +82,7 @@ pub struct SetTableExpression<E: ExtensionField> {
 pub struct ConstraintSystem<E: ExtensionField> {
     pub(crate) ns: NameSpace,
 
-    pub num_witin: WitnessId,
+    pub num_witin_fnord: WitnessId,
     pub witin_namespace_map: Vec<String>,
 
     pub num_fixed: usize,
@@ -134,7 +134,7 @@ pub struct ConstraintSystem<E: ExtensionField> {
 impl<E: ExtensionField> ConstraintSystem<E> {
     pub fn new<NR: Into<String>, N: FnOnce() -> NR>(root_name_fn: N) -> Self {
         Self {
-            num_witin: 0,
+            num_witin_fnord: 0,
             witin_namespace_map: vec![],
             num_fixed: 0,
             fixed_namespace_map: vec![],
@@ -200,8 +200,8 @@ impl<E: ExtensionField> ConstraintSystem<E> {
     ) -> Result<WitIn, ZKVMError> {
         let wit_in = WitIn {
             id: {
-                let id = self.num_witin;
-                self.num_witin += 1;
+                let id = self.num_witin_fnord;
+                self.num_witin_fnord += 1;
                 id
             },
         };

--- a/ceno_zkvm/src/instructions/riscv/arith.rs
+++ b/ceno_zkvm/src/instructions/riscv/arith.rs
@@ -198,7 +198,7 @@ mod test {
 
         let insn_code = encode_rv32(InsnKind::ADD, 2, 3, 4, 0);
         let (raw_witin, lkm) =
-            AddInstruction::assign_instances(&config, cb.cs.num_witin as usize, vec![
+            AddInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
                 StepRecord::new_r_instruction(
                     3,
                     MOCK_PC_START,
@@ -253,7 +253,7 @@ mod test {
 
         let insn_code = encode_rv32(InsnKind::ADD, 2, 3, 4, 0);
         let (raw_witin, lkm) =
-            AddInstruction::assign_instances(&config, cb.cs.num_witin as usize, vec![
+            AddInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
                 StepRecord::new_r_instruction(
                     3,
                     MOCK_PC_START,
@@ -308,7 +308,7 @@ mod test {
 
         let insn_code = encode_rv32(InsnKind::SUB, 2, 3, 4, 0);
         let (raw_witin, lkm) =
-            SubInstruction::assign_instances(&config, cb.cs.num_witin as usize, vec![
+            SubInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
                 StepRecord::new_r_instruction(
                     3,
                     MOCK_PC_START,
@@ -363,7 +363,7 @@ mod test {
 
         let insn_code = encode_rv32(InsnKind::SUB, 2, 3, 4, 0);
         let (raw_witin, _) =
-            SubInstruction::assign_instances(&config, cb.cs.num_witin as usize, vec![
+            SubInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
                 StepRecord::new_r_instruction(
                     3,
                     MOCK_PC_START,
@@ -413,7 +413,7 @@ mod test {
         // values assignment
         let insn_code = encode_rv32(InsnKind::MUL, 2, 3, 4, 0);
         let (raw_witin, lkm) =
-            MulInstruction::assign_instances(&config, cb.cs.num_witin as usize, vec![
+            MulInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
                 StepRecord::new_r_instruction(
                     3,
                     MOCK_PC_START,
@@ -460,7 +460,7 @@ mod test {
         // values assignment
         let insn_code = encode_rv32(InsnKind::MUL, 2, 3, 4, 0);
         let (raw_witin, lkm) =
-            MulInstruction::assign_instances(&config, cb.cs.num_witin as usize, vec![
+            MulInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
                 StepRecord::new_r_instruction(
                     3,
                     MOCK_PC_START,
@@ -511,7 +511,7 @@ mod test {
         // values assignment
         let insn_code = encode_rv32(InsnKind::MUL, 2, 3, 4, 0);
         let (raw_witin, lkm) =
-            MulInstruction::assign_instances(&config, cb.cs.num_witin as usize, vec![
+            MulInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
                 StepRecord::new_r_instruction(
                     3,
                     MOCK_PC_START,

--- a/ceno_zkvm/src/instructions/riscv/arith.rs
+++ b/ceno_zkvm/src/instructions/riscv/arith.rs
@@ -197,19 +197,18 @@ mod test {
             .unwrap();
 
         let insn_code = encode_rv32(InsnKind::ADD, 2, 3, 4, 0);
-        let (raw_witin, lkm) =
-            AddInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
-                StepRecord::new_r_instruction(
-                    3,
-                    MOCK_PC_START,
-                    insn_code,
-                    11,
-                    0xfffffffe,
-                    Change::new(0, 11_u32.wrapping_add(0xfffffffe)),
-                    0,
-                ),
-            ])
-            .unwrap();
+        let (raw_witin, lkm) = AddInstruction::assign_instances(&config, cb.cs.num_witin(), vec![
+            StepRecord::new_r_instruction(
+                3,
+                MOCK_PC_START,
+                insn_code,
+                11,
+                0xfffffffe,
+                Change::new(0, 11_u32.wrapping_add(0xfffffffe)),
+                0,
+            ),
+        ])
+        .unwrap();
 
         let expected_rd_written = UInt::from_const_unchecked(
             Value::new_unchecked(11_u32.wrapping_add(0xfffffffe))
@@ -252,19 +251,18 @@ mod test {
             .unwrap();
 
         let insn_code = encode_rv32(InsnKind::ADD, 2, 3, 4, 0);
-        let (raw_witin, lkm) =
-            AddInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
-                StepRecord::new_r_instruction(
-                    3,
-                    MOCK_PC_START,
-                    insn_code,
-                    u32::MAX - 1,
-                    u32::MAX - 1,
-                    Change::new(0, (u32::MAX - 1).wrapping_add(u32::MAX - 1)),
-                    0,
-                ),
-            ])
-            .unwrap();
+        let (raw_witin, lkm) = AddInstruction::assign_instances(&config, cb.cs.num_witin(), vec![
+            StepRecord::new_r_instruction(
+                3,
+                MOCK_PC_START,
+                insn_code,
+                u32::MAX - 1,
+                u32::MAX - 1,
+                Change::new(0, (u32::MAX - 1).wrapping_add(u32::MAX - 1)),
+                0,
+            ),
+        ])
+        .unwrap();
 
         let expected_rd_written = UInt::from_const_unchecked(
             Value::new_unchecked((u32::MAX - 1).wrapping_add(u32::MAX - 1))
@@ -307,19 +305,18 @@ mod test {
             .unwrap();
 
         let insn_code = encode_rv32(InsnKind::SUB, 2, 3, 4, 0);
-        let (raw_witin, lkm) =
-            SubInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
-                StepRecord::new_r_instruction(
-                    3,
-                    MOCK_PC_START,
-                    insn_code,
-                    11,
-                    2,
-                    Change::new(0, 11_u32.wrapping_sub(2)),
-                    0,
-                ),
-            ])
-            .unwrap();
+        let (raw_witin, lkm) = SubInstruction::assign_instances(&config, cb.cs.num_witin(), vec![
+            StepRecord::new_r_instruction(
+                3,
+                MOCK_PC_START,
+                insn_code,
+                11,
+                2,
+                Change::new(0, 11_u32.wrapping_sub(2)),
+                0,
+            ),
+        ])
+        .unwrap();
 
         let expected_rd_written = UInt::from_const_unchecked(
             Value::new_unchecked(11_u32.wrapping_sub(2))
@@ -362,19 +359,18 @@ mod test {
             .unwrap();
 
         let insn_code = encode_rv32(InsnKind::SUB, 2, 3, 4, 0);
-        let (raw_witin, _) =
-            SubInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
-                StepRecord::new_r_instruction(
-                    3,
-                    MOCK_PC_START,
-                    insn_code,
-                    3,
-                    11,
-                    Change::new(0, 3_u32.wrapping_sub(11)),
-                    0,
-                ),
-            ])
-            .unwrap();
+        let (raw_witin, _) = SubInstruction::assign_instances(&config, cb.cs.num_witin(), vec![
+            StepRecord::new_r_instruction(
+                3,
+                MOCK_PC_START,
+                insn_code,
+                3,
+                11,
+                Change::new(0, 3_u32.wrapping_sub(11)),
+                0,
+            ),
+        ])
+        .unwrap();
 
         let expected_rd_written = UInt::from_const_unchecked(
             Value::new_unchecked(3_u32.wrapping_sub(11))
@@ -412,19 +408,18 @@ mod test {
 
         // values assignment
         let insn_code = encode_rv32(InsnKind::MUL, 2, 3, 4, 0);
-        let (raw_witin, lkm) =
-            MulInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
-                StepRecord::new_r_instruction(
-                    3,
-                    MOCK_PC_START,
-                    insn_code,
-                    11,
-                    2,
-                    Change::new(0, 22),
-                    0,
-                ),
-            ])
-            .unwrap();
+        let (raw_witin, lkm) = MulInstruction::assign_instances(&config, cb.cs.num_witin(), vec![
+            StepRecord::new_r_instruction(
+                3,
+                MOCK_PC_START,
+                insn_code,
+                11,
+                2,
+                Change::new(0, 22),
+                0,
+            ),
+        ])
+        .unwrap();
 
         let expected_rd_written =
             UInt::from_const_unchecked(Value::new_unchecked(22u32).as_u16_limbs().to_vec());
@@ -459,19 +454,18 @@ mod test {
 
         // values assignment
         let insn_code = encode_rv32(InsnKind::MUL, 2, 3, 4, 0);
-        let (raw_witin, lkm) =
-            MulInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
-                StepRecord::new_r_instruction(
-                    3,
-                    MOCK_PC_START,
-                    insn_code,
-                    u32::MAX / 2 + 1,
-                    2,
-                    Change::new(0, 0),
-                    0,
-                ),
-            ])
-            .unwrap();
+        let (raw_witin, lkm) = MulInstruction::assign_instances(&config, cb.cs.num_witin(), vec![
+            StepRecord::new_r_instruction(
+                3,
+                MOCK_PC_START,
+                insn_code,
+                u32::MAX / 2 + 1,
+                2,
+                Change::new(0, 0),
+                0,
+            ),
+        ])
+        .unwrap();
 
         let expected_rd_written = UInt::from_const_unchecked(vec![0u64, 0]);
 
@@ -510,22 +504,21 @@ mod test {
 
         // values assignment
         let insn_code = encode_rv32(InsnKind::MUL, 2, 3, 4, 0);
-        let (raw_witin, lkm) =
-            MulInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
-                StepRecord::new_r_instruction(
-                    3,
-                    MOCK_PC_START,
-                    insn_code,
-                    a.as_u64() as u32,
-                    b.as_u64() as u32,
-                    Change::new(
-                        0,
-                        Value::<u32>::from_limb_unchecked(c_limb.clone()).as_u64() as u32,
-                    ),
+        let (raw_witin, lkm) = MulInstruction::assign_instances(&config, cb.cs.num_witin(), vec![
+            StepRecord::new_r_instruction(
+                3,
+                MOCK_PC_START,
+                insn_code,
+                a.as_u64() as u32,
+                b.as_u64() as u32,
+                Change::new(
                     0,
+                    Value::<u32>::from_limb_unchecked(c_limb.clone()).as_u64() as u32,
                 ),
-            ])
-            .unwrap();
+                0,
+            ),
+        ])
+        .unwrap();
 
         let expected_rd_written = UInt::from_const_unchecked(c_limb.clone());
 

--- a/ceno_zkvm/src/instructions/riscv/arith_imm.rs
+++ b/ceno_zkvm/src/instructions/riscv/arith_imm.rs
@@ -121,7 +121,7 @@ mod test {
         let insn_code = encode_rv32(InsnKind::ADDI, 2, 0, 4, imm(3));
         let (raw_witin, lkm) = AddiInstruction::<GoldilocksExt2>::assign_instances(
             &config,
-            cb.cs.num_witin as usize,
+            cb.cs.num_witin_fnord as usize,
             vec![StepRecord::new_i_instruction(
                 3,
                 Change::new(MOCK_PC_START, MOCK_PC_START + PC_STEP_SIZE),
@@ -165,7 +165,7 @@ mod test {
         let insn_code = encode_rv32(InsnKind::ADDI, 2, 0, 4, imm(-3));
         let (raw_witin, lkm) = AddiInstruction::<GoldilocksExt2>::assign_instances(
             &config,
-            cb.cs.num_witin as usize,
+            cb.cs.num_witin_fnord as usize,
             vec![StepRecord::new_i_instruction(
                 3,
                 Change::new(MOCK_PC_START, MOCK_PC_START + PC_STEP_SIZE),

--- a/ceno_zkvm/src/instructions/riscv/arith_imm.rs
+++ b/ceno_zkvm/src/instructions/riscv/arith_imm.rs
@@ -119,19 +119,18 @@ mod test {
             .unwrap();
 
         let insn_code = encode_rv32(InsnKind::ADDI, 2, 0, 4, imm(3));
-        let (raw_witin, lkm) = AddiInstruction::<GoldilocksExt2>::assign_instances(
-            &config,
-            cb.cs.num_witin_fnord as usize,
-            vec![StepRecord::new_i_instruction(
-                3,
-                Change::new(MOCK_PC_START, MOCK_PC_START + PC_STEP_SIZE),
-                insn_code,
-                1000,
-                Change::new(0, 1003),
-                0,
-            )],
-        )
-        .unwrap();
+        let (raw_witin, lkm) =
+            AddiInstruction::<GoldilocksExt2>::assign_instances(&config, cb.cs.num_witin(), vec![
+                StepRecord::new_i_instruction(
+                    3,
+                    Change::new(MOCK_PC_START, MOCK_PC_START + PC_STEP_SIZE),
+                    insn_code,
+                    1000,
+                    Change::new(0, 1003),
+                    0,
+                ),
+            ])
+            .unwrap();
 
         MockProver::assert_satisfied(
             &cb,
@@ -163,19 +162,18 @@ mod test {
             .unwrap();
 
         let insn_code = encode_rv32(InsnKind::ADDI, 2, 0, 4, imm(-3));
-        let (raw_witin, lkm) = AddiInstruction::<GoldilocksExt2>::assign_instances(
-            &config,
-            cb.cs.num_witin_fnord as usize,
-            vec![StepRecord::new_i_instruction(
-                3,
-                Change::new(MOCK_PC_START, MOCK_PC_START + PC_STEP_SIZE),
-                insn_code,
-                1000,
-                Change::new(0, 997),
-                0,
-            )],
-        )
-        .unwrap();
+        let (raw_witin, lkm) =
+            AddiInstruction::<GoldilocksExt2>::assign_instances(&config, cb.cs.num_witin(), vec![
+                StepRecord::new_i_instruction(
+                    3,
+                    Change::new(MOCK_PC_START, MOCK_PC_START + PC_STEP_SIZE),
+                    insn_code,
+                    1000,
+                    Change::new(0, 997),
+                    0,
+                ),
+            ])
+            .unwrap();
 
         MockProver::assert_satisfied(
             &cb,

--- a/ceno_zkvm/src/instructions/riscv/branch/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch/test.rs
@@ -47,7 +47,7 @@ fn impl_opcode_beq(equal: bool) {
     let insn_code = encode_rv32(InsnKind::BEQ, 2, 3, 0, imm(8));
     let pc_offset = if equal { 8 } else { PC_STEP_SIZE };
     let (raw_witin, lkm) =
-        BeqInstruction::assign_instances(&config, cb.cs.num_witin as usize, vec![
+        BeqInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
             StepRecord::new_b_instruction(
                 3,
                 Change::new(MOCK_PC_START, MOCK_PC_START + pc_offset),
@@ -96,7 +96,7 @@ fn impl_opcode_bne(equal: bool) {
     let insn_code = encode_rv32(InsnKind::BNE, 2, 3, 0, imm(8));
     let pc_offset = if equal { PC_STEP_SIZE } else { 8 };
     let (raw_witin, lkm) =
-        BneInstruction::assign_instances(&config, cb.cs.num_witin as usize, vec![
+        BneInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
             StepRecord::new_b_instruction(
                 3,
                 Change::new(MOCK_PC_START, MOCK_PC_START + pc_offset),
@@ -148,7 +148,7 @@ fn impl_bltu_circuit(taken: bool, a: u32, b: u32) -> Result<(), ZKVMError> {
     let insn_code = encode_rv32(InsnKind::BLTU, 2, 3, 0, imm(-8));
     println!("{:#b}", insn_code);
     let (raw_witin, lkm) =
-        BltuInstruction::assign_instances(&config, circuit_builder.cs.num_witin as usize, vec![
+        BltuInstruction::assign_instances(&config, circuit_builder.cs.num_witin_fnord as usize, vec![
             StepRecord::new_b_instruction(
                 12,
                 Change::new(MOCK_PC_START, pc_after),
@@ -200,7 +200,7 @@ fn impl_bgeu_circuit(taken: bool, a: u32, b: u32) -> Result<(), ZKVMError> {
 
     let insn_code = encode_rv32(InsnKind::BGEU, 2, 3, 0, imm(-8));
     let (raw_witin, lkm) =
-        BgeuInstruction::assign_instances(&config, circuit_builder.cs.num_witin as usize, vec![
+        BgeuInstruction::assign_instances(&config, circuit_builder.cs.num_witin_fnord as usize, vec![
             StepRecord::new_b_instruction(
                 12,
                 Change::new(MOCK_PC_START, pc_after),
@@ -253,7 +253,7 @@ fn impl_blt_circuit(taken: bool, a: i32, b: i32) -> Result<(), ZKVMError> {
 
     let insn_code = encode_rv32(InsnKind::BLT, 2, 3, 0, imm(-8));
     let (raw_witin, lkm) =
-        BltInstruction::assign_instances(&config, circuit_builder.cs.num_witin as usize, vec![
+        BltInstruction::assign_instances(&config, circuit_builder.cs.num_witin_fnord as usize, vec![
             StepRecord::new_b_instruction(
                 12,
                 Change::new(MOCK_PC_START, pc_after),
@@ -306,7 +306,7 @@ fn impl_bge_circuit(taken: bool, a: i32, b: i32) -> Result<(), ZKVMError> {
 
     let insn_code = encode_rv32(InsnKind::BGE, 2, 3, 0, imm(-8));
     let (raw_witin, lkm) =
-        BgeInstruction::assign_instances(&config, circuit_builder.cs.num_witin as usize, vec![
+        BgeInstruction::assign_instances(&config, circuit_builder.cs.num_witin_fnord as usize, vec![
             StepRecord::new_b_instruction(
                 12,
                 Change::new(MOCK_PC_START, pc_after),

--- a/ceno_zkvm/src/instructions/riscv/branch/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch/test.rs
@@ -46,18 +46,17 @@ fn impl_opcode_beq(equal: bool) {
 
     let insn_code = encode_rv32(InsnKind::BEQ, 2, 3, 0, imm(8));
     let pc_offset = if equal { 8 } else { PC_STEP_SIZE };
-    let (raw_witin, lkm) =
-        BeqInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
-            StepRecord::new_b_instruction(
-                3,
-                Change::new(MOCK_PC_START, MOCK_PC_START + pc_offset),
-                insn_code,
-                A,
-                if equal { A } else { B },
-                0,
-            ),
-        ])
-        .unwrap();
+    let (raw_witin, lkm) = BeqInstruction::assign_instances(&config, cb.cs.num_witin(), vec![
+        StepRecord::new_b_instruction(
+            3,
+            Change::new(MOCK_PC_START, MOCK_PC_START + pc_offset),
+            insn_code,
+            A,
+            if equal { A } else { B },
+            0,
+        ),
+    ])
+    .unwrap();
 
     MockProver::assert_satisfied(
         &cb,
@@ -95,18 +94,17 @@ fn impl_opcode_bne(equal: bool) {
 
     let insn_code = encode_rv32(InsnKind::BNE, 2, 3, 0, imm(8));
     let pc_offset = if equal { PC_STEP_SIZE } else { 8 };
-    let (raw_witin, lkm) =
-        BneInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
-            StepRecord::new_b_instruction(
-                3,
-                Change::new(MOCK_PC_START, MOCK_PC_START + pc_offset),
-                insn_code,
-                A,
-                if equal { A } else { B },
-                0,
-            ),
-        ])
-        .unwrap();
+    let (raw_witin, lkm) = BneInstruction::assign_instances(&config, cb.cs.num_witin(), vec![
+        StepRecord::new_b_instruction(
+            3,
+            Change::new(MOCK_PC_START, MOCK_PC_START + pc_offset),
+            insn_code,
+            A,
+            if equal { A } else { B },
+            0,
+        ),
+    ])
+    .unwrap();
 
     MockProver::assert_satisfied(
         &cb,
@@ -148,7 +146,7 @@ fn impl_bltu_circuit(taken: bool, a: u32, b: u32) -> Result<(), ZKVMError> {
     let insn_code = encode_rv32(InsnKind::BLTU, 2, 3, 0, imm(-8));
     println!("{:#b}", insn_code);
     let (raw_witin, lkm) =
-        BltuInstruction::assign_instances(&config, circuit_builder.cs.num_witin_fnord as usize, vec![
+        BltuInstruction::assign_instances(&config, circuit_builder.cs.num_witin(), vec![
             StepRecord::new_b_instruction(
                 12,
                 Change::new(MOCK_PC_START, pc_after),
@@ -200,7 +198,7 @@ fn impl_bgeu_circuit(taken: bool, a: u32, b: u32) -> Result<(), ZKVMError> {
 
     let insn_code = encode_rv32(InsnKind::BGEU, 2, 3, 0, imm(-8));
     let (raw_witin, lkm) =
-        BgeuInstruction::assign_instances(&config, circuit_builder.cs.num_witin_fnord as usize, vec![
+        BgeuInstruction::assign_instances(&config, circuit_builder.cs.num_witin(), vec![
             StepRecord::new_b_instruction(
                 12,
                 Change::new(MOCK_PC_START, pc_after),
@@ -253,7 +251,7 @@ fn impl_blt_circuit(taken: bool, a: i32, b: i32) -> Result<(), ZKVMError> {
 
     let insn_code = encode_rv32(InsnKind::BLT, 2, 3, 0, imm(-8));
     let (raw_witin, lkm) =
-        BltInstruction::assign_instances(&config, circuit_builder.cs.num_witin_fnord as usize, vec![
+        BltInstruction::assign_instances(&config, circuit_builder.cs.num_witin(), vec![
             StepRecord::new_b_instruction(
                 12,
                 Change::new(MOCK_PC_START, pc_after),
@@ -306,7 +304,7 @@ fn impl_bge_circuit(taken: bool, a: i32, b: i32) -> Result<(), ZKVMError> {
 
     let insn_code = encode_rv32(InsnKind::BGE, 2, 3, 0, imm(-8));
     let (raw_witin, lkm) =
-        BgeInstruction::assign_instances(&config, circuit_builder.cs.num_witin_fnord as usize, vec![
+        BgeInstruction::assign_instances(&config, circuit_builder.cs.num_witin(), vec![
             StepRecord::new_b_instruction(
                 12,
                 Change::new(MOCK_PC_START, pc_after),

--- a/ceno_zkvm/src/instructions/riscv/divu.rs
+++ b/ceno_zkvm/src/instructions/riscv/divu.rs
@@ -193,7 +193,7 @@ mod test {
             let insn_code = encode_rv32(InsnKind::DIVU, 2, 3, 4, 0);
             // values assignment
             let (raw_witin, lkm) =
-                DivUInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
+                DivUInstruction::assign_instances(&config, cb.cs.num_witin(), vec![
                     StepRecord::new_r_instruction(
                         3,
                         MOCK_PC_START,

--- a/ceno_zkvm/src/instructions/riscv/divu.rs
+++ b/ceno_zkvm/src/instructions/riscv/divu.rs
@@ -193,7 +193,7 @@ mod test {
             let insn_code = encode_rv32(InsnKind::DIVU, 2, 3, 4, 0);
             // values assignment
             let (raw_witin, lkm) =
-                DivUInstruction::assign_instances(&config, cb.cs.num_witin as usize, vec![
+                DivUInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
                     StepRecord::new_r_instruction(
                         3,
                         MOCK_PC_START,

--- a/ceno_zkvm/src/instructions/riscv/insn_base.rs
+++ b/ceno_zkvm/src/instructions/riscv/insn_base.rs
@@ -517,7 +517,7 @@ mod test {
 
         let mut lkm = LkMultiplicity::default();
         let num_rows = 2;
-        let mut raw_witin = RowMajorMatrix::<F>::new(num_rows, cb.cs.num_witin_fnord as usize);
+        let mut raw_witin = RowMajorMatrix::<F>::new(num_rows, cb.cs.num_witin());
         for instance in raw_witin.iter_mut() {
             mem_addr.assign_instance(instance, &mut lkm, addr)?;
         }

--- a/ceno_zkvm/src/instructions/riscv/insn_base.rs
+++ b/ceno_zkvm/src/instructions/riscv/insn_base.rs
@@ -517,7 +517,7 @@ mod test {
 
         let mut lkm = LkMultiplicity::default();
         let num_rows = 2;
-        let mut raw_witin = RowMajorMatrix::<F>::new(num_rows, cb.cs.num_witin as usize);
+        let mut raw_witin = RowMajorMatrix::<F>::new(num_rows, cb.cs.num_witin_fnord as usize);
         for instance in raw_witin.iter_mut() {
             mem_addr.assign_instance(instance, &mut lkm, addr)?;
         }

--- a/ceno_zkvm/src/instructions/riscv/jump/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/jump/test.rs
@@ -38,18 +38,17 @@ fn test_opcode_jal() {
     let pc_offset: i32 = -8i32;
     let new_pc: ByteAddr = ByteAddr(MOCK_PC_START.0.wrapping_add_signed(pc_offset));
     let insn_code = encode_rv32(InsnKind::JAL, 0, 0, 4, imm_j(pc_offset));
-    let (raw_witin, lkm) = JalInstruction::<GoldilocksExt2>::assign_instances(
-        &config,
-        cb.cs.num_witin_fnord as usize,
-        vec![StepRecord::new_j_instruction(
-            4,
-            Change::new(MOCK_PC_START, new_pc),
-            insn_code,
-            Change::new(0, (MOCK_PC_START + PC_STEP_SIZE).into()),
-            0,
-        )],
-    )
-    .unwrap();
+    let (raw_witin, lkm) =
+        JalInstruction::<GoldilocksExt2>::assign_instances(&config, cb.cs.num_witin(), vec![
+            StepRecord::new_j_instruction(
+                4,
+                Change::new(MOCK_PC_START, new_pc),
+                insn_code,
+                Change::new(0, (MOCK_PC_START + PC_STEP_SIZE).into()),
+                0,
+            ),
+        ])
+        .unwrap();
 
     MockProver::assert_satisfied(
         &cb,
@@ -85,19 +84,18 @@ fn test_opcode_jalr() {
     let new_pc: ByteAddr = ByteAddr(rs1_read.wrapping_add_signed(imm) & (!1));
     let insn_code = encode_rv32(InsnKind::JALR, 2, 0, 4, imm as u32);
 
-    let (raw_witin, lkm) = JalrInstruction::<GoldilocksExt2>::assign_instances(
-        &config,
-        cb.cs.num_witin_fnord as usize,
-        vec![StepRecord::new_i_instruction(
-            4,
-            Change::new(MOCK_PC_START, new_pc),
-            insn_code,
-            rs1_read,
-            Change::new(0, (MOCK_PC_START + PC_STEP_SIZE).into()),
-            0,
-        )],
-    )
-    .unwrap();
+    let (raw_witin, lkm) =
+        JalrInstruction::<GoldilocksExt2>::assign_instances(&config, cb.cs.num_witin(), vec![
+            StepRecord::new_i_instruction(
+                4,
+                Change::new(MOCK_PC_START, new_pc),
+                insn_code,
+                rs1_read,
+                Change::new(0, (MOCK_PC_START + PC_STEP_SIZE).into()),
+                0,
+            ),
+        ])
+        .unwrap();
 
     MockProver::assert_satisfied(
         &cb,
@@ -134,18 +132,17 @@ fn test_opcode_lui() {
 
     let imm_value = imm_u(0x90005);
     let insn_code = encode_rv32(InsnKind::LUI, 0, 0, 4, imm_value);
-    let (raw_witin, lkm) = LuiInstruction::<GoldilocksExt2>::assign_instances(
-        &config,
-        cb.cs.num_witin_fnord as usize,
-        vec![StepRecord::new_u_instruction(
-            4,
-            MOCK_PC_START,
-            insn_code,
-            Change::new(0, imm_value),
-            0,
-        )],
-    )
-    .unwrap();
+    let (raw_witin, lkm) =
+        LuiInstruction::<GoldilocksExt2>::assign_instances(&config, cb.cs.num_witin(), vec![
+            StepRecord::new_u_instruction(
+                4,
+                MOCK_PC_START,
+                insn_code,
+                Change::new(0, imm_value),
+                0,
+            ),
+        ])
+        .unwrap();
 
     MockProver::assert_satisfied(
         &cb,
@@ -178,18 +175,17 @@ fn test_opcode_auipc() {
 
     let imm_value = imm_u(0x90005);
     let insn_code = encode_rv32(InsnKind::AUIPC, 0, 0, 4, imm_value);
-    let (raw_witin, lkm) = AuipcInstruction::<GoldilocksExt2>::assign_instances(
-        &config,
-        cb.cs.num_witin_fnord as usize,
-        vec![StepRecord::new_u_instruction(
-            4,
-            MOCK_PC_START,
-            insn_code,
-            Change::new(0, MOCK_PC_START.0.wrapping_add(imm_value)),
-            0,
-        )],
-    )
-    .unwrap();
+    let (raw_witin, lkm) =
+        AuipcInstruction::<GoldilocksExt2>::assign_instances(&config, cb.cs.num_witin(), vec![
+            StepRecord::new_u_instruction(
+                4,
+                MOCK_PC_START,
+                insn_code,
+                Change::new(0, MOCK_PC_START.0.wrapping_add(imm_value)),
+                0,
+            ),
+        ])
+        .unwrap();
 
     MockProver::assert_satisfied(
         &cb,

--- a/ceno_zkvm/src/instructions/riscv/jump/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/jump/test.rs
@@ -40,7 +40,7 @@ fn test_opcode_jal() {
     let insn_code = encode_rv32(InsnKind::JAL, 0, 0, 4, imm_j(pc_offset));
     let (raw_witin, lkm) = JalInstruction::<GoldilocksExt2>::assign_instances(
         &config,
-        cb.cs.num_witin as usize,
+        cb.cs.num_witin_fnord as usize,
         vec![StepRecord::new_j_instruction(
             4,
             Change::new(MOCK_PC_START, new_pc),
@@ -87,7 +87,7 @@ fn test_opcode_jalr() {
 
     let (raw_witin, lkm) = JalrInstruction::<GoldilocksExt2>::assign_instances(
         &config,
-        cb.cs.num_witin as usize,
+        cb.cs.num_witin_fnord as usize,
         vec![StepRecord::new_i_instruction(
             4,
             Change::new(MOCK_PC_START, new_pc),
@@ -136,7 +136,7 @@ fn test_opcode_lui() {
     let insn_code = encode_rv32(InsnKind::LUI, 0, 0, 4, imm_value);
     let (raw_witin, lkm) = LuiInstruction::<GoldilocksExt2>::assign_instances(
         &config,
-        cb.cs.num_witin as usize,
+        cb.cs.num_witin_fnord as usize,
         vec![StepRecord::new_u_instruction(
             4,
             MOCK_PC_START,
@@ -180,7 +180,7 @@ fn test_opcode_auipc() {
     let insn_code = encode_rv32(InsnKind::AUIPC, 0, 0, 4, imm_value);
     let (raw_witin, lkm) = AuipcInstruction::<GoldilocksExt2>::assign_instances(
         &config,
-        cb.cs.num_witin as usize,
+        cb.cs.num_witin_fnord as usize,
         vec![StepRecord::new_u_instruction(
             4,
             MOCK_PC_START,

--- a/ceno_zkvm/src/instructions/riscv/logic/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/logic/test.rs
@@ -31,19 +31,10 @@ fn test_opcode_and() {
         .unwrap();
 
     let insn_code = encode_rv32(InsnKind::AND, 2, 3, 4, 0);
-    let (raw_witin, lkm) =
-        AndInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
-            StepRecord::new_r_instruction(
-                3,
-                MOCK_PC_START,
-                insn_code,
-                A,
-                B,
-                Change::new(0, A & B),
-                0,
-            ),
-        ])
-        .unwrap();
+    let (raw_witin, lkm) = AndInstruction::assign_instances(&config, cb.cs.num_witin(), vec![
+        StepRecord::new_r_instruction(3, MOCK_PC_START, insn_code, A, B, Change::new(0, A & B), 0),
+    ])
+    .unwrap();
 
     let expected_rd_written = UInt8::from_const_unchecked(split_to_u8::<u64>(A & B));
 
@@ -82,19 +73,10 @@ fn test_opcode_or() {
         .unwrap();
 
     let insn_code = encode_rv32(InsnKind::OR, 2, 3, 4, 0);
-    let (raw_witin, lkm) =
-        OrInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
-            StepRecord::new_r_instruction(
-                3,
-                MOCK_PC_START,
-                insn_code,
-                A,
-                B,
-                Change::new(0, A | B),
-                0,
-            ),
-        ])
-        .unwrap();
+    let (raw_witin, lkm) = OrInstruction::assign_instances(&config, cb.cs.num_witin(), vec![
+        StepRecord::new_r_instruction(3, MOCK_PC_START, insn_code, A, B, Change::new(0, A | B), 0),
+    ])
+    .unwrap();
 
     let expected_rd_written = UInt8::from_const_unchecked(split_to_u8::<u64>(A | B));
 
@@ -133,19 +115,10 @@ fn test_opcode_xor() {
         .unwrap();
 
     let insn_code = encode_rv32(InsnKind::XOR, 2, 3, 4, 0);
-    let (raw_witin, lkm) =
-        XorInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
-            StepRecord::new_r_instruction(
-                3,
-                MOCK_PC_START,
-                insn_code,
-                A,
-                B,
-                Change::new(0, A ^ B),
-                0,
-            ),
-        ])
-        .unwrap();
+    let (raw_witin, lkm) = XorInstruction::assign_instances(&config, cb.cs.num_witin(), vec![
+        StepRecord::new_r_instruction(3, MOCK_PC_START, insn_code, A, B, Change::new(0, A ^ B), 0),
+    ])
+    .unwrap();
 
     let expected_rd_written = UInt8::from_const_unchecked(split_to_u8::<u64>(A ^ B));
 

--- a/ceno_zkvm/src/instructions/riscv/logic/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/logic/test.rs
@@ -32,7 +32,7 @@ fn test_opcode_and() {
 
     let insn_code = encode_rv32(InsnKind::AND, 2, 3, 4, 0);
     let (raw_witin, lkm) =
-        AndInstruction::assign_instances(&config, cb.cs.num_witin as usize, vec![
+        AndInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
             StepRecord::new_r_instruction(
                 3,
                 MOCK_PC_START,
@@ -83,7 +83,7 @@ fn test_opcode_or() {
 
     let insn_code = encode_rv32(InsnKind::OR, 2, 3, 4, 0);
     let (raw_witin, lkm) =
-        OrInstruction::assign_instances(&config, cb.cs.num_witin as usize, vec![
+        OrInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
             StepRecord::new_r_instruction(
                 3,
                 MOCK_PC_START,
@@ -134,7 +134,7 @@ fn test_opcode_xor() {
 
     let insn_code = encode_rv32(InsnKind::XOR, 2, 3, 4, 0);
     let (raw_witin, lkm) =
-        XorInstruction::assign_instances(&config, cb.cs.num_witin as usize, vec![
+        XorInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
             StepRecord::new_r_instruction(
                 3,
                 MOCK_PC_START,

--- a/ceno_zkvm/src/instructions/riscv/logic_imm/logic_imm_circuit.rs
+++ b/ceno_zkvm/src/instructions/riscv/logic_imm/logic_imm_circuit.rs
@@ -188,7 +188,7 @@ mod test {
         let insn_code = encode_rv32(I::INST_KIND, 2, 0, 4, imm);
         let (raw_witin, lkm) = LogicInstruction::<GoldilocksExt2, I>::assign_instances(
             &config,
-            cb.cs.num_witin_fnord as usize,
+            cb.cs.num_witin(),
             vec![StepRecord::new_i_instruction(
                 3,
                 Change::new(MOCK_PC_START, MOCK_PC_START + PC_STEP_SIZE),

--- a/ceno_zkvm/src/instructions/riscv/logic_imm/logic_imm_circuit.rs
+++ b/ceno_zkvm/src/instructions/riscv/logic_imm/logic_imm_circuit.rs
@@ -188,7 +188,7 @@ mod test {
         let insn_code = encode_rv32(I::INST_KIND, 2, 0, 4, imm);
         let (raw_witin, lkm) = LogicInstruction::<GoldilocksExt2, I>::assign_instances(
             &config,
-            cb.cs.num_witin as usize,
+            cb.cs.num_witin_fnord as usize,
             vec![StepRecord::new_i_instruction(
                 3,
                 Change::new(MOCK_PC_START, MOCK_PC_START + PC_STEP_SIZE),

--- a/ceno_zkvm/src/instructions/riscv/memory/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/test.rs
@@ -68,7 +68,7 @@ fn impl_opcode_store<E: ExtensionField + Hash, I: RIVInstruction, Inst: Instruct
         InsnKind::SW => sw(prev_mem_value, rs2_word),
         x => unreachable!("{:?} is not store instruction", x),
     };
-    let (raw_witin, lkm) = Inst::assign_instances(&config, cb.cs.num_witin as usize, vec![
+    let (raw_witin, lkm) = Inst::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
         StepRecord::new_s_instruction(
             12,
             MOCK_PC_START,

--- a/ceno_zkvm/src/instructions/riscv/memory/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/test.rs
@@ -68,7 +68,7 @@ fn impl_opcode_store<E: ExtensionField + Hash, I: RIVInstruction, Inst: Instruct
         InsnKind::SW => sw(prev_mem_value, rs2_word),
         x => unreachable!("{:?} is not store instruction", x),
     };
-    let (raw_witin, lkm) = Inst::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
+    let (raw_witin, lkm) = Inst::assign_instances(&config, cb.cs.num_witin(), vec![
         StepRecord::new_s_instruction(
             12,
             MOCK_PC_START,

--- a/ceno_zkvm/src/instructions/riscv/mulh.rs
+++ b/ceno_zkvm/src/instructions/riscv/mulh.rs
@@ -152,7 +152,7 @@ mod test {
         // values assignment
         let insn_code = encode_rv32(InsnKind::MULHU, 2, 3, 4, 0);
         let (raw_witin, lkm) =
-            MulhuInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
+            MulhuInstruction::assign_instances(&config, cb.cs.num_witin(), vec![
                 StepRecord::new_r_instruction(
                     3,
                     MOCK_PC_START,

--- a/ceno_zkvm/src/instructions/riscv/mulh.rs
+++ b/ceno_zkvm/src/instructions/riscv/mulh.rs
@@ -152,7 +152,7 @@ mod test {
         // values assignment
         let insn_code = encode_rv32(InsnKind::MULHU, 2, 3, 4, 0);
         let (raw_witin, lkm) =
-            MulhuInstruction::assign_instances(&config, cb.cs.num_witin as usize, vec![
+            MulhuInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
                 StepRecord::new_r_instruction(
                     3,
                     MOCK_PC_START,

--- a/ceno_zkvm/src/instructions/riscv/shift.rs
+++ b/ceno_zkvm/src/instructions/riscv/shift.rs
@@ -281,7 +281,7 @@ mod tests {
 
         let (raw_witin, lkm) = ShiftLogicalInstruction::<GoldilocksExt2, I>::assign_instances(
             &config,
-            cb.cs.num_witin_fnord as usize,
+            cb.cs.num_witin(),
             vec![StepRecord::new_r_instruction(
                 3,
                 MOCK_PC_START,

--- a/ceno_zkvm/src/instructions/riscv/shift.rs
+++ b/ceno_zkvm/src/instructions/riscv/shift.rs
@@ -281,7 +281,7 @@ mod tests {
 
         let (raw_witin, lkm) = ShiftLogicalInstruction::<GoldilocksExt2, I>::assign_instances(
             &config,
-            cb.cs.num_witin as usize,
+            cb.cs.num_witin_fnord as usize,
             vec![StepRecord::new_r_instruction(
                 3,
                 MOCK_PC_START,

--- a/ceno_zkvm/src/instructions/riscv/shift_imm.rs
+++ b/ceno_zkvm/src/instructions/riscv/shift_imm.rs
@@ -165,7 +165,7 @@ mod test {
         let insn_code = encode_rv32(InsnKind::SRLI, 2, 0, 4, imm);
         let (raw_witin, lkm) = ShiftImmInstruction::<GoldilocksExt2, SrliOp>::assign_instances(
             &config,
-            cb.cs.num_witin as usize,
+            cb.cs.num_witin_fnord as usize,
             vec![StepRecord::new_i_instruction(
                 3,
                 Change::new(MOCK_PC_START, MOCK_PC_START + PC_STEP_SIZE),

--- a/ceno_zkvm/src/instructions/riscv/shift_imm.rs
+++ b/ceno_zkvm/src/instructions/riscv/shift_imm.rs
@@ -165,7 +165,7 @@ mod test {
         let insn_code = encode_rv32(InsnKind::SRLI, 2, 0, 4, imm);
         let (raw_witin, lkm) = ShiftImmInstruction::<GoldilocksExt2, SrliOp>::assign_instances(
             &config,
-            cb.cs.num_witin_fnord as usize,
+            cb.cs.num_witin(),
             vec![StepRecord::new_i_instruction(
                 3,
                 Change::new(MOCK_PC_START, MOCK_PC_START + PC_STEP_SIZE),

--- a/ceno_zkvm/src/instructions/riscv/slt.rs
+++ b/ceno_zkvm/src/instructions/riscv/slt.rs
@@ -117,7 +117,7 @@ mod test {
 
         let insn_code = encode_rv32(InsnKind::SLT, 2, 3, 4, 0);
         let (raw_witin, lkm) =
-            SltInstruction::assign_instances(&config, cb.cs.num_witin as usize, vec![
+            SltInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
                 StepRecord::new_r_instruction(
                     3,
                     MOCK_PC_START,

--- a/ceno_zkvm/src/instructions/riscv/slt.rs
+++ b/ceno_zkvm/src/instructions/riscv/slt.rs
@@ -116,19 +116,18 @@ mod test {
             .unwrap();
 
         let insn_code = encode_rv32(InsnKind::SLT, 2, 3, 4, 0);
-        let (raw_witin, lkm) =
-            SltInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
-                StepRecord::new_r_instruction(
-                    3,
-                    MOCK_PC_START,
-                    insn_code,
-                    rs1 as Word,
-                    rs2 as Word,
-                    Change::new(0, rd),
-                    0,
-                ),
-            ])
-            .unwrap();
+        let (raw_witin, lkm) = SltInstruction::assign_instances(&config, cb.cs.num_witin(), vec![
+            StepRecord::new_r_instruction(
+                3,
+                MOCK_PC_START,
+                insn_code,
+                rs1 as Word,
+                rs2 as Word,
+                Change::new(0, rd),
+                0,
+            ),
+        ])
+        .unwrap();
 
         let expected_rd_written =
             UInt::from_const_unchecked(Value::new_unchecked(rd).as_u16_limbs().to_vec());

--- a/ceno_zkvm/src/instructions/riscv/sltu.rs
+++ b/ceno_zkvm/src/instructions/riscv/sltu.rs
@@ -133,19 +133,18 @@ mod test {
             .unwrap();
 
         let insn_code = encode_rv32(InsnKind::SLTU, 2, 3, 4, 0);
-        let (raw_witin, lkm) =
-            SltuInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
-                StepRecord::new_r_instruction(
-                    3,
-                    MOCK_PC_START,
-                    insn_code,
-                    rs1,
-                    rs2,
-                    Change::new(0, rd),
-                    0,
-                ),
-            ])
-            .unwrap();
+        let (raw_witin, lkm) = SltuInstruction::assign_instances(&config, cb.cs.num_witin(), vec![
+            StepRecord::new_r_instruction(
+                3,
+                MOCK_PC_START,
+                insn_code,
+                rs1,
+                rs2,
+                Change::new(0, rd),
+                0,
+            ),
+        ])
+        .unwrap();
 
         let expected_rd_written =
             UInt::from_const_unchecked(Value::new_unchecked(rd).as_u16_limbs().to_vec());

--- a/ceno_zkvm/src/instructions/riscv/sltu.rs
+++ b/ceno_zkvm/src/instructions/riscv/sltu.rs
@@ -134,7 +134,7 @@ mod test {
 
         let insn_code = encode_rv32(InsnKind::SLTU, 2, 3, 4, 0);
         let (raw_witin, lkm) =
-            SltuInstruction::assign_instances(&config, cb.cs.num_witin as usize, vec![
+            SltuInstruction::assign_instances(&config, cb.cs.num_witin_fnord as usize, vec![
                 StepRecord::new_r_instruction(
                     3,
                     MOCK_PC_START,

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -896,7 +896,7 @@ mod tests {
         let mut lk_multiplicity = LkMultiplicity::default();
         let raw_witin = circuit
             .assign_instances::<GoldilocksExt2>(
-                builder.cs.num_witin as usize,
+                builder.cs.num_witin_fnord as usize,
                 vec![AssertLtCircuitInput { a: 3, b: 5 }, AssertLtCircuitInput {
                     a: 7,
                     b: 11,
@@ -928,7 +928,7 @@ mod tests {
         let mut lk_multiplicity = LkMultiplicity::default();
         let raw_witin = circuit
             .assign_instances::<GoldilocksExt2>(
-                builder.cs.num_witin as usize,
+                builder.cs.num_witin_fnord as usize,
                 vec![
                     AssertLtCircuitInput {
                         a: u32::MAX as u64 - 5,
@@ -1020,7 +1020,7 @@ mod tests {
         let mut lk_multiplicity = LkMultiplicity::default();
         let raw_witin = circuit
             .assign_instances::<GoldilocksExt2>(
-                builder.cs.num_witin as usize,
+                builder.cs.num_witin_fnord as usize,
                 vec![LtCircuitInput { a: 3, b: 5 }, LtCircuitInput {
                     a: 7,
                     b: 11,
@@ -1053,7 +1053,7 @@ mod tests {
         let mut lk_multiplicity = LkMultiplicity::default();
         let raw_witin = circuit
             .assign_instances::<GoldilocksExt2>(
-                builder.cs.num_witin as usize,
+                builder.cs.num_witin_fnord as usize,
                 vec![
                     LtCircuitInput {
                         a: u32::MAX as u64 - 5,

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -896,7 +896,7 @@ mod tests {
         let mut lk_multiplicity = LkMultiplicity::default();
         let raw_witin = circuit
             .assign_instances::<GoldilocksExt2>(
-                builder.cs.num_witin_fnord as usize,
+                builder.cs.num_witin(),
                 vec![AssertLtCircuitInput { a: 3, b: 5 }, AssertLtCircuitInput {
                     a: 7,
                     b: 11,
@@ -928,7 +928,7 @@ mod tests {
         let mut lk_multiplicity = LkMultiplicity::default();
         let raw_witin = circuit
             .assign_instances::<GoldilocksExt2>(
-                builder.cs.num_witin_fnord as usize,
+                builder.cs.num_witin(),
                 vec![
                     AssertLtCircuitInput {
                         a: u32::MAX as u64 - 5,
@@ -1020,7 +1020,7 @@ mod tests {
         let mut lk_multiplicity = LkMultiplicity::default();
         let raw_witin = circuit
             .assign_instances::<GoldilocksExt2>(
-                builder.cs.num_witin_fnord as usize,
+                builder.cs.num_witin(),
                 vec![LtCircuitInput { a: 3, b: 5 }, LtCircuitInput {
                     a: 7,
                     b: 11,
@@ -1053,7 +1053,7 @@ mod tests {
         let mut lk_multiplicity = LkMultiplicity::default();
         let raw_witin = circuit
             .assign_instances::<GoldilocksExt2>(
-                builder.cs.num_witin_fnord as usize,
+                builder.cs.num_witin(),
                 vec![
                     LtCircuitInput {
                         a: u32::MAX as u64 - 5,

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -600,7 +600,7 @@ impl<'a, E: ExtensionField + Hash> MockProver<E> {
             ProgramTableCircuit::<_, MOCK_PROGRAM_SIZE>::construct_circuit(&mut cb).unwrap();
         let fixed = ProgramTableCircuit::<E, MOCK_PROGRAM_SIZE>::generate_fixed_traces(
             &config,
-            cs.num_fixed_fnord,
+            cs.num_fixed(),
             programs,
         );
         for table_expr in &cs.lk_table_expressions {

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -600,7 +600,7 @@ impl<'a, E: ExtensionField + Hash> MockProver<E> {
             ProgramTableCircuit::<_, MOCK_PROGRAM_SIZE>::construct_circuit(&mut cb).unwrap();
         let fixed = ProgramTableCircuit::<E, MOCK_PROGRAM_SIZE>::generate_fixed_traces(
             &config,
-            cs.num_fixed,
+            cs.num_fixed_fnord,
             programs,
         );
         for table_expr in &cs.lk_table_expressions {

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -119,7 +119,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
                 tracing::debug!(
                     "opcode circuit {} has {} witnesses, {} reads, {} writes, {} lookups",
                     circuit_name,
-                    cs.num_witin_fnord,
+                    cs.num_witin(),
                     cs.r_expressions.len(),
                     cs.w_expressions.len(),
                     cs.lk_expressions.len(),
@@ -196,7 +196,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
         let (chip_record_alpha, _) = (challenges[0], challenges[1]);
 
         // sanity check
-        assert_eq!(witnesses.len(), cs.num_witin_fnord as usize);
+        assert_eq!(witnesses.len(), cs.num_witin());
         assert!(
             witnesses
                 .iter()
@@ -638,7 +638,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
             .collect::<Vec<ArcMultilinearExtension<E>>>();
 
         // sanity check
-        assert_eq!(witnesses.len(), cs.num_witin_fnord as usize);
+        assert_eq!(witnesses.len(), cs.num_witin());
         assert_eq!(fixed.len(), cs.num_fixed);
         // check all witness size are power of 2
         assert!(

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -119,7 +119,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
                 tracing::debug!(
                     "opcode circuit {} has {} witnesses, {} reads, {} writes, {} lookups",
                     circuit_name,
-                    cs.num_witin,
+                    cs.num_witin_fnord,
                     cs.r_expressions.len(),
                     cs.w_expressions.len(),
                     cs.lk_expressions.len(),
@@ -196,7 +196,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
         let (chip_record_alpha, _) = (challenges[0], challenges[1]);
 
         // sanity check
-        assert_eq!(witnesses.len(), cs.num_witin as usize);
+        assert_eq!(witnesses.len(), cs.num_witin_fnord as usize);
         assert!(
             witnesses
                 .iter()
@@ -638,7 +638,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
             .collect::<Vec<ArcMultilinearExtension<E>>>();
 
         // sanity check
-        assert_eq!(witnesses.len(), cs.num_witin as usize);
+        assert_eq!(witnesses.len(), cs.num_witin_fnord as usize);
         assert_eq!(fixed.len(), cs.num_fixed);
         // check all witness size are power of 2
         assert!(

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -639,7 +639,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
 
         // sanity check
         assert_eq!(witnesses.len(), cs.num_witin as usize);
-        assert_eq!(fixed.len(), cs.num_fixed);
+        assert_eq!(fixed.len(), cs.num_fixed_fnord);
         // check all witness size are power of 2
         assert!(
             witnesses

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -639,7 +639,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
 
         // sanity check
         assert_eq!(witnesses.len(), cs.num_witin as usize);
-        assert_eq!(fixed.len(), cs.num_fixed_fnord);
+        assert_eq!(fixed.len(), cs.num_fixed());
         // check all witness size are power of 2
         assert!(
             witnesses

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -220,8 +220,7 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
         assert!(self.combined_lk_mlt.is_none());
 
         let cs = cs.get_cs(&OC::name()).unwrap();
-        let (witness, logup_multiplicity) =
-            OC::assign_instances(config, cs.num_witin_fnord as usize, records)?;
+        let (witness, logup_multiplicity) = OC::assign_instances(config, cs.num_witin(), records)?;
         assert!(self.witnesses.insert(OC::name(), witness).is_none());
         assert!(
             self.lk_mlts
@@ -269,7 +268,7 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
         let cs = cs.get_cs(&TC::name()).unwrap();
         let witness = TC::assign_instances(
             config,
-            cs.num_witin_fnord as usize,
+            cs.num_witin(),
             self.combined_lk_mlt.as_ref().unwrap(),
             input,
         )?;

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -221,7 +221,7 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
 
         let cs = cs.get_cs(&OC::name()).unwrap();
         let (witness, logup_multiplicity) =
-            OC::assign_instances(config, cs.num_witin as usize, records)?;
+            OC::assign_instances(config, cs.num_witin_fnord as usize, records)?;
         assert!(self.witnesses.insert(OC::name(), witness).is_none());
         assert!(
             self.lk_mlts
@@ -269,7 +269,7 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
         let cs = cs.get_cs(&TC::name()).unwrap();
         let witness = TC::assign_instances(
             config,
-            cs.num_witin as usize,
+            cs.num_witin_fnord as usize,
             self.combined_lk_mlt.as_ref().unwrap(),
             input,
         )?;

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -196,7 +196,7 @@ impl<E: ExtensionField> ZKVMFixedTraces<E> {
             self.circuit_fixed_traces
                 .insert(
                     TC::name(),
-                    Some(TC::generate_fixed_traces(&config, cs.num_fixed, input)),
+                    Some(TC::generate_fixed_traces(&config, cs.num_fixed_fnord, input)),
                 )
                 .is_none()
         );

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -196,7 +196,7 @@ impl<E: ExtensionField> ZKVMFixedTraces<E> {
             self.circuit_fixed_traces
                 .insert(
                     TC::name(),
-                    Some(TC::generate_fixed_traces(&config, cs.num_fixed_fnord, input)),
+                    Some(TC::generate_fixed_traces(&config, cs.num_fixed(), input)),
                 )
                 .is_none()
         );

--- a/ceno_zkvm/src/virtual_polys.rs
+++ b/ceno_zkvm/src/virtual_polys.rs
@@ -195,7 +195,7 @@ mod tests {
         let x = cb.create_witin(|| "x").unwrap();
         let y = cb.create_witin(|| "y").unwrap();
 
-        let wits_in: Vec<ArcMultilinearExtension<E>> = (0..cs.num_witin_fnord as usize)
+        let wits_in: Vec<ArcMultilinearExtension<E>> = (0..cs.num_witin())
             .map(|_| vec![Goldilocks::from(1)].into_mle().into())
             .collect();
 

--- a/ceno_zkvm/src/virtual_polys.rs
+++ b/ceno_zkvm/src/virtual_polys.rs
@@ -195,7 +195,7 @@ mod tests {
         let x = cb.create_witin(|| "x").unwrap();
         let y = cb.create_witin(|| "y").unwrap();
 
-        let wits_in: Vec<ArcMultilinearExtension<E>> = (0..cs.num_witin as usize)
+        let wits_in: Vec<ArcMultilinearExtension<E>> = (0..cs.num_witin_fnord as usize)
             .map(|_| vec![Goldilocks::from(1)].into_mle().into())
             .collect();
 


### PR DESCRIPTION
Earlier, we cached the length of `witin_namespace_map` and `fixed_namespace_map` inside the `CircuitBuilder`.  That means we had to manually keep the cache in sync with the underlying source of truth.

In this PR, we remove the caches and instead ask for the lengths when we need them.

This makes our logic simpler and more robust: fewer moving parts that can go out of sync.

Git agrees:

> `20 files changed, 84 insertions(+), 134 deletions(-)`

For context, this PR prepares for removing the need to clone our `Expression`s.