### PR TITLE
Only use forest layer when profiling

### DIFF
--- a/ceno_zkvm/src/bin/e2e.rs
+++ b/ceno_zkvm/src/bin/e2e.rs
@@ -80,7 +80,7 @@ fn main() {
         .without_time();
 
     Registry::default()
-        .with(ForestLayer::default())
+        .with(args.profiling.is_some().then_some(ForestLayer::default()))
         .with(fmt_layer)
         // if some profiling granularity is specified, use the profiling filter,
         // otherwise use the default


### PR DESCRIPTION
Forest layer currently clashes with `fmt_layer`. This PRs disables forest layer for non-profiling use-cases, which is fine because profiling visualization was the only reason we introduced it.