### PR TITLE
fix: disable unintended parallel processing in sumcheck stage 1

### DIFF
--- a/ceno_zkvm/src/instructions/riscv/rv32im.rs
+++ b/ceno_zkvm/src/instructions/riscv/rv32im.rs
@@ -21,7 +21,8 @@ use crate::{
     structs::{ZKVMConstraintSystem, ZKVMFixedTraces, ZKVMWitnesses},
     tables::{
         AndTableCircuit, LtuTableCircuit, MemFinalRecord, MemInitRecord, MemTableCircuit,
-        RegTableCircuit, TableCircuit, U14TableCircuit, U16TableCircuit,
+        OrTableCircuit, RegTableCircuit, TableCircuit, U5TableCircuit, U8TableCircuit,
+        U14TableCircuit, U16TableCircuit, XorTableCircuit,
     },
 };
 use ceno_emul::{CENO_PLATFORM, InsnKind, InsnKind::*, StepRecord};
@@ -30,7 +31,6 @@ use itertools::Itertools;
 use num_traits::cast::ToPrimitive;
 use std::collections::{BTreeMap, BTreeSet};
 use strum::IntoEnumIterator;
-use crate::tables::{OrTableCircuit, U5TableCircuit, U8TableCircuit, XorTableCircuit};
 
 use super::{
     arith::AddInstruction,

--- a/sumcheck/src/prover_v2.rs
+++ b/sumcheck/src/prover_v2.rs
@@ -26,7 +26,7 @@ use crate::{
     structs::{IOPProof, IOPProverMessage, IOPProverStateV2},
     util::{
         AdditiveArray, AdditiveVec, barycentric_weights, ceil_log2, extrapolate,
-        merge_sumcheck_polys_v2,
+        merge_sumcheck_polys_v2, serial_extrapolate,
     },
 };
 
@@ -80,10 +80,12 @@ impl<'a, E: ExtensionField> IOPProverStateV2<'a, E> {
             })
             .collect::<Vec<_>>();
 
+        // spawn extra #(max_thread_id - 1) work threads
+        let num_worker_threads = max_thread_id - 1;
+        // whereas the main-thread be the last work thread
+        let main_thread_id = num_worker_threads;
         let scoped_fn = |s: &Scope<'a>| {
-            // spawn extra #(max_thread_id - 1) work threads, whereas the main-thread be the last
-            // work thread
-            for (thread_id, poly) in polys.iter_mut().enumerate().take(max_thread_id - 1) {
+            for (thread_id, poly) in polys.iter_mut().enumerate().take(num_worker_threads) {
                 let mut prover_state = Self::prover_init_with_extrapolation_aux(
                     mem::take(poly),
                     extrapolation_aux.clone(),
@@ -139,9 +141,8 @@ impl<'a, E: ExtensionField> IOPProverStateV2<'a, E> {
             }
 
             let mut prover_msgs = Vec::with_capacity(num_variables);
-            let thread_id = max_thread_id - 1;
             let mut prover_state = Self::prover_init_with_extrapolation_aux(
-                mem::take(&mut polys[thread_id]),
+                mem::take(&mut polys[main_thread_id]),
                 extrapolation_aux.clone(),
             );
             let tx_prover_state = tx_prover_state.clone();
@@ -155,13 +156,13 @@ impl<'a, E: ExtensionField> IOPProverStateV2<'a, E> {
             for _ in 0..num_variables {
                 let prover_msg =
                     IOPProverStateV2::prove_round_and_update_state(&mut prover_state, &challenge);
-                thread_based_transcript.append_field_element_exts(&prover_msg.evaluations);
 
                 // for each round, we must collect #SIZE prover message
                 let mut evaluations = AdditiveVec::new(max_degree + 1);
 
                 // sum for all round poly evaluations vector
-                for _ in 0..max_thread_id {
+                evaluations += AdditiveVec(prover_msg.evaluations);
+                for _ in 0..num_worker_threads {
                     let round_poly_coeffs = thread_based_transcript.read_field_element_exts();
                     evaluations += AdditiveVec(round_poly_coeffs);
                 }
@@ -170,7 +171,7 @@ impl<'a, E: ExtensionField> IOPProverStateV2<'a, E> {
                 transcript.append_field_element_exts(&evaluations.0);
 
                 let next_challenge = transcript.get_and_append_challenge(b"Internal round");
-                (0..max_thread_id).for_each(|_| {
+                (0..num_worker_threads).for_each(|_| {
                     thread_based_transcript.send_challenge(next_challenge.elements);
                 });
 
@@ -180,8 +181,7 @@ impl<'a, E: ExtensionField> IOPProverStateV2<'a, E> {
                     evaluations: evaluations.0,
                 });
 
-                challenge =
-                    Some(thread_based_transcript.get_and_append_challenge(b"Internal round"));
+                challenge = Some(next_challenge);
                 thread_based_transcript.commit_rolling();
             }
             exit_span!(span);
@@ -213,7 +213,7 @@ impl<'a, E: ExtensionField> IOPProverStateV2<'a, E> {
                         }
                     });
                 tx_prover_state
-                    .send(Some((thread_id, prover_state)))
+                    .send(Some((main_thread_id, prover_state)))
                     .unwrap();
             } else {
                 tx_prover_state.send(None).unwrap();
@@ -558,11 +558,10 @@ impl<'a, E: ExtensionField> IOPProverStateV2<'a, E> {
 
                 let span = entered_span!("extrapolation");
                 let extrapolation = (0..self.poly.aux_info.max_degree - products.len())
-                    .into_par_iter()
                     .map(|i| {
                         let (points, weights) = &self.extrapolation_aux[products.len() - 1];
                         let at = E::from((products.len() + 1 + i) as u64);
-                        extrapolate(points, weights, &sum, &at)
+                        serial_extrapolate(points, weights, &sum, &at)
                     })
                     .collect::<Vec<_>>();
                 sum.extend(extrapolation);


### PR DESCRIPTION
Fixed #511

### Root cause
We have 2 stage sumcheck
- stage 1: each rayon job isolated processing 
- stage 2: single thread aggregate results.

So in stage 1,  a rayon job shouldn't invoke parallel rayon internally, otherwise it will invoke deadlock, since there is 0 rayon idle thread in pool, so the parallel job will hang and never generate 1st round of univariate evaluation, so the main worker thread never get enough message to processing.

This only happened when `extrapolate`  was invoked on the situation when virtual polynomial got different degree monomial terms. In other word, it tend to happened on opcodes with different degree of monomial terms in a constrain.

The fix is we need to have stage 1 strictly serialized and do not invoke rayon parallel internally.

### Another minor optimisation
Previously main thread also be one of worker thread, thus it also exchange data via channel which might incur a unnecessary cost. This PR also remove this cost and exchange data locally.

### Testing
- cherry-pick commit into PR #368 and doen't hang anymore on `ceno-server`, previously with command `RAYON_NUM_THREADS=64 RUST_LOG=debug cargo run --release --example fibonacci_elf -- --nocapture` it's 100% reproduce
- before/after the change benchmark on 2^20 instances add remain the same, which is expected since there is no constrain in add opcode which got different degree monomial terms.