### PR TITLE
cleanup verbose log

### DIFF
--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -157,9 +157,6 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
                     cs.w_expressions.len(),
                     cs.lk_expressions.len(),
                 );
-                for lk_s in &cs.lk_expressions_namespace_map {
-                    tracing::debug!("opcode circuit {}: {}", circuit_name, lk_s);
-                }
                 let opcode_proof = self.create_opcode_proof(
                     circuit_name,
                     &self.pk.pp,
@@ -613,10 +610,9 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
         let pcs_open_span = entered_span!("pcs_open", profiling_3 = true);
         let opening_dur = std::time::Instant::now();
         tracing::debug!(
-            "[opcode {}]: build opening proof for {} polys at {:?}",
+            "[opcode {}]: build opening proof for {} polys",
             name,
-            witnesses.len(),
-            input_open_point
+            witnesses.len()
         );
         let wits_opening_proof = PCS::simple_batch_open(
             pp,
@@ -1051,7 +1047,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
         // TODO implement mechanism to skip commitment
 
         let pcs_opening = entered_span!("pcs_opening");
-        let (fixed_opening_proof, fixed_commit) = if !fixed.is_empty() {
+        let (fixed_opening_proof, _fixed_commit) = if !fixed.is_empty() {
             (
                 Some(
                     PCS::simple_batch_open(
@@ -1073,12 +1069,9 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
         };
 
         tracing::debug!(
-            "[table {}] build opening proof for {} fixed polys at {:?}: values = {:?}, commit = {:?}",
+            "[table {}] build opening proof for {} fixed polys",
             name,
-            fixed.len(),
-            input_open_point,
-            fixed_in_evals,
-            fixed_commit,
+            fixed.len()
         );
         let wits_opening_proof = PCS::simple_batch_open(
             pp,
@@ -1092,12 +1085,9 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
         exit_span!(pcs_opening);
         let wits_commit = PCS::get_pure_commitment(&wits_commit);
         tracing::debug!(
-            "[table {}] build opening proof for {} polys at {:?}: values = {:?}, commit = {:?}",
+            "[table {}] build opening proof for {} polys",
             name,
             witnesses.len(),
-            input_open_point,
-            wits_in_evals,
-            wits_commit,
         );
 
         Ok((
@@ -1249,7 +1239,6 @@ impl TowerProver {
                         virtual_polys.add_mle_list(vec![&eq, &q1, &q2], *alpha_denominator);
                     }
                 }
-                tracing::debug!("generated tower proof at round {}/{}", round, max_round_index);
 
                 let wrap_batch_span = entered_span!("wrap_batch");
                 // NOTE: at the time of adding this span, visualizing it with the flamegraph layer

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -478,10 +478,9 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         }
 
         tracing::debug!(
-            "[opcode {}] verify opening proof for {} polys at {:?}",
+            "[opcode {}] verify opening proof for {} polys",
             name,
             proof.wits_in_evals.len(),
-            input_opening_point
         );
         PCS::simple_batch_verify(
             vp,
@@ -770,12 +769,9 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         }
 
         tracing::debug!(
-            "[table {}] verified opening proof for {} fixed polys at {:?}: values = {:?}, commit = {:?}",
+            "[table {}] verified opening proof for {} fixed polys",
             name,
             proof.fixed_in_evals.len(),
-            input_opening_point,
-            proof.fixed_in_evals,
-            circuit_vk.fixed_commit,
         );
 
         PCS::simple_batch_verify(
@@ -788,12 +784,9 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         )
         .map_err(ZKVMError::PCSError)?;
         tracing::debug!(
-            "[table {}] verified opening proof for {} polys at {:?}: values = {:?}, commit = {:?}",
+            "[table {}] verified opening proof for {} polys",
             name,
             proof.wits_in_evals.len(),
-            input_opening_point,
-            proof.wits_in_evals,
-            proof.wits_commit
         );
 
         Ok(input_opening_point)
@@ -909,7 +902,6 @@ impl TowerVerify {
                     },
                     transcript,
                 );
-                tracing::debug!("verified tower proof at layer {}/{}", round + 1, max_num_variables-1);
 
                 // check expected_evaluation
                 let rt: Point<E> = sumcheck_claim.point.iter().map(|c| c.elements).collect();

--- a/sumcheck/src/prover_v2.rs
+++ b/sumcheck/src/prover_v2.rs
@@ -99,19 +99,11 @@ impl<'a, E: ExtensionField> IOPProverStateV2<'a, E> {
                     // Nesting is possible, but then `tracing-forest` does the wrong thing when measuring duration.
                     // TODO: investigate possibility of nesting with correct duration of parent span
                     let span = entered_span!("prove_rounds", profiling_5 = true);
-                    for i in 0..num_variables {
+                    for _ in 0..num_variables {
                         let prover_msg = IOPProverStateV2::prove_round_and_update_state(
                             &mut prover_state,
                             &challenge,
                         );
-                        if thread_id < 2 {
-                            tracing::debug!(
-                                "thread {}: sumcheck round {}/{}",
-                                thread_id,
-                                i + 1,
-                                num_variables
-                            );
-                        }
                         thread_based_transcript.append_field_element_exts(&prover_msg.evaluations);
 
                         challenge = Some(


### PR DESCRIPTION
With RUST_LOG="debug" by default there will log many verbose message which make result unreadable.
Most of debug log are left over to debug in https://github.com/scroll-tech/ceno/pull/368

As PR 368 already done, this PR is aim for debug log cleanup