### PR TITLE
fix/pow-table-index: Correct table index calculation

### DIFF
--- a/ceno_zkvm/src/tables/ops.rs
+++ b/ceno_zkvm/src/tables/ops.rs
@@ -113,7 +113,7 @@ mod tests {
     use goldilocks::{GoldilocksExt2 as E, SmallField};
 
     #[test]
-    fn test_ops_table_assign() {
+    fn test_ops_pow_table_assign() {
         let mut cs = ConstraintSystem::<E>::new(|| "riscv");
         let mut cb = CircuitBuilder::new(&mut cs);
 

--- a/ceno_zkvm/src/tables/ops.rs
+++ b/ceno_zkvm/src/tables/ops.rs
@@ -87,7 +87,49 @@ impl OpsTable for PowTable {
     }
 
     fn content() -> Vec<[u64; 3]> {
-        (0..Self::len() as u64).map(|b| [2, b, 1 << b]).collect()
+        (0..Self::len() as u64)
+            .map(|exponent| [2, exponent, 1 << exponent])
+            .collect()
+    }
+
+    fn pack(base: u64, exponent: u64) -> u64 {
+        assert_eq!(base, 2);
+        exponent
+    }
+
+    fn unpack(exponent: u64) -> (u64, u64) {
+        (2, exponent)
     }
 }
 pub type PowTableCircuit<E> = OpsTableCircuit<E, PowTable>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        circuit_builder::{CircuitBuilder, ConstraintSystem},
+        tables::TableCircuit,
+    };
+    use goldilocks::{GoldilocksExt2 as E, SmallField};
+
+    #[test]
+    fn test_ops_table_assign() {
+        let mut cs = ConstraintSystem::<E>::new(|| "riscv");
+        let mut cb = CircuitBuilder::new(&mut cs);
+
+        let config = PowTableCircuit::<E>::construct_circuit(&mut cb).unwrap();
+
+        let fixed = PowTableCircuit::<E>::generate_fixed_traces(&config, cb.cs.num_fixed, &());
+
+        for (i, row) in fixed.iter_rows().enumerate() {
+            let (base, exp) = PowTable::unpack(i as u64);
+            assert_eq!(PowTable::pack(base, exp), i as u64);
+            assert_eq!(base, unsafe { row[0].assume_init() }.to_canonical_u64());
+            assert_eq!(exp, unsafe { row[1].assume_init() }.to_canonical_u64());
+            assert_eq!(
+                base.pow(exp.try_into().unwrap()),
+                unsafe { row[2].assume_init() }.to_canonical_u64()
+            );
+        }
+    }
+}


### PR DESCRIPTION
_Blocking sproll-evm._

PowTable content is organized differently than binary ops. This breaks the assignment of multiplicities. Fixed by overriding the mapping between table indexes and entries.

This detail was not covered by the table checks of MockProver, hence why discovered only now.