### PR TITLE
refactor `assert_satisfied_full`

### DIFF
--- a/ceno_emul/src/elf.rs
+++ b/ceno_emul/src/elf.rs
@@ -40,6 +40,17 @@ pub struct Program {
     pub image: BTreeMap<u32, u32>,
 }
 
+impl From<&[Instruction]> for Program {
+    fn from(insn_codes: &[Instruction]) -> Program {
+        Self {
+            entry: CENO_PLATFORM.pc_base(),
+            base_address: CENO_PLATFORM.pc_base(),
+            instructions: insn_codes.to_vec(),
+            image: Default::default(),
+        }
+    }
+}
+
 impl Program {
     /// Create program
     pub fn new(
@@ -54,15 +65,6 @@ impl Program {
             instructions,
             image,
         }
-    }
-
-    pub fn from_insn_codes(insn_codes: &[Instruction]) -> Program {
-        Self::new(
-            CENO_PLATFORM.pc_base(),
-            CENO_PLATFORM.pc_base(),
-            insn_codes.to_vec(),
-            Default::default(),
-        )
     }
 
     /// Initialize a RISC Zero Program from an appropriate ELF file

--- a/ceno_emul/src/elf.rs
+++ b/ceno_emul/src/elf.rs
@@ -18,7 +18,7 @@ extern crate alloc;
 
 use alloc::collections::BTreeMap;
 
-use crate::{addr::WORD_SIZE, disassemble::transpile, rv32im::Instruction};
+use crate::{CENO_PLATFORM, addr::WORD_SIZE, disassemble::transpile, rv32im::Instruction};
 use anyhow::{Context, Result, anyhow, bail};
 use elf::{
     ElfBytes,
@@ -55,6 +55,16 @@ impl Program {
             image,
         }
     }
+
+    pub fn from_insn_codes(insn_codes: &[Instruction]) -> Program {
+        Self::new(
+            CENO_PLATFORM.pc_base(),
+            CENO_PLATFORM.pc_base(),
+            insn_codes.to_vec(),
+            Default::default(),
+        )
+    }
+
     /// Initialize a RISC Zero Program from an appropriate ELF file
     pub fn load_elf(input: &[u8], max_mem: u32) -> Result<Program> {
         let mut instructions: Vec<u32> = Vec::new();

--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -202,7 +202,7 @@ fn main() {
         config
             .assign_opcode_circuit(&zkvm_cs, &mut zkvm_witness, all_records)
             .unwrap();
-        zkvm_witness.finalize_lk_multiplicities();
+        zkvm_witness.finalize_lk_multiplicities(false);
 
         // Find the final register values and cycles.
         let reg_final = reg_init
@@ -281,7 +281,7 @@ fn main() {
             zkvm_fixed_traces.clone(),
             &zkvm_witness,
             &pi,
-            program.clone(),
+            &program,
         );
 
         let timer = Instant::now();

--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -76,6 +76,7 @@ fn main() {
         program_code,
         Default::default(),
     );
+    let program = Arc::new(program);
     let mem_addresses = CENO_PLATFORM.heap.clone();
     let io_addresses = CENO_PLATFORM.public_io.clone();
 
@@ -163,7 +164,7 @@ fn main() {
         // init vm.x1 = 1, vm.x2 = -1, vm.x3 = step_loop
         let public_io_init = init_public_io(&[1, u32::MAX, step_loop]);
 
-        let mut vm = VMState::new(CENO_PLATFORM, Arc::new(program.clone()));
+        let mut vm = VMState::new(CENO_PLATFORM, program.clone());
 
         // init memory mapped IO
         for record in &public_io_init {
@@ -275,7 +276,13 @@ fn main() {
         trace_report.save_json("report.json");
         trace_report.save_table("report.txt");
 
-        MockProver::assert_satisfied_full(&zkvm_cs, zkvm_fixed_traces.clone(), &zkvm_witness, &pi);
+        MockProver::assert_satisfied_full(
+            &zkvm_cs,
+            zkvm_fixed_traces.clone(),
+            &zkvm_witness,
+            &pi,
+            program.clone(),
+        );
 
         let timer = Instant::now();
 

--- a/ceno_zkvm/src/circuit_builder.rs
+++ b/ceno_zkvm/src/circuit_builder.rs
@@ -115,13 +115,10 @@ pub struct ConstraintSystem<E: ExtensionField> {
     pub w_table_expressions_namespace_map: Vec<String>,
 
     /// lookup expression
-    // TODO remove lk_table and use lk instead
     pub lk_expressions: Vec<Expression<E>>,
+    pub lk_table_expressions: Vec<LogupTableExpression<E>>,
     pub lk_expressions_namespace_map: Vec<String>,
     pub lk_expressions_items_map: Vec<(ROMType, Vec<Expression<E>>)>,
-    pub lk_table_expressions: Vec<LogupTableExpression<E>>,
-    pub lk_table_expressions_namespace_map: Vec<String>,
-    pub lk_table_expressions_items_map: Vec<(ROMType, Vec<Expression<E>>)>,
 
     /// main constraints zero expression
     pub assert_zero_expressions: Vec<Expression<E>>,
@@ -166,11 +163,9 @@ impl<E: ExtensionField> ConstraintSystem<E> {
             w_table_expressions: vec![],
             w_table_expressions_namespace_map: vec![],
             lk_expressions: vec![],
+            lk_table_expressions: vec![],
             lk_expressions_namespace_map: vec![],
             lk_expressions_items_map: vec![],
-            lk_table_expressions: vec![],
-            lk_table_expressions_namespace_map: vec![],
-            lk_table_expressions_items_map: vec![],
             assert_zero_expressions: vec![],
             assert_zero_expressions_namespace_map: vec![],
             assert_zero_sumcheck_expressions: vec![],
@@ -329,10 +324,10 @@ impl<E: ExtensionField> ConstraintSystem<E> {
             table_len,
         });
         let path = self.ns.compute_path(name_fn().into());
-        self.lk_table_expressions_namespace_map.push(path);
+        self.lk_expressions_namespace_map.push(path);
         // Since lk_expression is RLC(record) and when we're debugging
         // it's helpful to recover the value of record itself.
-        self.lk_table_expressions_items_map.push((rom_type, record));
+        self.lk_expressions_items_map.push((rom_type, record));
 
         Ok(())
     }

--- a/ceno_zkvm/src/circuit_builder.rs
+++ b/ceno_zkvm/src/circuit_builder.rs
@@ -115,10 +115,13 @@ pub struct ConstraintSystem<E: ExtensionField> {
     pub w_table_expressions_namespace_map: Vec<String>,
 
     /// lookup expression
+    // TODO remove lk_table and use lk instead
     pub lk_expressions: Vec<Expression<E>>,
     pub lk_expressions_namespace_map: Vec<String>,
+    pub lk_expressions_items_map: Vec<(ROMType, Vec<Expression<E>>)>,
     pub lk_table_expressions: Vec<LogupTableExpression<E>>,
     pub lk_table_expressions_namespace_map: Vec<String>,
+    pub lk_table_expressions_items_map: Vec<(ROMType, Vec<Expression<E>>)>,
 
     /// main constraints zero expression
     pub assert_zero_expressions: Vec<Expression<E>>,
@@ -136,7 +139,6 @@ pub struct ConstraintSystem<E: ExtensionField> {
     pub chip_record_beta: Expression<E>,
 
     pub debug_map: HashMap<usize, Vec<Expression<E>>>,
-    pub lk_expressions_items_map: Vec<(ROMType, Vec<Expression<E>>)>,
 
     pub(crate) phantom: PhantomData<E>,
 }
@@ -165,8 +167,10 @@ impl<E: ExtensionField> ConstraintSystem<E> {
             w_table_expressions_namespace_map: vec![],
             lk_expressions: vec![],
             lk_expressions_namespace_map: vec![],
+            lk_expressions_items_map: vec![],
             lk_table_expressions: vec![],
             lk_table_expressions_namespace_map: vec![],
+            lk_table_expressions_items_map: vec![],
             assert_zero_expressions: vec![],
             assert_zero_expressions_namespace_map: vec![],
             assert_zero_sumcheck_expressions: vec![],
@@ -176,7 +180,6 @@ impl<E: ExtensionField> ConstraintSystem<E> {
             chip_record_beta: Expression::Challenge(1, 1, E::ONE, E::ZERO),
 
             debug_map: HashMap::new(),
-            lk_expressions_items_map: vec![],
 
             phantom: std::marker::PhantomData,
         }
@@ -329,7 +332,7 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         self.lk_table_expressions_namespace_map.push(path);
         // Since lk_expression is RLC(record) and when we're debugging
         // it's helpful to recover the value of record itself.
-        self.lk_expressions_items_map.push((rom_type, record));
+        self.lk_table_expressions_items_map.push((rom_type, record));
 
         Ok(())
     }

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1,8 +1,11 @@
 use crate::{
     instructions::riscv::{DummyExtraConfig, MemPadder, MmuConfig, Rv32imConfig},
     scheme::{
-        PublicValues, ZKVMProof, constants::MAX_NUM_VARIABLES, mock_prover::MockProver,
-        prover::ZKVMProver, verifier::ZKVMVerifier,
+        PublicValues, ZKVMProof,
+        constants::MAX_NUM_VARIABLES,
+        mock_prover::{LkMultiplicityKey, MockProver},
+        prover::ZKVMProver,
+        verifier::ZKVMVerifier,
     },
     state::GlobalState,
     structs::{
@@ -370,7 +373,10 @@ pub type IntermediateState<E, PCS> = (ZKVMProof<E, PCS>, ZKVMVerifier<E, PCS>);
 // state external to this pipeline (e.g, sanity check in bin/e2e.rs)
 
 #[allow(clippy::type_complexity)]
-pub fn run_e2e_with_checkpoint<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>(
+pub fn run_e2e_with_checkpoint<
+    E: ExtensionField + LkMultiplicityKey,
+    PCS: PolynomialCommitmentScheme<E> + 'static,
+>(
     program: Program,
     platform: Platform,
     hints: Vec<u32>,
@@ -458,6 +464,7 @@ pub fn run_e2e_with_checkpoint<E: ExtensionField, PCS: PolynomialCommitmentSchem
             zkvm_fixed_traces.clone(),
             &zkvm_witness,
             &pi,
+            program,
         );
         tracing::info!("Mock proving passed");
     }
@@ -481,7 +488,7 @@ pub fn run_e2e_with_checkpoint<E: ExtensionField, PCS: PolynomialCommitmentSchem
 
 // Runs program emulation + witness generation + proving
 #[allow(clippy::too_many_arguments)]
-pub fn run_e2e_proof<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
+pub fn run_e2e_proof<E: ExtensionField + LkMultiplicityKey, PCS: PolynomialCommitmentScheme<E>>(
     program: Arc<Program>,
     max_steps: usize,
     init_full_mem: InitMemState,
@@ -509,6 +516,7 @@ pub fn run_e2e_proof<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
             zkvm_fixed_traces.clone(),
             &zkvm_witness,
             &pi,
+            program,
         );
         tracing::info!("Mock proving passed");
     }

--- a/ceno_zkvm/src/expression.rs
+++ b/ceno_zkvm/src/expression.rs
@@ -216,6 +216,10 @@ impl<E: ExtensionField> Expression<E> {
         self.to_monomial_form_inner()
     }
 
+    pub fn is_constant(&self) -> bool {
+        matches!(self, Expression::Constant(_))
+    }
+
     fn is_zero_expr(expr: &Expression<E>) -> bool {
         match expr {
             Expression::Fixed(_) => false,

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -573,8 +573,7 @@ impl<'a, E: ExtensionField + Hash> MockProver<E> {
 
             // Check each lookup expr exists in t vec
             for (inst_id, element) in enumerate(expr_evaluated) {
-                let vec = element.to_canonical_u64_vec();
-                if !table.contains(&vec) {
+                if !table.contains(&element.to_canonical_u64_vec()) {
                     errors.push(MockProverError::LookupError {
                         rom_type: *rom_type,
                         expression: expr.clone(),

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -569,10 +569,10 @@ impl<'a, E: ExtensionField + Hash> MockProver<E> {
             .zip_eq(cs.lk_expressions_items_map.iter())
         {
             let expr_evaluated = wit_infer_by_expr(&[], wits_in, &[], pi, &challenge, expr);
-            let expr_evaluated = expr_evaluated.get_ext_field_vec()[..num_instances].to_vec();
+            let expr_evaluated = &expr_evaluated.get_ext_field_vec()[..num_instances];
 
             // Check each lookup expr exists in t vec
-            for (inst_id, element) in enumerate(&expr_evaluated) {
+            for (inst_id, element) in enumerate(expr_evaluated) {
                 let vec = element.to_canonical_u64_vec();
                 if !table.contains(&vec) {
                     errors.push(MockProverError::LookupError {
@@ -588,7 +588,7 @@ impl<'a, E: ExtensionField + Hash> MockProver<E> {
             // Increment shared LK Multiplicity
             if let Some(shared_lkm) = shared_lkm.as_mut() {
                 for element in expr_evaluated {
-                    shared_lkm.increment(*rom_type, element);
+                    shared_lkm.increment(*rom_type, *element);
                 }
             }
         }

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -491,7 +491,7 @@ impl<'a, E: ExtensionField + Hash> MockProver<E> {
         pi: &[ArcMultilinearExtension<'a, E>],
         num_instances: usize,
         challenge: [E; 2],
-        lkm: Option<LkMultiplicity>,
+        expected_lkm: Option<LkMultiplicity>,
         mut shared_lkm: Option<&mut LkMultiplicityRaw<E>>,
     ) -> Result<(), Vec<MockProverError<E, u64>>> {
         let mut errors = vec![];
@@ -594,7 +594,7 @@ impl<'a, E: ExtensionField + Hash> MockProver<E> {
         }
 
         // LK Multiplicity check
-        if let Some(lkm_from_assignment) = lkm {
+        if let Some(lkm_from_assignment) = expected_lkm {
             // Infer LK Multiplicity from constraint system.
             let mut lkm_from_cs = LkMultiplicity::default();
             for (rom_type, args) in &cs.lk_expressions_items_map {
@@ -854,7 +854,9 @@ Hints:
                 );
                 // Assert opcode and check single opcode lk multiplicity
                 // Also combine multiplicity in lkm_opcodes
-                let lkm = witnesses.get_lk_mlt(circuit_name);
+                let lkm_from_assignments = witnesses
+                    .get_lk_mlt(circuit_name)
+                    .map(|lkm| lkm.deep_clone());
                 let errors = Self::run_with_challenge_plain(
                     cs,
                     &lookup_table,
@@ -862,7 +864,7 @@ Hints:
                     &[],
                     num_rows,
                     challenges,
-                    lkm,
+                    lkm_from_assignments,
                     Some(&mut lkm_opcodes),
                 );
                 match errors {

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -480,11 +480,11 @@ impl<'a, E: ExtensionField + Hash> MockProver<E> {
         let program = Arc::new(Program::from_insn_codes(program));
         let (table, challenge) = Self::load_tables_with_program(cb.cs, program, challenge);
 
-        Self::run_with_challenge_plain(cb.cs, &table, wits_in, pi, 1, challenge, lkm, None)
+        Self::run_maybe_challenge_with_table(cb.cs, &table, wits_in, pi, 1, challenge, lkm, None)
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn run_with_challenge_plain(
+    fn run_maybe_challenge_with_table(
         cs: &ConstraintSystem<E>,
         table: &HashSet<Vec<u64>>,
         wits_in: &[ArcMultilinearExtension<'a, E>],
@@ -850,7 +850,7 @@ Hints:
                 let lkm_from_assignments = witnesses
                     .get_lk_mlt(circuit_name)
                     .map(|lkm| lkm.deep_clone());
-                let errors = Self::run_with_challenge_plain(
+                let errors = Self::run_maybe_challenge_with_table(
                     cs,
                     &lookup_table,
                     &witness,

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -13,7 +13,7 @@ use crate::{
         AndTable, LtuTable, OpsTable, OrTable, PowTable, ProgramTableCircuit, RangeTable,
         TableCircuit, U5Table, U8Table, U14Table, U16Table, XorTable,
     },
-    witness::{LkMultiplicity, RowMajorMatrix},
+    witness::{LkMultiplicity, LkMultiplicityRaw, RowMajorMatrix},
 };
 use ark_std::test_rng;
 use base64::{Engine, engine::general_purpose::STANDARD_NO_PAD};
@@ -21,17 +21,18 @@ use ceno_emul::{ByteAddr, CENO_PLATFORM, Platform, Program};
 use ff::Field;
 use ff_ext::ExtensionField;
 use generic_static::StaticTypeMap;
-use goldilocks::SmallField;
+use goldilocks::{GoldilocksExt2, SmallField};
 use itertools::{Itertools, enumerate, izip};
 use multilinear_extensions::{mle::IntoMLEs, virtual_poly_v2::ArcMultilinearExtension};
 use rand::thread_rng;
 use std::{
     collections::{HashMap, HashSet},
+    fmt::Debug,
     fs::File,
     hash::Hash,
     io::{BufReader, ErrorKind},
     marker::PhantomData,
-    sync::OnceLock,
+    sync::{Arc, OnceLock},
 };
 use strum::IntoEnumIterator;
 
@@ -51,9 +52,27 @@ pub const MOCK_PC_START: ByteAddr = ByteAddr({
     CENO_PLATFORM.pc_base()
 });
 
+/// Allow LK Multiplicity's key to be used with `u64` and `GoldilocksExt2`.
+pub trait LkMultiplicityKey: Copy + Clone + Debug + Eq + Hash + Send {
+    /// If key is u64, return Some(u64), otherwise None.
+    fn to_u64(&self) -> Option<u64>;
+}
+
+impl LkMultiplicityKey for u64 {
+    fn to_u64(&self) -> Option<u64> {
+        Some(*self)
+    }
+}
+
+impl LkMultiplicityKey for GoldilocksExt2 {
+    fn to_u64(&self) -> Option<u64> {
+        None
+    }
+}
+
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone)]
-pub enum MockProverError<E: ExtensionField> {
+pub enum MockProverError<E: ExtensionField, K: LkMultiplicityKey> {
     AssertZeroError {
         expression: Expression<E>,
         evaluated: E::BaseField,
@@ -74,6 +93,7 @@ pub enum MockProverError<E: ExtensionField> {
         name: String,
     },
     LookupError {
+        rom_type: ROMType,
         expression: Expression<E>,
         evaluated: E,
         name: String,
@@ -84,13 +104,12 @@ pub enum MockProverError<E: ExtensionField> {
     // w_expressions
     LkMultiplicityError {
         rom_type: ROMType,
-        key: u64,
+        key: K,
         count: isize, // +ve => missing in cs, -ve => missing in assignments
-        inst_id: usize,
     },
 }
 
-impl<E: ExtensionField> PartialEq for MockProverError<E> {
+impl<E: ExtensionField, K: LkMultiplicityKey> PartialEq for MockProverError<E, K> {
     // Compare errors based on the content, ignoring the inst_id
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
@@ -154,13 +173,29 @@ impl<E: ExtensionField> PartialEq for MockProverError<E> {
                     && left_evaluated == right_evaluated
                     && left_name == right_name
             }
+            (
+                MockProverError::LkMultiplicityError {
+                    rom_type: left_rom_type,
+                    key: left_key,
+                    count: left_count,
+                },
+                MockProverError::LkMultiplicityError {
+                    rom_type: right_rom_type,
+                    key: right_key,
+                    count: right_count,
+                },
+            ) => {
+                left_rom_type == right_rom_type
+                    && left_key == right_key
+                    && left_count == right_count
+            }
             _ => false,
         }
     }
 }
 
-impl<E: ExtensionField> MockProverError<E> {
-    pub fn print(&self, wits_in: &[ArcMultilinearExtension<E>], wits_in_name: &[String]) {
+impl<E: ExtensionField, K: LkMultiplicityKey> MockProverError<E, K> {
+    fn print(&self, wits_in: &[ArcMultilinearExtension<E>], wits_in_name: &[String]) {
         let mut wtns = vec![];
 
         match self {
@@ -214,6 +249,7 @@ impl<E: ExtensionField> MockProverError<E> {
                 );
             }
             Self::LookupError {
+                rom_type,
                 expression,
                 evaluated,
                 name,
@@ -224,6 +260,7 @@ impl<E: ExtensionField> MockProverError<E> {
                 let eval_fmt = fmt::field(evaluated);
                 println!(
                     "\nLookupError {name:#?}: Evaluated expression does not exist in T vector\n\
+                    ROM Type: {rom_type:?}\n\
                     Expression: {expression_fmt}\n\
                     Evaluation: {eval_fmt}\n\
                     Inst[{inst_id}]:\n{wtns_fmt}\n",
@@ -240,36 +277,49 @@ impl<E: ExtensionField> MockProverError<E> {
                 } else {
                     "Lookup".to_string()
                 };
-                let location = if *count > 0 {
-                    "constraint system"
+
+                let (location, element) = if let Some(key) = key.to_u64() {
+                    let location = if *count > 0 {
+                        "constraint system"
+                    } else {
+                        "assignments"
+                    };
+                    let element = match rom_type {
+                        ROMType::U5 | ROMType::U8 | ROMType::U14 | ROMType::U16 => {
+                            format!("Element: {key:?}")
+                        }
+                        ROMType::And => {
+                            let (a, b) = AndTable::unpack(key);
+                            format!("Element: {a} < {b}")
+                        }
+                        ROMType::Or => {
+                            let (a, b) = OrTable::unpack(key);
+                            format!("Element: {a} || {b}")
+                        }
+                        ROMType::Xor => {
+                            let (a, b) = XorTable::unpack(key);
+                            format!("Element: {a} ^ {b}")
+                        }
+                        ROMType::Ltu => {
+                            let (a, b) = LtuTable::unpack(key);
+                            format!("Element: {a} < {b}")
+                        }
+                        ROMType::Pow => {
+                            let (a, b) = PowTable::unpack(key);
+                            format!("Element: {a} ** {b}")
+                        }
+                        ROMType::Instruction => format!("PC: {key}"),
+                    };
+                    (location, element)
                 } else {
-                    "assignments"
-                };
-                let element = match rom_type {
-                    ROMType::U5 | ROMType::U8 | ROMType::U14 | ROMType::U16 => {
-                        format!("Element: {key}")
-                    }
-                    ROMType::And => {
-                        let (a, b) = AndTable::unpack(*key);
-                        format!("Element: {a} < {b}")
-                    }
-                    ROMType::Or => {
-                        let (a, b) = OrTable::unpack(*key);
-                        format!("Element: {a} || {b}")
-                    }
-                    ROMType::Xor => {
-                        let (a, b) = XorTable::unpack(*key);
-                        format!("Element: {a} ^ {b}")
-                    }
-                    ROMType::Ltu => {
-                        let (a, b) = LtuTable::unpack(*key);
-                        format!("Element: {a} < {b}")
-                    }
-                    ROMType::Pow => {
-                        let (a, b) = PowTable::unpack(*key);
-                        format!("Element: {a} ** {b}")
-                    }
-                    ROMType::Instruction => format!("PC: {key}"),
+                    (
+                        if *count > 0 {
+                            "combined_lkm_tables"
+                        } else {
+                            "combined_lkm_opcodes"
+                        },
+                        format!("Element: {key:?}"),
+                    )
                 };
                 println!(
                     "\nLkMultiplicityError:\n\
@@ -285,9 +335,8 @@ impl<E: ExtensionField> MockProverError<E> {
         match self {
             Self::AssertZeroError { inst_id, .. }
             | Self::AssertEqualError { inst_id, .. }
-            | Self::LookupError { inst_id, .. }
-            | Self::LkMultiplicityError { inst_id, .. } => *inst_id,
-            Self::DegreeTooHigh { .. } => unreachable!(),
+            | Self::LookupError { inst_id, .. } => *inst_id,
+            _ => unreachable!(),
         }
     }
 
@@ -300,15 +349,18 @@ pub struct MockProver<E: ExtensionField> {
     _phantom: PhantomData<E>,
 }
 
-fn load_tables<E: ExtensionField>(cb: &CircuitBuilder<E>, challenge: [E; 2]) -> HashSet<Vec<u64>> {
+fn load_tables<E: ExtensionField>(
+    cs: &ConstraintSystem<E>,
+    challenge: [E; 2],
+) -> HashSet<Vec<u64>> {
     fn load_range_table<RANGE: RangeTable, E: ExtensionField>(
         t_vec: &mut Vec<Vec<u64>>,
-        cb: &CircuitBuilder<E>,
+        cs: &ConstraintSystem<E>,
         challenge: [E; 2],
     ) {
         for i in RANGE::content() {
             let rlc_record =
-                cb.rlc_chip_record(vec![(RANGE::ROM_TYPE as usize).into(), (i as usize).into()]);
+                cs.rlc_chip_record(vec![(RANGE::ROM_TYPE as usize).into(), (i as usize).into()]);
             let rlc_record = eval_by_expr(&[], &[], &challenge, &rlc_record);
             t_vec.push(rlc_record.to_canonical_u64_vec());
         }
@@ -316,11 +368,11 @@ fn load_tables<E: ExtensionField>(cb: &CircuitBuilder<E>, challenge: [E; 2]) -> 
 
     fn load_op_table<OP: OpsTable, E: ExtensionField>(
         t_vec: &mut Vec<Vec<u64>>,
-        cb: &CircuitBuilder<E>,
+        cs: &ConstraintSystem<E>,
         challenge: [E; 2],
     ) {
         for [a, b, c] in OP::content() {
-            let rlc_record = cb.rlc_chip_record(vec![
+            let rlc_record = cs.rlc_chip_record(vec![
                 (OP::ROM_TYPE as usize).into(),
                 (a as usize).into(),
                 (b as usize).into(),
@@ -332,15 +384,15 @@ fn load_tables<E: ExtensionField>(cb: &CircuitBuilder<E>, challenge: [E; 2]) -> 
     }
 
     let mut table_vec = vec![];
-    load_range_table::<U5Table, _>(&mut table_vec, cb, challenge);
-    load_range_table::<U8Table, _>(&mut table_vec, cb, challenge);
-    load_range_table::<U14Table, _>(&mut table_vec, cb, challenge);
-    load_range_table::<U16Table, _>(&mut table_vec, cb, challenge);
-    load_op_table::<AndTable, _>(&mut table_vec, cb, challenge);
-    load_op_table::<OrTable, _>(&mut table_vec, cb, challenge);
-    load_op_table::<XorTable, _>(&mut table_vec, cb, challenge);
-    load_op_table::<LtuTable, _>(&mut table_vec, cb, challenge);
-    load_op_table::<PowTable, _>(&mut table_vec, cb, challenge);
+    load_range_table::<U5Table, _>(&mut table_vec, cs, challenge);
+    load_range_table::<U8Table, _>(&mut table_vec, cs, challenge);
+    load_range_table::<U14Table, _>(&mut table_vec, cs, challenge);
+    load_range_table::<U16Table, _>(&mut table_vec, cs, challenge);
+    load_op_table::<AndTable, _>(&mut table_vec, cs, challenge);
+    load_op_table::<OrTable, _>(&mut table_vec, cs, challenge);
+    load_op_table::<XorTable, _>(&mut table_vec, cs, challenge);
+    load_op_table::<LtuTable, _>(&mut table_vec, cs, challenge);
+    load_op_table::<PowTable, _>(&mut table_vec, cs, challenge);
 
     HashSet::from_iter(table_vec)
 }
@@ -349,7 +401,7 @@ fn load_tables<E: ExtensionField>(cb: &CircuitBuilder<E>, challenge: [E; 2]) -> 
 // return challenge and table
 #[allow(clippy::type_complexity)]
 fn load_once_tables<E: ExtensionField + 'static + Sync + Send>(
-    cb: &CircuitBuilder<E>,
+    cs: &ConstraintSystem<E>,
 ) -> ([E; 2], HashSet<Vec<u64>>) {
     static CACHE: OnceLock<StaticTypeMap<([Vec<u64>; 2], HashSet<Vec<u64>>)>> = OnceLock::new();
     let cache = CACHE.get_or_init(StaticTypeMap::new);
@@ -373,7 +425,7 @@ fn load_once_tables<E: ExtensionField + 'static + Sync + Send>(
                 let mut file = tempfile::NamedTempFile::new_in(".").unwrap();
 
                 // load new table and seserialize to file for later use
-                let table = load_tables(cb, challenge);
+                let table = load_tables(cs, challenge);
                 serde_json::to_writer(&mut file, &table).unwrap();
                 // Persist the file to the target location
                 // This is an atomic operation on Posix-like systems, so we don't have to worry
@@ -404,58 +456,55 @@ impl<'a, E: ExtensionField + Hash> MockProver<E> {
         wits_in: &[ArcMultilinearExtension<'a, E>],
         challenge: [E; 2],
         lkm: Option<LkMultiplicity>,
-    ) -> Result<(), Vec<MockProverError<E>>> {
+    ) -> Result<(), Vec<MockProverError<E, u64>>> {
         Self::run_maybe_challenge(cb, wits_in, &[], &[], Some(challenge), lkm)
     }
 
     pub fn run(
         cb: &CircuitBuilder<E>,
         wits_in: &[ArcMultilinearExtension<'a, E>],
-        programs: &[ceno_emul::Instruction],
+        program: &[ceno_emul::Instruction],
         lkm: Option<LkMultiplicity>,
-    ) -> Result<(), Vec<MockProverError<E>>> {
-        Self::run_maybe_challenge(cb, wits_in, programs, &[], None, lkm)
+    ) -> Result<(), Vec<MockProverError<E, u64>>> {
+        Self::run_maybe_challenge(cb, wits_in, program, &[], None, lkm)
     }
 
     fn run_maybe_challenge(
         cb: &CircuitBuilder<E>,
         wits_in: &[ArcMultilinearExtension<'a, E>],
-        input_programs: &[ceno_emul::Instruction],
+        program: &[ceno_emul::Instruction],
         pi: &[ArcMultilinearExtension<'a, E>],
         challenge: Option<[E; 2]>,
         lkm: Option<LkMultiplicity>,
-    ) -> Result<(), Vec<MockProverError<E>>> {
-        let program = Program::new(
-            CENO_PLATFORM.pc_base(),
-            CENO_PLATFORM.pc_base(),
-            input_programs.to_vec(),
-            Default::default(),
-        );
+    ) -> Result<(), Vec<MockProverError<E, u64>>> {
+        let program = Arc::new(Program::from_insn_codes(program));
+        let (table, challenge) = Self::load_tables_with_program(cb.cs, program, challenge);
 
-        // load tables
-        let (challenge, mut table) = if let Some(challenge) = challenge {
-            (challenge, load_tables(cb, challenge))
-        } else {
-            load_once_tables(cb)
-        };
-        let mut prog_table = vec![];
-        Self::load_program_table(&mut prog_table, &program, challenge);
-        for prog in prog_table {
-            table.insert(prog);
-        }
+        Self::run_with_challenge_plain(cb.cs, &table, wits_in, pi, 1, challenge, lkm, None)
+    }
 
+    #[allow(clippy::too_many_arguments)]
+    fn run_with_challenge_plain(
+        cs: &ConstraintSystem<E>,
+        table: &HashSet<Vec<u64>>,
+        wits_in: &[ArcMultilinearExtension<'a, E>],
+        pi: &[ArcMultilinearExtension<'a, E>],
+        num_instances: usize,
+        challenge: [E; 2],
+        lkm: Option<LkMultiplicity>,
+        mut shared_lkm: Option<&mut LkMultiplicityRaw<E>>,
+    ) -> Result<(), Vec<MockProverError<E, u64>>> {
         let mut errors = vec![];
+
         // Assert zero expressions
-        for (expr, name) in cb
-            .cs
+        for (expr, name) in cs
             .assert_zero_expressions
             .iter()
-            .chain(&cb.cs.assert_zero_sumcheck_expressions)
+            .chain(&cs.assert_zero_sumcheck_expressions)
             .zip_eq(
-                cb.cs
-                    .assert_zero_expressions_namespace_map
+                cs.assert_zero_expressions_namespace_map
                     .iter()
-                    .chain(&cb.cs.assert_zero_sumcheck_expressions_namespace_map),
+                    .chain(&cs.assert_zero_sumcheck_expressions_namespace_map),
             )
         {
             if expr.degree() > MAX_CONSTRAINT_DEGREE {
@@ -513,19 +562,21 @@ impl<'a, E: ExtensionField + Hash> MockProver<E> {
         }
 
         // Lookup expressions
-        for (expr, name) in cb
-            .cs
+        for ((expr, name), (rom_type, _)) in cs
             .lk_expressions
             .iter()
-            .zip_eq(cb.cs.lk_expressions_namespace_map.iter())
+            .zip_eq(cs.lk_expressions_namespace_map.iter())
+            .zip_eq(cs.lk_expressions_items_map.iter())
         {
             let expr_evaluated = wit_infer_by_expr(&[], wits_in, &[], pi, &challenge, expr);
-            let expr_evaluated = expr_evaluated.get_ext_field_vec();
+            let expr_evaluated = expr_evaluated.get_ext_field_vec()[..num_instances].to_vec();
 
             // Check each lookup expr exists in t vec
-            for (inst_id, element) in enumerate(expr_evaluated) {
-                if !table.contains(&element.to_canonical_u64_vec()) {
+            for (inst_id, element) in enumerate(&expr_evaluated) {
+                let vec = element.to_canonical_u64_vec();
+                if !table.contains(&vec) {
                     errors.push(MockProverError::LookupError {
+                        rom_type: *rom_type,
                         expression: expr.clone(),
                         evaluated: *element,
                         name: name.clone(),
@@ -533,100 +584,70 @@ impl<'a, E: ExtensionField + Hash> MockProver<E> {
                     });
                 }
             }
+
+            // Increment shared LK Multiplicity
+            if let Some(shared_lkm) = shared_lkm.as_mut() {
+                for element in expr_evaluated {
+                    shared_lkm.increment(*rom_type, element);
+                }
+            }
         }
 
         // LK Multiplicity check
         if let Some(lkm_from_assignment) = lkm {
             // Infer LK Multiplicity from constraint system.
-            let lkm_from_cs = cb
-                .cs
-                .lk_expressions_items_map
-                .iter()
-                .map(|(rom_type, items)| {
-                    (
-                        rom_type,
-                        items
+            let mut lkm_from_cs = LkMultiplicity::default();
+            for (rom_type, args) in &cs.lk_expressions_items_map {
+                let mut args_eval = vec![];
+                let mut max_len = 0;
+                for args_expr in args {
+                    let args_expr_evaluated =
+                        wit_infer_by_expr(&[], wits_in, &[], pi, &challenge, args_expr);
+                    let args_expr_evaluated = args_expr_evaluated.get_base_field_vec();
+                    max_len = std::cmp::max(max_len, args_expr_evaluated.len());
+                    args_eval.push(
+                        args_expr_evaluated
                             .iter()
-                            .map(|expr| {
-                                // TODO generalized to all inst_id
-                                let inst_id = 0;
-                                wit_infer_by_expr(&[], wits_in, &[], pi, &challenge, expr)
-                                    .get_base_field_vec()[inst_id]
-                                    .to_canonical_u64()
-                            })
-                            .collect::<Vec<u64>>(),
-                    )
-                })
-                .fold(LkMultiplicity::default(), |mut lkm, (rom_type, args)| {
+                            .map(|f| f.to_canonical_u64())
+                            .collect_vec(),
+                    );
+                }
+                // Constant terms will have single element in `args_expr_evaluated`, so let's fix that.
+                for (args_expr, arg_eval) in args.iter().zip(args_eval.iter_mut()) {
+                    if args_expr.is_constant() {
+                        assert_eq!(arg_eval.len(), 1);
+                        for _ in 1..max_len {
+                            arg_eval.push(arg_eval[0]);
+                        }
+                    }
+                }
+
+                // Count lookups infered from ConstraintSystem from all instances into lkm_from_cs.
+                for inst_id in 0..num_instances {
                     match rom_type {
-                        ROMType::U5 => lkm.assert_ux::<5>(args[0]),
-                        ROMType::U8 => lkm.assert_ux::<8>(args[0]),
-                        ROMType::U14 => lkm.assert_ux::<14>(args[0]),
-                        ROMType::U16 => lkm.assert_ux::<16>(args[0]),
-                        ROMType::And => lkm.lookup_and_byte(args[0], args[1]),
-                        ROMType::Or => lkm.lookup_or_byte(args[0], args[1]),
-                        ROMType::Xor => lkm.lookup_xor_byte(args[0], args[1]),
-                        ROMType::Ltu => lkm.lookup_ltu_byte(args[0], args[1]),
+                        ROMType::U5 => lkm_from_cs.assert_ux::<5>(args_eval[0][inst_id]),
+                        ROMType::U8 => lkm_from_cs.assert_ux::<8>(args_eval[0][inst_id]),
+                        ROMType::U14 => lkm_from_cs.assert_ux::<14>(args_eval[0][inst_id]),
+                        ROMType::U16 => lkm_from_cs.assert_ux::<16>(args_eval[0][inst_id]),
+                        ROMType::And => lkm_from_cs
+                            .lookup_and_byte(args_eval[0][inst_id], args_eval[1][inst_id]),
+                        ROMType::Or => {
+                            lkm_from_cs.lookup_or_byte(args_eval[0][inst_id], args_eval[1][inst_id])
+                        }
+                        ROMType::Xor => lkm_from_cs
+                            .lookup_xor_byte(args_eval[0][inst_id], args_eval[1][inst_id]),
+                        ROMType::Ltu => lkm_from_cs
+                            .lookup_ltu_byte(args_eval[0][inst_id], args_eval[1][inst_id]),
                         ROMType::Pow => {
-                            assert_eq!(args[0], 2);
-                            lkm.lookup_pow2(args[1])
+                            assert_eq!(args_eval[0][inst_id], 2);
+                            lkm_from_cs.lookup_pow2(args_eval[1][inst_id])
                         }
-                        ROMType::Instruction => lkm.fetch(args[0] as u32),
+                        ROMType::Instruction => lkm_from_cs.fetch(args_eval[0][inst_id] as u32),
                     };
-
-                    lkm
-                });
-
-            let lkm_from_cs = lkm_from_cs.into_finalize_result();
-            let lkm_from_assignment = lkm_from_assignment.into_finalize_result();
-
-            // Compare each LK Multiplicity.
-
-            for (rom_type, cs_map, ass_map) in
-                izip!(ROMType::iter(), &lkm_from_cs, &lkm_from_assignment)
-            {
-                if *cs_map != *ass_map {
-                    let cs_keys: HashSet<_> = cs_map.keys().collect();
-                    let ass_keys: HashSet<_> = ass_map.keys().collect();
-
-                    // lookup missing in lkm Constraint System.
-                    ass_keys.difference(&cs_keys).for_each(|k| {
-                        let count_ass = ass_map.get(k).unwrap();
-                        errors.push(MockProverError::LkMultiplicityError {
-                            rom_type,
-                            key: **k,
-                            count: *count_ass as isize,
-                            inst_id: 0,
-                        })
-                    });
-
-                    // lookup missing in lkm Assignments.
-                    cs_keys.difference(&ass_keys).for_each(|k| {
-                        let count_cs = cs_map.get(k).unwrap();
-                        errors.push(MockProverError::LkMultiplicityError {
-                            rom_type,
-                            key: **k,
-                            count: -(*count_cs as isize),
-                            inst_id: 0,
-                        })
-                    });
-
-                    // count of specific lookup differ lkm assignments and lkm cs
-                    cs_keys.intersection(&ass_keys).for_each(|k| {
-                        let count_cs = cs_map.get(k).unwrap();
-                        let count_ass = ass_map.get(k).unwrap();
-
-                        if count_cs != count_ass {
-                            errors.push(MockProverError::LkMultiplicityError {
-                                rom_type,
-                                key: **k,
-                                count: (*count_ass as isize) - (*count_cs as isize),
-                                inst_id: 0,
-                            })
-                        }
-                    });
                 }
             }
+
+            compare_lkm(lkm_from_cs, lkm_from_assignment, &mut errors);
         }
 
         if errors.is_empty() {
@@ -636,15 +657,35 @@ impl<'a, E: ExtensionField + Hash> MockProver<E> {
         }
     }
 
-    fn load_program_table(t_vec: &mut Vec<Vec<u64>>, program: &Program, challenge: [E; 2]) {
+    fn load_tables_with_program(
+        cs: &ConstraintSystem<E>,
+        program: Arc<Program>,
+        challenge: Option<[E; 2]>,
+    ) -> (HashSet<Vec<u64>>, [E; 2]) {
+        // load tables
+        let (challenge, mut table) = if let Some(challenge) = challenge {
+            (challenge, load_tables(cs, challenge))
+        } else {
+            load_once_tables(cs)
+        };
+        let mut prog_table = vec![];
+        Self::load_program_table(&mut prog_table, program, challenge);
+        for prog in prog_table {
+            table.insert(prog);
+        }
+        (table, challenge)
+    }
+
+    fn load_program_table(t_vec: &mut Vec<Vec<u64>>, program: Arc<Program>, challenge: [E; 2]) {
         let mut cs = ConstraintSystem::<E>::new(|| "mock_program");
         let mut cb = CircuitBuilder::new_with_params(&mut cs, ProgramParams {
             platform: CENO_PLATFORM,
-            program_size: MOCK_PROGRAM_SIZE,
+            program_size: std::cmp::max(program.instructions.len(), MOCK_PROGRAM_SIZE),
             ..ProgramParams::default()
         });
         let config = ProgramTableCircuit::<_>::construct_circuit(&mut cb).unwrap();
-        let fixed = ProgramTableCircuit::<E>::generate_fixed_traces(&config, cs.num_fixed, program);
+        let fixed =
+            ProgramTableCircuit::<E>::generate_fixed_traces(&config, cs.num_fixed, &program);
         for table_expr in &cs.lk_table_expressions {
             for row in fixed.iter_rows() {
                 // TODO: Find a better way to obtain the row content.
@@ -663,7 +704,7 @@ impl<'a, E: ExtensionField + Hash> MockProver<E> {
     pub fn assert_with_expected_errors(
         cb: &CircuitBuilder<E>,
         wits_in: &[ArcMultilinearExtension<'a, E>],
-        programs: &[ceno_emul::Instruction],
+        program: &[ceno_emul::Instruction],
         constraint_names: &[&str],
         challenge: Option<[E; 2]>,
         lkm: Option<LkMultiplicity>,
@@ -671,7 +712,7 @@ impl<'a, E: ExtensionField + Hash> MockProver<E> {
         let error_groups = if let Some(challenge) = challenge {
             Self::run_with_challenge(cb, wits_in, challenge, lkm)
         } else {
-            Self::run(cb, wits_in, programs, lkm)
+            Self::run(cb, wits_in, program, lkm)
         }
         .err()
         .into_iter()
@@ -691,15 +732,7 @@ Hints:
                     "
             );
 
-            for (count, error) in errors.iter().dedup_with_count() {
-                error.print(wits_in, &cb.cs.witin_namespace_map);
-                if count > 1 {
-                    println!("Error: {} duplicates hidden.", count - 1);
-                }
-            }
-            println!("Error: {} constraints not satisfied", errors.len());
-            println!("======================================================");
-            panic!("(Unexpected) Constraints not satisfied");
+            print_errors(errors, wits_in, &cb.cs.witin_namespace_map, true);
         }
         for constraint_name in constraint_names {
             // Expected errors didn't happen:
@@ -715,7 +748,7 @@ Hints:
     pub fn assert_satisfied_raw(
         cb: &CircuitBuilder<E>,
         raw_witin: RowMajorMatrix<E::BaseField>,
-        programs: &[ceno_emul::Instruction],
+        program: &[ceno_emul::Instruction],
         challenge: Option<[E; 2]>,
         lkm: Option<LkMultiplicity>,
     ) {
@@ -724,17 +757,17 @@ Hints:
             .into_iter()
             .map(|v| v.into())
             .collect_vec();
-        Self::assert_satisfied(cb, &wits_in, programs, challenge, lkm);
+        Self::assert_satisfied(cb, &wits_in, program, challenge, lkm);
     }
 
     pub fn assert_satisfied(
         cb: &CircuitBuilder<E>,
         wits_in: &[ArcMultilinearExtension<'a, E>],
-        programs: &[ceno_emul::Instruction],
+        program: &[ceno_emul::Instruction],
         challenge: Option<[E; 2]>,
         lkm: Option<LkMultiplicity>,
     ) {
-        Self::assert_with_expected_errors(cb, wits_in, programs, &[], challenge, lkm);
+        Self::assert_with_expected_errors(cb, wits_in, program, &[], challenge, lkm);
     }
 
     pub fn assert_satisfied_full(
@@ -742,7 +775,10 @@ Hints:
         mut fixed_trace: ZKVMFixedTraces<E>,
         witnesses: &ZKVMWitnesses<E>,
         pi: &PublicValues<u32>,
-    ) {
+        program: Arc<Program>,
+    ) where
+        E: LkMultiplicityKey,
+    {
         let instance = pi
             .to_vec::<E>()
             .concat()
@@ -758,13 +794,21 @@ Hints:
         let mut rng = thread_rng();
         let challenges = [0u8; 2].map(|_| E::random(&mut rng));
 
+        // Load lookup table.
+        let (lookup_table, _) = Self::load_tables_with_program(
+            &ConstraintSystem::<E>::new(|| "temp for loading table"),
+            program,
+            Some(challenges),
+        );
+
         let mut wit_mles = HashMap::new();
         let mut fixed_mles = HashMap::new();
         let mut num_instances = HashMap::new();
-        // Lookup errors
-        let mut rom_inputs =
-            HashMap::<ROMType, Vec<(Vec<E>, String, String, Vec<Expression<E>>)>>::new();
-        let mut rom_tables = HashMap::<ROMType, HashMap<E, E::BaseField>>::new();
+
+        let mut lkm_tables = LkMultiplicityRaw::<E>::default();
+        let mut lkm_opcodes = LkMultiplicityRaw::<E>::default();
+
+        // Process all circuits.
         for (circuit_name, cs) in &cs.circuit_css {
             let is_opcode = cs.lk_table_expressions.is_empty()
                 && cs.r_table_expressions.is_empty()
@@ -795,7 +839,6 @@ Hints:
                 .circuit_fixed_traces
                 .remove(circuit_name)
                 .and_then(|fixed| fixed)
-                // .expect(format!("circuit {}'s fixed traces should not be None", circuit_name).as_str())
                 .map_or(vec![], |fixed| {
                     fixed
                         .into_mles()
@@ -805,36 +848,41 @@ Hints:
                 });
             if is_opcode {
                 tracing::info!(
-                    "preprocessing opcode {} with {} entries",
+                    "mock proving opcode {} with {} entries",
                     circuit_name,
                     num_rows
                 );
-                // gather lookup inputs
-                for (expr, annotation, (rom_type, values)) in izip!(
-                    &cs.lk_expressions,
-                    &cs.lk_expressions_namespace_map,
-                    &cs.lk_expressions_items_map
-                ) {
-                    let lk_input =
-                        (wit_infer_by_expr(&fixed, &witness, &[], &pi_mles, &challenges, expr)
-                            .get_ext_field_vec())[..num_rows]
-                            .to_vec();
-                    rom_inputs.entry(*rom_type).or_default().push((
-                        lk_input,
-                        circuit_name.clone(),
-                        annotation.clone(),
-                        values.clone(),
-                    ));
+                // Assert opcode and check single opcode lk multiplicity
+                // Also combine multiplicity in lkm_opcodes
+                let lkm = witnesses.get_lk_mlt(circuit_name);
+                let errors = Self::run_with_challenge_plain(
+                    cs,
+                    &lookup_table,
+                    &witness,
+                    &[],
+                    num_rows,
+                    challenges,
+                    lkm,
+                    Some(&mut lkm_opcodes),
+                );
+                match errors {
+                    Ok(_) => {
+                        tracing::info!("mock proving successful for opcode {}", circuit_name);
+                    }
+                    Err(errors) => {
+                        tracing::error!("mock proving failed for opcode {}", circuit_name);
+                        print_errors(&errors, &witness, &cs.witin_namespace_map, true);
+                    }
                 }
             } else {
                 tracing::info!(
-                    "preprocessing table {} with {} entries",
+                    "processing table {} with {} entries",
                     circuit_name,
                     num_rows
                 );
                 // gather lookup tables
                 for (expr, (rom_type, _)) in
-                    izip!(&cs.lk_table_expressions, &cs.lk_expressions_items_map)
+                    izip!(&cs.lk_table_expressions, &cs.lk_table_expressions_items_map)
                 {
                     let lk_table = wit_infer_by_expr(
                         &fixed,
@@ -858,16 +906,12 @@ Hints:
                     .get_base_field_vec()
                     .to_vec();
 
-                    assert!(
-                        rom_tables
-                            .insert(
-                                *rom_type,
-                                izip!(lk_table, multiplicity).collect::<HashMap<_, _>>(),
-                            )
-                            .is_none(),
-                        "cannot assign to rom table {:?} twice",
-                        rom_type
-                    );
+                    for (key, multiplicity) in lk_table.iter().zip(multiplicity.iter()) {
+                        let multiplicity = multiplicity.to_canonical_u64();
+                        if multiplicity > 0 {
+                            lkm_tables.set_count(*rom_type, *key, multiplicity as usize);
+                        }
+                    }
                 }
             }
             wit_mles.insert(circuit_name.clone(), witness);
@@ -875,72 +919,18 @@ Hints:
             num_instances.insert(circuit_name.clone(), num_rows);
         }
 
-        for (rom_type, inputs) in rom_inputs {
-            let table = rom_tables.get_mut(&rom_type).unwrap();
-            for (lk_input_values, circuit_name, lk_input_annotation, input_value_exprs) in inputs {
-                // counting multiplicity in rom_input
-                let mut lk_input_values_multiplicity = HashMap::new();
-                for (row, input_value) in enumerate(&lk_input_values) {
-                    // we only keep first row to restore debug information
-                    lk_input_values_multiplicity
-                        .entry(input_value)
-                        .or_insert([0u64, row as u64])[0] += 1;
-                }
+        // Assert lkm between all tables and combined opcode circuits
+        let mut errors: Vec<MockProverError<E, E>> = vec![];
+        compare_lkm(lkm_tables, lkm_opcodes, &mut errors);
 
-                for (k, [input_multiplicity, row]) in lk_input_values_multiplicity {
-                    let table_multiplicity = if let Some(table_multiplicity) = table.get_mut(k) {
-                        if input_multiplicity <= table_multiplicity.to_canonical_u64() {
-                            *table_multiplicity -= E::BaseField::from(input_multiplicity);
-                            continue;
-                        }
-                        table_multiplicity.to_canonical_u64()
-                    } else {
-                        0
-                    };
-                    // log mismatch error
-                    let witness = wit_mles
-                        .get(&circuit_name)
-                        .map(|mles| {
-                            mles.iter()
-                                .map(|mle| E::from(mle.get_base_field_vec()[row as usize]))
-                                .collect_vec()
-                        })
-                        .unwrap();
-                    let values = input_value_exprs
-                        .iter()
-                        .map(|expr| {
-                            eval_by_expr_with_instance(
-                                &[],
-                                &witness,
-                                &[],
-                                &instance,
-                                challenges.as_slice(),
-                                expr,
-                            )
-                            .as_bases()[0]
-                        })
-                        .collect_vec();
-                    tracing::error!(
-                        "{}: value {:x?} mismatch lk_multiplicity: real {:x} > remaining {:x} in {:?} table",
-                        lk_input_annotation,
-                        values,
-                        input_multiplicity,
-                        table_multiplicity,
-                        rom_type,
-                    );
-                }
-            }
-            // each table entry's multiplicity should equal to 0
-            for (k, multiplicity) in table {
-                if !multiplicity.is_zero_vartime() {
-                    tracing::error!(
-                        "table {:?}: {:x?} multiplicity = {:x}",
-                        rom_type,
-                        k,
-                        multiplicity.to_canonical_u64()
-                    );
-                }
-            }
+        if errors.is_empty() {
+            tracing::info!("mock proving successful for combined lkm");
+        } else {
+            tracing::error!(
+                "mock proving failed for combined lkm - {} errors",
+                errors.len()
+            );
+            print_errors(&errors, &[], &[], true);
         }
 
         // find out r != w errors
@@ -1205,6 +1195,84 @@ Hints:
     }
 }
 
+fn compare_lkm<E, K>(
+    lkm_a: LkMultiplicityRaw<K>,
+    lkm_b: LkMultiplicityRaw<K>,
+    errors: &mut Vec<MockProverError<E, K>>,
+) where
+    E: ExtensionField,
+    K: LkMultiplicityKey,
+{
+    let lkm_a = lkm_a.into_finalize_result();
+    let lkm_b = lkm_b.into_finalize_result();
+
+    // Compare each LK Multiplicity.
+    for (rom_type, a_map, b_map) in izip!(ROMType::iter(), &lkm_a, &lkm_b) {
+        if *a_map != *b_map {
+            let a_keys: HashSet<_> = a_map.keys().collect();
+            let b_keys: HashSet<_> = b_map.keys().collect();
+
+            // Lookup missing in lkm_a.
+            b_keys.difference(&a_keys).for_each(|k| {
+                let b_count = b_map.get(k).unwrap();
+                if *b_count != 0 {
+                    errors.push(MockProverError::LkMultiplicityError {
+                        rom_type,
+                        key: **k,
+                        count: *b_count as isize,
+                    })
+                }
+            });
+
+            // Lookup missing in lkm_b.
+            a_keys.difference(&b_keys).for_each(|k| {
+                let a_count = a_map.get(k).unwrap();
+                if *a_count != 0 {
+                    errors.push(MockProverError::LkMultiplicityError {
+                        rom_type,
+                        key: **k,
+                        count: -(*a_count as isize),
+                    })
+                }
+            });
+
+            // Count of specific lookup differ lkm_b and lkm_a.
+            a_keys.intersection(&b_keys).for_each(|k| {
+                let a_count = a_map.get(k).unwrap();
+                let b_count = b_map.get(k).unwrap();
+
+                if a_count != b_count {
+                    errors.push(MockProverError::LkMultiplicityError {
+                        rom_type,
+                        key: **k,
+                        count: (*b_count as isize) - (*a_count as isize),
+                    })
+                }
+            });
+        }
+    }
+}
+
+fn print_errors<E: ExtensionField, K: LkMultiplicityKey>(
+    errors: &[MockProverError<E, K>],
+    wits_in: &[ArcMultilinearExtension<E>],
+    wits_in_name: &[String],
+    panic_on_error: bool,
+) {
+    println!("======================================================");
+    for (count, error) in errors.iter().dedup_with_count() {
+        error.print(wits_in, wits_in_name);
+        if count > 1 {
+            println!("Error: {} duplicates hidden.", count - 1);
+        }
+    }
+    println!("Error: {} constraints not satisfied", errors.len());
+    println!("======================================================");
+    if panic_on_error {
+        panic!("(Unexpected) Constraints not satisfied");
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -1328,6 +1396,7 @@ mod tests {
         assert!(result.is_err(), "Expected error");
         let err = result.unwrap_err();
         assert_eq!(err, vec![MockProverError::LookupError {
+            rom_type: ROMType::U5,
             expression: Expression::Sum(
                 Box::new(Expression::ScaledSum(
                     Box::new(Expression::WitIn(0)),

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -841,7 +841,7 @@ Hints:
                 });
             if is_opcode {
                 tracing::info!(
-                    "mock proving opcode {} with {} entries",
+                    "Mock proving opcode {} with {} entries",
                     circuit_name,
                     num_rows
                 );
@@ -861,17 +861,15 @@ Hints:
                     Some(&mut lkm_opcodes),
                 );
                 match errors {
-                    Ok(_) => {
-                        tracing::info!("mock proving successful for opcode {}", circuit_name);
-                    }
+                    Ok(_) => {}
                     Err(errors) => {
-                        tracing::error!("mock proving failed for opcode {}", circuit_name);
+                        tracing::error!("Mock proving failed for opcode {}", circuit_name);
                         print_errors(&errors, &witness, &cs.witin_namespace_map, true);
                     }
                 }
             } else {
                 tracing::info!(
-                    "processing table {} with {} entries",
+                    "Mock proving table {} with {} entries",
                     circuit_name,
                     num_rows
                 );
@@ -919,12 +917,9 @@ Hints:
         compare_lkm(lkm_tables, lkm_opcodes, &mut errors);
 
         if errors.is_empty() {
-            tracing::info!("mock proving successful for combined lkm");
+            tracing::info!("Mock proving successful for tables");
         } else {
-            tracing::error!(
-                "mock proving failed for combined lkm - {} errors",
-                errors.len()
-            );
+            tracing::error!("Mock proving failed for tables - {} errors", errors.len());
             print_errors(&errors, &[], &[], true);
         }
 

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -882,7 +882,7 @@ Hints:
                 );
                 // gather lookup tables
                 for (expr, (rom_type, _)) in
-                    izip!(&cs.lk_table_expressions, &cs.lk_table_expressions_items_map)
+                    izip!(&cs.lk_table_expressions, &cs.lk_expressions_items_map)
                 {
                     let lk_table = wit_infer_by_expr(
                         &fixed,

--- a/ceno_zkvm/src/scheme/tests.rs
+++ b/ceno_zkvm/src/scheme/tests.rs
@@ -280,7 +280,7 @@ fn test_single_add_instance_e2e() {
     zkvm_witness
         .assign_opcode_circuit::<HaltInstruction<E>>(&zkvm_cs, &halt_config, halt_records)
         .unwrap();
-    zkvm_witness.finalize_lk_multiplicities();
+    zkvm_witness.finalize_lk_multiplicities(false);
     zkvm_witness
         .assign_table_circuit::<U16TableCircuit<E>>(&zkvm_cs, &u16_range_config, &())
         .unwrap();

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -281,14 +281,14 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
     }
 
     // merge the multiplicities in each opcode circuit into one
-    pub fn finalize_lk_multiplicities(&mut self) {
+    pub fn finalize_lk_multiplicities(&mut self, is_keep_raw_lk_mlts: bool) {
         assert!(self.combined_lk_mlt.is_none());
         assert!(!self.lk_mlts.is_empty());
 
         let mut combined_lk_mlt = vec![];
         let keys = self.lk_mlts.keys().cloned().collect_vec();
         for name in keys {
-            let lk_mlt = if std::env::var("MOCK_PROVING").is_ok() {
+            let lk_mlt = if is_keep_raw_lk_mlts {
                 // mock prover needs the lk_mlt for processing, so we do not remove it
                 self.lk_mlts
                     .get(&name)

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -254,8 +254,8 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
         self.witnesses_tables.get(name).cloned()
     }
 
-    pub fn get_lk_mlt(&self, name: &String) -> Option<LkMultiplicity> {
-        self.lk_mlts.get(name).map(|lkm| lkm.deep_clone())
+    pub fn get_lk_mlt(&self, name: &String) -> Option<&LkMultiplicity> {
+        self.lk_mlts.get(name)
     }
 
     pub fn assign_opcode_circuit<OC: Instruction<E>>(

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -254,6 +254,10 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
         self.witnesses_tables.get(name).cloned()
     }
 
+    pub fn get_lk_mlt(&self, name: &String) -> Option<LkMultiplicity> {
+        self.lk_mlts.get(name).map(|lkm| lkm.deep_clone())
+    }
+
     pub fn assign_opcode_circuit<OC: Instruction<E>>(
         &mut self,
         cs: &ZKVMConstraintSystem<E>,
@@ -284,7 +288,17 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
         let mut combined_lk_mlt = vec![];
         let keys = self.lk_mlts.keys().cloned().collect_vec();
         for name in keys {
-            let lk_mlt = self.lk_mlts.remove(&name).unwrap().into_finalize_result();
+            let lk_mlt = if std::env::var("MOCK_PROVING").is_ok() {
+                // mock prover needs the lk_mlt for processing, so we do not remove it
+                self.lk_mlts
+                    .get(&name)
+                    .unwrap()
+                    .deep_clone()
+                    .into_finalize_result()
+            } else {
+                self.lk_mlts.remove(&name).unwrap().into_finalize_result()
+            };
+
             if combined_lk_mlt.is_empty() {
                 combined_lk_mlt = lk_mlt.to_vec();
             } else {

--- a/ceno_zkvm/src/witness.rs
+++ b/ceno_zkvm/src/witness.rs
@@ -6,13 +6,12 @@ use rayon::{
     slice::ParallelSliceMut,
 };
 use std::{
-    array,
     cell::RefCell,
     collections::HashMap,
     fmt::Debug,
     hash::Hash,
     mem::{self},
-    ops::Index,
+    ops::{AddAssign, Index},
     slice::{Chunks, ChunksMut},
     sync::Arc,
 };
@@ -127,50 +126,110 @@ impl<F: Sync + Send + Copy> Index<usize> for RowMajorMatrix<F> {
     }
 }
 
+pub type MultiplicityRaw<K> = [HashMap<K, usize>; mem::variant_count::<ROMType>()];
+
+#[derive(Clone, Default, Debug)]
+pub struct Multiplicity<K>(pub MultiplicityRaw<K>);
+
 /// A lock-free thread safe struct to count logup multiplicity for each ROM type
 /// Lock-free by thread-local such that each thread will only have its local copy
 /// struct is cloneable, for internallly it use Arc so the clone will be low cost
 #[derive(Clone, Default, Debug)]
 #[allow(clippy::type_complexity)]
 pub struct LkMultiplicityRaw<K: Copy + Clone + Debug + Eq + Hash + Send> {
-    multiplicity: Arc<ThreadLocal<RefCell<[HashMap<K, usize>; mem::variant_count::<ROMType>()]>>>,
+    multiplicity: Arc<ThreadLocal<RefCell<Multiplicity<K>>>>,
 }
 
-impl<K: Copy + Clone + Debug + Eq + Hash + Send> LkMultiplicityRaw<K> {
-    /// Merge result from multiple thread local to single result.
-    pub fn into_finalize_result(self) -> [HashMap<K, usize>; mem::variant_count::<ROMType>()] {
-        let mut results = array::from_fn(|_| HashMap::new());
-        for y in Arc::try_unwrap(self.multiplicity).unwrap() {
-            for (result, addition) in izip!(&mut results, y.into_inner()) {
-                for (key, value) in addition {
-                    *result.entry(key).or_insert(0) += value;
-                }
+impl<K> AddAssign<Self> for LkMultiplicityRaw<K>
+where
+    K: Copy + Clone + Debug + Default + Eq + Hash + Send,
+{
+    fn add_assign(&mut self, rhs: Self) {
+        *self += Multiplicity(rhs.into_finalize_result());
+    }
+}
+
+impl<K> AddAssign<Self> for Multiplicity<K>
+where
+    K: Eq + Hash,
+{
+    fn add_assign(&mut self, rhs: Self) {
+        for (lhs, rhs) in izip!(&mut self.0, rhs.0) {
+            for (key, value) in rhs {
+                *lhs.entry(key).or_default() += value;
             }
         }
-        results
     }
+}
 
-    pub fn increment(&mut self, rom_type: ROMType, key: K) {
-        let multiplicity = self
-            .multiplicity
-            .get_or(|| RefCell::new(array::from_fn(|_| HashMap::new())));
-        (*multiplicity.borrow_mut()[rom_type as usize]
+impl<K> AddAssign<Multiplicity<K>> for LkMultiplicityRaw<K>
+where
+    K: Copy + Clone + Debug + Default + Eq + Hash + Send,
+{
+    fn add_assign(&mut self, rhs: Multiplicity<K>) {
+        let multiplicity = self.multiplicity.get_or_default();
+        for (lhs, rhs) in izip!(&mut multiplicity.borrow_mut().0, rhs.0) {
+            for (key, value) in rhs {
+                *lhs.entry(key).or_default() += value;
+            }
+        }
+    }
+}
+
+impl<K> AddAssign<((ROMType, K), usize)> for LkMultiplicityRaw<K>
+where
+    K: Copy + Clone + Debug + Default + Eq + Hash + Send,
+{
+    fn add_assign(&mut self, ((rom_type, key), value): ((ROMType, K), usize)) {
+        let multiplicity = self.multiplicity.get_or_default();
+        (*multiplicity.borrow_mut().0[rom_type as usize]
+            .entry(key)
+            .or_default()) += value;
+    }
+}
+
+impl<K> AddAssign<(ROMType, K)> for LkMultiplicityRaw<K>
+where
+    K: Copy + Clone + Debug + Default + Eq + Hash + Send,
+{
+    fn add_assign(&mut self, (rom_type, key): (ROMType, K)) {
+        let multiplicity = self.multiplicity.get_or_default();
+        (*multiplicity.borrow_mut().0[rom_type as usize]
             .entry(key)
             .or_default()) += 1;
     }
+}
+
+impl<K: Copy + Clone + Debug + Default + Eq + Hash + Send> LkMultiplicityRaw<K> {
+    /// Merge result from multiple thread local to single result.
+    pub fn into_finalize_result(self) -> MultiplicityRaw<K> {
+        let mut results = Multiplicity::default();
+        for y in Arc::try_unwrap(self.multiplicity).unwrap() {
+            results += y.into_inner();
+        }
+        results.0
+    }
+
+    pub fn increment(&mut self, rom_type: ROMType, key: K) {
+        *self += (rom_type, key);
+    }
 
     pub fn set_count(&mut self, rom_type: ROMType, key: K, count: usize) {
-        let multiplicity = self
-            .multiplicity
-            .get_or(|| RefCell::new(array::from_fn(|_| HashMap::new())));
-        multiplicity.borrow_mut()[rom_type as usize].insert(key, count);
+        if count == 0 {
+            return;
+        }
+        let multiplicity = self.multiplicity.get_or_default();
+        let table = &mut multiplicity.borrow_mut().0[rom_type as usize];
+        if count == 0 {
+            table.remove(&key);
+        } else {
+            table.insert(key, count);
+        }
     }
 
     /// Clone inner, expensive operation.
     pub fn deep_clone(&self) -> Self {
-        let multiplicity = self
-            .multiplicity
-            .get_or(|| RefCell::new(array::from_fn(|_| HashMap::new())));
+        let multiplicity = self.multiplicity.get_or_default();
         let deep_cloned = multiplicity.borrow().clone();
         let thread_local = ThreadLocal::new();
         thread_local.get_or(|| RefCell::new(deep_cloned));
@@ -187,13 +246,17 @@ impl LkMultiplicity {
     /// assert within range
     #[inline(always)]
     pub fn assert_ux<const C: usize>(&mut self, v: u64) {
-        match C {
-            16 => self.increment(ROMType::U16, v),
-            14 => self.increment(ROMType::U14, v),
-            8 => self.increment(ROMType::U8, v),
-            5 => self.increment(ROMType::U5, v),
-            _ => panic!("Unsupported bit range"),
-        }
+        use ROMType::*;
+        self.increment(
+            match C {
+                16 => U16,
+                14 => U14,
+                8 => U8,
+                5 => U5,
+                _ => panic!("Unsupported bit range"),
+            },
+            v,
+        );
     }
 
     /// Track a lookup into a logic table (AndTable, etc).


### PR DESCRIPTION
- uses MockProver utils inside `assert_satisfied_full` which enables additional missing checks for things like assert zero expressions.
- removes duplicate code to check of multiplicity
- enables MockProver to check for multiplicity of all instances (previously only instance 0 was considered)