### PR TITLE
feat/private-input: Unconstrained memory init

### DIFF
--- a/ceno_zkvm/src/instructions/riscv/memory/load.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/load.rs
@@ -84,6 +84,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for LoadInstruction<E,
     ) -> Result<Self::InstructionConfig, ZKVMError> {
         let rs1_read = UInt::new_unchecked(|| "rs1_read", circuit_builder)?; // unsigned 32-bit value
         let imm = circuit_builder.create_witin(|| "imm"); // signed 12-bit value
+        // Memory initialization is not guaranteed to contain u32. Decompose in [u16; 2] here.
         let memory_read = UInt::new(|| "memory_read", circuit_builder)?;
 
         let memory_addr = match I::INST_KIND {

--- a/ceno_zkvm/src/instructions/riscv/memory/load.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/load.rs
@@ -84,7 +84,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for LoadInstruction<E,
     ) -> Result<Self::InstructionConfig, ZKVMError> {
         let rs1_read = UInt::new_unchecked(|| "rs1_read", circuit_builder)?; // unsigned 32-bit value
         let imm = circuit_builder.create_witin(|| "imm"); // signed 12-bit value
-        // Memory initialization is not guaranteed to contain u32. Decompose in [u16; 2] here.
+        // Memory initialization is not guaranteed to contain u32. Range-check it here.
         let memory_read = UInt::new(|| "memory_read", circuit_builder)?;
 
         let memory_addr = match I::INST_KIND {

--- a/ceno_zkvm/src/instructions/riscv/memory/store.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/store.rs
@@ -65,7 +65,7 @@ impl<E: ExtensionField, I: RIVInstruction, const N_ZEROS: usize> Instruction<E>
     ) -> Result<Self::InstructionConfig, ZKVMError> {
         let rs1_read = UInt::new_unchecked(|| "rs1_read", circuit_builder)?; // unsigned 32-bit value
         let rs2_read = UInt::new_unchecked(|| "rs2_read", circuit_builder)?;
-        // Memory initialization is not guaranteed to contain u32. Decompose in [u16; 2] here.
+        // Memory initialization is not guaranteed to contain u32. Range-check it here.
         let prev_memory_value = UInt::new(|| "prev_memory_value", circuit_builder)?;
         let imm = circuit_builder.create_witin(|| "imm"); // signed 12-bit value
 

--- a/ceno_zkvm/src/instructions/riscv/memory/store.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/store.rs
@@ -65,6 +65,7 @@ impl<E: ExtensionField, I: RIVInstruction, const N_ZEROS: usize> Instruction<E>
     ) -> Result<Self::InstructionConfig, ZKVMError> {
         let rs1_read = UInt::new_unchecked(|| "rs1_read", circuit_builder)?; // unsigned 32-bit value
         let rs2_read = UInt::new_unchecked(|| "rs2_read", circuit_builder)?;
+        // Memory initialization is not guaranteed to contain u32. Decompose in [u16; 2] here.
         let prev_memory_value = UInt::new(|| "prev_memory_value", circuit_builder)?;
         let imm = circuit_builder.create_witin(|| "imm"); // signed 12-bit value
 

--- a/ceno_zkvm/src/tables/ram.rs
+++ b/ceno_zkvm/src/tables/ram.rs
@@ -1,4 +1,4 @@
-use ceno_emul::{Addr, CENO_PLATFORM, VMState, WORD_SIZE};
+use ceno_emul::{Addr, CENO_PLATFORM, VMState};
 use ram_circuit::{DynVolatileRamCircuit, NonVolatileRamCircuit, PubIORamCircuit};
 
 use crate::{instructions::riscv::constants::UINT_LIMBS, structs::RAMType};
@@ -8,25 +8,36 @@ mod ram_impl;
 pub use ram_circuit::{DynVolatileRamTable, MemFinalRecord, MemInitRecord, NonVolatileTable};
 
 #[derive(Clone)]
-pub struct MemTable;
+pub struct DynMemTable;
 
-impl DynVolatileRamTable for MemTable {
+impl DynVolatileRamTable for DynMemTable {
     const RAM_TYPE: RAMType = RAMType::Memory;
     const V_LIMBS: usize = 1; // See `MemoryExpr`.
     const OFFSET_ADDR: Addr = CENO_PLATFORM.ram_start();
     const END_ADDR: Addr = CENO_PLATFORM.ram_end() + 1;
+    const ZERO_INIT: bool = true;
 
     fn name() -> &'static str {
-        "MemTable"
-    }
-
-    fn max_len() -> usize {
-        let max_size = (Self::END_ADDR - Self::OFFSET_ADDR) / WORD_SIZE as Addr;
-        1 << (u32::BITS - 1 - max_size.leading_zeros()) // prev_power_of_2
+        "DynMemTable"
     }
 }
 
-pub type MemCircuit<E> = DynVolatileRamCircuit<E, MemTable>;
+pub type DynMemCircuit<E> = DynVolatileRamCircuit<E, DynMemTable>;
+
+#[derive(Clone)]
+pub struct PrivateMemTable;
+impl DynVolatileRamTable for PrivateMemTable {
+    const RAM_TYPE: RAMType = RAMType::Memory;
+    const V_LIMBS: usize = 1; // See `MemoryExpr`.
+    const OFFSET_ADDR: Addr = CENO_PLATFORM.ram_start();
+    const END_ADDR: Addr = CENO_PLATFORM.ram_end() + 1;
+    const ZERO_INIT: bool = false;
+
+    fn name() -> &'static str {
+        "PrivateMemTable"
+    }
+}
+pub type PrivateMemCircuit<E> = DynVolatileRamCircuit<E, PrivateMemTable>;
 
 /// RegTable, fix size without offset
 #[derive(Clone)]

--- a/ceno_zkvm/src/tables/ram/ram_impl.rs
+++ b/ceno_zkvm/src/tables/ram/ram_impl.rs
@@ -405,20 +405,3 @@ impl<DVRAM: DynVolatileRamTable + Send + Sync + Clone> DynVolatileRamTableConfig
         Ok(final_table)
     }
 }
-
-#[allow(dead_code)]
-/// DynUnConstrainRamTableConfig with unconstrain init value and final value
-/// dynamic address as witin, relied on augment of knowledge to prove address form
-/// do not check init_value
-/// TODO implement DynUnConstrainRamTableConfig
-#[derive(Clone, Debug)]
-pub struct DynUnConstrainRamTableConfig<RAM: DynVolatileRamTable + Send + Sync + Clone> {
-    addr: WitIn,
-
-    init_v: Vec<WitIn>,
-
-    final_v: Vec<WitIn>,
-    final_cycle: WitIn,
-
-    phantom: PhantomData<RAM>,
-}

--- a/ceno_zkvm/src/tables/ram/ram_impl.rs
+++ b/ceno_zkvm/src/tables/ram/ram_impl.rs
@@ -297,10 +297,17 @@ impl<DVRAM: DynVolatileRamTable + Send + Sync + Clone> DynVolatileRamTableConfig
             .collect::<Vec<WitIn>>();
         let final_cycle = cb.create_witin(|| "final_cycle");
 
+        let final_expr = final_v.iter().map(|v| v.expr()).collect_vec();
+        let init_expr = if DVRAM::ZERO_INIT {
+            vec![Expression::ZERO; DVRAM::V_LIMBS]
+        } else {
+            final_expr.clone()
+        };
+
         let init_table = [
             vec![(DVRAM::RAM_TYPE as usize).into()],
             vec![addr.expr()],
-            vec![Expression::ZERO],
+            init_expr,
             vec![Expression::ZERO], // Initial cycle.
         ]
         .concat();
@@ -309,7 +316,7 @@ impl<DVRAM: DynVolatileRamTable + Send + Sync + Clone> DynVolatileRamTableConfig
             // a v t
             vec![(DVRAM::RAM_TYPE as usize).into()],
             vec![addr.expr()],
-            final_v.iter().map(|v| v.expr()).collect_vec(),
+            final_expr,
             vec![final_cycle.expr()],
         ]
         .concat();


### PR DESCRIPTION
_Issues #614 and #607_

Initialize memory with unconstrained prover hints.

- It is practically identical to the zero-init circuit; just without the zero-init part.
- The address range must be contiguous, but its size is dynamic.
- The `u32` range check is already done by the LOAD and STORE circuits.

e2e integration will be done in another PR. Need #608 to configure the address space.
