### PR TITLE
Switch to `InsnKind` in the program table

### DIFF
--- a/ceno_emul/src/rv32im.rs
+++ b/ceno_emul/src/rv32im.rs
@@ -197,9 +197,9 @@ pub struct InsnCodes {
     pub format: InsnFormat,
     pub kind: InsnKind,
     category: InsnCategory,
-    pub opcode: u32,
-    pub func3: u32,
-    pub func7: u32,
+    pub(crate) opcode: u32,
+    pub(crate) func3: u32,
+    pub(crate) func7: u32,
 }
 
 impl DecodedInstruction {
@@ -236,14 +236,6 @@ impl DecodedInstruction {
         }
     }
 
-    /// Get the funct3 field, or zero if the instruction does not use funct3.
-    pub fn funct3_or_zero(&self) -> u32 {
-        match self.codes().format {
-            R | I | S | B => self.func3,
-            _ => 0,
-        }
-    }
-
     /// Get the rs1 field, regardless of the instruction format.
     pub fn rs1(&self) -> u32 {
         self.rs1
@@ -273,7 +265,7 @@ impl DecodedInstruction {
     /// The internal view of the immediate, for use in circuits.
     pub fn imm_internal(&self) -> u32 {
         match self.codes().format {
-            R => self.func7,
+            R => 0,
             I => match self.codes().kind {
                 // decode the shift as a multiplication/division by 1 << immediate
                 SLLI | SRLI | SRAI => 1 << self.imm_shamt(),
@@ -359,10 +351,7 @@ fn test_decode_imm() {
         ),
         // Example of R-type with funct7: SUB.
         // funct7     | rs2    | rs1     | funct3      | rd     | opcode
-        (
-            0x20 << 25 | 1 << 20 | 1 << 15 | 0 << 12 | 1 << 7 | 0x33,
-            0x20,
-        ),
+        (0x20 << 25 | 1 << 20 | 1 << 15 | 0 << 12 | 1 << 7 | 0x33, 0),
     ] {
         let imm = DecodedInstruction::new(i).imm_internal();
         assert_eq!(imm, expected);

--- a/ceno_emul/src/rv32im_encode.rs
+++ b/ceno_emul/src/rv32im_encode.rs
@@ -49,7 +49,8 @@ const fn encode_i(kind: InsnKind, rs1: u32, rd: u32, imm: u32) -> u32 {
     let rd = rd & MASK_5_BITS;
     let func3 = kind.codes().func3;
     let opcode = kind.codes().opcode;
-    let imm = imm & MASK_12_BITS;
+    let shift_func = (matches!(kind, InsnKind::SRAI) as u32) << 10; // SRAI kind is encoded in imm.
+    let imm = imm & MASK_12_BITS | shift_func;
     imm << 20 | rs1 << 15 | func3 << 12 | rd << 7 | opcode
 }
 

--- a/ceno_emul/src/rv32im_encode.rs
+++ b/ceno_emul/src/rv32im_encode.rs
@@ -49,8 +49,9 @@ const fn encode_i(kind: InsnKind, rs1: u32, rd: u32, imm: u32) -> u32 {
     let rd = rd & MASK_5_BITS;
     let func3 = kind.codes().func3;
     let opcode = kind.codes().opcode;
-    let shift_func = (matches!(kind, InsnKind::SRAI) as u32) << 10; // SRAI kind is encoded in imm.
-    let imm = imm & MASK_12_BITS | shift_func;
+    // SRLI/SRAI use a specialization of the I-type format with the shift type in imm[10].
+    let is_arithmetic_right_shift = (matches!(kind, InsnKind::SRAI) as u32) << 10;
+    let imm = imm & MASK_12_BITS | is_arithmetic_right_shift;
     imm << 20 | rs1 << 15 | func3 << 12 | rd << 7 | opcode
 }
 

--- a/ceno_zkvm/src/expression.rs
+++ b/ceno_zkvm/src/expression.rs
@@ -8,6 +8,7 @@ use std::{
     ops::{Add, AddAssign, Deref, Mul, MulAssign, Neg, Shl, ShlAssign, Sub, SubAssign},
 };
 
+use ceno_emul::InsnKind;
 use ff::Field;
 use ff_ext::ExtensionField;
 use goldilocks::SmallField;
@@ -831,7 +832,7 @@ macro_rules! impl_from_unsigned {
         )*
     };
 }
-impl_from_unsigned!(u8, u16, u32, u64, usize, RAMType);
+impl_from_unsigned!(u8, u16, u32, u64, usize, RAMType, InsnKind);
 
 // Implement From trait for u128 separately since it requires explicit reduction
 impl<F: SmallField, E: ExtensionField<BaseField = F>> From<u128> for Expression<E> {

--- a/ceno_zkvm/src/instructions/riscv/b_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/b_insn.rs
@@ -60,9 +60,8 @@ impl<E: ExtensionField> BInstructionConfig<E> {
         // Fetch instruction
         circuit_builder.lk_fetch(&InsnRecord::new(
             vm_state.pc.expr(),
-            insn_kind.codes().opcode.into(),
+            insn_kind.into(),
             None,
-            insn_kind.codes().func3.into(),
             rs1.id.expr(),
             rs2.id.expr(),
             imm.expr(),

--- a/ceno_zkvm/src/instructions/riscv/ecall_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall_insn.rs
@@ -39,9 +39,8 @@ impl EcallInstructionConfig {
 
         cb.lk_fetch(&InsnRecord::new(
             pc.expr(),
-            (EANY.codes().opcode as usize).into(),
+            EANY.into(),
             None,
-            (EANY.codes().func3 as usize).into(),
             0.into(),
             0.into(),
             0.into(), // imm = 0

--- a/ceno_zkvm/src/instructions/riscv/i_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/i_insn.rs
@@ -45,9 +45,8 @@ impl<E: ExtensionField> IInstructionConfig<E> {
         // Fetch the instruction.
         circuit_builder.lk_fetch(&InsnRecord::new(
             vm_state.pc.expr(),
-            insn_kind.codes().opcode.into(),
+            insn_kind.into(),
             Some(rd.id.expr()),
-            insn_kind.codes().func3.into(),
             rs1.id.expr(),
             0.into(),
             imm.clone(),

--- a/ceno_zkvm/src/instructions/riscv/im_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/im_insn.rs
@@ -45,9 +45,8 @@ impl<E: ExtensionField> IMInstructionConfig<E> {
         // Fetch the instruction
         circuit_builder.lk_fetch(&InsnRecord::new(
             vm_state.pc.expr(),
-            (insn_kind.codes().opcode as usize).into(),
+            insn_kind.into(),
             Some(rd.id.expr()),
-            (insn_kind.codes().func3 as usize).into(),
             rs1.id.expr(),
             0.into(),
             imm.clone(),

--- a/ceno_zkvm/src/instructions/riscv/j_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/j_insn.rs
@@ -41,9 +41,8 @@ impl<E: ExtensionField> JInstructionConfig<E> {
         // Fetch instruction
         circuit_builder.lk_fetch(&InsnRecord::new(
             vm_state.pc.expr(),
-            (insn_kind.codes().opcode as usize).into(),
+            insn_kind.into(),
             Some(rd.id.expr()),
-            0.into(),
             0.into(),
             0.into(),
             vm_state.next_pc.unwrap().expr() - vm_state.pc.expr(),

--- a/ceno_zkvm/src/instructions/riscv/r_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/r_insn.rs
@@ -44,9 +44,8 @@ impl<E: ExtensionField> RInstructionConfig<E> {
         // Fetch instruction
         circuit_builder.lk_fetch(&InsnRecord::new(
             vm_state.pc.expr(),
-            insn_kind.codes().opcode.into(),
+            insn_kind.into(),
             Some(rd.id.expr()),
-            insn_kind.codes().func3.into(),
             rs1.id.expr(),
             rs2.id.expr(),
             insn_kind.codes().func7.into(),

--- a/ceno_zkvm/src/instructions/riscv/r_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/r_insn.rs
@@ -48,7 +48,7 @@ impl<E: ExtensionField> RInstructionConfig<E> {
             Some(rd.id.expr()),
             rs1.id.expr(),
             rs2.id.expr(),
-            insn_kind.codes().func7.into(),
+            0.into(),
         ))?;
 
         Ok(RInstructionConfig {

--- a/ceno_zkvm/src/instructions/riscv/s_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/s_insn.rs
@@ -44,9 +44,8 @@ impl<E: ExtensionField> SInstructionConfig<E> {
         // Fetch instruction
         circuit_builder.lk_fetch(&InsnRecord::new(
             vm_state.pc.expr(),
-            (insn_kind.codes().opcode as usize).into(),
+            insn_kind.into(),
             None,
-            (insn_kind.codes().func3 as usize).into(),
             rs1.id.expr(),
             rs2.id.expr(),
             imm.clone(),

--- a/ceno_zkvm/src/instructions/riscv/u_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/u_insn.rs
@@ -39,9 +39,8 @@ impl<E: ExtensionField> UInstructionConfig<E> {
         // Fetch instruction
         circuit_builder.lk_fetch(&InsnRecord::new(
             vm_state.pc.expr(),
-            (insn_kind.codes().opcode as usize).into(),
+            insn_kind.into(),
             Some(rd.id.expr()),
-            0.into(),
             0.into(),
             0.into(),
             imm.clone(),


### PR DESCRIPTION
_Matthias:_

Risc-V instruction are encoded in multiple different 'types'.  These types have various fields.  One particularly common field is `opcode`, which typically (but not always) occupies the 7 least significant bits.

As the name suggests, opcode helps code _which_ operation is intended.  I say 'helps' because some operations share the same opcode.

Our code before this PR assumed that bits `12..=14` in the instruction word are exactly enough extra information to determine the operation.  (Confusingly enough, our code follows Risc0 convention, and calls that range of bits `funct3`.  Only some operations have a field named `funct3` in the spec, and not all of them have it in the same place.)  That assumption is wrong, and our circuits are unsound.  Specifically, the distinction between 'signed' (ie 'arithmetic') and 'unsigned' (ie 'logical') immediate right shifts is encoded in bit 30, as laid out in section 2.4.1 of the [spec](https://github.com/riscv/riscv-isa-manual/releases/download/20240411/unpriv-isa-asciidoc.pdf).

We could introduce a new column called 'bit 30' in the program table to fix the symptom.  But instead of such a piecemeal approach, we attack the underlying problem: we switch the program table to record `InsnKind`.  `InsnKind` directly reports the kind of instruction we are dealing with.  We already have that information available in the decoder, and just re-use it here.

Fixes https://github.com/scroll-tech/ceno/issues/539 and https://github.com/scroll-tech/ceno/issues/533