### PR TITLE
Feat: mock prover for zkvm

### DIFF
--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -27,19 +27,19 @@ strum_macros.workspace = true
 tracing.workspace = true
 tracing-flame.workspace = true
 tracing-subscriber.workspace = true
+serde_json.workspace = true
 
 clap = { version = "4.5", features = ["derive"] }
 generic_static = "0.2"
 rand.workspace = true
 tempfile = "3.13"
 thread_local = "1.1"
+base64 = "0.22"
 
 [dev-dependencies]
-base64 = "0.22"
 cfg-if.workspace = true
 criterion.workspace = true
 pprof.workspace = true
-serde_json.workspace = true
 
 [build-dependencies]
 glob = "0.3"

--- a/ceno_zkvm/examples/fibonacci_elf.rs
+++ b/ceno_zkvm/examples/fibonacci_elf.rs
@@ -5,7 +5,8 @@ use ceno_emul::{
 use ceno_zkvm::{
     instructions::riscv::{Rv32imConfig, constants::EXIT_PC},
     scheme::{
-        PublicValues, constants::MAX_NUM_VARIABLES, prover::ZKVMProver, verifier::ZKVMVerifier,
+        PublicValues, constants::MAX_NUM_VARIABLES, mock_prover::MockProver, prover::ZKVMProver,
+        verifier::ZKVMVerifier,
     },
     state::GlobalState,
     structs::{ZKVMConstraintSystem, ZKVMFixedTraces, ZKVMWitnesses},
@@ -73,7 +74,7 @@ fn main() {
 
     let pk = zkvm_cs
         .clone()
-        .key_gen::<Pcs>(pp.clone(), vp.clone(), zkvm_fixed_traces)
+        .key_gen::<Pcs>(pp.clone(), vp.clone(), zkvm_fixed_traces.clone())
         .expect("keygen failed");
     let vk = pk.get_vk();
 
@@ -158,6 +159,7 @@ fn main() {
         .assign_table_circuit::<ExampleProgramTableCircuit<E>>(&zkvm_cs, &prog_config, vm.program())
         .unwrap();
 
+    MockProver::assert_satisfied_full(zkvm_cs, zkvm_fixed_traces, zkvm_witness.clone(), &pi);
     let timer = Instant::now();
 
     let transcript = Transcript::new(b"riscv");

--- a/ceno_zkvm/src/chip_handler/general.rs
+++ b/ceno_zkvm/src/chip_handler/general.rs
@@ -7,7 +7,7 @@ use crate::{
     instructions::riscv::constants::{
         END_CYCLE_IDX, END_PC_IDX, EXIT_CODE_IDX, INIT_CYCLE_IDX, INIT_PC_IDX,
     },
-    structs::ROMType,
+    structs::{RAMType, ROMType},
     tables::InsnRecord,
 };
 
@@ -73,7 +73,8 @@ impl<'a, E: ExtensionField> CircuitBuilder<'a, E> {
         &mut self,
         name_fn: N,
         table_len: usize,
-        rlc_record: Expression<E>,
+        rom_type: ROMType,
+        items: Vec<Expression<E>>,
         multiplicity: Expression<E>,
     ) -> Result<(), ZKVMError>
     where
@@ -81,7 +82,7 @@ impl<'a, E: ExtensionField> CircuitBuilder<'a, E> {
         N: FnOnce() -> NR,
     {
         self.cs
-            .lk_table_record(name_fn, table_len, rlc_record, multiplicity)
+            .lk_table_record(name_fn, table_len, rom_type, items, multiplicity)
     }
 
     pub fn r_table_record<NR, N>(
@@ -118,25 +119,27 @@ impl<'a, E: ExtensionField> CircuitBuilder<'a, E> {
     pub fn read_record<NR, N>(
         &mut self,
         name_fn: N,
-        rlc_record: Expression<E>,
+        ram_type: RAMType,
+        record: Vec<Expression<E>>,
     ) -> Result<(), ZKVMError>
     where
         NR: Into<String>,
         N: FnOnce() -> NR,
     {
-        self.cs.read_record(name_fn, rlc_record)
+        self.cs.read_record(name_fn, ram_type, record)
     }
 
     pub fn write_record<NR, N>(
         &mut self,
         name_fn: N,
-        rlc_record: Expression<E>,
+        ram_type: RAMType,
+        record: Vec<Expression<E>>,
     ) -> Result<(), ZKVMError>
     where
         NR: Into<String>,
         N: FnOnce() -> NR,
     {
-        self.cs.write_record(name_fn, rlc_record)
+        self.cs.write_record(name_fn, ram_type, record)
     }
 
     pub fn rlc_chip_record(&self, records: Vec<Expression<E>>) -> Expression<E> {

--- a/ceno_zkvm/src/chip_handler/global_state.rs
+++ b/ceno_zkvm/src/chip_handler/global_state.rs
@@ -8,23 +8,21 @@ use super::GlobalStateRegisterMachineChipOperations;
 
 impl<'a, E: ExtensionField> GlobalStateRegisterMachineChipOperations<E> for CircuitBuilder<'a, E> {
     fn state_in(&mut self, pc: Expression<E>, ts: Expression<E>) -> Result<(), ZKVMError> {
-        let items: Vec<Expression<E>> = vec![
+        let record: Vec<Expression<E>> = vec![
             Expression::Constant(E::BaseField::from(RAMType::GlobalState as u64)),
             pc,
             ts,
         ];
 
-        let rlc_record = self.rlc_chip_record(items);
-        self.read_record(|| "state_in", rlc_record)
+        self.read_record(|| "state_in", RAMType::GlobalState, record)
     }
 
     fn state_out(&mut self, pc: Expression<E>, ts: Expression<E>) -> Result<(), ZKVMError> {
-        let items: Vec<Expression<E>> = vec![
+        let record: Vec<Expression<E>> = vec![
             Expression::Constant(E::BaseField::from(RAMType::GlobalState as u64)),
             pc,
             ts,
         ];
-        let rlc_record = self.rlc_chip_record(items);
-        self.write_record(|| "state_out", rlc_record)
+        self.write_record(|| "state_out", RAMType::GlobalState, record)
     }
 }

--- a/ceno_zkvm/src/chip_handler/memory.rs
+++ b/ceno_zkvm/src/chip_handler/memory.rs
@@ -22,31 +22,27 @@ impl<'a, E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> MemoryChipOpera
     ) -> Result<(Expression<E>, AssertLTConfig), ZKVMError> {
         self.namespace(name_fn, |cb| {
             // READ (a, v, t)
-            let read_record = cb.rlc_chip_record(
-                [
-                    vec![
-                        Expression::<E>::Constant(E::BaseField::from(RAMType::Memory as u64)),
-                        memory_addr.clone(),
-                    ],
-                    vec![value.clone()],
-                    vec![prev_ts.clone()],
-                ]
-                .concat(),
-            );
+            let read_record = [
+                vec![
+                    Expression::<E>::Constant(E::BaseField::from(RAMType::Memory as u64)),
+                    memory_addr.clone(),
+                ],
+                vec![value.clone()],
+                vec![prev_ts.clone()],
+            ]
+            .concat();
             // Write (a, v, t)
-            let write_record = cb.rlc_chip_record(
-                [
-                    vec![
-                        Expression::<E>::Constant(E::BaseField::from(RAMType::Memory as u64)),
-                        memory_addr.clone(),
-                    ],
-                    vec![value],
-                    vec![ts.clone()],
-                ]
-                .concat(),
-            );
-            cb.read_record(|| "read_record", read_record)?;
-            cb.write_record(|| "write_record", write_record)?;
+            let write_record = [
+                vec![
+                    Expression::<E>::Constant(E::BaseField::from(RAMType::Memory as u64)),
+                    memory_addr.clone(),
+                ],
+                vec![value],
+                vec![ts.clone()],
+            ]
+            .concat();
+            cb.read_record(|| "read_record", RAMType::Memory, read_record)?;
+            cb.write_record(|| "write_record", RAMType::Memory, write_record)?;
 
             // assert prev_ts < current_ts
             let lt_cfg = AssertLTConfig::construct_circuit(
@@ -74,31 +70,27 @@ impl<'a, E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> MemoryChipOpera
     ) -> Result<(Expression<E>, AssertLTConfig), ZKVMError> {
         self.namespace(name_fn, |cb| {
             // READ (a, v, t)
-            let read_record = cb.rlc_chip_record(
-                [
-                    vec![
-                        Expression::<E>::Constant(E::BaseField::from(RAMType::Memory as u64)),
-                        memory_addr.clone(),
-                    ],
-                    vec![prev_values],
-                    vec![prev_ts.clone()],
-                ]
-                .concat(),
-            );
+            let read_record = [
+                vec![
+                    Expression::<E>::Constant(E::BaseField::from(RAMType::Memory as u64)),
+                    memory_addr.clone(),
+                ],
+                vec![prev_values],
+                vec![prev_ts.clone()],
+            ]
+            .concat();
             // Write (a, v, t)
-            let write_record = cb.rlc_chip_record(
-                [
-                    vec![
-                        Expression::<E>::Constant(E::BaseField::from(RAMType::Memory as u64)),
-                        memory_addr.clone(),
-                    ],
-                    vec![value],
-                    vec![ts.clone()],
-                ]
-                .concat(),
-            );
-            cb.read_record(|| "read_record", read_record)?;
-            cb.write_record(|| "write_record", write_record)?;
+            let write_record = [
+                vec![
+                    Expression::<E>::Constant(E::BaseField::from(RAMType::Memory as u64)),
+                    memory_addr.clone(),
+                ],
+                vec![value],
+                vec![ts.clone()],
+            ]
+            .concat();
+            cb.read_record(|| "read_record", RAMType::Memory, read_record)?;
+            cb.write_record(|| "write_record", RAMType::Memory, write_record)?;
 
             let lt_cfg = AssertLTConfig::construct_circuit(
                 cb,

--- a/ceno_zkvm/src/chip_handler/register.rs
+++ b/ceno_zkvm/src/chip_handler/register.rs
@@ -24,31 +24,27 @@ impl<'a, E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> RegisterChipOpe
     ) -> Result<(Expression<E>, AssertLTConfig), ZKVMError> {
         self.namespace(name_fn, |cb| {
             // READ (a, v, t)
-            let read_record = cb.rlc_chip_record(
-                [
-                    vec![Expression::<E>::Constant(E::BaseField::from(
-                        RAMType::Register as u64,
-                    ))],
-                    vec![register_id.expr()],
-                    value.to_vec(),
-                    vec![prev_ts.clone()],
-                ]
-                .concat(),
-            );
+            let read_record = [
+                vec![Expression::<E>::Constant(E::BaseField::from(
+                    RAMType::Register as u64,
+                ))],
+                vec![register_id.expr()],
+                value.to_vec(),
+                vec![prev_ts.clone()],
+            ]
+            .concat();
             // Write (a, v, t)
-            let write_record = cb.rlc_chip_record(
-                [
-                    vec![Expression::<E>::Constant(E::BaseField::from(
-                        RAMType::Register as u64,
-                    ))],
-                    vec![register_id.expr()],
-                    value.to_vec(),
-                    vec![ts.clone()],
-                ]
-                .concat(),
-            );
-            cb.read_record(|| "read_record", read_record)?;
-            cb.write_record(|| "write_record", write_record)?;
+            let write_record = [
+                vec![Expression::<E>::Constant(E::BaseField::from(
+                    RAMType::Register as u64,
+                ))],
+                vec![register_id.expr()],
+                value.to_vec(),
+                vec![ts.clone()],
+            ]
+            .concat();
+            cb.read_record(|| "read_record", RAMType::Register, read_record)?;
+            cb.write_record(|| "write_record", RAMType::Register, write_record)?;
 
             // assert prev_ts < current_ts
             let lt_cfg = AssertLTConfig::construct_circuit(
@@ -77,31 +73,27 @@ impl<'a, E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> RegisterChipOpe
         assert!(register_id.expr().degree() <= 1);
         self.namespace(name_fn, |cb| {
             // READ (a, v, t)
-            let read_record = cb.rlc_chip_record(
-                [
-                    vec![Expression::<E>::Constant(E::BaseField::from(
-                        RAMType::Register as u64,
-                    ))],
-                    vec![register_id.expr()],
-                    prev_values.to_vec(),
-                    vec![prev_ts.clone()],
-                ]
-                .concat(),
-            );
+            let read_record = [
+                vec![Expression::<E>::Constant(E::BaseField::from(
+                    RAMType::Register as u64,
+                ))],
+                vec![register_id.expr()],
+                prev_values.to_vec(),
+                vec![prev_ts.clone()],
+            ]
+            .concat();
             // Write (a, v, t)
-            let write_record = cb.rlc_chip_record(
-                [
-                    vec![Expression::<E>::Constant(E::BaseField::from(
-                        RAMType::Register as u64,
-                    ))],
-                    vec![register_id.expr()],
-                    value.to_vec(),
-                    vec![ts.clone()],
-                ]
-                .concat(),
-            );
-            cb.read_record(|| "read_record", read_record)?;
-            cb.write_record(|| "write_record", write_record)?;
+            let write_record = [
+                vec![Expression::<E>::Constant(E::BaseField::from(
+                    RAMType::Register as u64,
+                ))],
+                vec![register_id.expr()],
+                value.to_vec(),
+                vec![ts.clone()],
+            ]
+            .concat();
+            cb.read_record(|| "read_record", RAMType::Register, read_record)?;
+            cb.write_record(|| "write_record", RAMType::Register, write_record)?;
 
             let lt_cfg = AssertLTConfig::construct_circuit(
                 cb,

--- a/ceno_zkvm/src/circuit_builder.rs
+++ b/ceno_zkvm/src/circuit_builder.rs
@@ -9,7 +9,7 @@ use crate::{
     chip_handler::utils::rlc_chip_record,
     error::ZKVMError,
     expression::{Expression, Fixed, Instance, WitIn},
-    structs::{ProvingKey, VerifyingKey, WitnessId},
+    structs::{ProvingKey, RAMType, VerifyingKey, WitnessId},
     witness::RowMajorMatrix,
 };
 
@@ -92,9 +92,15 @@ pub struct ConstraintSystem<E: ExtensionField> {
 
     pub r_expressions: Vec<Expression<E>>,
     pub r_expressions_namespace_map: Vec<String>,
+    // for each read expression we store its ram type and original value before doing RLC
+    // the original value will be used for debugging
+    pub r_ram_types: Vec<(RAMType, Vec<Expression<E>>)>,
 
     pub w_expressions: Vec<Expression<E>>,
     pub w_expressions_namespace_map: Vec<String>,
+    // for each write expression we store its ram type and original value before doing RLC
+    // the original value will be used for debugging
+    pub w_ram_types: Vec<(RAMType, Vec<Expression<E>>)>,
 
     /// init/final ram expression
     pub r_table_expressions: Vec<SetTableExpression<E>>,
@@ -123,9 +129,7 @@ pub struct ConstraintSystem<E: ExtensionField> {
     pub chip_record_alpha: Expression<E>,
     pub chip_record_beta: Expression<E>,
 
-    #[cfg(test)]
     pub debug_map: HashMap<usize, Vec<Expression<E>>>,
-    #[cfg(test)]
     pub lk_expressions_items_map: Vec<(ROMType, Vec<Expression<E>>)>,
 
     pub(crate) phantom: PhantomData<E>,
@@ -142,8 +146,10 @@ impl<E: ExtensionField> ConstraintSystem<E> {
             instance_name_map: HashMap::new(),
             r_expressions: vec![],
             r_expressions_namespace_map: vec![],
+            r_ram_types: vec![],
             w_expressions: vec![],
             w_expressions_namespace_map: vec![],
+            w_ram_types: vec![],
             r_table_expressions: vec![],
             r_table_expressions_namespace_map: vec![],
             w_table_expressions: vec![],
@@ -160,9 +166,7 @@ impl<E: ExtensionField> ConstraintSystem<E> {
             chip_record_alpha: Expression::Challenge(0, 1, E::ONE, E::ZERO),
             chip_record_beta: Expression::Challenge(1, 1, E::ONE, E::ZERO),
 
-            #[cfg(test)]
             debug_map: HashMap::new(),
-            #[cfg(test)]
             lk_expressions_items_map: vec![],
 
             phantom: std::marker::PhantomData,
@@ -247,16 +251,11 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         &mut self,
         name_fn: N,
         rom_type: ROMType,
-        items: Vec<Expression<E>>,
+        record: Vec<Expression<E>>,
     ) -> Result<(), ZKVMError> {
         let rlc_record = self.rlc_chip_record(
             std::iter::once(Expression::Constant(E::BaseField::from(rom_type as u64)))
-                .chain(
-                    #[cfg(test)]
-                    items.clone(),
-                    #[cfg(not(test))]
-                    items,
-                )
+                .chain(record.clone())
                 .collect(),
         );
         assert_eq!(
@@ -268,8 +267,9 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         self.lk_expressions.push(rlc_record);
         let path = self.ns.compute_path(name_fn().into());
         self.lk_expressions_namespace_map.push(path);
-        #[cfg(test)]
-        self.lk_expressions_items_map.push((rom_type, items));
+        // Since lk_expression is RLC(record) and when we're debugging
+        // it's helpful to recover the value of record itself.
+        self.lk_expressions_items_map.push((rom_type, record));
         Ok(())
     }
 
@@ -277,13 +277,20 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         &mut self,
         name_fn: N,
         table_len: usize,
-        rlc_record: Expression<E>,
+        rom_type: ROMType,
+        record: Vec<Expression<E>>,
         multiplicity: Expression<E>,
     ) -> Result<(), ZKVMError>
     where
         NR: Into<String>,
         N: FnOnce() -> NR,
     {
+        let rlc_record = self.rlc_chip_record(
+            vec![(rom_type as usize).into()]
+                .into_iter()
+                .chain(record.clone())
+                .collect_vec(),
+        );
         assert_eq!(
             rlc_record.degree(),
             1,
@@ -297,6 +304,9 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         });
         let path = self.ns.compute_path(name_fn().into());
         self.lk_table_expressions_namespace_map.push(path);
+        // Since lk_expression is RLC(record) and when we're debugging
+        // it's helpful to recover the value of record itself.
+        self.lk_expressions_items_map.push((rom_type, record));
 
         Ok(())
     }
@@ -356,8 +366,10 @@ impl<E: ExtensionField> ConstraintSystem<E> {
     pub fn read_record<NR: Into<String>, N: FnOnce() -> NR>(
         &mut self,
         name_fn: N,
-        rlc_record: Expression<E>,
+        ram_type: RAMType,
+        record: Vec<Expression<E>>,
     ) -> Result<(), ZKVMError> {
+        let rlc_record = self.rlc_chip_record(record.clone());
         assert_eq!(
             rlc_record.degree(),
             1,
@@ -367,14 +379,19 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         self.r_expressions.push(rlc_record);
         let path = self.ns.compute_path(name_fn().into());
         self.r_expressions_namespace_map.push(path);
+        // Since r_expression is RLC(record) and when we're debugging
+        // it's helpful to recover the value of record itself.
+        self.r_ram_types.push((ram_type, record));
         Ok(())
     }
 
     pub fn write_record<NR: Into<String>, N: FnOnce() -> NR>(
         &mut self,
         name_fn: N,
-        rlc_record: Expression<E>,
+        ram_type: RAMType,
+        record: Vec<Expression<E>>,
     ) -> Result<(), ZKVMError> {
+        let rlc_record = self.rlc_chip_record(record.clone());
         assert_eq!(
             rlc_record.degree(),
             1,
@@ -384,6 +401,7 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         self.w_expressions.push(rlc_record);
         let path = self.ns.compute_path(name_fn().into());
         self.w_expressions_namespace_map.push(path);
+        self.w_ram_types.push((ram_type, record));
         Ok(())
     }
 

--- a/ceno_zkvm/src/expression.rs
+++ b/ceno_zkvm/src/expression.rs
@@ -12,7 +12,6 @@ use ff::Field;
 use ff_ext::ExtensionField;
 use goldilocks::SmallField;
 
-#[cfg(test)]
 use multilinear_extensions::virtual_poly_v2::ArcMultilinearExtension;
 
 use crate::{
@@ -836,7 +835,6 @@ pub mod fmt {
         if add_parens { format!("({})", s) } else { s }
     }
 
-    #[cfg(test)]
     pub fn wtns<E: ExtensionField>(
         wtns: &[WitnessId],
         wits_in: &[ArcMultilinearExtension<E>],

--- a/ceno_zkvm/src/instructions/riscv/rv32im.rs
+++ b/ceno_zkvm/src/instructions/riscv/rv32im.rs
@@ -21,7 +21,8 @@ use crate::{
     structs::{ZKVMConstraintSystem, ZKVMFixedTraces, ZKVMWitnesses},
     tables::{
         AndTableCircuit, LtuTableCircuit, MemFinalRecord, MemInitRecord, MemTableCircuit,
-        RegTableCircuit, TableCircuit, U14TableCircuit, U16TableCircuit,
+        OrTableCircuit, RegTableCircuit, TableCircuit, U5TableCircuit, U8TableCircuit,
+        U14TableCircuit, U16TableCircuit, XorTableCircuit,
     },
 };
 use ceno_emul::{CENO_PLATFORM, InsnKind, InsnKind::*, StepRecord};
@@ -30,7 +31,6 @@ use itertools::Itertools;
 use num_traits::cast::ToPrimitive;
 use std::collections::{BTreeMap, BTreeSet};
 use strum::IntoEnumIterator;
-use crate::tables::{OrTableCircuit, U5TableCircuit, U8TableCircuit, XorTableCircuit};
 
 use super::{
     arith::AddInstruction,

--- a/ceno_zkvm/src/scheme.rs
+++ b/ceno_zkvm/src/scheme.rs
@@ -11,7 +11,6 @@ pub mod prover;
 pub mod utils;
 pub mod verifier;
 
-#[cfg(test)]
 pub mod mock_prover;
 #[cfg(test)]
 mod tests;

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -1,9 +1,13 @@
-use super::utils::{eval_by_expr, wit_infer_by_expr};
+use super::{
+    PublicValues,
+    utils::{eval_by_expr, wit_infer_by_expr},
+};
 use crate::{
     ROMType,
     circuit_builder::{CircuitBuilder, ConstraintSystem},
     expression::{Expression, fmt},
-    scheme::utils::eval_by_expr_with_fixed,
+    scheme::utils::{eval_by_expr_with_fixed, eval_by_expr_with_instance},
+    structs::{RAMType, ZKVMConstraintSystem, ZKVMFixedTraces, ZKVMWitnesses},
     tables::{
         AndTable, LtuTable, OpsTable, OrTable, PowTable, ProgramTableCircuit, RangeTable,
         TableCircuit, U5Table, U8Table, U14Table, U16Table, XorTable,
@@ -19,8 +23,9 @@ use generic_static::StaticTypeMap;
 use goldilocks::SmallField;
 use itertools::{Itertools, izip};
 use multilinear_extensions::{mle::IntoMLEs, virtual_poly_v2::ArcMultilinearExtension};
+use rand::thread_rng;
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fs::File,
     hash::Hash,
     io::{BufReader, ErrorKind},
@@ -36,7 +41,7 @@ pub const MOCK_PC_START: ByteAddr = ByteAddr(CENO_PLATFORM.pc_base());
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone)]
-pub(crate) enum MockProverError<E: ExtensionField> {
+pub enum MockProverError<E: ExtensionField> {
     AssertZeroError {
         expression: Expression<E>,
         evaluated: E::BaseField,
@@ -263,6 +268,7 @@ impl<E: ExtensionField> MockProverError<E> {
         }
     }
 
+    #[cfg(test)]
     fn inst_id(&self) -> usize {
         match self {
             Self::AssertZeroError { inst_id, .. }
@@ -278,7 +284,7 @@ impl<E: ExtensionField> MockProverError<E> {
     }
 }
 
-pub(crate) struct MockProver<E: ExtensionField> {
+pub struct MockProver<E: ExtensionField> {
     _phantom: PhantomData<E>,
 }
 
@@ -737,6 +743,403 @@ Hints:
         lkm: Option<LkMultiplicity>,
     ) {
         Self::assert_with_expected_errors(cb, wits_in, programs, &[], challenge, lkm);
+    }
+
+    pub fn assert_satisfied_full(
+        cs: ZKVMConstraintSystem<E>,
+        mut fixed_trace: ZKVMFixedTraces<E>,
+        mut witnesses: ZKVMWitnesses<E>,
+        pi: &PublicValues<u32>,
+    ) {
+        let instance = pi.to_vec::<E>();
+        let mut rng = thread_rng();
+        let challenges = [0u8; 2].map(|_| E::random(&mut rng));
+
+        let mut wit_mles = HashMap::new();
+        let mut fixed_mles = HashMap::new();
+        let mut num_instances = HashMap::new();
+        // Lookup errors
+        let mut rom_inputs =
+            HashMap::<ROMType, Vec<(Vec<E>, String, String, Vec<Expression<E>>)>>::new();
+        let mut rom_tables = HashMap::<ROMType, HashMap<E, E::BaseField>>::new();
+        for (circuit_name, cs) in cs.circuit_css.iter() {
+            let (is_opcode, witness) = witnesses.witnesses.remove(circuit_name).unwrap();
+            let num_rows = witness.num_instances();
+
+            if witness.num_instances() == 0 {
+                wit_mles.insert(circuit_name.clone(), vec![]);
+                fixed_mles.insert(circuit_name.clone(), vec![]);
+                num_instances.insert(circuit_name.clone(), num_rows);
+                continue;
+            }
+            let witness = witness
+                .into_mles()
+                .into_iter()
+                .map(|w| w.into())
+                .collect_vec();
+            let fixed: Vec<_> = fixed_trace
+                .circuit_fixed_traces
+                .remove(circuit_name)
+                .unwrap()
+                .map_or(vec![], |fixed| {
+                    fixed
+                        .into_mles()
+                        .into_iter()
+                        .map(|f| f.into())
+                        .collect_vec()
+                });
+            if is_opcode {
+                tracing::info!(
+                    "preprocessing opcode {} with {} entries",
+                    circuit_name,
+                    num_rows
+                );
+                // gather lookup inputs
+                for ((expr, annotation), (rom_type, values)) in cs
+                    .lk_expressions
+                    .iter()
+                    .zip(cs.lk_expressions_namespace_map.clone().into_iter())
+                    .zip(cs.lk_expressions_items_map.clone().into_iter())
+                {
+                    let lk_input =
+                        (wit_infer_by_expr(&fixed, &witness, &instance, &challenges, expr)
+                            .get_ext_field_vec())[..num_rows]
+                            .to_vec();
+                    rom_inputs.entry(rom_type).or_default().push((
+                        lk_input,
+                        circuit_name.clone(),
+                        annotation,
+                        values,
+                    ));
+                }
+            } else {
+                tracing::info!(
+                    "preprocessing table {} with {} entries",
+                    circuit_name,
+                    num_rows
+                );
+                // gather lookup tables
+                for (expr, (rom_type, _)) in cs
+                    .lk_table_expressions
+                    .iter()
+                    .zip(cs.lk_expressions_items_map.clone().into_iter())
+                {
+                    let lk_table =
+                        wit_infer_by_expr(&fixed, &witness, &instance, &challenges, &expr.values)
+                            .get_ext_field_vec()
+                            .to_vec();
+
+                    let multiplicity = wit_infer_by_expr(
+                        &fixed,
+                        &witness,
+                        &instance,
+                        &challenges,
+                        &expr.multiplicity,
+                    )
+                    .get_base_field_vec()
+                    .to_vec();
+
+                    assert!(
+                        rom_tables
+                            .insert(
+                                rom_type,
+                                lk_table
+                                    .into_iter()
+                                    .zip(multiplicity.into_iter())
+                                    .collect::<HashMap<_, _>>(),
+                            )
+                            .is_none(),
+                        "cannot assign to rom table {:?} twice",
+                        rom_type
+                    );
+                }
+            }
+            wit_mles.insert(circuit_name.clone(), witness);
+            fixed_mles.insert(circuit_name.clone(), fixed);
+            num_instances.insert(circuit_name.clone(), num_rows);
+        }
+
+        for (rom_type, inputs) in rom_inputs.into_iter() {
+            let table = rom_tables.get_mut(&rom_type).unwrap();
+            for (lk_input_values, circuit_name, lk_input_annotation, input_value_exprs) in inputs {
+                // counting multiplicity in rom_input
+                let mut lk_input_values_multiplicity = HashMap::new();
+                for (row, input_value) in lk_input_values.iter().enumerate() {
+                    // we only keep first row to restore debug information
+                    lk_input_values_multiplicity
+                        .entry(input_value)
+                        .or_insert([0u64, row as u64])[0] += 1;
+                }
+
+                for (k, [input_multiplicity, row]) in lk_input_values_multiplicity {
+                    let table_multiplicity = if let Some(table_multiplicity) = table.get_mut(k) {
+                        if input_multiplicity <= table_multiplicity.to_canonical_u64() {
+                            *table_multiplicity -= E::BaseField::from(input_multiplicity);
+                            continue;
+                        }
+                        table_multiplicity.to_canonical_u64()
+                    } else {
+                        0
+                    };
+                    // log mismatch error
+                    let witness = wit_mles
+                        .get(&circuit_name)
+                        .map(|mles| {
+                            mles.iter()
+                                .map(|mle| E::from(mle.get_base_field_vec()[row as usize]))
+                                .collect_vec()
+                        })
+                        .unwrap();
+                    let values = input_value_exprs
+                        .iter()
+                        .map(|expr| {
+                            eval_by_expr_with_instance(
+                                &[],
+                                &witness,
+                                &instance,
+                                challenges.as_slice(),
+                                expr,
+                            )
+                            .as_bases()[0]
+                        })
+                        .collect_vec();
+                    tracing::error!(
+                        "{}: value {:x?} mismatch lk_multiplicity: real {:x} > remaining {:x} in {:?} table",
+                        lk_input_annotation,
+                        values,
+                        input_multiplicity,
+                        table_multiplicity,
+                        rom_type,
+                    );
+                }
+            }
+            // each table entry's multiplicity should equal to 0
+            for (k, multiplicity) in table {
+                if !multiplicity.is_zero_vartime() {
+                    tracing::error!(
+                        "table {:?}: {:x?} multiplicity = {:x}",
+                        rom_type,
+                        k,
+                        multiplicity.to_canonical_u64()
+                    );
+                }
+            }
+        }
+
+        // find out r != w errors
+
+        macro_rules! derive_ram_rws {
+            ($ram_type:expr) => {{
+                let mut writes = HashSet::new();
+                let mut writes_grp_by_annotations = HashMap::new();
+                // store (pc, timestamp) for $ram_type == RAMType::GlobalState
+                let mut gs = HashMap::new();
+                for (circuit_name, cs) in cs.circuit_css.iter() {
+                    let fixed = fixed_mles.get(circuit_name).unwrap();
+                    let witness = wit_mles.get(circuit_name).unwrap();
+                    let num_rows = num_instances.get(circuit_name).unwrap();
+                    if *num_rows == 0 {
+                        continue;
+                    }
+                    for ((w_rlc_expr, annotation), (_, w_exprs)) in cs
+                        .w_expressions
+                        .iter()
+                        .zip(cs.w_expressions_namespace_map.iter())
+                        .zip(cs.w_ram_types.iter())
+                        .filter(|((_, _), (ram_type, _))| *ram_type == $ram_type)
+                    {
+                        let write_rlc_records =
+                            (wit_infer_by_expr(fixed, witness, &instance, &challenges, w_rlc_expr)
+                                .get_ext_field_vec())[..*num_rows]
+                                .to_vec();
+
+                        if $ram_type == RAMType::GlobalState {
+                            // w_exprs = [GlobalState, pc, timestamp]
+                            assert_eq!(w_exprs.len(), 3);
+                            let w = w_exprs
+                                .into_iter()
+                                .skip(1)
+                                .map(|expr| {
+                                    let v = wit_infer_by_expr(
+                                        fixed,
+                                        witness,
+                                        &instance,
+                                        &challenges,
+                                        expr,
+                                    );
+                                    v.get_base_field_vec()[..*num_rows].to_vec()
+                                })
+                                .collect_vec();
+                            // convert [[pc], [timestamp]] into [[pc, timestamp]]
+                            let w = (0..*num_rows)
+                                // TODO: use transpose
+                                .map(|row| w.iter().map(|w| w[row]).collect_vec())
+                                .collect_vec();
+
+                            assert!(gs.insert(circuit_name.clone(), w).is_none());
+                        };
+                        let mut records = vec![];
+                        for (row, record_rlc) in write_rlc_records.into_iter().enumerate() {
+                            // TODO: report error
+                            assert_eq!(writes.insert(record_rlc), true);
+                            records.push((record_rlc, row));
+                        }
+                        writes_grp_by_annotations
+                            .insert(annotation.clone(), (records, circuit_name.clone()));
+                    }
+                }
+
+                let mut reads = HashSet::new();
+                let mut reads_grp_by_annotations = HashMap::new();
+                for (circuit_name, cs) in cs.circuit_css.iter() {
+                    let fixed = fixed_mles.get(circuit_name).unwrap();
+                    let witness = wit_mles.get(circuit_name).unwrap();
+                    let num_rows = num_instances.get(circuit_name).unwrap();
+                    if *num_rows == 0 {
+                        continue;
+                    }
+                    for ((r_expr, annotation), _) in cs
+                        .r_expressions
+                        .iter()
+                        .zip(cs.r_expressions_namespace_map.iter())
+                        .zip(cs.r_ram_types.iter())
+                        .filter(|((_, _), (ram_type, _))| *ram_type == $ram_type)
+                    {
+                        let read_records =
+                            wit_infer_by_expr(fixed, witness, &instance, &challenges, r_expr)
+                                .get_ext_field_vec()[..*num_rows]
+                                .to_vec();
+                        let mut records = vec![];
+                        for (row, record) in read_records.into_iter().enumerate() {
+                            assert_eq!(reads.insert(record), true);
+                            records.push((record, row));
+                        }
+                        reads_grp_by_annotations
+                            .insert(annotation.clone(), (records, circuit_name.clone()));
+                    }
+                }
+
+                (
+                    reads,
+                    reads_grp_by_annotations,
+                    writes,
+                    writes_grp_by_annotations,
+                    gs,
+                )
+            }};
+        }
+        macro_rules! find_rw_mismatch {
+            ($reads:ident,$reads_grp_by_annotations:ident,$writes:ident,$writes_grp_by_annotations:ident,$ram_type:expr,$gs:expr) => {
+                for (annotation, (reads, circuit_name)) in $reads_grp_by_annotations.iter() {
+                    // (pc, timestamp)
+                    let gs_of_circuit = $gs.get(circuit_name).clone().unwrap();
+                    let num_missing = reads
+                        .iter()
+                        .filter(|(read, _)| !$writes.contains(read))
+                        .count();
+                    let num_reads = reads.len();
+                    reads
+                        .iter()
+                        .filter(|(read, _)| !$writes.contains(read))
+                        .take(10)
+                        .for_each(|(_, row)| {
+                            let pc = gs_of_circuit[*row][0].to_canonical_u64();
+                            let ts = gs_of_circuit[*row][1].to_canonical_u64();
+                            tracing::error!(
+                                "{} at row {} (pc={:x},ts={}) not found in {:?} writes",
+                                annotation,
+                                row,
+                                pc,
+                                ts,
+                                $ram_type,
+                            )
+                        });
+
+                    if num_missing > 10 {
+                        tracing::error!(
+                            ".... {} more missing (num_instances = {})",
+                            num_missing - 10,
+                            num_reads,
+                        );
+                    }
+                    if num_missing > 0 {
+                        tracing::error!("--------------------");
+                    }
+                }
+                for (annotation, (writes, circuit_name)) in $writes_grp_by_annotations.iter() {
+                    let gs_of_circuit = $gs.get(circuit_name).clone().unwrap();
+                    let num_missing = writes
+                        .iter()
+                        .filter(|(write, _)| !$reads.contains(write))
+                        .count();
+                    let num_writes = writes.len();
+                    writes
+                        .iter()
+                        .filter(|(write, _)| !$reads.contains(write))
+                        .take(10)
+                        .for_each(|(_, row)| {
+                            let pc = gs_of_circuit[*row][0].to_canonical_u64();
+                            let ts = gs_of_circuit[*row][1].to_canonical_u64();
+                            tracing::error!(
+                                "{} at row {} (pc={:x},ts={}) not found in {:?} reads",
+                                annotation,
+                                row,
+                                pc,
+                                ts,
+                                $ram_type,
+                            )
+                        });
+
+                    if num_missing > 10 {
+                        tracing::error!(
+                            ".... {} more missing (num_instances = {})",
+                            num_missing - 10,
+                            num_writes,
+                        );
+                    }
+                    if num_missing > 0 {
+                        tracing::error!("--------------------");
+                    }
+                }
+            };
+        }
+        // part1 global state
+        // get (pc, timestamp)
+        let (gs_rs, rs_grp_by_anno, gs_ws, ws_grp_by_anno, gs) =
+            derive_ram_rws!(RAMType::GlobalState);
+        let gs_clone = gs.clone();
+        find_rw_mismatch!(
+            gs_rs,
+            rs_grp_by_anno,
+            gs_ws,
+            ws_grp_by_anno,
+            RAMType::GlobalState,
+            gs_clone
+        );
+
+        // part2 registers
+        let (reg_rs, rs_grp_by_anno, reg_ws, ws_grp_by_anno, _) =
+            derive_ram_rws!(RAMType::Register);
+        let gs_clone = gs.clone();
+        find_rw_mismatch!(
+            reg_rs,
+            rs_grp_by_anno,
+            reg_ws,
+            ws_grp_by_anno,
+            RAMType::Register,
+            gs_clone
+        );
+
+        // part3 memory
+        let (mem_rs, rs_grp_by_anno, mem_ws, ws_grp_by_anno, _) = derive_ram_rws!(RAMType::Memory);
+        find_rw_mismatch!(
+            mem_rs,
+            rs_grp_by_anno,
+            mem_ws,
+            ws_grp_by_anno,
+            RAMType::Memory,
+            gs
+        );
     }
 }
 

--- a/ceno_zkvm/src/scheme/tests.rs
+++ b/ceno_zkvm/src/scheme/tests.rs
@@ -23,7 +23,9 @@ use crate::{
         riscv::{arith::AddInstruction, ecall::HaltInstruction},
     },
     set_val,
-    structs::{PointAndEval, ZKVMConstraintSystem, ZKVMFixedTraces, ZKVMWitnesses},
+    structs::{
+        PointAndEval, RAMType::Register, ZKVMConstraintSystem, ZKVMFixedTraces, ZKVMWitnesses,
+    },
     tables::{ProgramTableCircuit, U16TableCircuit},
     witness::LkMultiplicity,
 };
@@ -56,8 +58,8 @@ impl<E: ExtensionField, const L: usize, const RW: usize> Instruction<E> for Test
                 Expression::<E>::Constant(E::BaseField::ONE),
                 reg_id.expr(),
             ]);
-            cb.read_record(|| "read", record.clone())?;
-            cb.write_record(|| "write", record)?;
+            cb.read_record(|| "read", Register, record.clone())?;
+            cb.write_record(|| "write", Register, record)?;
             Result::<(), ZKVMError>::Ok(())
         })?;
         (0..L).try_for_each(|_| {

--- a/ceno_zkvm/src/scheme/utils.rs
+++ b/ceno_zkvm/src/scheme/utils.rs
@@ -352,7 +352,6 @@ pub(crate) fn wit_infer_by_expr<'a, E: ExtensionField, const N: usize>(
     )
 }
 
-#[cfg(test)]
 pub(crate) fn eval_by_expr<E: ExtensionField>(
     witnesses: &[E],
     challenges: &[E],
@@ -361,7 +360,6 @@ pub(crate) fn eval_by_expr<E: ExtensionField>(
     eval_by_expr_with_fixed(&[], witnesses, challenges, expr)
 }
 
-#[cfg(test)]
 pub(crate) fn eval_by_expr_with_fixed<E: ExtensionField>(
     fixed: &[E],
     witnesses: &[E],

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -43,7 +43,7 @@ pub struct TowerProverSpec<'a, E: ExtensionField> {
 pub type WitnessId = u16;
 pub type ChallengeId = u16;
 
-#[derive(Copy, Clone, Debug, EnumIter)]
+#[derive(Copy, Clone, Debug, EnumIter, PartialEq, Eq, Hash)]
 pub enum ROMType {
     U5 = 0,      // 2^5 = 32
     U8,          // 2^8 = 256
@@ -57,7 +57,7 @@ pub enum ROMType {
     Instruction, // Decoded instruction from the fixed program.
 }
 
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub enum RAMType {
     GlobalState,
     Register,
@@ -175,7 +175,7 @@ impl<E: ExtensionField> ZKVMConstraintSystem<E> {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ZKVMFixedTraces<E: ExtensionField> {
     pub circuit_fixed_traces: BTreeMap<String, Option<RowMajorMatrix<E::BaseField>>>,
 }
@@ -203,7 +203,7 @@ impl<E: ExtensionField> ZKVMFixedTraces<E> {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ZKVMWitnesses<E: ExtensionField> {
     pub witnesses: BTreeMap<String, (bool, RowMajorMatrix<E::BaseField>)>,
     lk_mlts: BTreeMap<String, LkMultiplicity>,

--- a/ceno_zkvm/src/tables/ops/ops_impl.rs
+++ b/ceno_zkvm/src/tables/ops/ops_impl.rs
@@ -2,6 +2,7 @@
 
 use ff_ext::ExtensionField;
 use goldilocks::SmallField;
+use itertools::Itertools;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use std::{collections::HashMap, mem::MaybeUninit};
 
@@ -34,14 +35,9 @@ impl OpTableConfig {
         ];
         let mlt = cb.create_witin(|| "mlt");
 
-        let rlc_record = cb.rlc_chip_record(vec![
-            (rom_type as usize).into(),
-            Expression::Fixed(abc[0]),
-            Expression::Fixed(abc[1]),
-            Expression::Fixed(abc[2]),
-        ]);
+        let record_exprs = abc.into_iter().map(|f| Expression::Fixed(f)).collect_vec();
 
-        cb.lk_table_record(|| "record", table_len, rlc_record, mlt.expr())?;
+        cb.lk_table_record(|| "record", table_len, rom_type, record_exprs, mlt.expr())?;
 
         Ok(Self { abc, mlt })
     }

--- a/ceno_zkvm/src/tables/range/range_impl.rs
+++ b/ceno_zkvm/src/tables/range/range_impl.rs
@@ -30,10 +30,9 @@ impl RangeTableConfig {
         let fixed = cb.create_fixed(|| "fixed")?;
         let mlt = cb.create_witin(|| "mlt");
 
-        let rlc_record =
-            cb.rlc_chip_record(vec![(rom_type as usize).into(), Expression::Fixed(fixed)]);
+        let record_exprs = vec![Expression::Fixed(fixed)];
 
-        cb.lk_table_record(|| "record", table_len, rlc_record, mlt.expr())?;
+        cb.lk_table_record(|| "record", table_len, rom_type, record_exprs, mlt.expr())?;
 
         Ok(Self { fixed, mlt })
     }

--- a/ceno_zkvm/src/witness.rs
+++ b/ceno_zkvm/src/witness.rs
@@ -39,14 +39,15 @@ macro_rules! set_fixed_val {
     };
 }
 
-pub struct RowMajorMatrix<T: Sized + Sync + Clone + Send> {
+#[derive(Clone)]
+pub struct RowMajorMatrix<T: Sized + Sync + Clone + Send + Copy> {
     // represent 2D in 1D linear memory and avoid double indirection by Vec<Vec<T>> to improve performance
     values: Vec<MaybeUninit<T>>,
     num_padding_rows: usize,
     num_col: usize,
 }
 
-impl<T: Sized + Sync + Clone + Send> RowMajorMatrix<T> {
+impl<T: Sized + Sync + Clone + Send + Copy> RowMajorMatrix<T> {
     pub fn new(num_rows: usize, num_col: usize) -> Self {
         let num_total_rows = next_pow2_instance_padding(num_rows);
         let num_padding_rows = num_total_rows - num_rows;


### PR DESCRIPTION
This PR aims to improve current mock prover to find out constraint errors in the zkvm setting.

- [x] lookup errors.
- [x] read / write not equal for global state 
- [x] read / write not equal for registers
- [x] read / write not equal for memory