### PR TITLE
feat/bin-e2e: Generalize fibonacci example to e2e bin

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -62,4 +62,4 @@ jobs:
         env:
           RAYON_NUM_THREADS: 8
           RUST_LOG: debug
-        run: cargo run --release --package ceno_zkvm --bin e2e --target ${{ matrix.target }} -- ceno_zkvm/examples/fibonacci.elf
+        run: cargo run --release --package ceno_zkvm --bin e2e --target ${{ matrix.target }} -- --platform=sp1 ceno_zkvm/examples/fibonacci.elf

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -62,4 +62,4 @@ jobs:
         env:
           RAYON_NUM_THREADS: 8
           RUST_LOG: debug
-        run: cargo run --release --package ceno_zkvm --example fibonacci_elf --target ${{ matrix.target }} -- 
+        run: cargo run --release --package ceno_zkvm --bin e2e --target ${{ matrix.target }} -- ceno_zkvm/examples/fibonacci.elf


### PR DESCRIPTION
- Upgrade example code to a CLI.
- Load ELF from file.
- Works with multiple programs including:
  - sp1 `fibonacci.elf`
  - ceno `examples/*`

**Example commands:**

`cargo run --package ceno_zkvm --bin e2e --  --max-steps=100 --platform=sp1 ceno_zkvm/examples/fibonacci.elf`

`cargo run --package ceno_zkvm --bin e2e -- examples/target/riscv32im-unknown-none-elf/release/examples/ceno_rt_mini`

**Not included:**

heap, IO, or generally memory not allocated in ELF headers.
