### PR TITLE
Remove unnecessary clones

### DIFF
--- a/ceno_zkvm/src/instructions/riscv/shift_imm.rs
+++ b/ceno_zkvm/src/instructions/riscv/shift_imm.rs
@@ -89,7 +89,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ShiftImmInstructio
                         let is_rs1_neg = IsLtConfig::construct_circuit(
                             circuit_builder,
                             || "lhs_msb",
-                            max_signed_limb_expr.clone(),
+                            max_signed_limb_expr,
                             rs1_read.limbs.iter().last().unwrap().expr(), // msb limb
                             1,
                         )?;

--- a/ceno_zkvm/src/instructions/riscv/slti.rs
+++ b/ceno_zkvm/src/instructions/riscv/slti.rs
@@ -51,7 +51,7 @@ impl<E: ExtensionField> Instruction<E> for SltiInstruction<E> {
         let is_rs1_neg = IsLtConfig::construct_circuit(
             cb,
             || "lhs_msb",
-            max_signed_limb_expr.clone(),
+            max_signed_limb_expr,
             rs1_read.limbs.iter().last().unwrap().expr(), // msb limb
             1,
         )?;


### PR DESCRIPTION
Copy-and-paste coding, again.  See 47f5572ff093b3467b53f4d535b94a162e922b49 / https://github.com/scroll-tech/ceno/pull/463

This PR only patches up the unnecessary clone, it doesn't fix the code-duplication-with-small-variations that's the actual problem with our pervasive copy-and-paste culture.