### PR TITLE
Feat/MULHSU opcode

### DIFF
--- a/ceno_zkvm/src/instructions/riscv/mulh.rs
+++ b/ceno_zkvm/src/instructions/riscv/mulh.rs
@@ -154,6 +154,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for MulhInstructionBas
     fn name() -> String {
         format!("{:?}", I::INST_KIND)
     }
+
     fn construct_circuit(
         circuit_builder: &mut CircuitBuilder<E>,
     ) -> Result<MulhConfig<E>, ZKVMError> {

--- a/ceno_zkvm/src/instructions/riscv/mulh.rs
+++ b/ceno_zkvm/src/instructions/riscv/mulh.rs
@@ -82,6 +82,7 @@ use std::{fmt::Display, marker::PhantomData};
 
 use ceno_emul::{InsnKind, StepRecord};
 use ff_ext::ExtensionField;
+use goldilocks::SmallField;
 
 use crate::{
     circuit_builder::CircuitBuilder,
@@ -156,6 +157,14 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for MulhInstructionBas
     fn construct_circuit(
         circuit_builder: &mut CircuitBuilder<E>,
     ) -> Result<MulhConfig<E>, ZKVMError> {
+        // The soundness analysis for these constraints is only valid for
+        // 32-bit registers represented over the Goldilocks field, so verify
+        // these parameters
+        assert_eq!(UInt::<E>::TOTAL_BITS, u32::BITS as usize);
+        assert_eq!(E::BaseField::MODULUS_U64, goldilocks::MODULUS);
+
+        // 0. Registers and instruction lookup
+
         let rs1_read = UInt::new_unchecked(|| "rs1_read", circuit_builder)?;
         let rs2_read = UInt::new_unchecked(|| "rs2_read", circuit_builder)?;
         let rd_written = UInt::new(|| "rd_written", circuit_builder)?;

--- a/ceno_zkvm/src/instructions/riscv/mulh.rs
+++ b/ceno_zkvm/src/instructions/riscv/mulh.rs
@@ -532,7 +532,7 @@ mod test {
             .unwrap();
 
         let signed_unsigned_prod_high =
-            (((rs1 as i32) as i64).wrapping_mul(rs2 as i64) >> 32) as u32;
+            ((rs1 as i64).wrapping_mul(rs2 as i64) >> 32) as u32;
 
         // values assignment
         let insn_code = encode_rv32(InsnKind::MULHSU, 2, 3, 4, 0);
@@ -543,7 +543,7 @@ mod test {
                     MOCK_PC_START,
                     insn_code,
                     rs1 as u32,
-                    rs2 as u32,
+                    rs2,
                     Change::new(0, signed_unsigned_prod_high),
                     0,
                 ),

--- a/ceno_zkvm/src/instructions/riscv/mulh.rs
+++ b/ceno_zkvm/src/instructions/riscv/mulh.rs
@@ -1,37 +1,105 @@
+//! Circuit implementations for MULH, MULHU, and MULHSU RISC-V opcodes
+//!
+//! Approach for computing the upper limb of a product of two 32-bit values
+//! which are signed/signed, unsigned/unsigned, or signed/unsigned is the
+//! following:
+//!
+//! - Compute the signed or unsigned value associated with input and output
+//!   registers of the instruction
+//! - Verify that the product of input values is equal to the value obtained
+//!   by interpreting the output register `rd` as the high limb of a signed or
+//!   unsigned 64-bit value with some additional 32-bit low limb
+//!
+//! Soundness of this approach is almost straightforward except for a
+//! complication, which is that the 64-bit values represented by `rd` as a
+//! high limb have a small number of values that are ambiguously represented
+//! as field elements over the Goldilocks field.  The numbers for which the
+//! projections into Goldilocks are unique are:
+//!
+//! - Signed 64-bits: `-2^63 + 2^32 - 1` to `2^63 - 2^32`
+//! - Unsigned 64-bits: `2^32 - 1` to `2^64 - 2^32`
+//!
+//! The intervals of values corresponding to products of signed and/or unsigned
+//! 32-bit integers are given by
+//!
+//! - Signed/signed: `-2^62 + 2^31` to `2^62`, length `2^63 - 2^31 + 1`
+//! - Unsigned/unsigned: `0` to `2^64 - 2^33 + 1`, length `2^64 - 2^33 + 2`
+//! - Signed/unsigned: `-2^63 + 2^31` to `2^63 - 2^32 - 2^31 + 1`, length
+//!   `2^64 - 2^33 + 2`
+//!
+//! In particular, all of these intervals have length smaller than the
+//! Goldilocks prime `p = 2^64 - 2^32 + 1`, and so these values are uniquely
+//! represented as Goldilocks elements.  To ensure that the equality of the
+//! product of input register values with the full 64-bit value with high limb
+//! represented by `rd` is fully unambiguous, it is sufficient to ensure that
+//! the domain of product values does not overlap with the intervals of
+//! ambiguous 64-bit number representations.
+//!
+//! This is immediately the case for the signed/signed products because of the
+//! smaller length of the interval of product values.  Since all signed/signed
+//! products lie in the unambiguous range `-2^63 + 2^32 - 1` to `2^63 - 2^32` of
+//! 64-bit 2s complement signed values, each such value associated with a
+//! product value is uniquely determined.
+//!
+//! For unsigned/unsigned and signed/unsigned products, the situation is
+//! different.  For unsigned/unsigned products, the interval of product values
+//! between `0` and `2^32 - 2` is represented ambiguously by two unsigned 64-bit
+//! values each, as Goldilocks field elements, but only the smaller of these
+//! two representations is the correct product value.  Similarly for signed/
+//! unsigned products, the product values between `-2^63 + 2^31` and
+//! `-2^63 + 2^32 - 2` are ambiguously represented by two signed 64-bit values
+//! each, as Goldilocks field elements, but only the smaller (more negative) of
+//! these gives the correct product.
+//!
+//! As it happens, this can be remedied in each case by the following
+//! mitigation: constrain the high limb `rd` to not be equal to its maximal
+//! value, which is `2^32 - 1` in the unsigned case, and `2^31 - 1` in the
+//! signed case.  Removing this possibility eliminates the entire high
+//! interval of ambiguous values represented in 64-bits, but still allows
+//! representing the entire range of product values in each case.
+//! Specifically, with this added restriction, the numbers represented by
+//! (restricted) 64-bit values unambiguously over Goldilocks are
+//!
+//! - Signed (restricted) 64-bits: `-2^63` to `2^63 - 2^32 - 1`
+//! - Unsigned (restricted) 64-bits: `0` to `2^64 - 2^32 - 1`
+//!
+//! With this added check in place, the 64-bit values represented with `rd` as
+//! the high limb uniquely represent the product values for unsigned/unsigned
+//! and signed/unsigned products.
+
 use std::{fmt::Display, marker::PhantomData};
 
 use ceno_emul::{InsnKind, StepRecord};
+use ff::Field;
 use ff_ext::ExtensionField;
 
 use crate::{
     circuit_builder::CircuitBuilder,
     error::ZKVMError,
-    expression::Expression,
+    expression::{Expression, ToExpr, WitIn},
     gadgets::SignedExtendConfig,
     instructions::{
         Instruction,
         riscv::{
             RIVInstruction,
-            constants::{BIT_WIDTH, UInt, UIntMul},
+            constants::{BIT_WIDTH, UInt},
             r_insn::RInstructionConfig,
         },
     },
+    set_val,
     uint::Value,
+    utils::i64_to_base,
     witness::LkMultiplicity,
 };
 use core::mem::MaybeUninit;
 
-/// This config handles R-Instructions that represent registers values as 2 * u16.
-#[derive(Debug)]
-pub struct ArithConfig<E: ExtensionField> {
-    r_insn: RInstructionConfig<E>,
-
-    rs1_read: UInt<E>,
-    rs2_read: UInt<E>,
-    rd_written: UIntMul<E>,
-}
-
 pub struct MulhInstructionBase<E, I>(PhantomData<(E, I)>);
+
+pub struct MulhOp;
+impl RIVInstruction for MulhOp {
+    const INST_KIND: InsnKind = InsnKind::MULH;
+}
+pub type MulhInstruction<E> = MulhInstructionBase<E, MulhOp>;
 
 pub struct MulhuOp;
 impl RIVInstruction for MulhuOp {
@@ -39,107 +107,37 @@ impl RIVInstruction for MulhuOp {
 }
 pub type MulhuInstruction<E> = MulhInstructionBase<E, MulhuOp>;
 
-impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for MulhInstructionBase<E, I> {
-    type InstructionConfig = ArithConfig<E>;
-
-    fn name() -> String {
-        format!("{:?}", I::INST_KIND)
-    }
-
-    fn construct_circuit(
-        circuit_builder: &mut CircuitBuilder<E>,
-    ) -> Result<Self::InstructionConfig, ZKVMError> {
-        let (rs1_read, rs2_read, rd_written, rd_written_reg_expr) = match I::INST_KIND {
-            InsnKind::MULHU => {
-                // rs1_read * rs2_read = rd_written
-                let mut rs1_read = UInt::new_unchecked(|| "rs1_read", circuit_builder)?;
-                let mut rs2_read = UInt::new_unchecked(|| "rs2_read", circuit_builder)?;
-                let rd_written: UIntMul<E> =
-                    rs1_read.mul(|| "rd_written", circuit_builder, &mut rs2_read, true)?;
-                let (_, rd_written_hi) = rd_written.as_lo_hi()?;
-                (
-                    rs1_read,
-                    rs2_read,
-                    rd_written,
-                    rd_written_hi.register_expr(),
-                )
-            }
-
-            _ => unreachable!("Unsupported instruction kind"),
-        };
-
-        let r_insn = RInstructionConfig::<E>::construct_circuit(
-            circuit_builder,
-            I::INST_KIND,
-            rs1_read.register_expr(),
-            rs2_read.register_expr(),
-            rd_written_reg_expr,
-        )?;
-
-        Ok(ArithConfig {
-            r_insn,
-            rs1_read,
-            rs2_read,
-            rd_written,
-        })
-    }
-
-    fn assign_instance(
-        config: &Self::InstructionConfig,
-        instance: &mut [MaybeUninit<<E as ExtensionField>::BaseField>],
-        lk_multiplicity: &mut LkMultiplicity,
-        step: &StepRecord,
-    ) -> Result<(), ZKVMError> {
-        config
-            .r_insn
-            .assign_instance(instance, lk_multiplicity, step)?;
-
-        let rs2_read = Value::new_unchecked(step.rs2().unwrap().value);
-        config
-            .rs2_read
-            .assign_limbs(instance, rs2_read.as_u16_limbs());
-
-        match I::INST_KIND {
-            InsnKind::MULHU => {
-                // rs1_read * rs2_read = rd_written
-                let rs1_read = Value::new_unchecked(step.rs1().unwrap().value);
-
-                config
-                    .rs1_read
-                    .assign_limbs(instance, rs1_read.as_u16_limbs());
-
-                let rd_written = rs1_read.mul_hi(&rs2_read, lk_multiplicity, true);
-
-                config
-                    .rd_written
-                    .assign_mul_outcome(instance, lk_multiplicity, &rd_written)?;
-            }
-
-            _ => unreachable!("Unsupported instruction kind"),
-        };
-
-        Ok(())
-    }
-}
-
-pub struct MulhInstruction<E>(PhantomData<E>);
-
 pub struct MulhConfig<E: ExtensionField> {
     rs1_read: UInt<E>,
     rs2_read: UInt<E>,
     rd_written: UInt<E>,
-    rs1_signed: Signed<E>,
-    rs2_signed: Signed<E>,
-    rd_signed: Signed<E>,
-    unsigned_prod_low: UInt<E>,
+    sign_deps: MulhSignDependencies<E>,
+    prod_low: UInt<E>,
     r_insn: RInstructionConfig<E>,
 }
 
-impl<E: ExtensionField> Instruction<E> for MulhInstruction<E> {
+enum MulhSignDependencies<E: ExtensionField> {
+    UU {
+        constrain_rd_inv: WitIn,
+    },
+    #[allow(dead_code)]
+    SU {
+        rs1_signed: Signed<E>,
+        rd_signed: Signed<E>,
+        constrain_rd_inv: WitIn,
+    },
+    SS {
+        rs1_signed: Signed<E>,
+        rs2_signed: Signed<E>,
+        rd_signed: Signed<E>,
+    },
+}
+
+impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for MulhInstructionBase<E, I> {
     type InstructionConfig = MulhConfig<E>;
 
     fn name() -> String {
-        format!("{:?}", InsnKind::MULH)
+        format!("{:?}", I::INST_KIND)
     }
     fn construct_circuit(
         circuit_builder: &mut CircuitBuilder<E>,
@@ -148,54 +146,72 @@ impl<E: ExtensionField> Instruction<E> for MulhInstruction<E> {
         let rs2_read = UInt::new_unchecked(|| "rs2_read", circuit_builder)?;
         let rd_written = UInt::new(|| "rd_written", circuit_builder)?;
 
+        let r_insn = RInstructionConfig::<E>::construct_circuit(
+            circuit_builder,
+            I::INST_KIND,
+            rs1_read.register_expr(),
+            rs2_read.register_expr(),
+            rd_written.register_expr(),
+        )?;
+
         // 1. Compute the signed values associated with `rs1`, `rs2`, and `rd`
 
-        let rs1_signed = Signed::construct_circuit(circuit_builder, || "rs1", &rs1_read)?;
-        let rs2_signed = Signed::construct_circuit(circuit_builder, || "rs2", &rs2_read)?;
-        let rd_signed = Signed::construct_circuit(circuit_builder, || "rd", &rd_written)?;
+        let (rs1_val, rs2_val, rd_val, sign_deps) = match I::INST_KIND {
+            InsnKind::MULHU => {
+                // constrain that rd does not represent 2^32 - 1 by witnessing
+                // the multiplicative inverse of (2^32 - 1) - rd, which must
+                // be nonzero
+                let constrain_rd_inv = circuit_builder.create_witin(|| "constrain_rd_inv");
+                let rd_avoid = Expression::<E>::from((1u64 << BIT_WIDTH) - 1);
+                let nonzero_expr: Expression<E> = rd_avoid - rd_written.value();
+                circuit_builder
+                    .require_one(|| "constrain_rd", nonzero_expr * constrain_rd_inv.expr())?;
+
+                (
+                    rs1_read.value(),
+                    rs2_read.value(),
+                    rd_written.value(),
+                    MulhSignDependencies::UU { constrain_rd_inv },
+                )
+            }
+
+            InsnKind::MULH => {
+                let rs1_signed = Signed::construct_circuit(circuit_builder, || "rs1", &rs1_read)?;
+                let rs2_signed = Signed::construct_circuit(circuit_builder, || "rs2", &rs2_read)?;
+                let rd_signed = Signed::construct_circuit(circuit_builder, || "rd", &rd_written)?;
+
+                (
+                    rs1_signed.expr(),
+                    rs2_signed.expr(),
+                    rd_signed.expr(),
+                    MulhSignDependencies::SS {
+                        rs1_signed,
+                        rs2_signed,
+                        rd_signed,
+                    },
+                )
+            }
+
+            _ => unreachable!("Unsupported instruction kind"),
+        };
 
         // 2. Verify that the product of signed inputs `rs1` and `rs2` is equal to
         //    the result of interpreting `rd` as the high limb of a 2s complement
         //    value with some 32-bit low limb
 
-        let unsigned_prod_low = UInt::new(|| "unsigned_prod_low", circuit_builder)?;
+        let prod_low = UInt::new(|| "prod_low", circuit_builder)?;
         circuit_builder.require_equal(
             || "validate_prod_high_limb",
-            rs1_signed.expr() * rs2_signed.expr(),
-            rd_signed.expr() * (1u64 << 32) + unsigned_prod_low.value(),
-        )?;
-
-        // The soundness here is a bit subtle.  The signed values of 32-bit
-        // inputs `rs1` and `rs2` have values between `-2^31` and `2^31 - 1`, so
-        // their product is constrained to lie between `-2^62 + 2^31` and
-        // `2^62`.  In a prime field of size smaller than `2^64`, the range of
-        // values represented by a 64-bit 2s complement value, integers between
-        // `-2^63` and `2^63 - 1`, have some ambiguity.  If `p = 2^64 - k`, then
-        // the values between `-2^63` and `-2^63 + k - 1` correspond with the
-        // values between `2^63 - k` and `2^63 - 1`.
-        //
-        // However, as long as the values required by signed products don't overlap
-        // with this ambiguous range, an arbitrary 64-bit 2s complement value can
-        // represent a signed 32-bit product in only one way, so there is no
-        // ambiguity in the representation.  This is the case for the Goldilocks
-        // field with order `p = 2^64 - 2^32 + 1`.
-
-        let r_insn = RInstructionConfig::<E>::construct_circuit(
-            circuit_builder,
-            InsnKind::MULH,
-            rs1_read.register_expr(),
-            rs2_read.register_expr(),
-            rd_written.register_expr(),
+            rs1_val * rs2_val,
+            rd_val * (1u64 << 32) + prod_low.value(),
         )?;
 
         Ok(MulhConfig {
             rs1_read,
             rs2_read,
             rd_written,
-            rs1_signed,
-            rs2_signed,
-            rd_signed,
-            unsigned_prod_low,
+            sign_deps,
+            prod_low,
             r_insn,
         })
     }
@@ -207,46 +223,62 @@ impl<E: ExtensionField> Instruction<E> for MulhInstruction<E> {
         step: &StepRecord,
     ) -> Result<(), ZKVMError> {
         // Read registers from step
-        let rs1_read = Value::new_unchecked(step.rs1().unwrap().value);
+        let rs1 = step.rs1().unwrap().value;
+        let rs1_val = Value::new_unchecked(rs1);
         config
             .rs1_read
-            .assign_limbs(instance, rs1_read.as_u16_limbs());
+            .assign_limbs(instance, rs1_val.as_u16_limbs());
 
-        let rs2_read = Value::new_unchecked(step.rs2().unwrap().value);
+        let rs2 = step.rs2().unwrap().value;
+        let rs2_val = Value::new_unchecked(rs2);
         config
             .rs2_read
-            .assign_limbs(instance, rs2_read.as_u16_limbs());
+            .assign_limbs(instance, rs2_val.as_u16_limbs());
 
-        let rd_written = Value::new(step.rd().unwrap().value.after, lk_multiplicity);
+        let rd = step.rd().unwrap().value.after;
+        let rd_val = Value::new(rd, lk_multiplicity);
         config
             .rd_written
-            .assign_limbs(instance, rd_written.as_u16_limbs());
-
-        // Signed register values
-        let rs1_signed = config
-            .rs1_signed
-            .assign_instance(instance, lk_multiplicity, &rs1_read)?;
-
-        let rs2_signed = config
-            .rs2_signed
-            .assign_instance(instance, lk_multiplicity, &rs2_read)?;
-
-        config
-            .rd_signed
-            .assign_instance(instance, lk_multiplicity, &rd_written)?;
-
-        // Low limb of product in 2s complement form
-        let prod = ((rs1_signed as i64) * (rs2_signed as i64)) as u64;
-        let unsigned_prod_low = (prod % (1u64 << BIT_WIDTH)) as u32;
-        let unsigned_prod_low_val = Value::new(unsigned_prod_low, lk_multiplicity);
-        config
-            .unsigned_prod_low
-            .assign_limbs(instance, unsigned_prod_low_val.as_u16_limbs());
+            .assign_limbs(instance, rd_val.as_u16_limbs());
 
         // R-type instruction
         config
             .r_insn
             .assign_instance(instance, lk_multiplicity, step)?;
+
+        // Assign signed values, if any, and compute low 32-bit limb of product
+        let prod_low = match &config.sign_deps {
+            MulhSignDependencies::UU { constrain_rd_inv } => {
+                // assign (u32::MAX - rd) field inverse to witness
+                let nonzero_val = ((1i64 << BIT_WIDTH) - 1) - (rd as i64);
+                let inv_field_elt = i64_to_base::<E::BaseField>(nonzero_val)
+                    .invert()
+                    .expect("rd cannot be u32::MAX");
+                set_val!(instance, constrain_rd_inv, inv_field_elt);
+
+                let prod = rs1_val.as_u64() * rs2_val.as_u64();
+                (prod % (1u64 << BIT_WIDTH)) as u32
+            }
+            MulhSignDependencies::SS {
+                rs1_signed,
+                rs2_signed,
+                rd_signed,
+            } => {
+                // Signed register values
+                let rs1_signed = rs1_signed.assign_instance(instance, lk_multiplicity, &rs1_val)?;
+                let rs2_signed = rs2_signed.assign_instance(instance, lk_multiplicity, &rs2_val)?;
+                rd_signed.assign_instance(instance, lk_multiplicity, &rd_val)?;
+
+                let prod = ((rs1_signed as i64) * (rs2_signed as i64)) as u64;
+                (prod % (1u64 << BIT_WIDTH)) as u32
+            }
+            _ => unreachable!("Unsupported instruction kind"),
+        };
+
+        let prod_low_val = Value::new(prod_low, lk_multiplicity);
+        config
+            .prod_low
+            .assign_limbs(instance, prod_low_val.as_u16_limbs());
 
         Ok(())
     }

--- a/ceno_zkvm/src/instructions/riscv/mulh.rs
+++ b/ceno_zkvm/src/instructions/riscv/mulh.rs
@@ -51,7 +51,18 @@
 //! each, as Goldilocks field elements, but only the smaller (more negative) of
 //! these gives the correct product.
 //!
-//! As it happens, this can be remedied in each case by the following
+//! Examples of these ambiguous representations:
+//! - Unsigned/unsigned: for `rs1 = rs2 = 0`, the product should be represented
+//!   by `rd = low = 0`, but can also be represented by `rd = 2^32 - 1` and
+//!   `low = 1`, so that `rd*2^32 + low = 2^64 - 2^32 + 1` which is congruent
+//!   to 0 mod the Goldilocks prime.
+//! - Signed/unsigned: for `rs1 = -2^31` and `rs2 = 2^32 - 1`, the product
+//!   `-2^63 + 2^31` should be represented by `rd = -2^31` and `low = 2^31`,
+//!   but can also be represented by `rd = 2^31 - 1` and `low = 2^31 + 1`,
+//!   such that `rd*2^32 + low = 2^63 - 2^32 + 2^31 + 1`, which can be written
+//!   as `(-2^63 + 2^31) + (2^64 - 2^32 + 1)`.
+//!
+//! As it happens, this issue can be remedied in each case by the following
 //! mitigation: constrain the high limb `rd` to not be equal to its maximal
 //! value, which is `2^32 - 1` in the unsigned case, and `2^31 - 1` in the
 //! signed case.  Removing this possibility eliminates the entire high

--- a/ceno_zkvm/src/instructions/riscv/mulh.rs
+++ b/ceno_zkvm/src/instructions/riscv/mulh.rs
@@ -531,8 +531,7 @@ mod test {
             .unwrap()
             .unwrap();
 
-        let signed_unsigned_prod_high =
-            ((rs1 as i64).wrapping_mul(rs2 as i64) >> 32) as u32;
+        let signed_unsigned_prod_high = ((rs1 as i64).wrapping_mul(rs2 as i64) >> 32) as u32;
 
         // values assignment
         let insn_code = encode_rv32(InsnKind::MULHSU, 2, 3, 4, 0);


### PR DESCRIPTION
Implements the MULHSU opcode using a circuit design similar to that used by MULH:
1. Map signed and unsigned inputs as corresponding field elements
2. Compute the product of the inputs, and verify that `rd` can be used as the upper limb for a 64-bit 2s complement signed value equal to this product.

A small complication comes up in this design because of the ambiguity of the representation of a small number of 64-bit signed values as Goldilocks field elements.  While this ambiguity did not have an impact on the signed/signed products for the MULH opcode, here the interval of signed/unsigned product values does overlap the ambiguous interval of 64-bit 2s complement values.  This is mitigated by explicitly constraining the value of the `rd` register to be not equal to its maximal signed value (`2^31 - 1`) by witnessing the inverse of `(2^31 - 1) - rd`.  This makes all remaining valid 64-bit values unambiguously represented, and also still permits representation of all valid signed/unsigned product values.  See the module doc comment for `mulh.rs` for a more complete soundness analysis.  (Some extra eyes on this analysis during the review would probably be a good idea, as the details are quite sensitive to the ranges of values and the size of the Goldilocks field.)

This PR additionally refactors the existing MULHU opcode to use an analogous circuit design to this, also requiring a one-element restriction on the value of `rd` to ensure soundness.  This implementation avoids the overhead of using `UInt::mul` to compute the product explicitly in `u16` limbs, which requires additional carry witnesses with range constraints, and should reduce the total number of `WitIn`s needed for the circuit fairly substantially.