### PR TITLE
Add timing tree 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-flame",
+ "tracing-forest",
  "tracing-subscriber",
  "transcript",
 ]
@@ -1952,6 +1953,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
 dependencies = [
  "lazy_static",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-forest"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee40835db14ddd1e3ba414292272eddde9dad04d3d4b65509656414d1c42592f"
+dependencies = [
+ "smallvec",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ tracing = { version = "0.1", features = [
   "attributes",
 ] }
 tracing-flame = "0.2"
-tracing-forest = {version = "0.1.6"}
+tracing-forest = { version = "0.1.6" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ tracing = { version = "0.1", features = [
   "attributes",
 ] }
 tracing-flame = "0.2"
+tracing-forest = {version = "0.1.6"}
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [profile.release]

--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -35,6 +35,7 @@ strum_macros.workspace = true
 tracing.workspace = true
 tracing-flame.workspace = true
 tracing-subscriber.workspace = true
+tracing-forest.workspace = true
 
 
 clap = { version = "4.5", features = ["derive"] }

--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -34,8 +34,8 @@ strum.workspace = true
 strum_macros.workspace = true
 tracing.workspace = true
 tracing-flame.workspace = true
-tracing-subscriber.workspace = true
 tracing-forest.workspace = true
+tracing-subscriber.workspace = true
 
 
 clap = { version = "4.5", features = ["derive"] }

--- a/ceno_zkvm/src/bin/e2e.rs
+++ b/ceno_zkvm/src/bin/e2e.rs
@@ -59,10 +59,6 @@ fn main() {
         args
     };
 
-    type E = GoldilocksExt2;
-    type Pcs = Basefold<GoldilocksExt2, BasefoldRSParams>;
-    type ExampleProgramTableCircuit<E> = ProgramTableCircuit<E>;
-
     // default filter
     let default_filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::DEBUG.into())

--- a/ceno_zkvm/src/bin/e2e.rs
+++ b/ceno_zkvm/src/bin/e2e.rs
@@ -111,8 +111,8 @@ fn main() {
         .with(fmt_layer)
         // if some profiling granularity is specified, use the profiling filter,
         // otherwise use the default
-        .with((args.profiling.is_some()).then(|| filter_by_profiling_level))
-        .with((args.profiling.is_none()).then(|| default_filter))
+        .with((args.profiling.is_some()).then_some(filter_by_profiling_level))
+        .with((args.profiling.is_none()).then_some(default_filter))
         .init();
 
     let elf_bytes = fs::read(&args.elf).expect("read elf file");

--- a/ceno_zkvm/src/bin/e2e.rs
+++ b/ceno_zkvm/src/bin/e2e.rs
@@ -25,14 +25,9 @@ use std::{
     time::Instant,
 };
 use tracing::level_filters::LevelFilter;
-use tracing_flame::FlameLayer;
 use tracing_forest::ForestLayer;
 use tracing_subscriber::{
-    EnvFilter, Layer, Registry,
-    filter::{self, filter_fn},
-    fmt,
-    layer::SubscriberExt,
-    util::SubscriberInitExt,
+    EnvFilter, Registry, filter::filter_fn, fmt, layer::SubscriberExt, util::SubscriberInitExt,
 };
 use transcript::Transcript;
 

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -653,7 +653,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
     /// support batch prove for logup + product arguments each with different num_vars()
     /// side effect: concurrency will be determine based on min(thread, num_vars()),
     /// so suggest dont batch too small table (size < threads) with large table together
-    #[tracing::instrument(skip_all, name = "create_table_proof", fields(table_name=name))]
+    #[tracing::instrument(skip_all, name = "create_table_proof", fields(table_name=name, profiling_2))]
     pub fn create_table_proof(
         &self,
         name: &str,

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -52,7 +52,12 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
     }
 
     /// create proof for zkvm execution
-    #[tracing::instrument(skip_all, name = "ZKVM_create_proof", fields(profiling_1))]
+    #[tracing::instrument(
+        skip_all,
+        name = "ZKVM_create_proof",
+        fields(profiling_1),
+        level = "trace"
+    )]
     pub fn create_proof(
         &self,
         witnesses: ZKVMWitnesses<E>,
@@ -207,7 +212,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
     /// 1: witness layer inferring from input -> output
     /// 2: proof (sumcheck reduce) from output to input
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip_all, name = "create_opcode_proof", fields(circuit_name=name,profiling_2))]
+    #[tracing::instrument(skip_all, name = "create_opcode_proof", fields(circuit_name=name,profiling_2), level="trace")]
     pub fn create_opcode_proof(
         &self,
         name: &str,
@@ -653,7 +658,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
     /// support batch prove for logup + product arguments each with different num_vars()
     /// side effect: concurrency will be determine based on min(thread, num_vars()),
     /// so suggest dont batch too small table (size < threads) with large table together
-    #[tracing::instrument(skip_all, name = "create_table_proof", fields(table_name=name, profiling_2))]
+    #[tracing::instrument(skip_all, name = "create_table_proof", fields(table_name=name, profiling_2), level="trace")]
     pub fn create_table_proof(
         &self,
         name: &str,
@@ -1152,7 +1157,7 @@ impl<E: ExtensionField> TowerProofs<E> {
 
 /// Tower Prover
 impl TowerProver {
-    #[tracing::instrument(skip_all, name = "tower_prover_create_proof")]
+    #[tracing::instrument(skip_all, name = "tower_prover_create_proof", level = "trace")]
     pub fn create_proof<'a, E: ExtensionField>(
         prod_specs: Vec<TowerProverSpec<'a, E>>,
         logup_specs: Vec<TowerProverSpec<'a, E>>,

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -52,13 +52,14 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
     }
 
     /// create proof for zkvm execution
-    #[tracing::instrument(skip_all, name = "ZKVM_create_proof")]
+    #[tracing::instrument(skip_all, name = "ZKVM_create_proof", fields(profiling_1))]
     pub fn create_proof(
         &self,
         witnesses: ZKVMWitnesses<E>,
         pi: PublicValues<u32>,
         mut transcript: Transcript<E>,
     ) -> Result<ZKVMProof<E, PCS>, ZKVMError> {
+        let span = entered_span!("commit_to_fixed_commit", profiling_1 = true);
         let mut vm_proof = ZKVMProof::empty(pi);
 
         // including raw public input to transcript
@@ -82,16 +83,21 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
                     .map_err(ZKVMError::PCSError)?;
             }
         }
+        exit_span!(span);
 
         // commit to main traces
         let mut commitments = BTreeMap::new();
         let mut wits = BTreeMap::new();
 
-        let commit_to_traces_span = entered_span!("commit_to_traces");
+        let commit_to_traces_span = entered_span!("commit_to_traces", profiling_1 = true);
         // commit to opcode circuits first and then commit to table circuits, sorted by name
         for (circuit_name, witness) in witnesses.into_iter_sorted() {
             let num_instances = witness.num_instances();
-            let span = entered_span!("commit to iteration", circuit_name = circuit_name);
+            let span = entered_span!(
+                "commit to iteration",
+                circuit_name = circuit_name,
+                profiling_2 = true
+            );
             let witness = match num_instances {
                 0 => vec![],
                 _ => {
@@ -116,7 +122,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
         ];
         tracing::debug!("challenges in prover: {:?}", challenges);
 
-        let main_proofs_span = entered_span!("main_proofs");
+        let main_proofs_span = entered_span!("main_proofs", profiling_1 = true);
         let mut transcripts = transcript.fork(self.pk.circuit_pks.len());
         for ((circuit_name, pk), (i, transcript)) in self
             .pk
@@ -201,7 +207,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
     /// 1: witness layer inferring from input -> output
     /// 2: proof (sumcheck reduce) from output to input
     #[allow(clippy::too_many_arguments)]
-    #[tracing::instrument(skip_all, name = "create_opcode_proof", fields(circuit_name=name))]
+    #[tracing::instrument(skip_all, name = "create_opcode_proof", fields(circuit_name=name,profiling_2))]
     pub fn create_opcode_proof(
         &self,
         name: &str,
@@ -227,7 +233,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
                 .all(|v| { v.evaluations().len() == next_pow2_instances })
         );
 
-        let wit_inference_span = entered_span!("wit_inference");
+        let wit_inference_span = entered_span!("wit_inference", profiling_3 = true);
         // main constraint: read/write record witness inference
         let record_span = entered_span!("record");
         let records_wit: Vec<ArcMultilinearExtension<'_, E>> = cs
@@ -329,7 +335,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
             }));
         }
 
-        let sumcheck_span = entered_span!("SUMCHECK");
+        let sumcheck_span = entered_span!("SUMCHECK", profiling_3 = true);
         // product constraint tower sumcheck
         let tower_span = entered_span!("tower");
         // final evals for verifier
@@ -592,14 +598,14 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
         exit_span!(main_sel_span);
         exit_span!(sumcheck_span);
 
-        let span = entered_span!("witin::evals");
+        let span = entered_span!("witin::evals", profiling_3 = true);
         let wits_in_evals: Vec<E> = witnesses
             .par_iter()
             .map(|poly| poly.evaluate(&input_open_point))
             .collect();
         exit_span!(span);
 
-        let pcs_open_span = entered_span!("pcs_open");
+        let pcs_open_span = entered_span!("pcs_open", profiling_3 = true);
         let opening_dur = std::time::Instant::now();
         tracing::debug!(
             "[opcode {}]: build opening proof for {} polys at {:?}",

--- a/sumcheck/src/macros.rs
+++ b/sumcheck/src/macros.rs
@@ -10,10 +10,10 @@ macro_rules! entered_span {
 #[macro_export]
 macro_rules! tracing_span {
     ($first:expr, $($fields:tt)*) => {
-        tracing::span!(tracing::Level::INFO, $first, $($fields)*)
+        tracing::span!(tracing::Level::TRACE, $first, $($fields)*)
     };
     ($first:expr $(,)*) => {
-        tracing::span!(tracing::Level::INFO, $first)
+        tracing::span!(tracing::Level::TRACE, $first)
     };
 }
 #[macro_export]


### PR DESCRIPTION
Fixes #655.

Integrates `tracing-forest` for its nice timing-tree summary.
In addition, I added a trick to control "granularity": spans have a `profiling_{LEVEL}` field which one can prune from the command line. For example, compare:

```
cargo run --release --package ceno_zkvm --bin e2e -- --profiling=1 --max-steps=10000 --platform=sp1 ceno_zkvm/examples/fibonacci.elf 

INFO     ZKVM_create_proof [ 790ms | 0.00% / 100.00% ]
INFO     ┝━ commit_to_fixed_commit [ 129µs | 0.02% ] profiling_1: true
INFO     ┝━ commit_to_traces [ 147ms | 18.62% ] profiling_1: true
INFO     ┕━ main_proofs [ 643ms | 81.36% ] profiling_1: true
```
to
```
cargo run --release --package ceno_zkvm --bin e2e -- --profiling=2 --max-steps=10000 --platform=sp1 ceno_zkvm/examples/fibonacci.elf 

INFO     ZKVM_create_proof [ 1.10s | 0.00% / 100.00% ]
INFO     ┝━ commit_to_fixed_commit [ 162µs | 0.01% ] profiling_1: true
INFO     ┝━ commit_to_traces [ 151ms | 0.02% / 13.78% ] profiling_1: true
INFO     │  ┝━ commit to iteration [ 7.66ms | 0.70% ] circuit_name: "ADD" | profiling_2: true
INFO     │  ┝━ commit to iteration [ 4.17ms | 0.38% ] circuit_name: "ADDI" | profiling_2: true
INFO     │  ┝━ commit to iteration [ 163ns | 0.00% ] circuit_name: "AND" | profiling_2: true
INFO     │  ┝━ commit to iteration [ 297µs | 0.03% ] circuit_name: "ANDI" | profiling_2: true
INFO     │  ┝━ commit to iteration [ 201µs | 0.02% ] circuit_name: "AUIPC" | profiling_2: true
[... more lines follow]
```

I haven't gone too far in assigning adequate levels to spans, I'm not sure what's relevant.

LE: I also set the `entered_span!` log level to TRACE to keep them silent outside the profiling option.