### PR TITLE
Remove `Rng` from PCS type paramter.

### DIFF
--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -25,7 +25,6 @@ use ff_ext::ff::Field;
 use goldilocks::GoldilocksExt2;
 use itertools::Itertools;
 use mpcs::{Basefold, BasefoldRSParams, PolynomialCommitmentScheme};
-use rand_chacha::ChaCha8Rng;
 use tracing_flame::FlameLayer;
 use tracing_subscriber::{EnvFilter, Registry, fmt, layer::SubscriberExt};
 use transcript::Transcript;
@@ -76,7 +75,7 @@ struct Args {
 fn main() {
     let args = Args::parse();
     type E = GoldilocksExt2;
-    type Pcs = Basefold<GoldilocksExt2, BasefoldRSParams, ChaCha8Rng>;
+    type Pcs = Basefold<GoldilocksExt2, BasefoldRSParams>;
 
     let program = Program::new(
         CENO_PLATFORM.pc_base(),

--- a/ceno_zkvm/src/scheme/tests.rs
+++ b/ceno_zkvm/src/scheme/tests.rs
@@ -10,7 +10,6 @@ use ff_ext::ExtensionField;
 use goldilocks::GoldilocksExt2;
 use itertools::Itertools;
 use mpcs::{Basefold, BasefoldDefault, BasefoldRSParams, PolynomialCommitmentScheme};
-use rand_chacha::ChaCha8Rng;
 use transcript::Transcript;
 
 use crate::{
@@ -197,7 +196,7 @@ const PROGRAM_CODE: [u32; PROGRAM_SIZE] = {
 #[test]
 fn test_single_add_instance_e2e() {
     type E = GoldilocksExt2;
-    type Pcs = Basefold<GoldilocksExt2, BasefoldRSParams, ChaCha8Rng>;
+    type Pcs = Basefold<GoldilocksExt2, BasefoldRSParams>;
 
     // set up program
     let program = Program::new(

--- a/mpcs/benches/basecode.rs
+++ b/mpcs/benches/basecode.rs
@@ -18,7 +18,7 @@ use rand::{SeedableRng, rngs::OsRng};
 use rand_chacha::ChaCha8Rng;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
-type Pcs = Basefold<GoldilocksExt2, BasefoldBasecodeParams, ChaCha8Rng>;
+type Pcs = Basefold<GoldilocksExt2, BasefoldBasecodeParams>;
 type E = GoldilocksExt2;
 
 const NUM_SAMPLES: usize = 10;

--- a/mpcs/benches/commit_open_verify_basecode.rs
+++ b/mpcs/benches/commit_open_verify_basecode.rs
@@ -15,7 +15,7 @@ use rand::{SeedableRng, rngs::OsRng};
 use rand_chacha::ChaCha8Rng;
 use transcript::Transcript;
 
-type Pcs = Basefold<GoldilocksExt2, BasefoldBasecodeParams, ChaCha8Rng>;
+type Pcs = Basefold<GoldilocksExt2, BasefoldBasecodeParams>;
 type T = Transcript<GoldilocksExt2>;
 type E = GoldilocksExt2;
 

--- a/mpcs/benches/commit_open_verify_rs.rs
+++ b/mpcs/benches/commit_open_verify_rs.rs
@@ -19,7 +19,7 @@ use rand_chacha::ChaCha8Rng;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use transcript::Transcript;
 
-type Pcs = Basefold<GoldilocksExt2, BasefoldRSParams, ChaCha8Rng>;
+type Pcs = Basefold<GoldilocksExt2, BasefoldRSParams>;
 type T = Transcript<GoldilocksExt2>;
 type E = GoldilocksExt2;
 

--- a/mpcs/benches/rscode.rs
+++ b/mpcs/benches/rscode.rs
@@ -18,7 +18,7 @@ use rand::{SeedableRng, rngs::OsRng};
 use rand_chacha::ChaCha8Rng;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
-type Pcs = Basefold<GoldilocksExt2, BasefoldRSParams, ChaCha8Rng>;
+type Pcs = Basefold<GoldilocksExt2, BasefoldRSParams>;
 type E = GoldilocksExt2;
 
 const NUM_SAMPLES: usize = 10;

--- a/mpcs/src/basefold.rs
+++ b/mpcs/src/basefold.rs
@@ -567,7 +567,7 @@ where
         if cfg!(feature = "sanity-check") {
             evals.iter().for_each(|eval| {
                 assert_eq!(
-                    &polys[eval.poly()].evaluate(points[eval.point()]),
+                    &polys[eval.poly()].evaluate(&points[eval.point()]),
                     eval.value(),
                 )
             })

--- a/mpcs/src/basefold.rs
+++ b/mpcs/src/basefold.rs
@@ -47,7 +47,6 @@ use multilinear_extensions::{
     virtual_poly::build_eq_x_r_vec,
 };
 
-use rand_chacha::ChaCha8Rng;
 use rayon::{
     iter::IntoParallelIterator,
     prelude::{IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator},
@@ -278,7 +277,6 @@ where
     type Commitment = BasefoldCommitment<E>;
     type CommitmentChunk = Digest<E::BaseField>;
     type Proof = BasefoldProof<E>;
-    type Rng = ChaCha8Rng;
 
     fn setup(poly_size: usize) -> Result<Self::Param, Error> {
         let pp = <Spec::EncodingScheme as EncodingScheme<E>>::setup(log2_strict(poly_size));

--- a/mpcs/src/basefold.rs
+++ b/mpcs/src/basefold.rs
@@ -47,7 +47,7 @@ use multilinear_extensions::{
     virtual_poly::build_eq_x_r_vec,
 };
 
-use rand_chacha::{ChaCha8Rng, rand_core::RngCore};
+use rand_chacha::ChaCha8Rng;
 use rayon::{
     iter::IntoParallelIterator,
     prelude::{IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator},
@@ -80,7 +80,7 @@ enum PolyEvalsCodeword<E: ExtensionField> {
     TooBig(usize),
 }
 
-impl<E: ExtensionField, Spec: BasefoldSpec<E>, Rng: RngCore> Basefold<E, Spec, Rng>
+impl<E: ExtensionField, Spec: BasefoldSpec<E>> Basefold<E, Spec>
 where
     E: Serialize + DeserializeOwned,
     E::BaseField: Serialize + DeserializeOwned,
@@ -266,8 +266,7 @@ where
 ///     positions are (i >> k) and (i >> k) XOR 1.
 /// (c) The verifier checks that the folding has been correctly computed
 ///     at these positions.
-impl<E: ExtensionField, Spec: BasefoldSpec<E>, Rng: RngCore + std::fmt::Debug>
-    PolynomialCommitmentScheme<E> for Basefold<E, Spec, Rng>
+impl<E: ExtensionField, Spec: BasefoldSpec<E>> PolynomialCommitmentScheme<E> for Basefold<E, Spec>
 where
     E: Serialize + DeserializeOwned,
     E::BaseField: Serialize + DeserializeOwned,
@@ -568,7 +567,7 @@ where
         if cfg!(feature = "sanity-check") {
             evals.iter().for_each(|eval| {
                 assert_eq!(
-                    &polys[eval.poly()].evaluate(&points[eval.point()]),
+                    &polys[eval.poly()].evaluate(points[eval.point()]),
                     eval.value(),
                 )
             })
@@ -1170,8 +1169,7 @@ where
     }
 }
 
-impl<E: ExtensionField, Spec: BasefoldSpec<E>, Rng: RngCore + std::fmt::Debug> NoninteractivePCS<E>
-    for Basefold<E, Spec, Rng>
+impl<E: ExtensionField, Spec: BasefoldSpec<E>> NoninteractivePCS<E> for Basefold<E, Spec>
 where
     E: Serialize + DeserializeOwned,
     E::BaseField: Serialize + DeserializeOwned,
@@ -1188,12 +1186,11 @@ mod test {
         },
     };
     use goldilocks::GoldilocksExt2;
-    use rand_chacha::ChaCha8Rng;
 
     use super::{BasefoldRSParams, structure::BasefoldBasecodeParams};
 
-    type PcsGoldilocksRSCode = Basefold<GoldilocksExt2, BasefoldRSParams, ChaCha8Rng>;
-    type PcsGoldilocksBaseCode = Basefold<GoldilocksExt2, BasefoldBasecodeParams, ChaCha8Rng>;
+    type PcsGoldilocksRSCode = Basefold<GoldilocksExt2, BasefoldRSParams>;
+    type PcsGoldilocksBaseCode = Basefold<GoldilocksExt2, BasefoldBasecodeParams>;
 
     #[test]
     fn commit_open_verify_goldilocks_basecode_base() {

--- a/mpcs/src/basefold/structure.rs
+++ b/mpcs/src/basefold/structure.rs
@@ -5,12 +5,10 @@ use crate::{
 use core::fmt::Debug;
 use ff_ext::ExtensionField;
 
-use rand::RngCore;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use multilinear_extensions::mle::FieldType;
 
-use rand_chacha::ChaCha8Rng;
 use std::{marker::PhantomData, slice};
 
 pub use super::encoding::{EncodingProverParameters, EncodingScheme, RSCode, RSCodeDefaultSpec};
@@ -248,13 +246,11 @@ where
 }
 
 #[derive(Debug)]
-pub struct Basefold<E: ExtensionField, Spec: BasefoldSpec<E>, Rng: RngCore>(
-    PhantomData<(E, Spec, Rng)>,
-);
+pub struct Basefold<E: ExtensionField, Spec: BasefoldSpec<E>>(PhantomData<(E, Spec)>);
 
-pub type BasefoldDefault<F> = Basefold<F, BasefoldRSParams, ChaCha8Rng>;
+pub type BasefoldDefault<F> = Basefold<F, BasefoldRSParams>;
 
-impl<E: ExtensionField, Spec: BasefoldSpec<E>, Rng: RngCore> Clone for Basefold<E, Spec, Rng> {
+impl<E: ExtensionField, Spec: BasefoldSpec<E>> Clone for Basefold<E, Spec> {
     fn clone(&self) -> Self {
         Self(PhantomData)
     }

--- a/mpcs/src/lib.rs
+++ b/mpcs/src/lib.rs
@@ -115,7 +115,6 @@ pub trait PolynomialCommitmentScheme<E: ExtensionField>: Clone + Debug {
     type Commitment: Clone + Debug + Default + Serialize + DeserializeOwned;
     type CommitmentChunk: Clone + Debug + Default;
     type Proof: Clone + Debug + Serialize + DeserializeOwned;
-    type Rng: RngCore + Clone;
 
     fn setup(poly_size: usize) -> Result<Self::Param, Error>;
 
@@ -374,7 +373,6 @@ pub mod test_util {
         num_vars_start: usize,
         num_vars_end: usize,
     ) where
-        Pcs: PolynomialCommitmentScheme<E, Rng = ChaCha8Rng>,
         Pcs: PolynomialCommitmentScheme<E>,
     {
         for num_vars in num_vars_start..num_vars_end {
@@ -434,7 +432,6 @@ pub mod test_util {
         num_vars_end: usize,
     ) where
         E: ExtensionField,
-        Pcs: PolynomialCommitmentScheme<E, Rng = ChaCha8Rng>,
         Pcs: PolynomialCommitmentScheme<E>,
     {
         for num_vars in num_vars_start..num_vars_end {

--- a/mpcs/src/lib.rs
+++ b/mpcs/src/lib.rs
@@ -1,7 +1,6 @@
 use ff_ext::ExtensionField;
 use itertools::Itertools;
 use multilinear_extensions::mle::DenseMultilinearExtension;
-use rand::RngCore;
 use serde::{Serialize, de::DeserializeOwned};
 use std::fmt::Debug;
 use transcript::Transcript;
@@ -376,6 +375,7 @@ pub mod test_util {
         num_vars_end: usize,
     ) where
         Pcs: PolynomialCommitmentScheme<E, Rng = ChaCha8Rng>,
+        Pcs: PolynomialCommitmentScheme<E>,
     {
         for num_vars in num_vars_start..num_vars_end {
             // Setup
@@ -435,6 +435,7 @@ pub mod test_util {
     ) where
         E: ExtensionField,
         Pcs: PolynomialCommitmentScheme<E, Rng = ChaCha8Rng>,
+        Pcs: PolynomialCommitmentScheme<E>,
     {
         for num_vars in num_vars_start..num_vars_end {
             let batch_size = 2;
@@ -550,7 +551,7 @@ pub mod test_util {
         batch_size: usize,
     ) where
         E: ExtensionField,
-        Pcs: PolynomialCommitmentScheme<E, Rng = ChaCha8Rng>,
+        Pcs: PolynomialCommitmentScheme<E>,
     {
         for num_vars in num_vars_start..num_vars_end {
             let rng = ChaCha8Rng::from_seed([0u8; 32]);


### PR DESCRIPTION
Extracting a small PR from #294.

The random generator is used only when the encoding scheme is Basecode, and not used for RS code. So remove it from the type parameter for Basefold, i.e., `Basefold<E, Spec, Rng>` is replaced with `Basefold<E, Spec>` to make the API simpler. Fix it to `ChaCha8Rng` in the implementation of Basecode.