### PR TITLE
fix/fixed_commit_unwrap

### DIFF
--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -758,7 +758,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
             proof.fixed_in_evals.len(),
             input_opening_point,
             proof.fixed_in_evals,
-            circuit_vk.fixed_commit.as_ref().unwrap(),
+            circuit_vk.fixed_commit,
         );
 
         PCS::simple_batch_verify(


### PR DESCRIPTION
Integration test currently broken with `RUST_LOG=debug`:

```
thread 'main' panicked at /home/a/INV/scroll/ceno/ceno_zkvm/src/scheme/verifier.rs:761:46:
called `Option::unwrap()` on a `None` value
```

Fixed here.