### PR TITLE
emul-cache: Cache instruction decoding

### DIFF
--- a/ceno_emul/src/vm_state.rs
+++ b/ceno_emul/src/vm_state.rs
@@ -83,17 +83,17 @@ impl VMState {
     }
 
     pub fn iter_until_halt(&mut self) -> impl Iterator<Item = Result<StepRecord>> + '_ {
-        let emu = Emulator::new();
+        let mut emu = Emulator::new();
         from_fn(move || {
             if self.halted() {
                 None
             } else {
-                Some(self.step(&emu))
+                Some(self.step(&mut emu))
             }
         })
     }
 
-    fn step(&mut self, emu: &Emulator) -> Result<StepRecord> {
+    fn step(&mut self, emu: &mut Emulator) -> Result<StepRecord> {
         emu.step(self)?;
         let step = self.tracer.advance();
         if step.is_busy_loop() && !self.halted() {


### PR DESCRIPTION
_Issue #524_

This is an approach to accelerate decoding. The original idea was to pre-decode all instructions of the program.

This PR does it by caching instead. It caches from instruction word to decoded structure. This may make the emulator marginally faster; did not benchmark.

In principle it could cache from PC to decoded, saving one hash table lookup. However, that’s a little more complicated because you’d need to change the tracer too.