### PR TITLE
[exp] Dynamic platform attempt

### DIFF
--- a/ceno_emul/src/platform.rs
+++ b/ceno_emul/src/platform.rs
@@ -5,7 +5,7 @@ use crate::addr::{Addr, RegIdx};
 /// - the layout of virtual memory,
 /// - special addresses, such as the initial PC,
 /// - codes of environment calls.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Platform {
     pub rom_start: Addr,
     pub rom_end: Addr,

--- a/ceno_emul/src/platform.rs
+++ b/ceno_emul/src/platform.rs
@@ -78,13 +78,13 @@ impl Platform {
     }
 
     /// Virtual address of a register.
-    pub const fn register_vma(&self, index: RegIdx) -> Addr {
+    pub const fn register_vma(index: RegIdx) -> Addr {
         // Register VMAs are aligned, cannot be confused with indices, and readable in hex.
         (index << 8) as Addr
     }
 
     /// Register index from a virtual address (unchecked).
-    pub const fn register_index(&self, vma: Addr) -> RegIdx {
+    pub const fn register_index(vma: Addr) -> RegIdx {
         (vma >> 8) as RegIdx
     }
 
@@ -111,27 +111,27 @@ impl Platform {
     // Environment calls.
 
     /// Register containing the ecall function code. (x5, t0)
-    pub const fn reg_ecall(&self) -> RegIdx {
+    pub const fn reg_ecall() -> RegIdx {
         5
     }
 
     /// Register containing the first function argument. (x10, a0)
-    pub const fn reg_arg0(&self) -> RegIdx {
+    pub const fn reg_arg0() -> RegIdx {
         10
     }
 
     /// Register containing the 2nd function argument. (x11, a1)
-    pub const fn reg_arg1(&self) -> RegIdx {
+    pub const fn reg_arg1() -> RegIdx {
         11
     }
 
     /// The code of ecall HALT.
-    pub const fn ecall_halt(&self) -> u32 {
+    pub const fn ecall_halt() -> u32 {
         0
     }
 
     /// The code of success.
-    pub const fn code_success(&self) -> u32 {
+    pub const fn code_success() -> u32 {
         0
     }
 }
@@ -151,7 +151,10 @@ mod tests {
         assert!(!p.is_ram(p.rom_start()));
         assert!(!p.is_ram(p.rom_end()));
         // Registers do not overlap with ROM or RAM.
-        for reg in [p.register_vma(0), p.register_vma(VMState::REG_COUNT - 1)] {
+        for reg in [
+            Platform::register_vma(0),
+            Platform::register_vma(VMState::REG_COUNT - 1),
+        ] {
             assert!(!p.is_rom(reg));
             assert!(!p.is_ram(reg));
         }

--- a/ceno_emul/src/tracer.rs
+++ b/ceno_emul/src/tracer.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, fmt, mem};
 
 use crate::{
-    CENO_PLATFORM, InsnKind, PC_STEP_SIZE,
+    CENO_PLATFORM, InsnKind, PC_STEP_SIZE, Platform,
     addr::{ByteAddr, Cycle, RegIdx, Word, WordAddr},
     encode_rv32,
     rv32im::DecodedInstruction,
@@ -35,7 +35,7 @@ pub struct StepRecord {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct MemOp<T> {
     /// Virtual Memory Address.
-    /// For registers, get it from `CENO_PLATFORM.register_vma(idx)`.
+    /// For registers, get it from `Platform::register_vma(idx)`.
     pub addr: WordAddr,
     /// The Word read, or the Change<Word> to be written.
     pub value: T,
@@ -46,7 +46,7 @@ pub struct MemOp<T> {
 impl<T> MemOp<T> {
     /// Get the register index of this operation.
     pub fn register_index(&self) -> RegIdx {
-        CENO_PLATFORM.register_index(self.addr.into())
+        Platform::register_index(self.addr.into())
     }
 }
 
@@ -227,19 +227,17 @@ impl StepRecord {
             pc,
             insn_code,
             rs1: rs1_read.map(|rs1| ReadOp {
-                addr: CENO_PLATFORM.register_vma(insn.rs1() as RegIdx).into(),
+                addr: Platform::register_vma(insn.rs1() as RegIdx).into(),
                 value: rs1,
                 previous_cycle,
             }),
             rs2: rs2_read.map(|rs2| ReadOp {
-                addr: CENO_PLATFORM.register_vma(insn.rs2() as RegIdx).into(),
+                addr: Platform::register_vma(insn.rs2() as RegIdx).into(),
                 value: rs2,
                 previous_cycle,
             }),
             rd: rd.map(|rd| WriteOp {
-                addr: CENO_PLATFORM
-                    .register_vma(insn.rd_internal() as RegIdx)
-                    .into(),
+                addr: Platform::register_vma(insn.rd_internal() as RegIdx).into(),
                 value: rd,
                 previous_cycle,
             }),
@@ -335,7 +333,7 @@ impl Tracer {
     }
 
     pub fn load_register(&mut self, idx: RegIdx, value: Word) {
-        let addr = CENO_PLATFORM.register_vma(idx).into();
+        let addr = Platform::register_vma(idx).into();
 
         match (&self.record.rs1, &self.record.rs2) {
             (None, None) => {
@@ -361,7 +359,7 @@ impl Tracer {
             unimplemented!("Only one register write is supported");
         }
 
-        let addr = CENO_PLATFORM.register_vma(idx).into();
+        let addr = Platform::register_vma(idx).into();
         self.record.rd = Some(WriteOp {
             addr,
             value,

--- a/ceno_emul/src/vm_state.rs
+++ b/ceno_emul/src/vm_state.rs
@@ -111,9 +111,9 @@ impl VMState {
 impl EmuContext for VMState {
     // Expect an ecall to terminate the program: function HALT with argument exit_code.
     fn ecall(&mut self) -> Result<bool> {
-        let function = self.load_register(self.platform.reg_ecall())?;
-        let arg0 = self.load_register(self.platform.reg_arg0())?;
-        if function == self.platform.ecall_halt() {
+        let function = self.load_register(Platform::reg_ecall())?;
+        let arg0 = self.load_register(Platform::reg_arg0())?;
+        if function == Platform::ecall_halt() {
             tracing::debug!("halt with exit_code={}", arg0);
 
             self.halt();

--- a/ceno_emul/tests/test_elf.rs
+++ b/ceno_emul/tests/test_elf.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use ceno_emul::{ByteAddr, CENO_PLATFORM, EmuContext, InsnKind, StepRecord, VMState};
+use ceno_emul::{ByteAddr, CENO_PLATFORM, EmuContext, InsnKind, Platform, StepRecord, VMState};
 
 #[test]
 fn test_ceno_rt_mini() -> Result<()> {
@@ -16,7 +16,7 @@ fn test_ceno_rt_panic() -> Result<()> {
     let steps = run(&mut state)?;
     let last = steps.last().unwrap();
     assert_eq!(last.insn().codes().kind, InsnKind::EANY);
-    assert_eq!(last.rs1().unwrap().value, CENO_PLATFORM.ecall_halt());
+    assert_eq!(last.rs1().unwrap().value, Platform::ecall_halt());
     assert_eq!(last.rs2().unwrap().value, 1); // panic / halt(1)
     Ok(())
 }

--- a/ceno_emul/tests/test_vm_trace.rs
+++ b/ceno_emul/tests/test_vm_trace.rs
@@ -3,8 +3,8 @@ use anyhow::Result;
 use std::collections::{BTreeMap, HashMap};
 
 use ceno_emul::{
-    CENO_PLATFORM, Cycle, EmuContext, InsnKind, Program, StepRecord, Tracer, VMState, WORD_SIZE,
-    WordAddr,
+    CENO_PLATFORM, Cycle, EmuContext, InsnKind, Platform, Program, StepRecord, Tracer, VMState,
+    WORD_SIZE, WordAddr,
 };
 
 #[test]
@@ -119,7 +119,7 @@ fn expected_ops_fibonacci_20() -> Vec<InsnKind> {
 /// Reconstruct the last access of each register.
 fn expected_final_accesses_fibonacci_20() -> HashMap<WordAddr, Cycle> {
     let mut accesses = HashMap::new();
-    let x = |i| WordAddr::from(CENO_PLATFORM.register_vma(i));
+    let x = |i| WordAddr::from(Platform::register_vma(i));
     const C: Cycle = Tracer::SUBCYCLES_PER_INSN;
 
     let mut cycle = C; // First cycle.
@@ -141,8 +141,8 @@ fn expected_final_accesses_fibonacci_20() -> HashMap<WordAddr, Cycle> {
     cycle += C;
 
     // Now at the final ECALL cycle.
-    accesses.insert(x(CENO_PLATFORM.reg_ecall()), cycle + Tracer::SUBCYCLE_RS1);
-    accesses.insert(x(CENO_PLATFORM.reg_arg0()), cycle + Tracer::SUBCYCLE_RS2);
+    accesses.insert(x(Platform::reg_ecall()), cycle + Tracer::SUBCYCLE_RS1);
+    accesses.insert(x(Platform::reg_arg0()), cycle + Tracer::SUBCYCLE_RS2);
 
     accesses
 }

--- a/ceno_zkvm/examples/fibonacci_elf.rs
+++ b/ceno_zkvm/examples/fibonacci_elf.rs
@@ -74,7 +74,7 @@ fn main() {
     // keygen
     let pcs_param = Pcs::setup(1 << MAX_NUM_VARIABLES).expect("Basefold PCS setup");
     let (pp, vp) = Pcs::trim(pcs_param, 1 << MAX_NUM_VARIABLES).expect("Basefold trim");
-    let mut zkvm_cs = ZKVMConstraintSystem::default();
+    let mut zkvm_cs = ZKVMConstraintSystem::new_with_platform(sp1_platform);
 
     let config = Rv32imConfig::<E>::construct_circuits(&mut zkvm_cs);
     let mmu_config = MmuConfig::<E>::construct_circuits(&mut zkvm_cs);

--- a/ceno_zkvm/examples/fibonacci_elf.rs
+++ b/ceno_zkvm/examples/fibonacci_elf.rs
@@ -106,13 +106,13 @@ fn main() {
 
         let mem_init = chain!(program_addrs, stack_addrs).collect_vec();
 
-        mem_padder.padded_sorted(MmuConfig::<E>::static_mem_len(), mem_init)
+        mem_padder.padded_sorted(mmu_config.static_mem_len(), mem_init)
     };
 
     // IO is not used in this program, but it must have a particular size at the moment.
-    let io_init = mem_padder.padded_sorted(MmuConfig::<E>::public_io_len(), vec![]);
+    let io_init = mem_padder.padded_sorted(mmu_config.public_io_len(), vec![]);
 
-    let reg_init = MmuConfig::<E>::initial_registers();
+    let reg_init = mmu_config.initial_registers();
     config.generate_fixed_traces(&zkvm_cs, &mut zkvm_fixed_traces);
     mmu_config.generate_fixed_traces(
         &zkvm_cs,

--- a/ceno_zkvm/examples/fibonacci_elf.rs
+++ b/ceno_zkvm/examples/fibonacci_elf.rs
@@ -1,6 +1,6 @@
 use ceno_emul::{
-    ByteAddr, CENO_PLATFORM, EmuContext, InsnKind::EANY, Platform, StepRecord, Tracer, VMState,
-    WORD_SIZE, WordAddr,
+    ByteAddr, EmuContext, InsnKind::EANY, Platform, StepRecord, Tracer, VMState, WORD_SIZE,
+    WordAddr,
 };
 use ceno_zkvm::{
     instructions::riscv::{DummyExtraConfig, MemPadder, MmuConfig, Rv32imConfig},

--- a/ceno_zkvm/examples/fibonacci_elf.rs
+++ b/ceno_zkvm/examples/fibonacci_elf.rs
@@ -151,7 +151,7 @@ fn main() {
         .rev()
         .find(|record| {
             record.insn().codes().kind == EANY
-                && record.rs1().unwrap().value == CENO_PLATFORM.ecall_halt()
+                && record.rs1().unwrap().value == Platform::ecall_halt()
         })
         .and_then(|halt_record| halt_record.rs2())
         .map(|rs2| rs2.value);
@@ -184,7 +184,7 @@ fn main() {
         .map(|rec| {
             let index = rec.addr as usize;
             if index < VMState::REG_COUNT {
-                let vma: WordAddr = CENO_PLATFORM.register_vma(index).into();
+                let vma: WordAddr = Platform::register_vma(index).into();
                 MemFinalRecord {
                     addr: rec.addr,
                     value: vm.peek_register(index),

--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -12,7 +12,7 @@ use clap::Parser;
 use ceno_emul::{
     CENO_PLATFORM, EmuContext,
     InsnKind::{ADD, BLTU, EANY, LUI, LW},
-    PC_WORD_SIZE, Program, StepRecord, Tracer, VMState, Word, WordAddr, encode_rv32,
+    PC_WORD_SIZE, Platform, Program, StepRecord, Tracer, VMState, Word, WordAddr, encode_rv32,
 };
 use ceno_zkvm::{
     scheme::{PublicValues, constants::MAX_NUM_VARIABLES, verifier::ZKVMVerifier},
@@ -197,7 +197,7 @@ fn main() {
             .rev()
             .find(|record| {
                 record.insn().codes().kind == EANY
-                    && record.rs1().unwrap().value == CENO_PLATFORM.ecall_halt()
+                    && record.rs1().unwrap().value == Platform::ecall_halt()
             })
             .expect("halt record not found");
 
@@ -227,7 +227,7 @@ fn main() {
             .map(|rec| {
                 let index = rec.addr as usize;
                 if index < VMState::REG_COUNT {
-                    let vma: WordAddr = CENO_PLATFORM.register_vma(index).into();
+                    let vma: WordAddr = Platform::register_vma(index).into();
                     MemFinalRecord {
                         addr: rec.addr,
                         value: vm.peek_register(index),

--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -136,17 +136,13 @@ fn main() {
 
     let static_report = StaticReport::new(&zkvm_cs);
 
-    let reg_init = MmuConfig::<E>::initial_registers();
+    let reg_init = mmu_config.initial_registers();
 
     // RAM is not used in this program, but it must have a particular size at the moment.
-    let mem_init = MemPadder::init_mem(mem_addresses, MmuConfig::<E>::static_mem_len(), &[]);
+    let mem_init = MemPadder::init_mem(mem_addresses, mmu_config.static_mem_len(), &[]);
 
     let init_public_io = |values: &[Word]| {
-        MemPadder::init_mem(
-            io_addresses.clone(),
-            MmuConfig::<E>::public_io_len(),
-            values,
-        )
+        MemPadder::init_mem(io_addresses.clone(), mmu_config.public_io_len(), values)
     };
 
     let io_addrs = init_public_io(&[]).iter().map(|v| v.addr).collect_vec();

--- a/ceno_zkvm/src/chip_handler/general.rs
+++ b/ceno_zkvm/src/chip_handler/general.rs
@@ -15,14 +15,7 @@ use crate::{
 
 impl<'a, E: ExtensionField> CircuitBuilder<'a, E> {
     pub fn new(cs: &'a mut ConstraintSystem<E>) -> Self {
-        Self {
-            cs,
-            platform: CENO_PLATFORM,
-        }
-    }
-
-    pub fn new_with_platform(cs: &'a mut ConstraintSystem<E>, platform: Platform) -> Self {
-        Self { cs, platform }
+        Self { cs }
     }
 
     pub fn create_witin<NR, N>(&mut self, name_fn: N) -> WitIn
@@ -329,7 +322,7 @@ impl<'a, E: ExtensionField> CircuitBuilder<'a, E> {
         cb: impl FnOnce(&mut CircuitBuilder<E>) -> Result<T, ZKVMError>,
     ) -> Result<T, ZKVMError> {
         self.cs.namespace(name_fn, |cs| {
-            let mut inner_circuit_builder = CircuitBuilder::new_with_platform(cs, self.platform);
+            let mut inner_circuit_builder = CircuitBuilder::new(cs);
             cb(&mut inner_circuit_builder)
         })
     }

--- a/ceno_zkvm/src/chip_handler/general.rs
+++ b/ceno_zkvm/src/chip_handler/general.rs
@@ -1,3 +1,4 @@
+use ceno_emul::{CENO_PLATFORM, Platform};
 use ff_ext::ExtensionField;
 
 use crate::{
@@ -14,7 +15,14 @@ use crate::{
 
 impl<'a, E: ExtensionField> CircuitBuilder<'a, E> {
     pub fn new(cs: &'a mut ConstraintSystem<E>) -> Self {
-        Self { cs }
+        Self {
+            cs,
+            platform: CENO_PLATFORM,
+        }
+    }
+
+    pub fn new_with_platform(cs: &'a mut ConstraintSystem<E>, platform: Platform) -> Self {
+        Self { cs, platform }
     }
 
     pub fn create_witin<NR, N>(&mut self, name_fn: N) -> WitIn
@@ -321,7 +329,7 @@ impl<'a, E: ExtensionField> CircuitBuilder<'a, E> {
         cb: impl FnOnce(&mut CircuitBuilder<E>) -> Result<T, ZKVMError>,
     ) -> Result<T, ZKVMError> {
         self.cs.namespace(name_fn, |cs| {
-            let mut inner_circuit_builder = CircuitBuilder::new(cs);
+            let mut inner_circuit_builder = CircuitBuilder::new_with_platform(cs, self.platform);
             cb(&mut inner_circuit_builder)
         })
     }

--- a/ceno_zkvm/src/chip_handler/general.rs
+++ b/ceno_zkvm/src/chip_handler/general.rs
@@ -1,4 +1,3 @@
-use ceno_emul::{CENO_PLATFORM, Platform};
 use ff_ext::ExtensionField;
 
 use crate::{

--- a/ceno_zkvm/src/circuit_builder.rs
+++ b/ceno_zkvm/src/circuit_builder.rs
@@ -1,4 +1,4 @@
-use ceno_emul::Addr;
+use ceno_emul::{Addr, Platform};
 use itertools::{Itertools, chain};
 use std::{collections::HashMap, iter::once, marker::PhantomData};
 
@@ -496,4 +496,5 @@ impl<E: ExtensionField> ConstraintSystem<E> {
 #[derive(Debug)]
 pub struct CircuitBuilder<'a, E: ExtensionField> {
     pub(crate) cs: &'a mut ConstraintSystem<E>,
+    pub platform: Platform,
 }

--- a/ceno_zkvm/src/circuit_builder.rs
+++ b/ceno_zkvm/src/circuit_builder.rs
@@ -1,4 +1,4 @@
-use ceno_emul::{Addr, Platform};
+use ceno_emul::{Addr, CENO_PLATFORM, Platform};
 use itertools::{Itertools, chain};
 use std::{collections::HashMap, iter::once, marker::PhantomData};
 
@@ -106,6 +106,7 @@ pub struct SetTableExpression<E: ExtensionField> {
 pub struct ConstraintSystem<E: ExtensionField> {
     pub(crate) ns: NameSpace,
 
+    pub platform: Platform,
     pub num_witin: WitnessId,
     pub witin_namespace_map: Vec<String>,
 
@@ -161,8 +162,15 @@ pub struct ConstraintSystem<E: ExtensionField> {
 
 impl<E: ExtensionField> ConstraintSystem<E> {
     pub fn new<NR: Into<String>, N: FnOnce() -> NR>(root_name_fn: N) -> Self {
+        Self::new_with_platform(root_name_fn, CENO_PLATFORM)
+    }
+    pub fn new_with_platform<NR: Into<String>, N: FnOnce() -> NR>(
+        root_name_fn: N,
+        platform: Platform,
+    ) -> Self {
         Self {
             num_witin: 0,
+            platform,
             witin_namespace_map: vec![],
             num_fixed: 0,
             fixed_namespace_map: vec![],
@@ -496,5 +504,4 @@ impl<E: ExtensionField> ConstraintSystem<E> {
 #[derive(Debug)]
 pub struct CircuitBuilder<'a, E: ExtensionField> {
     pub(crate) cs: &'a mut ConstraintSystem<E>,
-    pub platform: Platform,
 }

--- a/ceno_zkvm/src/instructions/riscv/ecall/halt.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/halt.rs
@@ -50,7 +50,7 @@ impl<E: ExtensionField> Instruction<E> for HaltInstruction<E> {
         // read exit_code from arg0 (X10 register)
         let (_, lt_x10_cfg) = cb.register_read(
             || "read x10",
-            E::BaseField::from(ceno_emul::CENO_PLATFORM.reg_arg0() as u64),
+            E::BaseField::from(ceno_emul::Platform::reg_arg0() as u64),
             prev_x10_ts.expr(),
             ecall_cfg.ts.expr() + Tracer::SUBCYCLE_RS2,
             exit_code,

--- a/ceno_zkvm/src/instructions/riscv/ecall_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall_insn.rs
@@ -10,7 +10,7 @@ use crate::{
     tables::InsnRecord,
     witness::LkMultiplicity,
 };
-use ceno_emul::{CENO_PLATFORM, InsnKind::EANY, PC_STEP_SIZE, Platform, StepRecord, Tracer};
+use ceno_emul::{InsnKind::EANY, PC_STEP_SIZE, Platform, StepRecord, Tracer};
 use ff_ext::ExtensionField;
 use std::mem::MaybeUninit;
 

--- a/ceno_zkvm/src/instructions/riscv/ecall_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall_insn.rs
@@ -10,7 +10,7 @@ use crate::{
     tables::InsnRecord,
     witness::LkMultiplicity,
 };
-use ceno_emul::{CENO_PLATFORM, InsnKind::EANY, PC_STEP_SIZE, StepRecord, Tracer};
+use ceno_emul::{CENO_PLATFORM, InsnKind::EANY, PC_STEP_SIZE, Platform, StepRecord, Tracer};
 use ff_ext::ExtensionField;
 use std::mem::MaybeUninit;
 
@@ -51,7 +51,7 @@ impl EcallInstructionConfig {
         // read syscall_id from x5 and write return value to x5
         let (_, lt_x5_cfg) = cb.register_write(
             || "write x5",
-            E::BaseField::from(CENO_PLATFORM.reg_ecall() as u64),
+            E::BaseField::from(Platform::reg_ecall() as u64),
             prev_x5_ts.expr(),
             ts.expr() + Tracer::SUBCYCLE_RS1,
             syscall_id.clone(),

--- a/ceno_zkvm/src/instructions/riscv/memory/store.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/store.rs
@@ -79,8 +79,8 @@ impl<E: ExtensionField, I: RIVInstruction, const N_ZEROS: usize> Instruction<E>
             const MAX_RAM_ADDR: u32 = u32::MAX - 0x7FF; // max positive imm is 0x7FF
             const MIN_RAM_ADDR: u32 = 0x800; // min negative imm is -0x800
             assert!(
-                !circuit_builder.platform.can_write(MAX_RAM_ADDR + 1)
-                    && !circuit_builder.platform.can_write(MIN_RAM_ADDR - 1)
+                !circuit_builder.cs.platform.can_write(MAX_RAM_ADDR + 1)
+                    && !circuit_builder.cs.platform.can_write(MIN_RAM_ADDR - 1)
             );
         }
         circuit_builder.require_equal(

--- a/ceno_zkvm/src/instructions/riscv/memory/store.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/store.rs
@@ -79,8 +79,8 @@ impl<E: ExtensionField, I: RIVInstruction, const N_ZEROS: usize> Instruction<E>
             const MAX_RAM_ADDR: u32 = u32::MAX - 0x7FF; // max positive imm is 0x7FF
             const MIN_RAM_ADDR: u32 = 0x800; // min negative imm is -0x800
             assert!(
-                !CENO_PLATFORM.can_write(MAX_RAM_ADDR + 1)
-                    && !CENO_PLATFORM.can_write(MIN_RAM_ADDR - 1)
+                !circuit_builder.platform.can_write(MAX_RAM_ADDR + 1)
+                    && !circuit_builder.platform.can_write(MIN_RAM_ADDR - 1)
             );
         }
         circuit_builder.require_equal(

--- a/ceno_zkvm/src/instructions/riscv/memory/store.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/store.rs
@@ -15,7 +15,7 @@ use crate::{
     utils::i64_to_base,
     witness::LkMultiplicity,
 };
-use ceno_emul::{ByteAddr, CENO_PLATFORM, InsnKind, StepRecord};
+use ceno_emul::{ByteAddr, InsnKind, StepRecord};
 use ff_ext::ExtensionField;
 use std::{marker::PhantomData, mem::MaybeUninit};
 

--- a/ceno_zkvm/src/instructions/riscv/rv32im.rs
+++ b/ceno_zkvm/src/instructions/riscv/rv32im.rs
@@ -25,7 +25,6 @@ use crate::{
     },
 };
 use ceno_emul::{
-    CENO_PLATFORM,
     InsnKind::{self, *},
     Platform, StepRecord,
 };

--- a/ceno_zkvm/src/instructions/riscv/rv32im.rs
+++ b/ceno_zkvm/src/instructions/riscv/rv32im.rs
@@ -24,7 +24,11 @@ use crate::{
         U5TableCircuit, U8TableCircuit, U14TableCircuit, U16TableCircuit, XorTableCircuit,
     },
 };
-use ceno_emul::{CENO_PLATFORM, InsnKind, InsnKind::*, StepRecord};
+use ceno_emul::{
+    CENO_PLATFORM,
+    InsnKind::{self, *},
+    Platform, StepRecord,
+};
 use divu::{DivDummy, RemDummy, RemuDummy};
 use ecall::EcallDummy;
 use ff_ext::ExtensionField;
@@ -324,7 +328,7 @@ impl<E: ExtensionField> Rv32imConfig<E> {
             let insn_kind = record.insn().codes().kind;
             match insn_kind {
                 // ecall / halt
-                EANY if record.rs1().unwrap().value == CENO_PLATFORM.ecall_halt() => {
+                EANY if record.rs1().unwrap().value == Platform::ecall_halt() => {
                     halt_records.push(record);
                 }
                 // other type of ecalls are handled by dummy ecall instruction

--- a/ceno_zkvm/src/instructions/riscv/rv32im/mmu.rs
+++ b/ceno_zkvm/src/instructions/riscv/rv32im/mmu.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, iter::zip, ops::RangeInclusive};
 
-use ceno_emul::{Addr, Cycle, WORD_SIZE, Word};
+use ceno_emul::{Addr, CENO_PLATFORM, Cycle, WORD_SIZE, Word};
 use ff_ext::ExtensionField;
 use itertools::{Itertools, chain};
 
@@ -87,7 +87,7 @@ impl<E: ExtensionField> MmuConfig<E> {
     }
 
     pub fn initial_registers() -> Vec<MemInitRecord> {
-        (0..<RegTable as NonVolatileTable>::len())
+        (0..<RegTable as NonVolatileTable>::len(&CENO_PLATFORM))
             .map(|index| MemInitRecord {
                 addr: index as Addr,
                 value: 0,
@@ -96,11 +96,11 @@ impl<E: ExtensionField> MmuConfig<E> {
     }
 
     pub fn static_mem_len() -> usize {
-        <StaticMemTable as NonVolatileTable>::len()
+        <StaticMemTable as NonVolatileTable>::len(&CENO_PLATFORM)
     }
 
     pub fn public_io_len() -> usize {
-        <PubIOTable as NonVolatileTable>::len()
+        <PubIOTable as NonVolatileTable>::len(&CENO_PLATFORM)
     }
 }
 

--- a/ceno_zkvm/src/instructions/riscv/rv32im/mmu.rs
+++ b/ceno_zkvm/src/instructions/riscv/rv32im/mmu.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, iter::zip, ops::RangeInclusive};
 
-use ceno_emul::{Addr, CENO_PLATFORM, Cycle, WORD_SIZE, Word};
+use ceno_emul::{Addr, Cycle, Platform, WORD_SIZE, Word};
 use ff_ext::ExtensionField;
 use itertools::{Itertools, chain};
 
@@ -20,6 +20,7 @@ pub struct MmuConfig<E: ExtensionField> {
     pub static_mem_config: <StaticMemCircuit<E> as TableCircuit<E>>::TableConfig,
     /// Initialization of public IO.
     pub public_io_config: <PubIOCircuit<E> as TableCircuit<E>>::TableConfig,
+    pub platform: Platform,
 }
 
 impl<E: ExtensionField> MmuConfig<E> {
@@ -34,6 +35,7 @@ impl<E: ExtensionField> MmuConfig<E> {
             reg_config,
             static_mem_config,
             public_io_config,
+            platform: cs.platform,
         }
     }
 
@@ -86,8 +88,8 @@ impl<E: ExtensionField> MmuConfig<E> {
         Ok(())
     }
 
-    pub fn initial_registers() -> Vec<MemInitRecord> {
-        (0..<RegTable as NonVolatileTable>::len(&CENO_PLATFORM))
+    pub fn initial_registers(&self) -> Vec<MemInitRecord> {
+        (0..<RegTable as NonVolatileTable>::len(&self.platform))
             .map(|index| MemInitRecord {
                 addr: index as Addr,
                 value: 0,
@@ -95,12 +97,12 @@ impl<E: ExtensionField> MmuConfig<E> {
             .collect()
     }
 
-    pub fn static_mem_len() -> usize {
-        <StaticMemTable as NonVolatileTable>::len(&CENO_PLATFORM)
+    pub fn static_mem_len(&self) -> usize {
+        <StaticMemTable as NonVolatileTable>::len(&self.platform)
     }
 
-    pub fn public_io_len() -> usize {
-        <PubIOTable as NonVolatileTable>::len(&CENO_PLATFORM)
+    pub fn public_io_len(&self) -> usize {
+        <PubIOTable as NonVolatileTable>::len(&self.platform)
     }
 }
 

--- a/ceno_zkvm/src/scheme/tests.rs
+++ b/ceno_zkvm/src/scheme/tests.rs
@@ -3,7 +3,7 @@ use std::{marker::PhantomData, mem::MaybeUninit};
 use ceno_emul::{
     CENO_PLATFORM,
     InsnKind::{ADD, EANY},
-    PC_WORD_SIZE, Program, StepRecord, VMState,
+    PC_WORD_SIZE, Platform, Program, StepRecord, VMState,
 };
 use ff::Field;
 use ff_ext::ExtensionField;
@@ -269,7 +269,7 @@ fn test_single_add_instance_e2e() {
         match kind {
             ADD => add_records.push(record),
             EANY => {
-                if record.rs1().unwrap().value == CENO_PLATFORM.ecall_halt() {
+                if record.rs1().unwrap().value == Platform::ecall_halt() {
                     halt_records.push(record);
                 }
             }

--- a/ceno_zkvm/src/tables/ram.rs
+++ b/ceno_zkvm/src/tables/ram.rs
@@ -13,8 +13,6 @@ pub struct MemTable;
 impl DynVolatileRamTable for MemTable {
     const RAM_TYPE: RAMType = RAMType::Memory;
     const V_LIMBS: usize = 1; // See `MemoryExpr`.
-    // const OFFSET_ADDR: Addr = CENO_PLATFORM.ram_start();
-    // const END_ADDR: Addr = CENO_PLATFORM.ram_end() + 1;
 
     fn offset_addr(platform: &Platform) -> Addr {
         platform.ram_start()

--- a/ceno_zkvm/src/tables/ram/ram_circuit.rs
+++ b/ceno_zkvm/src/tables/ram/ram_circuit.rs
@@ -37,7 +37,7 @@ pub trait NonVolatileTable {
     fn name() -> &'static str;
 
     /// Maximum number of words in the table.
-    fn len() -> usize;
+    fn len(platform: &Platform) -> usize;
 }
 
 /// non-volatile indicates initial value is configurable

--- a/ceno_zkvm/src/tables/ram/ram_circuit.rs
+++ b/ceno_zkvm/src/tables/ram/ram_circuit.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, marker::PhantomData};
 
-use ceno_emul::{Addr, Cycle, WORD_SIZE, Word};
+use ceno_emul::{Addr, Cycle, Platform, WORD_SIZE, Word};
 use ff_ext::ExtensionField;
 
 use crate::{
@@ -128,17 +128,20 @@ pub trait DynVolatileRamTable {
     const RAM_TYPE: RAMType;
     const V_LIMBS: usize;
 
-    const OFFSET_ADDR: Addr;
-    const END_ADDR: Addr;
+    // const OFFSET_ADDR: Addr;
+    // const END_ADDR: Addr;
+
+    fn offset_addr(platform: &Platform) -> Addr;
+    fn end_addr(platform: &Platform) -> Addr;
 
     fn name() -> &'static str;
 
-    fn max_len() -> usize {
-        (Self::END_ADDR - Self::OFFSET_ADDR) as usize / WORD_SIZE
+    fn max_len(platform: &Platform) -> usize {
+        (Self::end_addr(platform) - Self::offset_addr(platform)) as usize / WORD_SIZE
     }
 
-    fn addr(entry_index: usize) -> Addr {
-        Self::OFFSET_ADDR + (entry_index * WORD_SIZE) as Addr
+    fn addr(platform: &Platform, entry_index: usize) -> Addr {
+        Self::offset_addr(platform) + (entry_index * WORD_SIZE) as Addr
     }
 }
 

--- a/ceno_zkvm/src/tables/ram/ram_impl.rs
+++ b/ceno_zkvm/src/tables/ram/ram_impl.rs
@@ -79,7 +79,7 @@ impl<NVRAM: NonVolatileTable + Send + Sync + Clone> NonVolatileTableConfig<NVRAM
             NVRAM::RAM_TYPE,
             SetTableSpec {
                 addr_type: SetTableAddrType::FixedAddr,
-                len: NVRAM::len(&cb.platform),
+                len: NVRAM::len(&cb.cs.platform),
             },
             init_table,
         )?;
@@ -88,7 +88,7 @@ impl<NVRAM: NonVolatileTable + Send + Sync + Clone> NonVolatileTableConfig<NVRAM
             NVRAM::RAM_TYPE,
             SetTableSpec {
                 addr_type: SetTableAddrType::FixedAddr,
-                len: NVRAM::len(&cb.platform),
+                len: NVRAM::len(&cb.cs.platform),
             },
             final_table,
         )?;
@@ -99,7 +99,7 @@ impl<NVRAM: NonVolatileTable + Send + Sync + Clone> NonVolatileTableConfig<NVRAM
             addr,
             final_cycle,
             phantom: PhantomData,
-            platform: cb.platform,
+            platform: cb.cs.platform,
         })
     }
 
@@ -215,7 +215,7 @@ impl<NVRAM: NonVolatileTable + Send + Sync + Clone> PubIOTableConfig<NVRAM> {
             NVRAM::RAM_TYPE,
             SetTableSpec {
                 addr_type: SetTableAddrType::FixedAddr,
-                len: NVRAM::len(&cb.platform),
+                len: NVRAM::len(&cb.cs.platform),
             },
             init_table,
         )?;
@@ -224,7 +224,7 @@ impl<NVRAM: NonVolatileTable + Send + Sync + Clone> PubIOTableConfig<NVRAM> {
             NVRAM::RAM_TYPE,
             SetTableSpec {
                 addr_type: SetTableAddrType::FixedAddr,
-                len: NVRAM::len(&cb.platform),
+                len: NVRAM::len(&cb.cs.platform),
             },
             final_table,
         )?;
@@ -233,7 +233,7 @@ impl<NVRAM: NonVolatileTable + Send + Sync + Clone> PubIOTableConfig<NVRAM> {
             addr,
             final_cycle,
             phantom: PhantomData,
-            platform: cb.platform,
+            platform: cb.cs.platform,
         })
     }
 
@@ -325,9 +325,9 @@ impl<DVRAM: DynVolatileRamTable + Send + Sync + Clone> DynVolatileRamTableConfig
             SetTableSpec {
                 addr_type: SetTableAddrType::DynamicAddr(DynamicAddr {
                     addr_witin_id: addr.id.into(),
-                    offset: DVRAM::offset_addr(&cb.platform),
+                    offset: DVRAM::offset_addr(&cb.cs.platform),
                 }),
-                len: DVRAM::max_len(&cb.platform),
+                len: DVRAM::max_len(&cb.cs.platform),
             },
             init_table,
         )?;
@@ -337,9 +337,9 @@ impl<DVRAM: DynVolatileRamTable + Send + Sync + Clone> DynVolatileRamTableConfig
             SetTableSpec {
                 addr_type: SetTableAddrType::DynamicAddr(DynamicAddr {
                     addr_witin_id: addr.id.into(),
-                    offset: DVRAM::offset_addr(&cb.platform),
+                    offset: DVRAM::offset_addr(&cb.cs.platform),
                 }),
-                len: DVRAM::max_len(&cb.platform),
+                len: DVRAM::max_len(&cb.cs.platform),
             },
             final_table,
         )?;
@@ -349,7 +349,7 @@ impl<DVRAM: DynVolatileRamTable + Send + Sync + Clone> DynVolatileRamTableConfig
             final_v,
             final_cycle,
             phantom: PhantomData,
-            platform: cb.platform,
+            platform: cb.cs.platform,
         })
     }
 


### PR DESCRIPTION
Makes the platform dynamic:
- Extracts some of the more fixed behaviors of `Platform` into static methods, which replace some calls to `CENO_PLATFORM`.
- Makes the `NVRAM/DVRAM` trait methods take a `Platform` argument
- Config types now store a `Platform` argument to supply `NVRAM/DVRAM` calls.
- Config types get their platform from `ConstraintSystem`, which in turn gets it from `ZKVMConstraintSystem`.
- Makes the constraint system take an explicit platform (currently the old constructors default to `CENO_PLATFORM`). See `fibonacci_elf.rs`.

Observations:
- Could instate some safeguards to use the same platform throughout the pipeline. One example: presently it's technically possible to use one platform for building the `VM` and another for the constraint system.
