### PR TITLE
Ignore `MockProver`'s temporary files

### DIFF
--- a/ceno_zkvm/.gitignore
+++ b/ceno_zkvm/.gitignore
@@ -1,1 +1,2 @@
 tracing.folded
+.tmp*


### PR DESCRIPTION
`load_once_tables` produces temporary files.  Generally, the function tries to clean them up.  But if you kill your process at just the right (or wrong) time, it can leak these files.

Here we tell git to ignore them, so they don't accidentally become part of the repository with a careless commit.

(We could put some extra time and effort into avoiding the leaking of the temporary files in the first place.  But it's not really a big enough problem for us to care.)