### PR TITLE
Feat/ecall nop

### DIFF
--- a/ceno_zkvm/src/instructions/riscv/dummy/mod.rs
+++ b/ceno_zkvm/src/instructions/riscv/dummy/mod.rs
@@ -10,7 +10,16 @@
 //!     type AddDummy<E> = DummyInstruction<E, AddOp>;
 
 mod dummy_circuit;
+use ceno_emul::InsnKind;
 pub use dummy_circuit::DummyInstruction;
+
+use super::RIVInstruction;
+
+pub struct EcallOp;
+impl RIVInstruction for EcallOp {
+    const INST_KIND: InsnKind = InsnKind::EANY;
+}
+pub type EcallDummy<E> = DummyInstruction<E, EcallOp>;
 
 #[cfg(test)]
 mod test;

--- a/ceno_zkvm/src/instructions/riscv/dummy/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/dummy/test.rs
@@ -15,6 +15,29 @@ type AddDummy<E> = DummyInstruction<E, AddOp>;
 type BeqDummy<E> = DummyInstruction<E, BeqOp>;
 
 #[test]
+fn test_dummy_ecall() {
+    let mut cs = ConstraintSystem::<GoldilocksExt2>::new(|| "riscv");
+    let mut cb = CircuitBuilder::new(&mut cs);
+    let config = cb
+        .namespace(
+            || "ecall_dummy",
+            |cb| {
+                let config = EcallDummy::construct_circuit(cb);
+                Ok(config)
+            },
+        )
+        .unwrap()
+        .unwrap();
+
+    let step = StepRecord::new_ecall_instruction(4, MOCK_PC_START, 123, 456, 0);
+    let insn_code = step.insn_code();
+    let (raw_witin, lkm) =
+        EcallDummy::assign_instances(&config, cb.cs.num_witin as usize, vec![step]).unwrap();
+
+    MockProver::assert_satisfied_raw(&cb, raw_witin, &[insn_code], None, Some(lkm));
+}
+
+#[test]
 fn test_dummy_r() {
     let mut cs = ConstraintSystem::<GoldilocksExt2>::new(|| "riscv");
     let mut cb = CircuitBuilder::new(&mut cs);

--- a/ceno_zkvm/src/instructions/riscv/insn_base.rs
+++ b/ceno_zkvm/src/instructions/riscv/insn_base.rs
@@ -111,16 +111,15 @@ impl<E: ExtensionField> ReadRS1<E> {
         lk_multiplicity: &mut LkMultiplicity,
         step: &StepRecord,
     ) -> Result<(), ZKVMError> {
-        set_val!(instance, self.id, step.insn().rs1() as u64);
-
-        // Register state
-        set_val!(instance, self.prev_ts, step.rs1().unwrap().previous_cycle);
+        let op = step.rs1().expect("rs1 op");
+        set_val!(instance, self.id, op.register_index() as u64);
+        set_val!(instance, self.prev_ts, op.previous_cycle);
 
         // Register read
         self.lt_cfg.assign_instance(
             instance,
             lk_multiplicity,
-            step.rs1().unwrap().previous_cycle,
+            op.previous_cycle,
             step.cycle() + Tracer::SUBCYCLE_RS1,
         )?;
 
@@ -166,16 +165,15 @@ impl<E: ExtensionField> ReadRS2<E> {
         lk_multiplicity: &mut LkMultiplicity,
         step: &StepRecord,
     ) -> Result<(), ZKVMError> {
-        set_val!(instance, self.id, step.insn().rs2() as u64);
-
-        // Register state
-        set_val!(instance, self.prev_ts, step.rs2().unwrap().previous_cycle);
+        let op = step.rs2().expect("rs2 op");
+        set_val!(instance, self.id, op.register_index() as u64);
+        set_val!(instance, self.prev_ts, op.previous_cycle);
 
         // Register read
         self.lt_cfg.assign_instance(
             instance,
             lk_multiplicity,
-            step.rs2().unwrap().previous_cycle,
+            op.previous_cycle,
             step.cycle() + Tracer::SUBCYCLE_RS2,
         )?;
 
@@ -223,20 +221,21 @@ impl<E: ExtensionField> WriteRD<E> {
         lk_multiplicity: &mut LkMultiplicity,
         step: &StepRecord,
     ) -> Result<(), ZKVMError> {
-        set_val!(instance, self.id, step.insn().rd_internal() as u64);
-        set_val!(instance, self.prev_ts, step.rd().unwrap().previous_cycle);
+        let op = step.rd().expect("rd op");
+        set_val!(instance, self.id, op.register_index() as u64);
+        set_val!(instance, self.prev_ts, op.previous_cycle);
 
         // Register state
         self.prev_value.assign_limbs(
             instance,
-            Value::new_unchecked(step.rd().unwrap().value.before).as_u16_limbs(),
+            Value::new_unchecked(op.value.before).as_u16_limbs(),
         );
 
         // Register write
         self.lt_cfg.assign_instance(
             instance,
             lk_multiplicity,
-            step.rd().unwrap().previous_cycle,
+            op.previous_cycle,
             step.cycle() + Tracer::SUBCYCLE_RD,
         )?;
 


### PR DESCRIPTION
_Built over #369_ 

This PR highlights the difference between regular instructions (I-type…), and ecalls as defined in `VMState::ecall()`. It has to be precise regarding registers: the instruction encoding does not imply the actual operations.