### PR TITLE
[experiment] Extend profiling using `tracing`

### DIFF
--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -94,15 +94,17 @@ fn main() {
             .collect(),
     );
     let (flame_layer, _guard) = FlameLayer::with_file("./tracing.folded").unwrap();
+    let mut fmt_layer =             fmt::layer()
+    .compact()
+    .with_span_events(FmtSpan::CLOSE)
+    .with_thread_ids(false)
+    .with_thread_names(false);
+    fmt_layer.set_ansi(false);
+
     let subscriber = Registry::default()
         .with(
-            fmt::layer()
-                .compact()
-                .with_span_events(FmtSpan::CLOSE)
-                .with_thread_ids(false)
-                .with_thread_names(false),
+            fmt_layer
         )
-        //.with(EnvFilter::from_default_env())
         .with(EnvFilter::new("info"))
         .with(flame_layer.with_threads_collapsed(true));
     tracing::subscriber::set_global_default(subscriber).unwrap();
@@ -287,16 +289,14 @@ fn main() {
 
         let transcript = Transcript::new(b"riscv");
 
-        let span = entered_span!("CREATE_PROOF");
         let mut zkvm_proof = prover
             .create_proof(zkvm_witness, pi, transcript)
             .expect("create_proof failed");
-        exit_span!(span);
 
         println!(
             "riscv_opcodes::create_proof, instance_num_vars = {}, time = {}",
             instance_num_vars,
-            timer.elapsed().as_secs_f64()
+            timer.elapsed().as_secs()
         );
 
         let transcript = Transcript::new(b"riscv");

--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -102,13 +102,15 @@ fn main() {
                 .with_thread_ids(false)
                 .with_thread_names(false),
         )
-        .with(EnvFilter::from_default_env())
+        //.with(EnvFilter::from_default_env())
+        .with(EnvFilter::new("info"))
         .with(flame_layer.with_threads_collapsed(true));
     tracing::subscriber::set_global_default(subscriber).unwrap();
 
     let top_level = entered_span!("TOPLEVEL");
 
     let keygen = entered_span!("KEYGEN");
+
     // keygen
     let pcs_param = Pcs::setup(1 << MAX_NUM_VARIABLES).expect("Basefold PCS setup");
     let (pp, vp) = Pcs::trim(&pcs_param, 1 << MAX_NUM_VARIABLES).expect("Basefold trim");

--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -102,6 +102,7 @@ fn main() {
 
     // Take filtering directives from RUST_LOG env_var
     // Directive syntax: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
+    // Example: RUST_LOG="info" cargo run.. to get spans/events at info level; profiling spans are info
     // Example: RUST_LOG="[sumcheck]" cargo run.. to get only events under the "sumcheck" span
     let filter = EnvFilter::from_default_env();
 

--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -27,8 +27,7 @@ use itertools::Itertools;
 use mpcs::{Basefold, BasefoldRSParams, PolynomialCommitmentScheme};
 use sumcheck::{entered_span, exit_span};
 use tracing_flame::FlameLayer;
-use tracing_subscriber::{EnvFilter, Registry, fmt, layer::SubscriberExt};
-use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::{EnvFilter, Registry, fmt, fmt::format::FmtSpan, layer::SubscriberExt};
 use transcript::Transcript;
 
 const PROGRAM_SIZE: usize = 16;
@@ -94,11 +93,11 @@ fn main() {
             .collect(),
     );
     let (flame_layer, _guard) = FlameLayer::with_file("./tracing.folded").unwrap();
-    let mut fmt_layer =             fmt::layer()
-    .compact()
-    .with_span_events(FmtSpan::CLOSE)
-    .with_thread_ids(false)
-    .with_thread_names(false);
+    let mut fmt_layer = fmt::layer()
+        .compact()
+        .with_span_events(FmtSpan::CLOSE)
+        .with_thread_ids(false)
+        .with_thread_names(false);
     fmt_layer.set_ansi(false);
 
     // Take filtering directives from RUST_LOG env_var
@@ -107,9 +106,7 @@ fn main() {
     let filter = EnvFilter::from_default_env();
 
     let subscriber = Registry::default()
-        .with(
-            fmt_layer
-        )
+        .with(fmt_layer)
         .with(filter)
         .with(flame_layer.with_threads_collapsed(true));
     tracing::subscriber::set_global_default(subscriber).unwrap();

--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -101,11 +101,16 @@ fn main() {
     .with_thread_names(false);
     fmt_layer.set_ansi(false);
 
+    // Take filtering directives from RUST_LOG env_var
+    // Directive syntax: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
+    // Example: RUST_LOG="[sumcheck]" cargo run.. to get only events under the "sumcheck" span
+    let filter = EnvFilter::from_default_env();
+
     let subscriber = Registry::default()
         .with(
             fmt_layer
         )
-        .with(EnvFilter::new("info"))
+        .with(filter)
         .with(flame_layer.with_threads_collapsed(true));
     tracing::subscriber::set_global_default(subscriber).unwrap();
 

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -91,6 +91,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
         for (circuit_name, witness) in witnesses.into_iter_sorted() {
             let commit_dur = std::time::Instant::now();
             let num_instances = witness.num_instances();
+            let span = entered_span!("commit to opcode traces", circuit_name=circuit_name);
             let witness = match num_instances {
                 0 => vec![],
                 _ => {
@@ -107,6 +108,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
                     );
                     witness
                 }
+                exit_span!(span);
             };
             wits.insert(circuit_name, (witness, num_instances));
         }

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -92,7 +92,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
         // commit to opcode circuits first and then commit to table circuits, sorted by name
         for (circuit_name, witness) in witnesses.into_iter_sorted() {
             let num_instances = witness.num_instances();
-            let span = entered_span!("commit to iteration", circuit_name=circuit_name);
+            let span = entered_span!("commit to iteration", circuit_name = circuit_name);
             let witness = match num_instances {
                 0 => vec![],
                 _ => {
@@ -1237,7 +1237,7 @@ impl TowerProver {
                         virtual_polys.add_mle_list(vec![&eq, &q1, &q2], *alpha_denominator);
                     }
                 }
-                
+                                
                 let wrap_batch_span = entered_span!("wrap_batch");
                 // NOTE: at the time of adding this span, visualizing it with the flamegraph layer
                 // shows it to be (inexplicably) much more time-consuming than the call to `prove_batch_polys`

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -1237,7 +1237,7 @@ impl TowerProver {
                         virtual_polys.add_mle_list(vec![&eq, &q1, &q2], *alpha_denominator);
                     }
                 }
-                                
+
                 let wrap_batch_span = entered_span!("wrap_batch");
                 // NOTE: at the time of adding this span, visualizing it with the flamegraph layer
                 // shows it to be (inexplicably) much more time-consuming than the call to `prove_batch_polys`

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -42,7 +42,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
     pub fn new(vk: ZKVMVerifyingKey<E, PCS>) -> Self {
         ZKVMVerifier { vk }
     }
-
+    #[tracing::instrument(skip_all, name = "verify_proof")]
     pub fn verify_proof(
         &self,
         vm_proof: ZKVMProof<E, PCS>,

--- a/sumcheck/src/macros.rs
+++ b/sumcheck/src/macros.rs
@@ -1,17 +1,20 @@
 #[macro_export]
 macro_rules! entered_span {
+    ($first:expr, $($fields:tt)*) => {
+        $crate::tracing_span!($first, $($fields)*).entered()
+    };
     ($first:expr $(,)*) => {
         $crate::tracing_span!($first).entered()
     };
-}
-
-#[macro_export]
+}#[macro_export]
 macro_rules! tracing_span {
+    ($first:expr, $($fields:tt)*) => {
+        tracing::span!(tracing::Level::DEBUG, $first, $($fields)*)
+    };
     ($first:expr $(,)*) => {
         tracing::span!(tracing::Level::DEBUG, $first)
     };
 }
-
 #[macro_export]
 macro_rules! exit_span {
     ($first:expr $(,)*) => {

--- a/sumcheck/src/macros.rs
+++ b/sumcheck/src/macros.rs
@@ -9,10 +9,10 @@ macro_rules! entered_span {
 }#[macro_export]
 macro_rules! tracing_span {
     ($first:expr, $($fields:tt)*) => {
-        tracing::span!(tracing::Level::DEBUG, $first, $($fields)*)
+        tracing::span!(tracing::Level::INFO, $first, $($fields)*)
     };
     ($first:expr $(,)*) => {
-        tracing::span!(tracing::Level::DEBUG, $first)
+        tracing::span!(tracing::Level::INFO, $first)
     };
 }
 #[macro_export]

--- a/sumcheck/src/macros.rs
+++ b/sumcheck/src/macros.rs
@@ -6,7 +6,8 @@ macro_rules! entered_span {
     ($first:expr $(,)*) => {
         $crate::tracing_span!($first).entered()
     };
-}#[macro_export]
+}
+#[macro_export]
 macro_rules! tracing_span {
     ($first:expr, $($fields:tt)*) => {
         tracing::span!(tracing::Level::INFO, $first, $($fields)*)

--- a/sumcheck/src/prover_v2.rs
+++ b/sumcheck/src/prover_v2.rs
@@ -90,8 +90,9 @@ impl<'a, E: ExtensionField> IOPProverStateV2<'a, E> {
                 );
                 let tx_prover_state = tx_prover_state.clone();
                 let mut thread_based_transcript = thread_based_transcript.clone();
-
+                let current_span = tracing::Span::current();
                 s.spawn(move |_| {
+                    current_span.in_scope(||{
                     let mut challenge = None;
                     let span = entered_span!("prove_rounds");
                     for _ in 0..num_variables {
@@ -127,7 +128,7 @@ impl<'a, E: ExtensionField> IOPProverStateV2<'a, E> {
                     } else {
                         tx_prover_state.send(None).unwrap();
                     }
-                });
+                })});
             }
 
             let mut prover_msgs = Vec::with_capacity(num_variables);

--- a/sumcheck/src/prover_v2.rs
+++ b/sumcheck/src/prover_v2.rs
@@ -91,6 +91,8 @@ impl<'a, E: ExtensionField> IOPProverStateV2<'a, E> {
                 let tx_prover_state = tx_prover_state.clone();
                 let mut thread_based_transcript = thread_based_transcript.clone();
                 let current_span = tracing::Span::current();
+                // NOTE: Apply the span.in_scope(||) pattern to record work of spawned thread inside
+                // span of parent thread.
                 s.spawn(move |_| {
                     current_span.in_scope(||{
                     let mut challenge = None;


### PR DESCRIPTION
### Initial comment (Nov 7th)
This PR aims to improve profiling using spans from the `tracing` library. Some observations up to this point:
- This is how a flamegraph looks for me on this branch (open in browser for interaction): 
![tracing-flamechart](https://github.com/user-attachments/assets/2bae35e3-5ee7-4da7-b40e-01195a5126ed)

- When spawning threads, we need to be explicit about recording the work performed by the spawn thread within the current span in the parent thread. See first commit, where before the change the `sumcheck::prove_rounds` span was a sibling of the `TOPLEVEL` span in the flamechart, instead of being contained by it.
- Span names must be constants. To distinguish between different spans in the same loop we need to use fields: 
           ` let span = entered_span!("commit to iteration", circuit_name=circuit_name);`
Unfortunately the flamegraph doesn't include fields in labels. Currently, in this situation it's better to filter after the parent span (in this case `commit_to_traces` and look at the spans textually. It looks like this:
![Screenshot from 2024-11-07 16-32-52](https://github.com/user-attachments/assets/aea2e758-a8bd-4252-9829-ddaefef4083f) Filtering by _span name_ for manual inspections is simple as:
`.with(EnvFilter::new("[commit_to_traces]=info"))`
I can make it an option.
- Filtering spans over fields and field values would be quite powerful (for example for easy granularity flags).. if it worked like the docs said, but I am currently of the opinion that it does not :). 

I can apply these improvements in more places if they sound good. 

### Later edit (Nov 8th)
I've applied the changes in several places. I've added comments about pitfalls I'm aware of.

I believe the `invisible gap` symptom (as pointed out by @hero78119 in the comments) is (at least in some cases) a bug in the `tracing-flame` crate. 
![tracing-flamechart](https://github.com/user-attachments/assets/ce9fed1f-8464-4753-bb57-075a148977cd)
As can be seen in the code, the `wrap_batch` span is a direct wrapper of its child span, but it introduces a huge `invisible gap`. I believe it's a bug in how `tracing-flame` generates the timings for in the `.folded` file because:
- Inspecting the text logs, the duration of `wrap_batch` is only fractionally longer than the child, as one would expect.
- The flamegraph suggests a total runtime which is over twice the real time.

If I get the time I will try to minimize and post an issue upstream. 

I would've liked to include an easy way to filter away small spans for easier inspection of the logs, but it's a bit complicated. Maybe let's merge this first and let me know about your experience with it. 