### PR TITLE
Simplify tracing-span macros

### DIFF
--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -24,7 +24,7 @@ use ff_ext::ff::Field;
 use goldilocks::GoldilocksExt2;
 use itertools::Itertools;
 use mpcs::{Basefold, BasefoldRSParams, PolynomialCommitmentScheme};
-use sumcheck::{entered_span, exit_span};
+use sumcheck::macros::{entered_span, exit_span};
 use tracing_flame::FlameLayer;
 use tracing_subscriber::{EnvFilter, Registry, fmt, fmt::format::FmtSpan, layer::SubscriberExt};
 use transcript::Transcript;

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -15,7 +15,7 @@ use multilinear_extensions::{
 };
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use sumcheck::{
-    entered_span, exit_span,
+    macros::{entered_span, exit_span},
     structs::{IOPProverMessage, IOPProverStateV2},
 };
 use transcript::Transcript;

--- a/sumcheck/src/lib.rs
+++ b/sumcheck/src/lib.rs
@@ -1,7 +1,8 @@
 #![deny(clippy::cargo)]
+#![feature(decl_macro)]
 #[cfg(feature = "non_pow2_rayon_thread")]
 pub mod local_thread_pool;
-mod macros;
+pub mod macros;
 mod prover;
 mod prover_v2;
 pub mod structs;

--- a/sumcheck/src/macros.rs
+++ b/sumcheck/src/macros.rs
@@ -1,20 +1,14 @@
 use tracing::span;
 
 pub macro entered_span {
-    ($first:expr, $($fields:tt)*) => {
-        tracing_span!($first, $($fields)*).entered()
-    },
-    ($first:expr $(,)*) => {
-        tracing_span!($first).entered()
-    },
+    ($first:expr $(, $($fields:tt)*)?) => {
+        tracing_span!($first, $($($fields)*)?).entered()
+    }
 }
 
 pub macro tracing_span {
-    ($first:expr, $($fields:tt)*) => {
-        span!(tracing::Level::INFO, $first, $($fields)*)
-    },
-    ($first:expr $(,)*) => {
-        span!(tracing::Level::INFO, $first)
+    ($first:expr $(, $($fields:tt)*)?) => {
+        span!(tracing::Level::INFO, $first, $($($fields)*)?)
     },
 }
 

--- a/sumcheck/src/macros.rs
+++ b/sumcheck/src/macros.rs
@@ -1,24 +1,21 @@
-#[macro_export]
-macro_rules! entered_span {
+pub macro entered_span {
     ($first:expr, $($fields:tt)*) => {
-        $crate::tracing_span!($first, $($fields)*).entered()
-    };
+        tracing_span!($first, $($fields)*).entered()
+    },
     ($first:expr $(,)*) => {
-        $crate::tracing_span!($first).entered()
-    };
+        tracing_span!($first).entered()
+    },
 }
-#[macro_export]
-macro_rules! tracing_span {
+
+pub macro tracing_span {
     ($first:expr, $($fields:tt)*) => {
         tracing::span!(tracing::Level::INFO, $first, $($fields)*)
-    };
+    },
     ($first:expr $(,)*) => {
         tracing::span!(tracing::Level::INFO, $first)
-    };
+    },
 }
-#[macro_export]
-macro_rules! exit_span {
-    ($first:expr $(,)*) => {
-        $first.exit();
-    };
+
+pub macro exit_span($first:expr $(,)*) {
+    $first.exit();
 }

--- a/sumcheck/src/macros.rs
+++ b/sumcheck/src/macros.rs
@@ -9,7 +9,7 @@ pub macro entered_span {
     },
 }
 
-macro tracing_span {
+pub macro tracing_span {
     ($first:expr, $($fields:tt)*) => {
         span!(tracing::Level::INFO, $first, $($fields)*)
     },

--- a/sumcheck/src/macros.rs
+++ b/sumcheck/src/macros.rs
@@ -1,3 +1,5 @@
+use tracing::span;
+
 pub macro entered_span {
     ($first:expr, $($fields:tt)*) => {
         tracing_span!($first, $($fields)*).entered()
@@ -7,12 +9,12 @@ pub macro entered_span {
     },
 }
 
-pub macro tracing_span {
+macro tracing_span {
     ($first:expr, $($fields:tt)*) => {
-        tracing::span!(tracing::Level::INFO, $first, $($fields)*)
+        span!(tracing::Level::INFO, $first, $($fields)*)
     },
     ($first:expr $(,)*) => {
-        tracing::span!(tracing::Level::INFO, $first)
+        span!(tracing::Level::INFO, $first)
     },
 }
 

--- a/sumcheck/src/prover.rs
+++ b/sumcheck/src/prover.rs
@@ -16,7 +16,7 @@ use transcript::{Challenge, Transcript, TranscriptSyncronized};
 use crate::local_thread_pool::{LOCAL_THREAD_POOL, create_local_pool_once};
 
 use crate::{
-    entered_span, exit_span,
+    macros::{entered_span, exit_span},
     structs::{IOPProof, IOPProverMessage, IOPProverState},
     util::{
         AdditiveArray, AdditiveVec, barycentric_weights, ceil_log2, extrapolate,

--- a/sumcheck/src/prover_v2.rs
+++ b/sumcheck/src/prover_v2.rs
@@ -22,7 +22,7 @@ use transcript::{Challenge, Transcript, TranscriptSyncronized};
 use crate::local_thread_pool::{LOCAL_THREAD_POOL, create_local_pool_once};
 
 use crate::{
-    entered_span, exit_span,
+    macros::{entered_span, exit_span},
     structs::{IOPProof, IOPProverMessage, IOPProverStateV2},
     util::{
         AdditiveArray, AdditiveVec, barycentric_weights, ceil_log2, extrapolate,


### PR DESCRIPTION
Just something that came up when I tried to understand how https://github.com/scroll-tech/ceno/pull/657 works.