### PR TITLE
refactor/move-circuit-imm: Move circuit-specific logic out of the emulator

### DIFF
--- a/ceno_emul/src/lib.rs
+++ b/ceno_emul/src/lib.rs
@@ -11,7 +11,7 @@ mod vm_state;
 pub use vm_state::VMState;
 
 mod rv32im;
-pub use rv32im::{DecodedInstruction, EmuContext, InsnCodes, InsnKind};
+pub use rv32im::{DecodedInstruction, EmuContext, InsnCodes, InsnFormat, InsnKind};
 
 mod elf;
 pub use elf::Program;

--- a/ceno_emul/src/rv32im.rs
+++ b/ceno_emul/src/rv32im.rs
@@ -270,42 +270,23 @@ impl DecodedInstruction {
         }
     }
 
-    /// The internal view of the immediate, for use in circuits.
-    pub fn imm_internal(&self) -> u32 {
+    pub fn codes(&self) -> InsnCodes {
+        FastDecodeTable::get().lookup(self)
+    }
+
+    pub fn immediate_msb(&self) -> u32 {
+        self.top_bit
+    }
+
+    pub fn immediate(&self) -> u32 {
         match self.codes().format {
-            R => self.func7,
-            I => match self.codes().kind {
-                // decode the shift as a multiplication/division by 1 << immediate
-                SLLI | SRLI | SRAI => 1 << self.imm_shamt(),
-                _ => self.imm_i(),
-            },
+            R => 0,
+            I => self.imm_i(),
             S => self.imm_s(),
             B => self.imm_b(),
             U => self.imm_u(),
             J => self.imm_j(),
         }
-    }
-
-    /// The internal interpretation of the immediate sign, for use in circuits.
-    /// Indicates if the immediate value, when signed, needs to be encoded as field negative.
-    /// example:
-    /// imm = ux::MAX - 1 implies
-    /// imm_field = FIELD_MODULUS - 1 if imm_field_is_negative
-    /// imm_field = ux::MAX - 1 otherwise
-    /// see InsnRecord::imm_internal_field
-    pub fn imm_field_is_negative(&self) -> bool {
-        match self.codes() {
-            InsnCodes { format: R | U, .. } => false,
-            InsnCodes {
-                kind: SLLI | SRLI | SRAI | ADDI | SLTIU | ANDI | XORI | ORI,
-                ..
-            } => false,
-            _ => self.top_bit != 0,
-        }
-    }
-
-    pub fn codes(&self) -> InsnCodes {
-        FastDecodeTable::get().lookup(self)
     }
 
     fn imm_b(&self) -> u32 {
@@ -317,11 +298,6 @@ impl DecodedInstruction {
 
     fn imm_i(&self) -> u32 {
         (self.top_bit * 0xffff_f000) | (self.func7 << 5) | self.rs2
-    }
-
-    /// Shift amount field of SLLI, SRLI, SRAI.
-    fn imm_shamt(&self) -> u32 {
-        self.rs2
     }
 
     fn imm_s(&self) -> u32 {
@@ -339,33 +315,6 @@ impl DecodedInstruction {
 
     fn imm_u(&self) -> u32 {
         self.insn & 0xfffff000
-    }
-}
-
-#[cfg(test)]
-#[test]
-#[allow(clippy::identity_op)]
-fn test_decode_imm() {
-    for (i, expected) in [
-        // Example of I-type: ADDI.
-        // imm    | rs1     | funct3      | rd     | opcode
-        (89 << 20 | 1 << 15 | 0b000 << 12 | 1 << 7 | 0x13, 89),
-        // Shifts get a precomputed power of 2: SLLI, SRLI, SRAI.
-        (31 << 20 | 1 << 15 | 0b001 << 12 | 1 << 7 | 0x13, 1 << 31),
-        (31 << 20 | 1 << 15 | 0b101 << 12 | 1 << 7 | 0x13, 1 << 31),
-        (
-            1 << 30 | 31 << 20 | 1 << 15 | 0b101 << 12 | 1 << 7 | 0x13,
-            1 << 31,
-        ),
-        // Example of R-type with funct7: SUB.
-        // funct7     | rs2    | rs1     | funct3      | rd     | opcode
-        (
-            0x20 << 25 | 1 << 20 | 1 << 15 | 0 << 12 | 1 << 7 | 0x33,
-            0x20,
-        ),
-    ] {
-        let imm = DecodedInstruction::new(i).imm_internal();
-        assert_eq!(imm, expected);
     }
 }
 

--- a/ceno_emul/src/rv32im.rs
+++ b/ceno_emul/src/rv32im.rs
@@ -262,10 +262,6 @@ impl DecodedInstruction {
         }
     }
 
-    pub fn codes(&self) -> InsnCodes {
-        FastDecodeTable::get().lookup(self)
-    }
-
     pub fn immediate(&self) -> u32 {
         match self.codes().format {
             R => 0,
@@ -275,6 +271,10 @@ impl DecodedInstruction {
             U => self.imm_u(),
             J => self.imm_j(),
         }
+    }
+
+    pub fn codes(&self) -> InsnCodes {
+        FastDecodeTable::get().lookup(self)
     }
 
     fn imm_b(&self) -> u32 {

--- a/ceno_emul/src/rv32im.rs
+++ b/ceno_emul/src/rv32im.rs
@@ -266,10 +266,6 @@ impl DecodedInstruction {
         FastDecodeTable::get().lookup(self)
     }
 
-    pub fn immediate_msb(&self) -> u32 {
-        self.top_bit
-    }
-
     pub fn immediate(&self) -> u32 {
         match self.codes().format {
             R => 0,

--- a/ceno_zkvm/src/instructions/riscv/arith_imm.rs
+++ b/ceno_zkvm/src/instructions/riscv/arith_imm.rs
@@ -5,7 +5,7 @@ use ff_ext::ExtensionField;
 
 use crate::{
     Value, circuit_builder::CircuitBuilder, error::ZKVMError, instructions::Instruction,
-    witness::LkMultiplicity,
+    tables::InsnRecord, witness::LkMultiplicity,
 };
 
 use super::{RIVInstruction, constants::UInt, i_insn::IInstructionConfig};
@@ -62,7 +62,7 @@ impl<E: ExtensionField> Instruction<E> for AddiInstruction<E> {
         step: &StepRecord,
     ) -> Result<(), ZKVMError> {
         let rs1_read = Value::new_unchecked(step.rs1().unwrap().value);
-        let imm = Value::new(step.insn().immediate(), lk_multiplicity);
+        let imm = Value::new(InsnRecord::imm_internal(&step.insn()), lk_multiplicity);
 
         let result = rs1_read.add(&imm, lk_multiplicity, true);
 

--- a/ceno_zkvm/src/instructions/riscv/arith_imm.rs
+++ b/ceno_zkvm/src/instructions/riscv/arith_imm.rs
@@ -62,7 +62,10 @@ impl<E: ExtensionField> Instruction<E> for AddiInstruction<E> {
         step: &StepRecord,
     ) -> Result<(), ZKVMError> {
         let rs1_read = Value::new_unchecked(step.rs1().unwrap().value);
-        let imm = Value::new(InsnRecord::imm_internal(&step.insn()), lk_multiplicity);
+        let imm = Value::new(
+            InsnRecord::imm_internal(&step.insn()) as u32,
+            lk_multiplicity,
+        );
 
         let result = rs1_read.add(&imm, lk_multiplicity, true);
 

--- a/ceno_zkvm/src/instructions/riscv/arith_imm.rs
+++ b/ceno_zkvm/src/instructions/riscv/arith_imm.rs
@@ -62,7 +62,7 @@ impl<E: ExtensionField> Instruction<E> for AddiInstruction<E> {
         step: &StepRecord,
     ) -> Result<(), ZKVMError> {
         let rs1_read = Value::new_unchecked(step.rs1().unwrap().value);
-        let imm = Value::new(step.insn().imm_internal(), lk_multiplicity);
+        let imm = Value::new(step.insn().immediate(), lk_multiplicity);
 
         let result = rs1_read.add(&imm, lk_multiplicity, true);
 

--- a/ceno_zkvm/src/instructions/riscv/b_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/b_insn.rs
@@ -100,7 +100,7 @@ impl<E: ExtensionField> BInstructionConfig<E> {
         set_val!(
             instance,
             self.imm,
-            InsnRecord::imm_internal_field::<E::BaseField>(&step.insn())
+            InsnRecord::<E::BaseField>::imm_internal_field(&step.insn())
         );
 
         // Fetch the instruction.

--- a/ceno_zkvm/src/instructions/riscv/b_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/b_insn.rs
@@ -10,6 +10,7 @@ use crate::{
     instructions::riscv::insn_base::{ReadRS1, ReadRS2, StateInOut},
     set_val,
     tables::InsnRecord,
+    utils::i64_to_base,
     witness::LkMultiplicity,
 };
 use core::mem::MaybeUninit;
@@ -99,7 +100,7 @@ impl<E: ExtensionField> BInstructionConfig<E> {
         set_val!(
             instance,
             self.imm,
-            InsnRecord::<E::BaseField>::imm_internal_field(&step.insn())
+            i64_to_base::<E::BaseField>(InsnRecord::imm_internal(&step.insn()))
         );
 
         // Fetch the instruction.

--- a/ceno_zkvm/src/instructions/riscv/jump/auipc.rs
+++ b/ceno_zkvm/src/instructions/riscv/jump/auipc.rs
@@ -13,6 +13,7 @@ use crate::{
         riscv::{constants::UInt, u_insn::UInstructionConfig},
     },
     set_val,
+    tables::InsnRecord,
     witness::LkMultiplicity,
 };
 
@@ -74,10 +75,11 @@ impl<E: ExtensionField> Instruction<E> for AuipcInstruction<E> {
         step: &ceno_emul::StepRecord,
     ) -> Result<(), ZKVMError> {
         let pc: u32 = step.pc().before.0;
-        let imm: u32 = step.insn().imm_internal();
+        let imm: u32 = step.insn().immediate();
         let (sum, overflow) = pc.overflowing_add(imm);
 
-        set_val!(instance, config.imm, imm as u64);
+        let imm_field: E::BaseField = InsnRecord::imm_internal_field(&step.insn());
+        set_val!(instance, config.imm, imm_field);
         set_val!(instance, config.overflow_bit, overflow as u64);
 
         let sum_limbs = Value::new(sum, lk_multiplicity);

--- a/ceno_zkvm/src/instructions/riscv/jump/auipc.rs
+++ b/ceno_zkvm/src/instructions/riscv/jump/auipc.rs
@@ -75,7 +75,7 @@ impl<E: ExtensionField> Instruction<E> for AuipcInstruction<E> {
         step: &ceno_emul::StepRecord,
     ) -> Result<(), ZKVMError> {
         let pc: u32 = step.pc().before.0;
-        let imm: u32 = step.insn().immediate();
+        let imm: u32 = InsnRecord::imm_internal(&step.insn());
         let (sum, overflow) = pc.overflowing_add(imm);
 
         let imm_field: E::BaseField = InsnRecord::imm_internal_field(&step.insn());

--- a/ceno_zkvm/src/instructions/riscv/jump/auipc.rs
+++ b/ceno_zkvm/src/instructions/riscv/jump/auipc.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     set_val,
     tables::InsnRecord,
+    utils::i64_to_base,
     witness::LkMultiplicity,
 };
 
@@ -75,11 +76,10 @@ impl<E: ExtensionField> Instruction<E> for AuipcInstruction<E> {
         step: &ceno_emul::StepRecord,
     ) -> Result<(), ZKVMError> {
         let pc: u32 = step.pc().before.0;
-        let imm: u32 = InsnRecord::imm_internal(&step.insn());
-        let (sum, overflow) = pc.overflowing_add(imm);
+        let imm = InsnRecord::imm_internal(&step.insn());
+        let (sum, overflow) = pc.overflowing_add(imm as u32);
 
-        let imm_field: E::BaseField = InsnRecord::imm_internal_field(&step.insn());
-        set_val!(instance, config.imm, imm_field);
+        set_val!(instance, config.imm, i64_to_base::<E::BaseField>(imm));
         set_val!(instance, config.overflow_bit, overflow as u64);
 
         let sum_limbs = Value::new(sum, lk_multiplicity);

--- a/ceno_zkvm/src/instructions/riscv/jump/jalr.rs
+++ b/ceno_zkvm/src/instructions/riscv/jump/jalr.rs
@@ -116,7 +116,7 @@ impl<E: ExtensionField> Instruction<E> for JalrInstruction<E> {
         let insn = step.insn();
 
         let rs1 = step.rs1().unwrap().value;
-        let imm: i32 = insn.imm_internal() as i32;
+        let imm: i32 = insn.immediate() as i32;
         let rd = step.rd().unwrap().value.after;
 
         let (sum, overflowing) = rs1.overflowing_add_signed(imm);
@@ -128,7 +128,7 @@ impl<E: ExtensionField> Instruction<E> for JalrInstruction<E> {
             .rd_written
             .assign_value(instance, Value::new(rd, lk_multiplicity));
 
-        let imm_field = InsnRecord::imm_internal_field::<E::BaseField>(&insn);
+        let imm_field: E::BaseField = InsnRecord::imm_internal_field(&insn);
         set_val!(instance, config.imm, imm_field);
 
         config

--- a/ceno_zkvm/src/instructions/riscv/jump/jalr.rs
+++ b/ceno_zkvm/src/instructions/riscv/jump/jalr.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     set_val,
     tables::InsnRecord,
+    utils::i64_to_base,
     witness::LkMultiplicity,
 };
 use ceno_emul::{InsnKind, PC_STEP_SIZE};
@@ -116,10 +117,10 @@ impl<E: ExtensionField> Instruction<E> for JalrInstruction<E> {
         let insn = step.insn();
 
         let rs1 = step.rs1().unwrap().value;
-        let imm: i32 = InsnRecord::imm_internal(&insn) as i32;
+        let imm = InsnRecord::imm_internal(&insn);
         let rd = step.rd().unwrap().value.after;
 
-        let (sum, overflowing) = rs1.overflowing_add_signed(imm);
+        let (sum, overflowing) = rs1.overflowing_add_signed(imm as i32);
 
         config
             .rs1_read
@@ -128,8 +129,7 @@ impl<E: ExtensionField> Instruction<E> for JalrInstruction<E> {
             .rd_written
             .assign_value(instance, Value::new(rd, lk_multiplicity));
 
-        let imm_field: E::BaseField = InsnRecord::imm_internal_field(&insn);
-        set_val!(instance, config.imm, imm_field);
+        set_val!(instance, config.imm, i64_to_base::<E::BaseField>(imm));
 
         config
             .next_pc_addr

--- a/ceno_zkvm/src/instructions/riscv/jump/jalr.rs
+++ b/ceno_zkvm/src/instructions/riscv/jump/jalr.rs
@@ -116,7 +116,7 @@ impl<E: ExtensionField> Instruction<E> for JalrInstruction<E> {
         let insn = step.insn();
 
         let rs1 = step.rs1().unwrap().value;
-        let imm: i32 = insn.immediate() as i32;
+        let imm: i32 = InsnRecord::imm_internal(&insn) as i32;
         let rd = step.rd().unwrap().value.after;
 
         let (sum, overflowing) = rs1.overflowing_add_signed(imm);

--- a/ceno_zkvm/src/instructions/riscv/logic_imm/logic_imm_circuit.rs
+++ b/ceno_zkvm/src/instructions/riscv/logic_imm/logic_imm_circuit.rs
@@ -11,7 +11,7 @@ use crate::{
         Instruction,
         riscv::{constants::UInt8, i_insn::IInstructionConfig},
     },
-    tables::OpsTable,
+    tables::{InsnRecord, OpsTable},
     utils::split_to_u8,
     witness::LkMultiplicity,
 };
@@ -57,7 +57,7 @@ impl<E: ExtensionField, I: LogicOp> Instruction<E> for LogicInstruction<E, I> {
         UInt8::<E>::logic_assign::<I::OpsTable>(
             lkm,
             step.rs1().unwrap().value.into(),
-            step.insn().immediate().into(),
+            InsnRecord::imm_internal(&step.insn()).into(),
         );
 
         config.assign_instance(instance, lkm, step)
@@ -112,7 +112,7 @@ impl<E: ExtensionField> LogicConfig<E> {
         let rs1_read = split_to_u8(step.rs1().unwrap().value);
         self.rs1_read.assign_limbs(instance, &rs1_read);
 
-        let imm = split_to_u8::<u16>(step.insn().immediate());
+        let imm = split_to_u8::<u16>(InsnRecord::imm_internal(&step.insn()));
         self.imm.assign_limbs(instance, &imm);
 
         let rd_written = split_to_u8(step.rd().unwrap().value.after);

--- a/ceno_zkvm/src/instructions/riscv/logic_imm/logic_imm_circuit.rs
+++ b/ceno_zkvm/src/instructions/riscv/logic_imm/logic_imm_circuit.rs
@@ -57,7 +57,7 @@ impl<E: ExtensionField, I: LogicOp> Instruction<E> for LogicInstruction<E, I> {
         UInt8::<E>::logic_assign::<I::OpsTable>(
             lkm,
             step.rs1().unwrap().value.into(),
-            InsnRecord::imm_internal(&step.insn()).into(),
+            InsnRecord::imm_internal(&step.insn()) as u64,
         );
 
         config.assign_instance(instance, lkm, step)
@@ -112,7 +112,7 @@ impl<E: ExtensionField> LogicConfig<E> {
         let rs1_read = split_to_u8(step.rs1().unwrap().value);
         self.rs1_read.assign_limbs(instance, &rs1_read);
 
-        let imm = split_to_u8::<u16>(InsnRecord::imm_internal(&step.insn()));
+        let imm = split_to_u8::<u16>(InsnRecord::imm_internal(&step.insn()) as u32);
         self.imm.assign_limbs(instance, &imm);
 
         let rd_written = split_to_u8(step.rd().unwrap().value.after);

--- a/ceno_zkvm/src/instructions/riscv/logic_imm/logic_imm_circuit.rs
+++ b/ceno_zkvm/src/instructions/riscv/logic_imm/logic_imm_circuit.rs
@@ -57,7 +57,7 @@ impl<E: ExtensionField, I: LogicOp> Instruction<E> for LogicInstruction<E, I> {
         UInt8::<E>::logic_assign::<I::OpsTable>(
             lkm,
             step.rs1().unwrap().value.into(),
-            step.insn().imm_internal().into(),
+            step.insn().immediate().into(),
         );
 
         config.assign_instance(instance, lkm, step)
@@ -112,7 +112,7 @@ impl<E: ExtensionField> LogicConfig<E> {
         let rs1_read = split_to_u8(step.rs1().unwrap().value);
         self.rs1_read.assign_limbs(instance, &rs1_read);
 
-        let imm = split_to_u8::<u16>(step.insn().imm_internal());
+        let imm = split_to_u8::<u16>(step.insn().immediate());
         self.imm.assign_limbs(instance, &imm);
 
         let rd_written = split_to_u8(step.rd().unwrap().value.after);

--- a/ceno_zkvm/src/instructions/riscv/memory/load.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/load.rs
@@ -210,7 +210,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for LoadInstruction<E,
             step.rs1()
                 .unwrap()
                 .value
-                .wrapping_add(step.insn().imm_internal()),
+                .wrapping_add(step.insn().immediate()),
         );
         let shift = unaligned_addr.shift();
         let addr_low_bits = [shift & 0x01, (shift >> 1) & 0x01];

--- a/ceno_zkvm/src/instructions/riscv/memory/load.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/load.rs
@@ -210,7 +210,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for LoadInstruction<E,
             step.rs1()
                 .unwrap()
                 .value
-                .wrapping_add(step.insn().immediate()),
+                .wrapping_add(InsnRecord::imm_internal(&step.insn())),
         );
         let shift = unaligned_addr.shift();
         let addr_low_bits = [shift & 0x01, (shift >> 1) & 0x01];

--- a/ceno_zkvm/src/instructions/riscv/memory/load.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/load.rs
@@ -13,6 +13,7 @@ use crate::{
     },
     set_val,
     tables::InsnRecord,
+    utils::i64_to_base,
     witness::LkMultiplicity,
 };
 use ceno_emul::{ByteAddr, InsnKind, StepRecord};
@@ -205,19 +206,15 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for LoadInstruction<E,
         let memory_value = step.memory_op().unwrap().value.before;
         let memory_read = Value::new(memory_value, lk_multiplicity);
         // imm is signed 12-bit value
-        let imm: E::BaseField = InsnRecord::imm_internal_field(&step.insn());
-        let unaligned_addr = ByteAddr::from(
-            step.rs1()
-                .unwrap()
-                .value
-                .wrapping_add(InsnRecord::imm_internal(&step.insn())),
-        );
+        let imm = InsnRecord::imm_internal(&step.insn());
+        let unaligned_addr =
+            ByteAddr::from(step.rs1().unwrap().value.wrapping_add_signed(imm as i32));
         let shift = unaligned_addr.shift();
         let addr_low_bits = [shift & 0x01, (shift >> 1) & 0x01];
         let target_limb = memory_read.as_u16_limbs()[addr_low_bits[1] as usize];
         let mut target_limb_bytes = target_limb.to_le_bytes();
 
-        set_val!(instance, config.imm, imm);
+        set_val!(instance, config.imm, i64_to_base::<E::BaseField>(imm));
         config
             .im_insn
             .assign_instance(instance, lk_multiplicity, step)?;

--- a/ceno_zkvm/src/instructions/riscv/memory/store.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/store.rs
@@ -149,7 +149,7 @@ impl<E: ExtensionField, I: RIVInstruction, const N_ZEROS: usize> Instruction<E>
             step.rs1()
                 .unwrap()
                 .value
-                .wrapping_add(step.insn().immediate()),
+                .wrapping_add(InsnRecord::imm_internal(&step.insn())),
         );
         config
             .s_insn

--- a/ceno_zkvm/src/instructions/riscv/memory/store.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/store.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     set_val,
     tables::InsnRecord,
+    utils::i64_to_base,
     witness::LkMultiplicity,
 };
 use ceno_emul::{ByteAddr, CENO_PLATFORM, InsnKind, StepRecord};
@@ -142,21 +143,16 @@ impl<E: ExtensionField, I: RIVInstruction, const N_ZEROS: usize> Instruction<E>
         let rs1 = Value::new_unchecked(step.rs1().unwrap().value);
         let rs2 = Value::new_unchecked(step.rs2().unwrap().value);
         let memory_op = step.memory_op().unwrap();
-        let imm: E::BaseField = InsnRecord::imm_internal_field(&step.insn());
+        let imm = InsnRecord::imm_internal(&step.insn());
         let prev_mem_value = Value::new(memory_op.value.before, lk_multiplicity);
 
-        let addr = ByteAddr::from(
-            step.rs1()
-                .unwrap()
-                .value
-                .wrapping_add(InsnRecord::imm_internal(&step.insn())),
-        );
+        let addr = ByteAddr::from(step.rs1().unwrap().value.wrapping_add_signed(imm as i32));
         config
             .s_insn
             .assign_instance(instance, lk_multiplicity, step)?;
         config.rs1_read.assign_value(instance, rs1);
         config.rs2_read.assign_value(instance, rs2);
-        set_val!(instance, config.imm, imm);
+        set_val!(instance, config.imm, i64_to_base::<E::BaseField>(imm));
         config
             .prev_memory_value
             .assign_value(instance, prev_mem_value);

--- a/ceno_zkvm/src/instructions/riscv/memory/store.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/store.rs
@@ -149,7 +149,7 @@ impl<E: ExtensionField, I: RIVInstruction, const N_ZEROS: usize> Instruction<E>
             step.rs1()
                 .unwrap()
                 .value
-                .wrapping_add(step.insn().imm_internal()),
+                .wrapping_add(step.insn().immediate()),
         );
         config
             .s_insn

--- a/ceno_zkvm/src/instructions/riscv/shift_imm.rs
+++ b/ceno_zkvm/src/instructions/riscv/shift_imm.rs
@@ -13,7 +13,7 @@ use crate::{
     tables::InsnRecord,
     witness::LkMultiplicity,
 };
-use ceno_emul::{DecodedInstruction, InsnKind, StepRecord};
+use ceno_emul::{InsnKind, StepRecord};
 use ff_ext::ExtensionField;
 use std::{marker::PhantomData, mem::MaybeUninit};
 
@@ -145,7 +145,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ShiftImmInstructio
         lk_multiplicity: &mut LkMultiplicity,
         step: &StepRecord,
     ) -> Result<(), ZKVMError> {
-        let imm = InsnRecord::<E::BaseField>::imm_internal(&step.insn());
+        let imm = InsnRecord::imm_internal(&step.insn());
         let rs1_read = Value::new_unchecked(step.rs1().unwrap().value);
         let rd_written = Value::new(step.rd().unwrap().value.after, lk_multiplicity);
 
@@ -180,12 +180,6 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ShiftImmInstructio
 
         Ok(())
     }
-}
-
-/// Decode the immediate into the format of this circuit.
-/// The shift is implemented as a multiplication/division by 1 << immediate.
-pub fn process_imm(insn: &DecodedInstruction) -> u32 {
-    1 << (insn.immediate() & 0x1F)
 }
 
 #[cfg(test)]

--- a/ceno_zkvm/src/instructions/riscv/shift_imm.rs
+++ b/ceno_zkvm/src/instructions/riscv/shift_imm.rs
@@ -12,7 +12,7 @@ use crate::{
     set_val,
     witness::LkMultiplicity,
 };
-use ceno_emul::{InsnKind, StepRecord};
+use ceno_emul::{DecodedInstruction, InsnKind, StepRecord};
 use ff_ext::ExtensionField;
 use std::{marker::PhantomData, mem::MaybeUninit};
 
@@ -144,7 +144,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ShiftImmInstructio
         lk_multiplicity: &mut LkMultiplicity,
         step: &StepRecord,
     ) -> Result<(), ZKVMError> {
-        let imm = step.insn().imm_internal();
+        let imm = process_imm(&step.insn());
         let rs1_read = Value::new_unchecked(step.rs1().unwrap().value);
         let rd_written = Value::new(step.rd().unwrap().value.after, lk_multiplicity);
 
@@ -179,6 +179,12 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ShiftImmInstructio
 
         Ok(())
     }
+}
+
+/// Decode the immediate into the format of this circuit.
+/// The shift is implemented as a multiplication/division by 1 << immediate.
+pub fn process_imm(insn: &DecodedInstruction) -> u32 {
+    1 << (insn.immediate() & 0x1F)
 }
 
 #[cfg(test)]

--- a/ceno_zkvm/src/instructions/riscv/shift_imm.rs
+++ b/ceno_zkvm/src/instructions/riscv/shift_imm.rs
@@ -145,16 +145,17 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ShiftImmInstructio
         lk_multiplicity: &mut LkMultiplicity,
         step: &StepRecord,
     ) -> Result<(), ZKVMError> {
-        let imm = InsnRecord::imm_internal(&step.insn());
+        // imm_internal is a precomputed 2**shift.
+        let imm = InsnRecord::imm_internal(&step.insn()) as u64;
         let rs1_read = Value::new_unchecked(step.rs1().unwrap().value);
         let rd_written = Value::new(step.rd().unwrap().value.after, lk_multiplicity);
 
-        set_val!(instance, config.imm, imm as u64);
+        set_val!(instance, config.imm, imm);
         config.rs1_read.assign_value(instance, rs1_read.clone());
         config.rd_written.assign_value(instance, rd_written);
 
         let outflow = match I::INST_KIND {
-            InsnKind::SLLI => (rs1_read.as_u64() * imm as u64) >> UInt::<E>::TOTAL_BITS,
+            InsnKind::SLLI => (rs1_read.as_u64() * imm) >> UInt::<E>::TOTAL_BITS,
             InsnKind::SRAI | InsnKind::SRLI => {
                 if I::INST_KIND == InsnKind::SRAI {
                     config.is_lt_config.as_ref().unwrap().assign_instance(
@@ -164,7 +165,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ShiftImmInstructio
                     )?;
                 }
 
-                rs1_read.as_u64() & (imm as u64 - 1)
+                rs1_read.as_u64() & (imm - 1)
             }
             _ => unreachable!("Unsupported instruction kind {:?}", I::INST_KIND),
         };
@@ -172,7 +173,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ShiftImmInstructio
         set_val!(instance, config.outflow, outflow);
         config
             .assert_lt_config
-            .assign_instance(instance, lk_multiplicity, outflow, imm as u64)?;
+            .assign_instance(instance, lk_multiplicity, outflow, imm)?;
 
         config
             .i_insn

--- a/ceno_zkvm/src/instructions/riscv/shift_imm.rs
+++ b/ceno_zkvm/src/instructions/riscv/shift_imm.rs
@@ -10,6 +10,7 @@ use crate::{
         riscv::{constants::UInt, i_insn::IInstructionConfig},
     },
     set_val,
+    tables::InsnRecord,
     witness::LkMultiplicity,
 };
 use ceno_emul::{DecodedInstruction, InsnKind, StepRecord};
@@ -144,7 +145,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ShiftImmInstructio
         lk_multiplicity: &mut LkMultiplicity,
         step: &StepRecord,
     ) -> Result<(), ZKVMError> {
-        let imm = process_imm(&step.insn());
+        let imm = InsnRecord::<E::BaseField>::imm_internal(&step.insn());
         let rs1_read = Value::new_unchecked(step.rs1().unwrap().value);
         let rd_written = Value::new(step.rd().unwrap().value.after, lk_multiplicity);
 

--- a/ceno_zkvm/src/instructions/riscv/slti.rs
+++ b/ceno_zkvm/src/instructions/riscv/slti.rs
@@ -105,7 +105,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for SetLessThanImmInst
             .rs1_read
             .assign_value(instance, Value::new_unchecked(rs1));
 
-        let imm = step.insn().immediate();
+        let imm = InsnRecord::imm_internal(&step.insn());
         let imm_field: E::BaseField = InsnRecord::imm_internal_field(&step.insn());
         set_val!(instance, config.imm, imm_field);
 

--- a/ceno_zkvm/src/instructions/riscv/slti.rs
+++ b/ceno_zkvm/src/instructions/riscv/slti.rs
@@ -17,6 +17,7 @@ use crate::{
     set_val,
     tables::InsnRecord,
     uint::Value,
+    utils::i64_to_base,
     witness::LkMultiplicity,
 };
 use core::mem::MaybeUninit;
@@ -106,8 +107,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for SetLessThanImmInst
             .assign_value(instance, Value::new_unchecked(rs1));
 
         let imm = InsnRecord::imm_internal(&step.insn());
-        let imm_field: E::BaseField = InsnRecord::imm_internal_field(&step.insn());
-        set_val!(instance, config.imm, imm_field);
+        set_val!(instance, config.imm, i64_to_base::<E::BaseField>(imm));
 
         match I::INST_KIND {
             InsnKind::SLTIU => {

--- a/ceno_zkvm/src/instructions/riscv/slti.rs
+++ b/ceno_zkvm/src/instructions/riscv/slti.rs
@@ -105,8 +105,8 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for SetLessThanImmInst
             .rs1_read
             .assign_value(instance, Value::new_unchecked(rs1));
 
-        let imm = step.insn().imm_internal();
-        let imm_field = InsnRecord::imm_internal_field::<E::BaseField>(&step.insn());
+        let imm = step.insn().immediate();
+        let imm_field: E::BaseField = InsnRecord::imm_internal_field(&step.insn());
         set_val!(instance, config.imm, imm_field);
 
         match I::INST_KIND {

--- a/ceno_zkvm/src/tables/program.rs
+++ b/ceno_zkvm/src/tables/program.rs
@@ -65,15 +65,17 @@ impl<F: SmallField> InsnRecord<F> {
     /// Interpret the immediate as unsigned or signed depending on the instruction.
     /// Convert negative values from two's complement to field.
     pub fn imm_internal_field(insn: &DecodedInstruction) -> F {
-        let imm = Self::imm_internal(insn);
-        if Self::imm_field_is_negative(insn) {
+        let imm = InsnRecord::imm_internal(insn);
+        if InsnRecord::imm_field_is_negative(insn) {
             -F::from(-(imm as i32) as u64)
         } else {
             F::from(imm as u64)
         }
     }
+}
 
-    /// The internal view of the immediate, for use in circuits.
+impl InsnRecord<()> {
+    /// The internal view of the immediate in the program table, for use in circuits.
     pub fn imm_internal(insn: &DecodedInstruction) -> u32 {
         let codes = insn.codes();
         match codes.format {
@@ -210,8 +212,6 @@ impl<E: ExtensionField, const PROGRAM_SIZE: usize> TableCircuit<E>
 #[test]
 #[allow(clippy::identity_op)]
 fn test_decode_imm() {
-    use goldilocks::Goldilocks as F;
-
     for (i, expected) in [
         // Example of I-type: ADDI.
         // imm    | rs1     | funct3      | rd     | opcode
@@ -227,7 +227,7 @@ fn test_decode_imm() {
         // funct7     | rs2    | rs1     | funct3      | rd     | opcode
         (0x20 << 25 | 1 << 20 | 1 << 15 | 0 << 12 | 1 << 7 | 0x33, 0),
     ] {
-        let imm = InsnRecord::<F>::imm_internal(&DecodedInstruction::new(i));
+        let imm = InsnRecord::imm_internal(&DecodedInstruction::new(i));
         assert_eq!(imm, expected);
     }
 }

--- a/ceno_zkvm/src/tables/program.rs
+++ b/ceno_zkvm/src/tables/program.rs
@@ -8,6 +8,7 @@ use crate::{
     set_fixed_val, set_val,
     structs::ROMType,
     tables::TableCircuit,
+    utils::i64_to_base,
     witness::RowMajorMatrix,
 };
 use ceno_emul::{
@@ -58,51 +59,38 @@ impl<F: SmallField> InsnRecord<F> {
             (insn.rd_internal() as u64).into(),
             (insn.rs1_or_zero() as u64).into(),
             (insn.rs2_or_zero() as u64).into(),
-            Self::imm_internal_field(insn),
+            i64_to_base(InsnRecord::imm_internal(insn)),
         ])
-    }
-
-    /// Interpret the immediate as unsigned or signed depending on the instruction.
-    /// Convert negative values from two's complement to field.
-    pub fn imm_internal_field(insn: &DecodedInstruction) -> F {
-        let imm = InsnRecord::imm_internal(insn);
-        if InsnRecord::imm_field_is_negative(insn) {
-            -F::from(-(imm as i32) as u64)
-        } else {
-            F::from(imm as u64)
-        }
     }
 }
 
 impl InsnRecord<()> {
-    /// The internal view of the immediate in the program table, for use in circuits.
-    pub fn imm_internal(insn: &DecodedInstruction) -> u32 {
-        let codes = insn.codes();
-        match codes.format {
-            R => 0,
-            _ if matches!(codes.kind, SLLI | SRLI | SRAI) => {
-                // Decode the immediate for ShiftImmInstruction.
-                // The shift is implemented as a multiplication/division by 1 << immediate.
-                1 << (insn.immediate() & 0x1F)
-            }
-            _ => insn.immediate(),
-        }
-    }
-
-    /// The internal interpretation of the immediate sign, for use in circuits.
-    /// Indicates if the immediate value, when signed, needs to be encoded as field negative.
-    /// example:
-    /// imm = ux::MAX - 1 implies
-    /// imm_field = FIELD_MODULUS - 1 if imm_field_is_negative
-    /// imm_field = ux::MAX - 1 otherwise
-    fn imm_field_is_negative(insn: &DecodedInstruction) -> bool {
+    /// The internal view of the immediate in the program table.
+    /// This is encoded in a way that is efficient for circuits, depending on the instruction.
+    ///
+    /// These conversions are legal:
+    /// - `as u32` and `as i32` as usual.
+    /// - `i64_to_base(imm)` gives the field element going into the program table.
+    /// - `as u64` in unsigned cases.
+    pub fn imm_internal(insn: &DecodedInstruction) -> i64 {
+        let imm: u32 = insn.immediate();
         match insn.codes() {
-            InsnCodes { format: R | U, .. } => false,
+            // Prepare the immediate for ShiftImmInstruction.
+            // The shift is implemented as a multiplication/division by 1 << immediate.
             InsnCodes {
-                kind: SLLI | SRLI | SRAI | ADDI | SLTIU | ANDI | XORI | ORI,
+                kind: SLLI | SRLI | SRAI,
                 ..
-            } => false,
-            _ => insn.immediate_msb() != 0,
+            } => 1 << (imm & 0x1F),
+            // Unsigned view.
+            // For example, u32::MAX is `u32::MAX mod p` in the finite field.
+            InsnCodes { format: R | U, .. }
+            | InsnCodes {
+                kind: ADDI | SLTIU | ANDI | XORI | ORI,
+                ..
+            } => imm as u64 as i64,
+            // Signed view.
+            // For example, u32::MAX is `-1 mod p` in the finite field.
+            _ => imm as i32 as i64,
         }
     }
 }


### PR DESCRIPTION
- Move any circuit-specific logic of the immediate column of the program table, into the program table module.
- Simplify InsnRecord back to a simple list.
- Minimize API into a single function `imm_internal`. It uses an intermediate i64 instead of previous u32 and bool.

This was an abstraction leakage across crates. This PR finally moves it at the right place.
