### PR TITLE
Convert internal immediate through i64

### DIFF
--- a/ceno_emul/src/rv32im.rs
+++ b/ceno_emul/src/rv32im.rs
@@ -266,10 +266,6 @@ impl DecodedInstruction {
         FastDecodeTable::get().lookup(self)
     }
 
-    pub fn immediate_msb(&self) -> u32 {
-        self.top_bit
-    }
-
     pub fn immediate(&self) -> u32 {
         match self.codes().format {
             R => 0,

--- a/ceno_zkvm/src/instructions/riscv/arith_imm.rs
+++ b/ceno_zkvm/src/instructions/riscv/arith_imm.rs
@@ -62,7 +62,10 @@ impl<E: ExtensionField> Instruction<E> for AddiInstruction<E> {
         step: &StepRecord,
     ) -> Result<(), ZKVMError> {
         let rs1_read = Value::new_unchecked(step.rs1().unwrap().value);
-        let imm = Value::new(InsnRecord::imm_internal(&step.insn()), lk_multiplicity);
+        let imm = Value::new(
+            InsnRecord::imm_internal(&step.insn()) as u32,
+            lk_multiplicity,
+        );
 
         let result = rs1_read.add(&imm, lk_multiplicity, true);
 

--- a/ceno_zkvm/src/instructions/riscv/b_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/b_insn.rs
@@ -10,6 +10,7 @@ use crate::{
     instructions::riscv::insn_base::{ReadRS1, ReadRS2, StateInOut},
     set_val,
     tables::InsnRecord,
+    utils::i64_to_base,
     witness::LkMultiplicity,
 };
 use core::mem::MaybeUninit;
@@ -99,7 +100,7 @@ impl<E: ExtensionField> BInstructionConfig<E> {
         set_val!(
             instance,
             self.imm,
-            InsnRecord::<E::BaseField>::imm_internal_field(&step.insn())
+            i64_to_base::<E::BaseField>(InsnRecord::imm_internal(&step.insn()))
         );
 
         // Fetch the instruction.

--- a/ceno_zkvm/src/instructions/riscv/jump/auipc.rs
+++ b/ceno_zkvm/src/instructions/riscv/jump/auipc.rs
@@ -75,7 +75,7 @@ impl<E: ExtensionField> Instruction<E> for AuipcInstruction<E> {
         step: &ceno_emul::StepRecord,
     ) -> Result<(), ZKVMError> {
         let pc: u32 = step.pc().before.0;
-        let imm: u32 = InsnRecord::imm_internal(&step.insn());
+        let imm = InsnRecord::imm_internal(&step.insn()) as u32;
         let (sum, overflow) = pc.overflowing_add(imm);
 
         let imm_field: E::BaseField = InsnRecord::imm_internal_field(&step.insn());

--- a/ceno_zkvm/src/instructions/riscv/jump/auipc.rs
+++ b/ceno_zkvm/src/instructions/riscv/jump/auipc.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     set_val,
     tables::InsnRecord,
+    utils::i64_to_base,
     witness::LkMultiplicity,
 };
 
@@ -75,11 +76,10 @@ impl<E: ExtensionField> Instruction<E> for AuipcInstruction<E> {
         step: &ceno_emul::StepRecord,
     ) -> Result<(), ZKVMError> {
         let pc: u32 = step.pc().before.0;
-        let imm = InsnRecord::imm_internal(&step.insn()) as u32;
-        let (sum, overflow) = pc.overflowing_add(imm);
+        let imm = InsnRecord::imm_internal(&step.insn());
+        let (sum, overflow) = pc.overflowing_add(imm as u32);
 
-        let imm_field: E::BaseField = InsnRecord::imm_internal_field(&step.insn());
-        set_val!(instance, config.imm, imm_field);
+        set_val!(instance, config.imm, i64_to_base::<E::BaseField>(imm));
         set_val!(instance, config.overflow_bit, overflow as u64);
 
         let sum_limbs = Value::new(sum, lk_multiplicity);

--- a/ceno_zkvm/src/instructions/riscv/jump/jalr.rs
+++ b/ceno_zkvm/src/instructions/riscv/jump/jalr.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     set_val,
     tables::InsnRecord,
+    utils::i64_to_base,
     witness::LkMultiplicity,
 };
 use ceno_emul::{InsnKind, PC_STEP_SIZE};
@@ -116,10 +117,10 @@ impl<E: ExtensionField> Instruction<E> for JalrInstruction<E> {
         let insn = step.insn();
 
         let rs1 = step.rs1().unwrap().value;
-        let imm: i32 = InsnRecord::imm_internal(&insn) as i32;
+        let imm = InsnRecord::imm_internal(&insn);
         let rd = step.rd().unwrap().value.after;
 
-        let (sum, overflowing) = rs1.overflowing_add_signed(imm);
+        let (sum, overflowing) = rs1.overflowing_add_signed(imm as i32);
 
         config
             .rs1_read
@@ -128,8 +129,7 @@ impl<E: ExtensionField> Instruction<E> for JalrInstruction<E> {
             .rd_written
             .assign_value(instance, Value::new(rd, lk_multiplicity));
 
-        let imm_field: E::BaseField = InsnRecord::imm_internal_field(&insn);
-        set_val!(instance, config.imm, imm_field);
+        set_val!(instance, config.imm, i64_to_base::<E::BaseField>(imm));
 
         config
             .next_pc_addr

--- a/ceno_zkvm/src/instructions/riscv/logic_imm/logic_imm_circuit.rs
+++ b/ceno_zkvm/src/instructions/riscv/logic_imm/logic_imm_circuit.rs
@@ -57,7 +57,7 @@ impl<E: ExtensionField, I: LogicOp> Instruction<E> for LogicInstruction<E, I> {
         UInt8::<E>::logic_assign::<I::OpsTable>(
             lkm,
             step.rs1().unwrap().value.into(),
-            InsnRecord::imm_internal(&step.insn()).into(),
+            InsnRecord::imm_internal(&step.insn()) as u64,
         );
 
         config.assign_instance(instance, lkm, step)
@@ -112,7 +112,7 @@ impl<E: ExtensionField> LogicConfig<E> {
         let rs1_read = split_to_u8(step.rs1().unwrap().value);
         self.rs1_read.assign_limbs(instance, &rs1_read);
 
-        let imm = split_to_u8::<u16>(InsnRecord::imm_internal(&step.insn()));
+        let imm = split_to_u8::<u16>(InsnRecord::imm_internal(&step.insn()) as u32);
         self.imm.assign_limbs(instance, &imm);
 
         let rd_written = split_to_u8(step.rd().unwrap().value.after);

--- a/ceno_zkvm/src/instructions/riscv/memory/load.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/load.rs
@@ -206,8 +206,9 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for LoadInstruction<E,
         let memory_value = step.memory_op().unwrap().value.before;
         let memory_read = Value::new(memory_value, lk_multiplicity);
         // imm is signed 12-bit value
-        let imm: i64 = InsnRecord::imm_internal(&step.insn());
-        let unaligned_addr = ByteAddr::from(step.rs1().unwrap().value.wrapping_add(imm as u32));
+        let imm = InsnRecord::imm_internal(&step.insn());
+        let unaligned_addr =
+            ByteAddr::from(step.rs1().unwrap().value.wrapping_add_signed(imm as i32));
         let shift = unaligned_addr.shift();
         let addr_low_bits = [shift & 0x01, (shift >> 1) & 0x01];
         let target_limb = memory_read.as_u16_limbs()[addr_low_bits[1] as usize];

--- a/ceno_zkvm/src/instructions/riscv/memory/load.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/load.rs
@@ -13,6 +13,7 @@ use crate::{
     },
     set_val,
     tables::InsnRecord,
+    utils::i64_to_base,
     witness::LkMultiplicity,
 };
 use ceno_emul::{ByteAddr, InsnKind, StepRecord};
@@ -205,19 +206,14 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for LoadInstruction<E,
         let memory_value = step.memory_op().unwrap().value.before;
         let memory_read = Value::new(memory_value, lk_multiplicity);
         // imm is signed 12-bit value
-        let imm: E::BaseField = InsnRecord::imm_internal_field(&step.insn());
-        let unaligned_addr = ByteAddr::from(
-            step.rs1()
-                .unwrap()
-                .value
-                .wrapping_add(InsnRecord::imm_internal(&step.insn())),
-        );
+        let imm: i64 = InsnRecord::imm_internal(&step.insn());
+        let unaligned_addr = ByteAddr::from(step.rs1().unwrap().value.wrapping_add(imm as u32));
         let shift = unaligned_addr.shift();
         let addr_low_bits = [shift & 0x01, (shift >> 1) & 0x01];
         let target_limb = memory_read.as_u16_limbs()[addr_low_bits[1] as usize];
         let mut target_limb_bytes = target_limb.to_le_bytes();
 
-        set_val!(instance, config.imm, imm);
+        set_val!(instance, config.imm, i64_to_base::<E::BaseField>(imm));
         config
             .im_insn
             .assign_instance(instance, lk_multiplicity, step)?;

--- a/ceno_zkvm/src/instructions/riscv/memory/store.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/store.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     set_val,
     tables::InsnRecord,
+    utils::i64_to_base,
     witness::LkMultiplicity,
 };
 use ceno_emul::{ByteAddr, CENO_PLATFORM, InsnKind, StepRecord};
@@ -142,21 +143,16 @@ impl<E: ExtensionField, I: RIVInstruction, const N_ZEROS: usize> Instruction<E>
         let rs1 = Value::new_unchecked(step.rs1().unwrap().value);
         let rs2 = Value::new_unchecked(step.rs2().unwrap().value);
         let memory_op = step.memory_op().unwrap();
-        let imm: E::BaseField = InsnRecord::imm_internal_field(&step.insn());
+        let imm: i64 = InsnRecord::imm_internal(&step.insn());
         let prev_mem_value = Value::new(memory_op.value.before, lk_multiplicity);
 
-        let addr = ByteAddr::from(
-            step.rs1()
-                .unwrap()
-                .value
-                .wrapping_add(InsnRecord::imm_internal(&step.insn())),
-        );
+        let addr = ByteAddr::from(step.rs1().unwrap().value.wrapping_add(imm as u32));
         config
             .s_insn
             .assign_instance(instance, lk_multiplicity, step)?;
         config.rs1_read.assign_value(instance, rs1);
         config.rs2_read.assign_value(instance, rs2);
-        set_val!(instance, config.imm, imm);
+        set_val!(instance, config.imm, i64_to_base::<E::BaseField>(imm));
         config
             .prev_memory_value
             .assign_value(instance, prev_mem_value);

--- a/ceno_zkvm/src/instructions/riscv/memory/store.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/store.rs
@@ -143,10 +143,10 @@ impl<E: ExtensionField, I: RIVInstruction, const N_ZEROS: usize> Instruction<E>
         let rs1 = Value::new_unchecked(step.rs1().unwrap().value);
         let rs2 = Value::new_unchecked(step.rs2().unwrap().value);
         let memory_op = step.memory_op().unwrap();
-        let imm: i64 = InsnRecord::imm_internal(&step.insn());
+        let imm = InsnRecord::imm_internal(&step.insn());
         let prev_mem_value = Value::new(memory_op.value.before, lk_multiplicity);
 
-        let addr = ByteAddr::from(step.rs1().unwrap().value.wrapping_add(imm as u32));
+        let addr = ByteAddr::from(step.rs1().unwrap().value.wrapping_add_signed(imm as i32));
         config
             .s_insn
             .assign_instance(instance, lk_multiplicity, step)?;

--- a/ceno_zkvm/src/instructions/riscv/shift_imm.rs
+++ b/ceno_zkvm/src/instructions/riscv/shift_imm.rs
@@ -145,16 +145,17 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ShiftImmInstructio
         lk_multiplicity: &mut LkMultiplicity,
         step: &StepRecord,
     ) -> Result<(), ZKVMError> {
-        let imm = InsnRecord::imm_internal(&step.insn());
+        // imm_internal is a precomputed 2**shift.
+        let imm = InsnRecord::imm_internal(&step.insn()) as u64;
         let rs1_read = Value::new_unchecked(step.rs1().unwrap().value);
         let rd_written = Value::new(step.rd().unwrap().value.after, lk_multiplicity);
 
-        set_val!(instance, config.imm, imm as u64);
+        set_val!(instance, config.imm, imm);
         config.rs1_read.assign_value(instance, rs1_read.clone());
         config.rd_written.assign_value(instance, rd_written);
 
         let outflow = match I::INST_KIND {
-            InsnKind::SLLI => (rs1_read.as_u64() * imm as u64) >> UInt::<E>::TOTAL_BITS,
+            InsnKind::SLLI => (rs1_read.as_u64() * imm) >> UInt::<E>::TOTAL_BITS,
             InsnKind::SRAI | InsnKind::SRLI => {
                 if I::INST_KIND == InsnKind::SRAI {
                     config.is_lt_config.as_ref().unwrap().assign_instance(
@@ -164,7 +165,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ShiftImmInstructio
                     )?;
                 }
 
-                rs1_read.as_u64() & (imm as u64 - 1)
+                rs1_read.as_u64() & (imm - 1)
             }
             _ => unreachable!("Unsupported instruction kind {:?}", I::INST_KIND),
         };
@@ -172,7 +173,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ShiftImmInstructio
         set_val!(instance, config.outflow, outflow);
         config
             .assert_lt_config
-            .assign_instance(instance, lk_multiplicity, outflow, imm as u64)?;
+            .assign_instance(instance, lk_multiplicity, outflow, imm)?;
 
         config
             .i_insn

--- a/ceno_zkvm/src/instructions/riscv/slti.rs
+++ b/ceno_zkvm/src/instructions/riscv/slti.rs
@@ -17,6 +17,7 @@ use crate::{
     set_val,
     tables::InsnRecord,
     uint::Value,
+    utils::i64_to_base,
     witness::LkMultiplicity,
 };
 use core::mem::MaybeUninit;
@@ -106,8 +107,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for SetLessThanImmInst
             .assign_value(instance, Value::new_unchecked(rs1));
 
         let imm = InsnRecord::imm_internal(&step.insn());
-        let imm_field: E::BaseField = InsnRecord::imm_internal_field(&step.insn());
-        set_val!(instance, config.imm, imm_field);
+        set_val!(instance, config.imm, i64_to_base::<E::BaseField>(imm));
 
         match I::INST_KIND {
             InsnKind::SLTIU => {

--- a/ceno_zkvm/src/tables/program.rs
+++ b/ceno_zkvm/src/tables/program.rs
@@ -59,25 +59,19 @@ impl<F: SmallField> InsnRecord<F> {
             (insn.rd_internal() as u64).into(),
             (insn.rs1_or_zero() as u64).into(),
             (insn.rs2_or_zero() as u64).into(),
-            Self::imm_internal_field(insn),
+            i64_to_base(InsnRecord::imm_internal(insn)),
         ])
-    }
-
-    /// Interpret the immediate as unsigned or signed depending on the instruction.
-    /// Convert negative values from two's complement to field.
-    pub fn imm_internal_field(insn: &DecodedInstruction) -> F {
-        i64_to_base(InsnRecord::imm_internal(insn))
     }
 }
 
 impl InsnRecord<()> {
     /// The internal view of the immediate in the program table.
-    /// This is encoded in way that is efficient for circuits, depending on the instruction.
+    /// This is encoded in a way that is efficient for circuits, depending on the instruction.
     ///
-    /// Three conversions are legal:
-    /// - `as u32`: unsigned view.
-    /// - `as i32`: two's complement signed view.
-    /// - `i64_to_base(imm)`: the field element going into the table.
+    /// These conversions are legal:
+    /// - `as u32` and `as i32` as usual.
+    /// - `i64_to_base(imm)` gives the field element going into the program table.
+    /// - `as u64` in unsigned cases.
     pub fn imm_internal(insn: &DecodedInstruction) -> i64 {
         let imm: u32 = insn.immediate();
         match insn.codes() {


### PR DESCRIPTION
_Follow-up to #536 _

Consolidate the processing of immediate values into a single `i64` instead of previous `u32` and `bool`.