### PR TITLE
Feat: allow constraint_system to take record as input instead of record's rlc

### DIFF
--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -26,19 +26,19 @@ strum_macros.workspace = true
 tracing.workspace = true
 tracing-flame.workspace = true
 tracing-subscriber.workspace = true
-serde_json.workspace = true
 
 clap = { version = "4.5", features = ["derive"] }
 generic_static = "0.2"
 rand.workspace = true
 tempfile = "3.13"
 thread_local = "1.1"
-base64 = "0.22"
 
 [dev-dependencies]
+base64 = "0.22"
 cfg-if.workspace = true
 criterion.workspace = true
 pprof.workspace = true
+serde_json.workspace = true
 
 [build-dependencies]
 glob = "0.3"

--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -26,19 +26,19 @@ strum_macros.workspace = true
 tracing.workspace = true
 tracing-flame.workspace = true
 tracing-subscriber.workspace = true
+serde_json.workspace = true
 
 clap = { version = "4.5", features = ["derive"] }
 generic_static = "0.2"
 rand.workspace = true
 tempfile = "3.13"
 thread_local = "1.1"
+base64 = "0.22"
 
 [dev-dependencies]
-base64 = "0.22"
 cfg-if.workspace = true
 criterion.workspace = true
 pprof.workspace = true
-serde_json.workspace = true
 
 [build-dependencies]
 glob = "0.3"

--- a/ceno_zkvm/src/chip_handler/general.rs
+++ b/ceno_zkvm/src/chip_handler/general.rs
@@ -8,7 +8,7 @@ use crate::{
         END_CYCLE_IDX, END_PC_IDX, EXIT_CODE_IDX, INIT_CYCLE_IDX, INIT_PC_IDX, PUBLIC_IO_IDX,
         UINT_LIMBS,
     },
-    structs::ROMType,
+    structs::{RAMType, ROMType},
     tables::InsnRecord,
 };
 
@@ -78,7 +78,8 @@ impl<'a, E: ExtensionField> CircuitBuilder<'a, E> {
         &mut self,
         name_fn: N,
         table_len: usize,
-        rlc_record: Expression<E>,
+        rom_type: ROMType,
+        items: Vec<Expression<E>>,
         multiplicity: Expression<E>,
     ) -> Result<(), ZKVMError>
     where
@@ -86,7 +87,7 @@ impl<'a, E: ExtensionField> CircuitBuilder<'a, E> {
         N: FnOnce() -> NR,
     {
         self.cs
-            .lk_table_record(name_fn, table_len, rlc_record, multiplicity)
+            .lk_table_record(name_fn, table_len, rom_type, items, multiplicity)
     }
 
     pub fn r_table_record<NR, N>(
@@ -123,25 +124,27 @@ impl<'a, E: ExtensionField> CircuitBuilder<'a, E> {
     pub fn read_record<NR, N>(
         &mut self,
         name_fn: N,
-        rlc_record: Expression<E>,
+        ram_type: RAMType,
+        record: Vec<Expression<E>>,
     ) -> Result<(), ZKVMError>
     where
         NR: Into<String>,
         N: FnOnce() -> NR,
     {
-        self.cs.read_record(name_fn, rlc_record)
+        self.cs.read_record(name_fn, ram_type, record)
     }
 
     pub fn write_record<NR, N>(
         &mut self,
         name_fn: N,
-        rlc_record: Expression<E>,
+        ram_type: RAMType,
+        record: Vec<Expression<E>>,
     ) -> Result<(), ZKVMError>
     where
         NR: Into<String>,
         N: FnOnce() -> NR,
     {
-        self.cs.write_record(name_fn, rlc_record)
+        self.cs.write_record(name_fn, ram_type, record)
     }
 
     pub fn rlc_chip_record(&self, records: Vec<Expression<E>>) -> Expression<E> {

--- a/ceno_zkvm/src/chip_handler/general.rs
+++ b/ceno_zkvm/src/chip_handler/general.rs
@@ -79,7 +79,7 @@ impl<'a, E: ExtensionField> CircuitBuilder<'a, E> {
         name_fn: N,
         table_len: usize,
         rom_type: ROMType,
-        items: Vec<Expression<E>>,
+        record: Vec<Expression<E>>,
         multiplicity: Expression<E>,
     ) -> Result<(), ZKVMError>
     where
@@ -87,7 +87,7 @@ impl<'a, E: ExtensionField> CircuitBuilder<'a, E> {
         N: FnOnce() -> NR,
     {
         self.cs
-            .lk_table_record(name_fn, table_len, rom_type, items, multiplicity)
+            .lk_table_record(name_fn, table_len, rom_type, record, multiplicity)
     }
 
     pub fn r_table_record<NR, N>(

--- a/ceno_zkvm/src/chip_handler/global_state.rs
+++ b/ceno_zkvm/src/chip_handler/global_state.rs
@@ -8,23 +8,21 @@ use super::GlobalStateRegisterMachineChipOperations;
 
 impl<'a, E: ExtensionField> GlobalStateRegisterMachineChipOperations<E> for CircuitBuilder<'a, E> {
     fn state_in(&mut self, pc: Expression<E>, ts: Expression<E>) -> Result<(), ZKVMError> {
-        let items: Vec<Expression<E>> = vec![
+        let record: Vec<Expression<E>> = vec![
             Expression::Constant(E::BaseField::from(RAMType::GlobalState as u64)),
             pc,
             ts,
         ];
 
-        let rlc_record = self.rlc_chip_record(items);
-        self.read_record(|| "state_in", rlc_record)
+        self.read_record(|| "state_in", RAMType::GlobalState, record)
     }
 
     fn state_out(&mut self, pc: Expression<E>, ts: Expression<E>) -> Result<(), ZKVMError> {
-        let items: Vec<Expression<E>> = vec![
+        let record: Vec<Expression<E>> = vec![
             Expression::Constant(E::BaseField::from(RAMType::GlobalState as u64)),
             pc,
             ts,
         ];
-        let rlc_record = self.rlc_chip_record(items);
-        self.write_record(|| "state_out", rlc_record)
+        self.write_record(|| "state_out", RAMType::GlobalState, record)
     }
 }

--- a/ceno_zkvm/src/chip_handler/memory.rs
+++ b/ceno_zkvm/src/chip_handler/memory.rs
@@ -22,25 +22,21 @@ impl<'a, E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> MemoryChipOpera
     ) -> Result<(Expression<E>, AssertLTConfig), ZKVMError> {
         self.namespace(name_fn, |cb| {
             // READ (a, v, t)
-            let read_record = cb.rlc_chip_record(
-                [
-                    vec![RAMType::Memory.into(), memory_addr.clone()],
-                    vec![value.clone()],
-                    vec![prev_ts.clone()],
-                ]
-                .concat(),
-            );
+            let read_record = [
+                vec![RAMType::Memory.into(), memory_addr.clone()],
+                vec![value.clone()],
+                vec![prev_ts.clone()],
+            ]
+            .concat();
             // Write (a, v, t)
-            let write_record = cb.rlc_chip_record(
-                [
-                    vec![RAMType::Memory.into(), memory_addr.clone()],
-                    vec![value],
-                    vec![ts.clone()],
-                ]
-                .concat(),
-            );
-            cb.read_record(|| "read_record", read_record)?;
-            cb.write_record(|| "write_record", write_record)?;
+            let write_record = [
+                vec![RAMType::Memory.into(), memory_addr.clone()],
+                vec![value],
+                vec![ts.clone()],
+            ]
+            .concat();
+            cb.read_record(|| "read_record", RAMType::Memory, read_record)?;
+            cb.write_record(|| "write_record", RAMType::Memory, write_record)?;
 
             // assert prev_ts < current_ts
             let lt_cfg = AssertLTConfig::construct_circuit(
@@ -68,25 +64,21 @@ impl<'a, E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> MemoryChipOpera
     ) -> Result<(Expression<E>, AssertLTConfig), ZKVMError> {
         self.namespace(name_fn, |cb| {
             // READ (a, v, t)
-            let read_record = cb.rlc_chip_record(
-                [
-                    vec![RAMType::Memory.into(), memory_addr.clone()],
-                    vec![prev_values],
-                    vec![prev_ts.clone()],
-                ]
-                .concat(),
-            );
+            let read_record = [
+                vec![RAMType::Memory.into(), memory_addr.clone()],
+                vec![prev_values],
+                vec![prev_ts.clone()],
+            ]
+            .concat();
             // Write (a, v, t)
-            let write_record = cb.rlc_chip_record(
-                [
-                    vec![RAMType::Memory.into(), memory_addr.clone()],
-                    vec![value],
-                    vec![ts.clone()],
-                ]
-                .concat(),
-            );
-            cb.read_record(|| "read_record", read_record)?;
-            cb.write_record(|| "write_record", write_record)?;
+            let write_record = [
+                vec![RAMType::Memory.into(), memory_addr.clone()],
+                vec![value],
+                vec![ts.clone()],
+            ]
+            .concat();
+            cb.read_record(|| "read_record", RAMType::Memory, read_record)?;
+            cb.write_record(|| "write_record", RAMType::Memory, write_record)?;
 
             let lt_cfg = AssertLTConfig::construct_circuit(
                 cb,

--- a/ceno_zkvm/src/chip_handler/register.rs
+++ b/ceno_zkvm/src/chip_handler/register.rs
@@ -24,27 +24,23 @@ impl<'a, E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> RegisterChipOpe
     ) -> Result<(Expression<E>, AssertLTConfig), ZKVMError> {
         self.namespace(name_fn, |cb| {
             // READ (a, v, t)
-            let read_record = cb.rlc_chip_record(
-                [
-                    vec![RAMType::Register.into()],
-                    vec![register_id.expr()],
-                    value.to_vec(),
-                    vec![prev_ts.clone()],
-                ]
-                .concat(),
-            );
+            let read_record = [
+                vec![RAMType::Register.into()],
+                vec![register_id.expr()],
+                value.to_vec(),
+                vec![prev_ts.clone()],
+            ]
+            .concat();
             // Write (a, v, t)
-            let write_record = cb.rlc_chip_record(
-                [
-                    vec![RAMType::Register.into()],
-                    vec![register_id.expr()],
-                    value.to_vec(),
-                    vec![ts.clone()],
-                ]
-                .concat(),
-            );
-            cb.read_record(|| "read_record", read_record)?;
-            cb.write_record(|| "write_record", write_record)?;
+            let write_record = [
+                vec![RAMType::Register.into()],
+                vec![register_id.expr()],
+                value.to_vec(),
+                vec![ts.clone()],
+            ]
+            .concat();
+            cb.read_record(|| "read_record", RAMType::Register, read_record)?;
+            cb.write_record(|| "write_record", RAMType::Register, write_record)?;
 
             // assert prev_ts < current_ts
             let lt_cfg = AssertLTConfig::construct_circuit(
@@ -73,27 +69,23 @@ impl<'a, E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> RegisterChipOpe
         assert!(register_id.expr().degree() <= 1);
         self.namespace(name_fn, |cb| {
             // READ (a, v, t)
-            let read_record = cb.rlc_chip_record(
-                [
-                    vec![RAMType::Register.into()],
-                    vec![register_id.expr()],
-                    prev_values.to_vec(),
-                    vec![prev_ts.clone()],
-                ]
-                .concat(),
-            );
+            let read_record = [
+                vec![RAMType::Register.into()],
+                vec![register_id.expr()],
+                prev_values.to_vec(),
+                vec![prev_ts.clone()],
+            ]
+            .concat();
             // Write (a, v, t)
-            let write_record = cb.rlc_chip_record(
-                [
-                    vec![RAMType::Register.into()],
-                    vec![register_id.expr()],
-                    value.to_vec(),
-                    vec![ts.clone()],
-                ]
-                .concat(),
-            );
-            cb.read_record(|| "read_record", read_record)?;
-            cb.write_record(|| "write_record", write_record)?;
+            let write_record = [
+                vec![RAMType::Register.into()],
+                vec![register_id.expr()],
+                value.to_vec(),
+                vec![ts.clone()],
+            ]
+            .concat();
+            cb.read_record(|| "read_record", RAMType::Register, read_record)?;
+            cb.write_record(|| "write_record", RAMType::Register, write_record)?;
 
             let lt_cfg = AssertLTConfig::construct_circuit(
                 cb,

--- a/ceno_zkvm/src/expression.rs
+++ b/ceno_zkvm/src/expression.rs
@@ -13,7 +13,6 @@ use ff::Field;
 use ff_ext::ExtensionField;
 use goldilocks::SmallField;
 
-#[cfg(test)]
 use multilinear_extensions::virtual_poly_v2::ArcMultilinearExtension;
 
 use crate::{
@@ -977,7 +976,6 @@ pub mod fmt {
         if add_parens { format!("({})", s) } else { s }
     }
 
-    #[cfg(test)]
     pub fn wtns<E: ExtensionField>(
         wtns: &[WitnessId],
         wits_in: &[ArcMultilinearExtension<E>],

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 use super::utils::{eval_by_expr, wit_infer_by_expr};
 use crate::{
     ROMType,

--- a/ceno_zkvm/src/scheme/tests.rs
+++ b/ceno_zkvm/src/scheme/tests.rs
@@ -22,7 +22,9 @@ use crate::{
         riscv::{arith::AddInstruction, ecall::HaltInstruction},
     },
     set_val,
-    structs::{PointAndEval, ZKVMConstraintSystem, ZKVMFixedTraces, ZKVMWitnesses},
+    structs::{
+        PointAndEval, RAMType::Register, ZKVMConstraintSystem, ZKVMFixedTraces, ZKVMWitnesses,
+    },
     tables::{ProgramTableCircuit, U16TableCircuit},
     witness::LkMultiplicity,
 };
@@ -51,9 +53,9 @@ impl<E: ExtensionField, const L: usize, const RW: usize> Instruction<E> for Test
     fn construct_circuit(cb: &mut CircuitBuilder<E>) -> Result<Self::InstructionConfig, ZKVMError> {
         let reg_id = cb.create_witin(|| "reg_id");
         (0..RW).try_for_each(|_| {
-            let record = cb.rlc_chip_record(vec![1.into(), reg_id.expr()]);
-            cb.read_record(|| "read", record.clone())?;
-            cb.write_record(|| "write", record)?;
+            let record = vec![1.into(), reg_id.expr()];
+            cb.read_record(|| "read", Register, record.clone())?;
+            cb.write_record(|| "write", Register, record)?;
             Result::<(), ZKVMError>::Ok(())
         })?;
         (0..L).try_for_each(|_| {

--- a/ceno_zkvm/src/scheme/utils.rs
+++ b/ceno_zkvm/src/scheme/utils.rs
@@ -380,7 +380,7 @@ pub(crate) fn eval_by_expr_with_fixed<E: ExtensionField>(
     )
 }
 
-pub(crate) fn eval_by_expr_with_instance<E: ExtensionField>(
+pub fn eval_by_expr_with_instance<E: ExtensionField>(
     fixed: &[E],
     witnesses: &[E],
     instance: &[E],

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -43,7 +43,7 @@ pub struct TowerProverSpec<'a, E: ExtensionField> {
 pub type WitnessId = u16;
 pub type ChallengeId = u16;
 
-#[derive(Copy, Clone, Debug, EnumIter)]
+#[derive(Copy, Clone, Debug, EnumIter, PartialEq, Eq, Hash)]
 pub enum ROMType {
     U5 = 0,      // 2^5 = 32
     U8,          // 2^8 = 256
@@ -57,7 +57,7 @@ pub enum ROMType {
     Instruction, // Decoded instruction from the fixed program.
 }
 
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub enum RAMType {
     GlobalState,
     Register,
@@ -175,7 +175,7 @@ impl<E: ExtensionField> ZKVMConstraintSystem<E> {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ZKVMFixedTraces<E: ExtensionField> {
     pub circuit_fixed_traces: BTreeMap<String, Option<RowMajorMatrix<E::BaseField>>>,
 }
@@ -203,7 +203,7 @@ impl<E: ExtensionField> ZKVMFixedTraces<E> {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ZKVMWitnesses<E: ExtensionField> {
     witnesses_opcodes: BTreeMap<String, RowMajorMatrix<E::BaseField>>,
     witnesses_tables: BTreeMap<String, RowMajorMatrix<E::BaseField>>,

--- a/ceno_zkvm/src/tables/ops/ops_impl.rs
+++ b/ceno_zkvm/src/tables/ops/ops_impl.rs
@@ -2,6 +2,7 @@
 
 use ff_ext::ExtensionField;
 use goldilocks::SmallField;
+use itertools::Itertools;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 use std::{collections::HashMap, mem::MaybeUninit};
 
@@ -34,14 +35,9 @@ impl OpTableConfig {
         ];
         let mlt = cb.create_witin(|| "mlt");
 
-        let rlc_record = cb.rlc_chip_record(vec![
-            (rom_type as usize).into(),
-            Expression::Fixed(abc[0]),
-            Expression::Fixed(abc[1]),
-            Expression::Fixed(abc[2]),
-        ]);
+        let record_exprs = abc.into_iter().map(|f| Expression::Fixed(f)).collect_vec();
 
-        cb.lk_table_record(|| "record", table_len, rlc_record, mlt.expr())?;
+        cb.lk_table_record(|| "record", table_len, rom_type, record_exprs, mlt.expr())?;
 
         Ok(Self { abc, mlt })
     }

--- a/ceno_zkvm/src/tables/program.rs
+++ b/ceno_zkvm/src/tables/program.rs
@@ -129,13 +129,19 @@ impl<E: ExtensionField, const PROGRAM_SIZE: usize> TableCircuit<E>
 
         let mlt = cb.create_witin(|| "mlt");
 
-        let record_exprs = {
-            let mut fields = vec![E::BaseField::from(ROMType::Instruction as u64).expr()];
-            fields.extend(record.as_slice().iter().map(|f| Expression::Fixed(*f)));
-            cb.rlc_chip_record(fields)
-        };
+        let record_exprs = record
+            .as_slice()
+            .iter()
+            .map(|f| Expression::Fixed(*f))
+            .collect_vec();
 
-        cb.lk_table_record(|| "prog table", PROGRAM_SIZE, record_exprs, mlt.expr())?;
+        cb.lk_table_record(
+            || "prog table",
+            PROGRAM_SIZE,
+            ROMType::Instruction,
+            record_exprs,
+            mlt.expr(),
+        )?;
 
         Ok(ProgramTableConfig { record, mlt })
     }
@@ -147,6 +153,7 @@ impl<E: ExtensionField, const PROGRAM_SIZE: usize> TableCircuit<E>
     ) -> RowMajorMatrix<E::BaseField> {
         let num_instructions = program.instructions.len();
         let pc_base = program.base_address;
+        assert!(num_instructions <= PROGRAM_SIZE);
 
         let mut fixed = RowMajorMatrix::<E::BaseField>::new(num_instructions, num_fixed);
 

--- a/ceno_zkvm/src/tables/range/range_impl.rs
+++ b/ceno_zkvm/src/tables/range/range_impl.rs
@@ -30,10 +30,9 @@ impl RangeTableConfig {
         let fixed = cb.create_fixed(|| "fixed")?;
         let mlt = cb.create_witin(|| "mlt");
 
-        let rlc_record =
-            cb.rlc_chip_record(vec![(rom_type as usize).into(), Expression::Fixed(fixed)]);
+        let record_exprs = vec![Expression::Fixed(fixed)];
 
-        cb.lk_table_record(|| "record", table_len, rlc_record, mlt.expr())?;
+        cb.lk_table_record(|| "record", table_len, rom_type, record_exprs, mlt.expr())?;
 
         Ok(Self { fixed, mlt })
     }

--- a/ceno_zkvm/src/witness.rs
+++ b/ceno_zkvm/src/witness.rs
@@ -39,14 +39,15 @@ macro_rules! set_fixed_val {
     };
 }
 
-pub struct RowMajorMatrix<T: Sized + Sync + Clone + Send> {
+#[derive(Clone)]
+pub struct RowMajorMatrix<T: Sized + Sync + Clone + Send + Copy> {
     // represent 2D in 1D linear memory and avoid double indirection by Vec<Vec<T>> to improve performance
     values: Vec<MaybeUninit<T>>,
     num_padding_rows: usize,
     num_col: usize,
 }
 
-impl<T: Sized + Sync + Clone + Send> RowMajorMatrix<T> {
+impl<T: Sized + Sync + Clone + Send + Copy> RowMajorMatrix<T> {
     pub fn new(num_rows: usize, num_col: usize) -> Self {
         let num_total_rows = next_pow2_instance_padding(num_rows);
         let num_padding_rows = num_total_rows - num_rows;


### PR DESCRIPTION
This PR is extracted from #526. 

In practice, when we use mock prover to find out constraint errors like r/w mismatch, we want to know the exact value of these records. However, currently we only store the RLC of record in the `ConstraintSystem`. Therefore in this PR we change the interface of `ConstraintSystem`. 