### PR TITLE
Update BaseFold number of queries to 200 according to the recent papers.

### DIFF
--- a/mpcs/src/basefold/encoding/rs.rs
+++ b/mpcs/src/basefold/encoding/rs.rs
@@ -193,6 +193,15 @@ pub fn coset_fft<E: ExtensionField>(
 pub struct RSCodeDefaultSpec {}
 
 impl RSCodeSpec for RSCodeDefaultSpec {
+    // According to Theorem 1 of paper <BaseFold in the List Decoding Regime>
+    // (https://eprint.iacr.org/2024/1571), the soundness error is bounded by
+    // $O(1/|F|) + (\sqrt{\rho}+\epsilon)^s$
+    // where $s$ is the query complexity and $\epsilon$ is a small value
+    // that can be ignored. So the number of queries can be estimated by
+    // $$
+    // \frac{2\lambda}{-\log\rho}
+    // $$
+    // If we take $\lambda=100$ and $\rho=1/2$, then the number of queries is $200$.
     fn get_number_queries() -> usize {
         200
     }

--- a/mpcs/src/basefold/encoding/rs.rs
+++ b/mpcs/src/basefold/encoding/rs.rs
@@ -194,7 +194,7 @@ pub struct RSCodeDefaultSpec {}
 
 impl RSCodeSpec for RSCodeDefaultSpec {
     fn get_number_queries() -> usize {
-        972
+        200
     }
 
     fn get_rate_log() -> usize {


### PR DESCRIPTION
Extracting small PRs from #294 