### PR TITLE
remove tracing-flame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,6 @@ dependencies = [
  "tempfile",
  "thread_local",
  "tracing",
- "tracing-flame",
  "tracing-forest",
  "tracing-subscriber",
  "transcript",
@@ -1944,17 +1943,6 @@ checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-flame"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
-dependencies = [
- "lazy_static",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ strum_macros = "0.26"
 tracing = { version = "0.1", features = [
   "attributes",
 ] }
-tracing-flame = "0.2"
 tracing-forest = { version = "0.1.6" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -33,7 +33,6 @@ prettytable-rs.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 tracing.workspace = true
-tracing-flame.workspace = true
 tracing-forest.workspace = true
 tracing-subscriber.workspace = true
 

--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -25,7 +25,6 @@ use goldilocks::{Goldilocks, GoldilocksExt2};
 use itertools::Itertools;
 use mpcs::{Basefold, BasefoldRSParams, PolynomialCommitmentScheme};
 use sumcheck::macros::{entered_span, exit_span};
-use tracing_flame::FlameLayer;
 use tracing_subscriber::{EnvFilter, Registry, fmt, fmt::format::FmtSpan, layer::SubscriberExt};
 use transcript::Transcript;
 const PROGRAM_SIZE: usize = 16;
@@ -93,7 +92,6 @@ fn main() {
     let mem_addresses = CENO_PLATFORM.ram.clone();
     let io_addresses = CENO_PLATFORM.public_io.clone();
 
-    let (flame_layer, _guard) = FlameLayer::with_file("./tracing.folded").unwrap();
     let mut fmt_layer = fmt::layer()
         .compact()
         .with_span_events(FmtSpan::CLOSE)
@@ -107,10 +105,7 @@ fn main() {
     // Example: RUST_LOG="[sumcheck]" cargo run.. to get only events under the "sumcheck" span
     let filter = EnvFilter::from_default_env();
 
-    let subscriber = Registry::default()
-        .with(fmt_layer)
-        .with(filter)
-        .with(flame_layer.with_threads_collapsed(true));
+    let subscriber = Registry::default().with(fmt_layer).with(filter);
     tracing::subscriber::set_global_default(subscriber).unwrap();
 
     let top_level = entered_span!("TOPLEVEL");

--- a/ceno_zkvm/src/bin/e2e.rs
+++ b/ceno_zkvm/src/bin/e2e.rs
@@ -4,7 +4,6 @@ use clap::{Parser, ValueEnum};
 use itertools::Itertools;
 use std::fs;
 use tracing::level_filters::LevelFilter;
-use tracing_flame::FlameLayer;
 use tracing_forest::ForestLayer;
 use tracing_subscriber::{
     EnvFilter, Registry, filter::filter_fn, fmt, layer::SubscriberExt, util::SubscriberInitExt,
@@ -80,9 +79,6 @@ fn main() {
         .with_thread_names(false)
         .without_time();
 
-    // set up logger
-    let (flame_layer, _guard) = FlameLayer::with_file("./tracing.folded").unwrap();
-
     Registry::default()
         .with(ForestLayer::default())
         .with(fmt_layer)
@@ -94,7 +90,6 @@ fn main() {
                 .then_some(filter_by_profiling_level),
         )
         .with(args.profiling.is_none().then_some(default_filter))
-        .with(flame_layer.with_threads_collapsed(true))
         .init();
 
     let args = {


### PR DESCRIPTION
Removes the `tracing-flame` dependency. 

As discussed [here](https://github.com/scroll-tech/ceno/pull/572) the flamegraphs generated via `tracing-flame` suffered from at least two problems:
- Unexplainable time gaps which made the graph hard to read/misleading. Possibly a bug in the crate itself.
- Collapsing all spans with the same name (but different fields) into one column, making it impossible to distinguish particular iterations in loops (such as particular circuits during construction).

In addition, the generation of  `tracing.folded` itself can take significant time and distort profiling for short executions.