### PR TITLE
Add circuit reports to riscv_opcodes example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,6 +273,7 @@ dependencies = [
  "multilinear_extensions",
  "paste",
  "pprof",
+ "prettytable-rs",
  "rand",
  "rand_chacha",
  "rayon",
@@ -525,6 +526,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +562,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -559,6 +602,12 @@ name = "embedded-hal"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_filter"
@@ -922,6 +971,16 @@ name = "libc"
 version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1333,6 +1392,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettytable-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
+dependencies = [
+ "csv",
+ "encode_unicode",
+ "is-terminal",
+ "lazy_static",
+ "term",
+ "unicode-width",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,6 +1506,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1755,6 +1839,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,6 +2005,12 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unroll"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ paste = "1"
 plonky2 = "0.2"
 poseidon = { path = "./poseidon" }
 pprof = { version = "0.13", features = ["flamegraph"] }
+prettytable-rs = "^0.10"
 rand = "0.8"
 rand_chacha = { version = "0.3", features = ["serde1"] }
 rand_core = "0.6"
@@ -44,7 +45,6 @@ tracing = { version = "0.1", features = [
 ] }
 tracing-flame = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-prettytable-rs = "^0.10"
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ tracing = { version = "0.1", features = [
 ] }
 tracing-flame = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+prettytable-rs = "^0.10"
 
 [profile.release]
 lto = "thin"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -53,6 +53,11 @@ args = ["fmt", "-p", "ceno_zkvm", "--", "--check"]
 command = "cargo"
 workspace = false
 
+[tasks.riscv_stats]
+args = ["run", "--bin", "riscv_stats"]
+command = "cargo"
+workspace = false
+
 [tasks.clippy]
 args = [
   "clippy",

--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -28,6 +28,7 @@ strum_macros.workspace = true
 tracing.workspace = true
 tracing-flame.workspace = true
 tracing-subscriber.workspace = true
+prettytable-rs.workspace = true
 
 clap = { version = "4.5", features = ["derive"] }
 generic_static = "0.2"

--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -23,12 +23,13 @@ transcript = { path = "../transcript" }
 
 itertools.workspace = true
 paste.workspace = true
+prettytable-rs.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 tracing.workspace = true
 tracing-flame.workspace = true
 tracing-subscriber.workspace = true
-prettytable-rs.workspace = true
+
 
 clap = { version = "4.5", features = ["derive"] }
 generic_static = "0.2"

--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -299,6 +299,7 @@ fn main() {
         );
 
         trace_report.save_json("report.json");
+        // trace_report.save_table();
 
         MockProver::assert_satisfied_full(
             zkvm_cs.clone(),

--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, panic, time::Instant};
+use std::{panic, time::Instant};
 
 use ceno_zkvm::{
     declare_program,

--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -1,4 +1,4 @@
-use std::{panic, time::Instant};
+use std::{collections::BTreeMap, panic, time::Instant};
 
 use ceno_zkvm::{
     declare_program,
@@ -19,6 +19,7 @@ use ceno_emul::{
 };
 use ceno_zkvm::{
     scheme::{PublicValues, constants::MAX_NUM_VARIABLES, verifier::ZKVMVerifier},
+    stats::{StaticReport, TraceReport},
     structs::{ZKVMConstraintSystem, ZKVMFixedTraces, ZKVMWitnesses},
 };
 use ff_ext::ff::Field;
@@ -29,7 +30,6 @@ use sumcheck::{entered_span, exit_span};
 use tracing_flame::FlameLayer;
 use tracing_subscriber::{EnvFilter, Registry, fmt, fmt::format::FmtSpan, layer::SubscriberExt};
 use transcript::Transcript;
-
 const PROGRAM_SIZE: usize = 16;
 // For now, we assume registers
 //  - x0 is not touched,
@@ -122,6 +122,7 @@ fn main() {
     let mut zkvm_cs = ZKVMConstraintSystem::default();
 
     let config = Rv32imConfig::<E>::construct_circuits(&mut zkvm_cs);
+
     let prog_config = zkvm_cs.register_table_circuit::<ExampleProgramTableCircuit<E>>();
     zkvm_cs.register_global_state::<GlobalState>();
 
@@ -132,6 +133,8 @@ fn main() {
         &prog_config,
         &program,
     );
+
+    let static_report = StaticReport::new(&zkvm_cs);
 
     let reg_init = initial_registers();
     // Define program constant here
@@ -287,6 +290,15 @@ fn main() {
         zkvm_witness
             .assign_table_circuit::<ExampleProgramTableCircuit<E>>(&zkvm_cs, &prog_config, &program)
             .unwrap();
+
+        // get instance counts from witness matrices
+        let trace_report = TraceReport::new_via_witnesses(
+            &static_report,
+            &zkvm_witness,
+            "EXAMPLE_PROGRAM in riscv_opcodes.rs",
+        );
+
+        trace_report.save_json("report.json");
 
         MockProver::assert_satisfied_full(
             zkvm_cs.clone(),

--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -299,7 +299,7 @@ fn main() {
         );
 
         trace_report.save_json("report.json");
-        // trace_report.save_table();
+        trace_report.save_table();
 
         MockProver::assert_satisfied_full(
             zkvm_cs.clone(),

--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -299,7 +299,7 @@ fn main() {
         );
 
         trace_report.save_json("report.json");
-        trace_report.save_table();
+        trace_report.save_table("report.txt");
 
         MockProver::assert_satisfied_full(
             zkvm_cs.clone(),

--- a/ceno_zkvm/src/bin/riscv_stats.rs
+++ b/ceno_zkvm/src/bin/riscv_stats.rs
@@ -1,0 +1,18 @@
+use std::collections::BTreeMap;
+
+use ceno_zkvm::{
+    instructions::riscv::Rv32imConfig,
+    stats::{StaticReport, TraceReport},
+    structs::ZKVMConstraintSystem,
+};
+use goldilocks::GoldilocksExt2;
+type E = GoldilocksExt2;
+fn main() {
+    let mut zkvm_cs = ZKVMConstraintSystem::default();
+
+    let _ = Rv32imConfig::<E>::construct_circuits(&mut zkvm_cs);
+    let static_report = StaticReport::new(&zkvm_cs);
+    let report = TraceReport::new(&static_report, BTreeMap::new(), "no program");
+    report.save_table("riscv_stats.txt");
+    println!("INFO: generated riscv_stats.txt");
+}

--- a/ceno_zkvm/src/circuit_builder.rs
+++ b/ceno_zkvm/src/circuit_builder.rs
@@ -10,7 +10,7 @@ use crate::{
     chip_handler::utils::rlc_chip_record,
     error::ZKVMError,
     expression::{Expression, Fixed, Instance, WitIn},
-    structs::{ProvingKey, RAMType, VerifyingKey, WitnessId, ZKVMConstraintSystem},
+    structs::{ProvingKey, RAMType, VerifyingKey, WitnessId},
     witness::RowMajorMatrix,
 };
 

--- a/ceno_zkvm/src/circuit_builder.rs
+++ b/ceno_zkvm/src/circuit_builder.rs
@@ -10,12 +10,12 @@ use crate::{
     chip_handler::utils::rlc_chip_record,
     error::ZKVMError,
     expression::{Expression, Fixed, Instance, WitIn},
-    structs::{ProvingKey, RAMType, VerifyingKey, WitnessId},
+    structs::{ProvingKey, RAMType, VerifyingKey, WitnessId, ZKVMConstraintSystem},
     witness::RowMajorMatrix,
 };
 
 /// namespace used for annotation, preserve meta info during circuit construction
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct NameSpace {
     namespace: Vec<String>,
 }

--- a/ceno_zkvm/src/circuit_builder.rs
+++ b/ceno_zkvm/src/circuit_builder.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 /// namespace used for annotation, preserve meta info during circuit construction
-#[derive(Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, Default, serde::Serialize)]
 pub struct NameSpace {
     namespace: Vec<String>,
 }

--- a/ceno_zkvm/src/lib.rs
+++ b/ceno_zkvm/src/lib.rs
@@ -14,6 +14,7 @@ pub mod expression;
 pub mod gadgets;
 mod keygen;
 pub mod state;
+pub mod stats;
 pub mod structs;
 mod uint;
 mod utils;

--- a/ceno_zkvm/src/stats.rs
+++ b/ceno_zkvm/src/stats.rs
@@ -179,7 +179,7 @@ impl CircuitStatsTrace {
 pub type TraceReport = Report<CircuitStatsTrace>;
 
 impl Report<CircuitStatsTrace> {
-    pub fn new<E: ExtensionField>(
+    pub fn new(
         static_report: &Report<CircuitStats>,
         num_instances: BTreeMap<String, usize>,
         program_name: &str,
@@ -231,7 +231,7 @@ impl Report<CircuitStatsTrace> {
             .into_iter_sorted()
             .map(|(key, value)| (key, value.num_instances()))
             .collect::<BTreeMap<_, _>>();
-        Self::new::<E>(static_report, num_instances, program_name)
+        Self::new(static_report, num_instances, program_name)
     }
 
     pub fn save_table(&self, filename: &str) {

--- a/ceno_zkvm/src/stats.rs
+++ b/ceno_zkvm/src/stats.rs
@@ -51,7 +51,7 @@ impl CircuitStats {
                 ),
             })
         } else {
-            let table_len = if system.lk_table_expressions.len() > 0 {
+            let table_len = if !system.lk_table_expressions.is_empty() {
                 system.lk_table_expressions[0].table_len
             } else {
                 0
@@ -114,10 +114,10 @@ pub struct CircuitStatsTrace {
 
 impl CircuitStatsTrace {
     pub fn new(static_stats: CircuitStats, num_instances: usize) -> Self {
-        return CircuitStatsTrace {
+        CircuitStatsTrace {
             static_stats,
             num_instances,
-        };
+        }
     }
 }
 
@@ -135,10 +135,7 @@ impl Report<CircuitStatsTrace> {
 
         // Ensure we recognize all circuits from the num_instances map
         num_instances.keys().for_each(|key| {
-            assert!(
-                matches!(static_report.get(key), Some(_)),
-                r"unrecognized key {key}."
-            );
+            assert!(static_report.get(key).is_some(), r"unrecognized key {key}.");
         });
 
         // Stitch num instances to corresponding entries. Sort by num instances

--- a/ceno_zkvm/src/stats.rs
+++ b/ceno_zkvm/src/stats.rs
@@ -1,0 +1,172 @@
+use crate::{
+    circuit_builder::{ConstraintSystem, NameSpace},
+    expression::Expression,
+    structs::{ZKVMConstraintSystem, ZKVMWitnesses},
+};
+use ff_ext::ExtensionField;
+use itertools::Itertools;
+use serde_json::json;
+use std::{collections::BTreeMap, fs::File, io::Write};
+
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct OpCodeStats {
+    namespace: NameSpace,
+    witnesses: usize,
+    reads: usize,
+    writes: usize,
+    lookups: usize,
+    assert_zero_expr_degrees: Vec<usize>,
+    assert_zero_sumcheck_expr_degrees: Vec<usize>,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct TableStats {
+    table_len: usize,
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+pub enum CircuitStats {
+    OpCode(OpCodeStats),
+    Table(TableStats),
+}
+
+impl CircuitStats {
+    pub fn new<E: ExtensionField>(system: &ConstraintSystem<E>) -> Self {
+        let just_degrees =
+            |exprs: &Vec<Expression<E>>| exprs.iter().map(|e| e.degree()).collect_vec();
+        let is_opcode = system.lk_table_expressions.is_empty()
+            && system.r_table_expressions.is_empty()
+            && system.w_table_expressions.is_empty();
+        // distinguishing opcodes from tables as done in ZKVMProver::create_proof
+        if is_opcode {
+            CircuitStats::OpCode(OpCodeStats {
+                namespace: system.ns.clone(),
+                witnesses: system.num_witin as usize,
+                reads: system.r_expressions.len(),
+                writes: system.w_expressions.len(),
+                lookups: system.lk_expressions.len(),
+                assert_zero_expr_degrees: just_degrees(&system.assert_zero_expressions),
+                assert_zero_sumcheck_expr_degrees: just_degrees(
+                    &system.assert_zero_sumcheck_expressions,
+                ),
+            })
+        } else {
+            let table_len = if system.lk_table_expressions.len() > 0 {
+                system.lk_table_expressions[0].table_len
+            } else {
+                0
+            };
+            CircuitStats::Table(TableStats { table_len })
+        }
+    }
+}
+
+pub struct Report<INFO> {
+    metadata: BTreeMap<String, String>,
+    circuits: Vec<(String, INFO)>,
+}
+
+impl<INFO> Report<INFO>
+where
+    INFO: serde::Serialize,
+{
+    pub fn get(&self, circuit_name: &str) -> Option<&INFO> {
+        self.circuits.iter().find_map(|(name, info)| {
+            if name == circuit_name {
+                Some(info)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn save_json(&self, filename: &str) {
+        let json_data = json!({
+            "metadata": self.metadata,
+            "circuits": self.circuits,
+        });
+
+        let mut file = File::create(filename).expect("Unable to create file");
+        file.write_all(serde_json::to_string_pretty(&json_data).unwrap().as_bytes())
+            .expect("Unable to write data");
+    }
+}
+pub type StaticReport = Report<CircuitStats>;
+
+impl Report<CircuitStats> {
+    pub fn new<E: ExtensionField>(zkvm_system: &ZKVMConstraintSystem<E>) -> Self {
+        Report {
+            metadata: BTreeMap::default(),
+            circuits: zkvm_system
+                .get_css()
+                .iter()
+                .map(|(k, v)| (k.clone(), CircuitStats::new(v)))
+                .collect_vec(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CircuitStatsTrace {
+    static_stats: CircuitStats,
+    num_instances: usize,
+}
+
+impl CircuitStatsTrace {
+    pub fn new(static_stats: CircuitStats, num_instances: usize) -> Self {
+        return CircuitStatsTrace {
+            static_stats,
+            num_instances,
+        };
+    }
+}
+
+pub type TraceReport = Report<CircuitStatsTrace>;
+
+impl Report<CircuitStatsTrace> {
+    pub fn new<E: ExtensionField>(
+        static_report: &Report<CircuitStats>,
+        num_instances: BTreeMap<String, usize>,
+        program_name: &str,
+    ) -> Self {
+        let mut metadata = static_report.metadata.clone();
+        // Note where the num_instances are extracted from
+        metadata.insert("PROGRAM_NAME".to_owned(), program_name.to_owned());
+
+        // Ensure we recognize all circuits from the num_instances map
+        num_instances.keys().for_each(|key| {
+            assert!(
+                matches!(static_report.get(key), Some(_)),
+                r"unrecognized key {key}."
+            );
+        });
+
+        // Stitch num instances to corresponding entries. Sort by num instances
+        let circuits = static_report
+            .circuits
+            .iter()
+            .map(|(key, value)| {
+                (
+                    key.to_owned(),
+                    CircuitStatsTrace::new(value.clone(), *num_instances.get(key).unwrap_or(&0)),
+                )
+            })
+            .sorted_by(|lhs, rhs| rhs.1.num_instances.cmp(&lhs.1.num_instances))
+            .collect_vec();
+        Report { metadata, circuits }
+    }
+
+    // Extract num_instances from witness data
+    pub fn new_via_witnesses<E: ExtensionField>(
+        static_report: &Report<CircuitStats>,
+        zkvm_witnesses: &ZKVMWitnesses<E>,
+        program_name: &str,
+    ) -> Self {
+        let num_instances = zkvm_witnesses
+            .clone()
+            .into_iter_sorted()
+            .map(|(key, value)| (key, value.num_instances()))
+            .collect::<BTreeMap<_, _>>();
+        Self::new::<E>(static_report, num_instances, program_name)
+    }
+}

--- a/ceno_zkvm/src/stats.rs
+++ b/ceno_zkvm/src/stats.rs
@@ -2,10 +2,10 @@ use crate::{
     circuit_builder::{ConstraintSystem, NameSpace},
     expression::Expression,
     structs::{ZKVMConstraintSystem, ZKVMWitnesses},
-    tables, utils,
+    utils,
 };
 use ff_ext::ExtensionField;
-use itertools::{Itertools, join};
+use itertools::Itertools;
 use prettytable::{Table, row};
 use serde_json::json;
 use std::{

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -170,6 +170,10 @@ impl<E: ExtensionField> ZKVMConstraintSystem<E> {
             SC::finalize_global_state(&mut circuit_builder).expect("global_state_out failed");
     }
 
+    pub fn get_css(&self) -> &BTreeMap<String, ConstraintSystem<E>> {
+        &self.circuit_css
+    }
+
     pub fn get_cs(&self, name: &String) -> Option<&ConstraintSystem<E>> {
         self.circuit_css.get(name)
     }

--- a/ceno_zkvm/src/utils.rs
+++ b/ceno_zkvm/src/utils.rs
@@ -1,3 +1,5 @@
+use std::{collections::HashMap, fmt::Display, hash::Hash};
+
 use ff::Field;
 use ff_ext::ExtensionField;
 use goldilocks::SmallField;
@@ -179,4 +181,22 @@ pub fn transpose<T>(v: Vec<Vec<T>>) -> Vec<Vec<T>> {
 /// get next power of 2 instance with minimal size 2
 pub fn next_pow2_instance_padding(num_instance: usize) -> usize {
     num_instance.next_power_of_two().max(2)
+}
+
+pub fn display_hashmap<K: Display, V: Display>(map: &HashMap<K, V>) -> String {
+    format!(
+        "[{}]",
+        map.iter().map(|(k, v)| format!("{k}: {v}")).join(",")
+    )
+}
+
+pub fn merge_frequency_tables<K: Hash + std::cmp::Eq>(
+    lhs: HashMap<K, usize>,
+    rhs: HashMap<K, usize>,
+) -> HashMap<K, usize> {
+    let mut ret = lhs;
+    rhs.into_iter().for_each(|(key, value)| {
+        *ret.entry(key).or_insert(0) += value;
+    });
+    ret
 }


### PR DESCRIPTION
Fixes #553.

You can take a look at [report.json](https://github.com/user-attachments/files/17733549/report.json), generated by:
` cargo run  --release --example riscv_opcodes -- --start 2 --end 3 > logs.txt`.

Slight caveat:
- In the case of table circuits, `num_instances` as given by the witness matrices gives the table size, while for opcodes it's the number of occurrences. 

If there's more interesting information to include in the report, please let me know!

Later edit: You can run `cargo make riscv_stats` to get statistics about the circuits in tabular form. 
