### PR TITLE
Turn Transcript into trait

### DIFF
--- a/ceno_zkvm/benches/riscv_add.rs
+++ b/ceno_zkvm/benches/riscv_add.rs
@@ -15,7 +15,7 @@ use goldilocks::{Goldilocks, GoldilocksExt2};
 use itertools::Itertools;
 use mpcs::{BasefoldDefault, PolynomialCommitmentScheme};
 use multilinear_extensions::mle::IntoMLE;
-use transcript::Transcript;
+use transcript::{BasicTranscript, Transcript};
 
 cfg_if::cfg_if! {
   if #[cfg(feature = "flamegraph")] {
@@ -87,7 +87,7 @@ fn bench_add(c: &mut Criterion) {
                     |wits_in| {
                         let timer = Instant::now();
                         let num_instances = 1 << instance_num_vars;
-                        let mut transcript = Transcript::new(b"riscv");
+                        let mut transcript = BasicTranscript::new(b"riscv");
                         let commit =
                             Pcs::batch_commit_and_write(&prover.pk.pp, &wits_in, &mut transcript)
                                 .unwrap();

--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -26,7 +26,7 @@ use itertools::Itertools;
 use mpcs::{Basefold, BasefoldRSParams, PolynomialCommitmentScheme};
 use sumcheck::macros::{entered_span, exit_span};
 use tracing_subscriber::{EnvFilter, Registry, fmt, fmt::format::FmtSpan, layer::SubscriberExt};
-use transcript::Transcript;
+use transcript::BasicTranscript as Transcript;
 const PROGRAM_SIZE: usize = 16;
 // For now, we assume registers
 //  - x0 is not touched,

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -22,7 +22,7 @@ use std::{
     panic,
     time::Instant,
 };
-use transcript::Transcript;
+use transcript::BasicTranscript as Transcript;
 
 pub fn run_e2e(
     program: Program,

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -18,7 +18,7 @@ use sumcheck::{
     macros::{entered_span, exit_span},
     structs::{IOPProverMessage, IOPProverStateV2},
 };
-use transcript::Transcript;
+use transcript::{ForkableTranscript, Transcript};
 
 use crate::{
     circuit_builder::SetTableAddrType,
@@ -62,7 +62,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
         &self,
         witnesses: ZKVMWitnesses<E>,
         pi: PublicValues<u32>,
-        mut transcript: Transcript<E>,
+        mut transcript: impl ForkableTranscript<E>,
     ) -> Result<ZKVMProof<E, PCS>, ZKVMError> {
         let span = entered_span!("commit_to_fixed_commit", profiling_1 = true);
         let mut vm_proof = ZKVMProof::empty(pi);
@@ -219,7 +219,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
         wits_commit: PCS::CommitmentWithData,
         pi: &[ArcMultilinearExtension<'_, E>],
         num_instances: usize,
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
         challenges: &[E; 2],
     ) -> Result<ZKVMOpcodeProof<E, PCS>, ZKVMError> {
         let cs = circuit_pk.get_cs();
@@ -663,7 +663,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
         witnesses: Vec<ArcMultilinearExtension<'_, E>>,
         wits_commit: PCS::CommitmentWithData,
         pi: &[ArcMultilinearExtension<'_, E>],
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
         challenges: &[E; 2],
     ) -> Result<ResultCreateTableProof<E, PCS>, ZKVMError> {
         let cs = circuit_pk.get_cs();
@@ -1152,7 +1152,7 @@ impl TowerProver {
         prod_specs: Vec<TowerProverSpec<'a, E>>,
         logup_specs: Vec<TowerProverSpec<'a, E>>,
         num_fanin: usize,
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
     ) -> (Point<E>, TowerProofs<E>) {
         // XXX to sumcheck batched product argument with logup, we limit num_product_fanin to 2
         // TODO mayber give a better naming?

--- a/ceno_zkvm/src/scheme/tests.rs
+++ b/ceno_zkvm/src/scheme/tests.rs
@@ -14,7 +14,7 @@ use mpcs::{Basefold, BasefoldDefault, BasefoldRSParams, PolynomialCommitmentSche
 use multilinear_extensions::{
     mle::IntoMLE, util::ceil_log2, virtual_poly_v2::ArcMultilinearExtension,
 };
-use transcript::Transcript;
+use transcript::{BasicTranscript, Transcript};
 
 use crate::{
     circuit_builder::CircuitBuilder,
@@ -126,7 +126,7 @@ fn test_rw_lk_expression_combination() {
 
         // get proof
         let prover = ZKVMProver::new(pk);
-        let mut transcript = Transcript::new(b"test");
+        let mut transcript = BasicTranscript::new(b"test");
         let wits_in = zkvm_witness
             .into_iter_sorted()
             .next()
@@ -157,7 +157,7 @@ fn test_rw_lk_expression_combination() {
 
         // verify proof
         let verifier = ZKVMVerifier::new(vk.clone());
-        let mut v_transcript = Transcript::new(b"test");
+        let mut v_transcript = BasicTranscript::new(b"test");
         // write commitment into transcript and derive challenges from it
         Pcs::write_commitment(&proof.wits_commit, &mut v_transcript).unwrap();
         let verifier_challenges = [
@@ -305,12 +305,12 @@ fn test_single_add_instance_e2e() {
         .unwrap();
 
     let pi = PublicValues::new(0, 0, 0, 0, 0, vec![0]);
-    let transcript = Transcript::new(b"riscv");
+    let transcript = BasicTranscript::new(b"riscv");
     let zkvm_proof = prover
         .create_proof(zkvm_witness, pi, transcript)
         .expect("create_proof failed");
 
-    let transcript = Transcript::new(b"riscv");
+    let transcript = BasicTranscript::new(b"riscv");
     assert!(
         verifier
             .verify_proof(zkvm_proof, transcript)
@@ -325,7 +325,7 @@ fn test_tower_proof_various_prod_size() {
         let num_vars = ceil_log2(leaf_layer_size);
         let mut rng = test_rng();
         type E = GoldilocksExt2;
-        let mut transcript = Transcript::new(b"test_tower_proof");
+        let mut transcript = BasicTranscript::new(b"test_tower_proof");
         let leaf_layer: ArcMultilinearExtension<E> = (0..leaf_layer_size)
             .map(|_| E::random(&mut rng))
             .collect_vec()
@@ -348,7 +348,7 @@ fn test_tower_proof_various_prod_size() {
             &mut transcript,
         );
 
-        let mut transcript = Transcript::new(b"test_tower_proof");
+        let mut transcript = BasicTranscript::new(b"test_tower_proof");
         let (rt_tower_v, prod_point_and_eval, _, _) = TowerVerify::verify(
             vec![
                 layers[0]

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -12,7 +12,7 @@ use multilinear_extensions::{
     virtual_poly::{VPAuxInfo, build_eq_x_r_vec_sequential, eq_eval},
 };
 use sumcheck::structs::{IOPProof, IOPVerifierState};
-use transcript::Transcript;
+use transcript::{ForkableTranscript, Transcript};
 
 use crate::{
     circuit_builder::SetTableAddrType,
@@ -48,7 +48,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
     pub fn verify_proof(
         &self,
         vm_proof: ZKVMProof<E, PCS>,
-        transcript: Transcript<E>,
+        transcript: impl ForkableTranscript<E>,
     ) -> Result<bool, ZKVMError> {
         self.verify_proof_halt(vm_proof, transcript, true)
     }
@@ -57,7 +57,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
     pub fn verify_proof_halt(
         &self,
         vm_proof: ZKVMProof<E, PCS>,
-        transcript: Transcript<E>,
+        transcript: impl ForkableTranscript<E>,
         does_halt: bool,
     ) -> Result<bool, ZKVMError> {
         // require ecall/halt proof to exist, depending whether we expect a halt.
@@ -79,7 +79,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
     fn verify_proof_validity(
         &self,
         vm_proof: ZKVMProof<E, PCS>,
-        mut transcript: Transcript<E>,
+        mut transcript: impl ForkableTranscript<E>,
     ) -> Result<bool, ZKVMError> {
         // main invariant between opcode circuits and table circuits
         let mut prod_r = E::ONE;
@@ -255,7 +255,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         circuit_vk: &VerifyingKey<E, PCS>,
         proof: &ZKVMOpcodeProof<E, PCS>,
         pi: &[E],
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
         num_product_fanin: usize,
         _out_evals: &PointAndEval<E>,
         challenges: &[E; 2], // derive challenge from PCS
@@ -504,7 +504,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         proof: &ZKVMTableProof<E, PCS>,
         raw_pi: &[Vec<E::BaseField>],
         pi: &[E],
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
         num_logup_fanin: usize,
         _out_evals: &PointAndEval<E>,
         challenges: &[E; 2],
@@ -812,7 +812,7 @@ impl TowerVerify {
         tower_proofs: &TowerProofs<E>,
         num_variables: Vec<usize>,
         num_fanin: usize,
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
     ) -> TowerVerifyResult<E> {
         // XXX to sumcheck batched product argument with logup, we limit num_product_fanin to 2
         // TODO mayber give a better naming?

--- a/ceno_zkvm/src/utils.rs
+++ b/ceno_zkvm/src/utils.rs
@@ -56,7 +56,7 @@ pub(crate) fn add_one_to_big_num<F: Field>(limb_modulo: F, limbs: &[F]) -> Vec<F
 /// derive challenge from transcript and return all pows result
 pub fn get_challenge_pows<E: ExtensionField>(
     size: usize,
-    transcript: &mut Transcript<E>,
+    transcript: &mut impl Transcript<E>,
 ) -> Vec<E> {
     // println!("alpha_pow");
     let alpha = transcript

--- a/ceno_zkvm/src/virtual_polys.rs
+++ b/ceno_zkvm/src/virtual_polys.rs
@@ -177,7 +177,7 @@ mod tests {
         virtual_poly_v2::{ArcMultilinearExtension, VirtualPolynomialV2},
     };
     use sumcheck::structs::{IOPProverStateV2, IOPVerifierState};
-    use transcript::Transcript;
+    use transcript::BasicTranscript as Transcript;
 
     use crate::{
         circuit_builder::{CircuitBuilder, ConstraintSystem},

--- a/mpcs/benches/basefold.rs
+++ b/mpcs/benches/basefold.rs
@@ -18,11 +18,11 @@ use multilinear_extensions::{
     mle::{DenseMultilinearExtension, MultilinearExtension},
     virtual_poly_v2::ArcMultilinearExtension,
 };
-use transcript::Transcript;
+use transcript::{BasicTranscript, Transcript};
 
 type PcsGoldilocksRSCode = Basefold<GoldilocksExt2, BasefoldRSParams>;
 type PcsGoldilocksBasecode = Basefold<GoldilocksExt2, BasefoldBasecodeParams>;
-type T = Transcript<GoldilocksExt2>;
+type T = BasicTranscript<GoldilocksExt2>;
 type E = GoldilocksExt2;
 
 const NUM_SAMPLES: usize = 10;
@@ -292,7 +292,7 @@ fn bench_simple_batch_commit_open_verify_goldilocks<Pcs: PolynomialCommitmentSch
             let comm = Pcs::get_pure_commitment(&comm);
 
             // Batch verify
-            let mut transcript = Transcript::new(b"BaseFold");
+            let mut transcript = BasicTranscript::new(b"BaseFold");
             Pcs::write_commitment(&comm, &mut transcript).unwrap();
 
             let point = get_point_from_challenge(num_vars, &mut transcript);

--- a/mpcs/src/basefold.rs
+++ b/mpcs/src/basefold.rs
@@ -451,7 +451,7 @@ where
 
     fn write_commitment(
         comm: &Self::Commitment,
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
     ) -> Result<(), Error> {
         write_digest_to_transcript(&comm.root(), transcript);
         Ok(())
@@ -470,7 +470,7 @@ where
         comm: &Self::CommitmentWithData,
         point: &[E],
         _eval: &E, // Opening does not need eval, except for sanity check
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
     ) -> Result<Self::Proof, Error> {
         let timer = start_timer!(|| "Basefold::open");
 
@@ -550,7 +550,7 @@ where
         comms: &[Self::CommitmentWithData],
         points: &[Vec<E>],
         evals: &[Evaluation<E>],
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
     ) -> Result<Self::Proof, Error> {
         let timer = start_timer!(|| "Basefold::batch_open");
         let num_vars = polys.iter().map(|poly| poly.num_vars).max().unwrap();
@@ -772,7 +772,7 @@ where
         comm: &Self::CommitmentWithData,
         point: &[E],
         evals: &[E],
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
     ) -> Result<Self::Proof, Error> {
         let timer = start_timer!(|| "Basefold::batch_open");
         let num_vars = polys[0].num_vars();
@@ -858,7 +858,7 @@ where
         point: &[E],
         eval: &E,
         proof: &Self::Proof,
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
     ) -> Result<(), Error> {
         let timer = start_timer!(|| "Basefold::verify");
 
@@ -944,7 +944,7 @@ where
         points: &[Vec<E>],
         evals: &[Evaluation<E>],
         proof: &Self::Proof,
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
     ) -> Result<(), Error> {
         let timer = start_timer!(|| "Basefold::batch_verify");
         // 	let key = "RAYON_NUM_THREADS";
@@ -1071,7 +1071,7 @@ where
         point: &[E],
         evals: &[E],
         proof: &Self::Proof,
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
     ) -> Result<(), Error> {
         let timer = start_timer!(|| "Basefold::simple batch verify");
         let batch_size = evals.len();

--- a/mpcs/src/basefold/commit_phase.rs
+++ b/mpcs/src/basefold/commit_phase.rs
@@ -34,7 +34,7 @@ pub fn commit_phase<E: ExtensionField, Spec: BasefoldSpec<E>>(
     pp: &<Spec::EncodingScheme as EncodingScheme<E>>::ProverParameters,
     point: &[E],
     comm: &BasefoldCommitmentWithData<E>,
-    transcript: &mut Transcript<E>,
+    transcript: &mut impl Transcript<E>,
     num_vars: usize,
     num_rounds: usize,
 ) -> (Vec<MerkleTree<E>>, BasefoldCommitPhaseProof<E>)
@@ -180,7 +180,7 @@ pub fn batch_commit_phase<E: ExtensionField, Spec: BasefoldSpec<E>>(
     pp: &<Spec::EncodingScheme as EncodingScheme<E>>::ProverParameters,
     point: &[E],
     comms: &[BasefoldCommitmentWithData<E>],
-    transcript: &mut Transcript<E>,
+    transcript: &mut impl Transcript<E>,
     num_vars: usize,
     num_rounds: usize,
     coeffs: &[E],
@@ -351,7 +351,7 @@ pub fn simple_batch_commit_phase<E: ExtensionField, Spec: BasefoldSpec<E>>(
     point: &[E],
     batch_coeffs: &[E],
     comm: &BasefoldCommitmentWithData<E>,
-    transcript: &mut Transcript<E>,
+    transcript: &mut impl Transcript<E>,
     num_vars: usize,
     num_rounds: usize,
 ) -> (Vec<MerkleTree<E>>, BasefoldCommitPhaseProof<E>)

--- a/mpcs/src/basefold/query_phase.rs
+++ b/mpcs/src/basefold/query_phase.rs
@@ -29,7 +29,7 @@ use super::{
 };
 
 pub fn prover_query_phase<E: ExtensionField>(
-    transcript: &mut Transcript<E>,
+    transcript: &mut impl Transcript<E>,
     comm: &BasefoldCommitmentWithData<E>,
     trees: &[MerkleTree<E>],
     num_verifier_queries: usize,
@@ -65,7 +65,7 @@ where
 }
 
 pub fn batch_prover_query_phase<E: ExtensionField>(
-    transcript: &mut Transcript<E>,
+    transcript: &mut impl Transcript<E>,
     codeword_size: usize,
     comms: &[BasefoldCommitmentWithData<E>],
     trees: &[MerkleTree<E>],
@@ -102,7 +102,7 @@ where
 }
 
 pub fn simple_batch_prover_query_phase<E: ExtensionField>(
-    transcript: &mut Transcript<E>,
+    transcript: &mut impl Transcript<E>,
     comm: &BasefoldCommitmentWithData<E>,
     trees: &[MerkleTree<E>],
     num_verifier_queries: usize,

--- a/mpcs/src/sum_check.rs
+++ b/mpcs/src/sum_check.rs
@@ -62,7 +62,7 @@ where
         num_vars: usize,
         virtual_poly: VirtualPolynomial<E>,
         sum: E,
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
     ) -> Result<SumCheckProverOutput<E, Self>, Error>;
 
     fn verify(
@@ -71,7 +71,7 @@ where
         degree: usize,
         sum: E,
         proof: &SumcheckProof<E, Self::RoundMessage>,
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
     ) -> Result<(E, Vec<E>), Error>;
 }
 

--- a/mpcs/src/sum_check/classic/coeff.rs
+++ b/mpcs/src/sum_check/classic/coeff.rs
@@ -37,7 +37,7 @@ pub struct Coefficients<E: ExtensionField>(FieldType<E>);
 impl<E: ExtensionField> ClassicSumCheckRoundMessage<E> for Coefficients<E> {
     type Auxiliary = ();
 
-    fn write(&self, transcript: &mut Transcript<E>) -> Result<(), Error> {
+    fn write(&self, transcript: &mut impl Transcript<E>) -> Result<(), Error> {
         match &self.0 {
             FieldType::Ext(coeffs) => transcript.append_field_element_exts(coeffs),
             FieldType::Base(coeffs) => coeffs

--- a/mpcs/src/util/hash.rs
+++ b/mpcs/src/util/hash.rs
@@ -9,7 +9,7 @@ use poseidon::poseidon::Poseidon;
 
 pub fn write_digest_to_transcript<E: ExtensionField>(
     digest: &Digest<E::BaseField>,
-    transcript: &mut Transcript<E>,
+    transcript: &mut impl Transcript<E>,
 ) {
     digest
         .0

--- a/mpcs/src/util/merkle_tree.rs
+++ b/mpcs/src/util/merkle_tree.rs
@@ -182,7 +182,7 @@ where
         self.inner.iter()
     }
 
-    pub fn write_transcript(&self, transcript: &mut Transcript<E>) {
+    pub fn write_transcript(&self, transcript: &mut impl Transcript<E>) {
         self.inner
             .iter()
             .for_each(|hash| write_digest_to_transcript(hash, transcript));

--- a/sumcheck/benches/devirgo_sumcheck.rs
+++ b/sumcheck/benches/devirgo_sumcheck.rs
@@ -16,7 +16,7 @@ use multilinear_extensions::{
     util::max_usable_threads,
     virtual_poly_v2::{ArcMultilinearExtension, VirtualPolynomialV2 as VirtualPolynomial},
 };
-use transcript::Transcript;
+use transcript::BasicTranscript as Transcript;
 
 criterion_group!(benches, sumcheck_fn, devirgo_sumcheck_fn,);
 criterion_main!(benches);

--- a/sumcheck/src/prover.rs
+++ b/sumcheck/src/prover.rs
@@ -33,7 +33,7 @@ impl<E: ExtensionField> IOPProverState<E> {
     pub fn prove_batch_polys(
         max_thread_id: usize,
         mut polys: Vec<VirtualPolynomial<E>>,
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
     ) -> (IOPProof<E>, IOPProverState<E>) {
         assert!(!polys.is_empty());
         assert_eq!(polys.len(), max_thread_id);
@@ -476,7 +476,7 @@ impl<E: ExtensionField> IOPProverState<E> {
     #[tracing::instrument(skip_all, name = "sumcheck::prove_parallel")]
     pub fn prove_parallel(
         poly: VirtualPolynomial<E>,
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
     ) -> (IOPProof<E>, IOPProverState<E>) {
         let (num_variables, max_degree) = (poly.aux_info.num_variables, poly.aux_info.max_degree);
 

--- a/sumcheck/src/prover_v2.rs
+++ b/sumcheck/src/prover_v2.rs
@@ -39,7 +39,7 @@ impl<'a, E: ExtensionField> IOPProverStateV2<'a, E> {
     pub fn prove_batch_polys(
         max_thread_id: usize,
         mut polys: Vec<VirtualPolynomialV2<'a, E>>,
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
     ) -> (IOPProof<E>, IOPProverStateV2<'a, E>) {
         assert!(!polys.is_empty());
         assert_eq!(polys.len(), max_thread_id);
@@ -604,7 +604,7 @@ impl<'a, E: ExtensionField> IOPProverStateV2<'a, E> {
     #[tracing::instrument(skip_all, name = "sumcheck::prove_parallel")]
     pub fn prove_parallel(
         poly: VirtualPolynomialV2<'a, E>,
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
     ) -> (IOPProof<E>, IOPProverStateV2<'a, E>) {
         let (num_variables, max_degree) =
             (poly.aux_info.max_num_variables, poly.aux_info.max_degree);

--- a/sumcheck/src/test.rs
+++ b/sumcheck/src/test.rs
@@ -6,7 +6,7 @@ use ff_ext::ExtensionField;
 use goldilocks::GoldilocksExt2;
 use multilinear_extensions::{mle::MultilinearExtension, virtual_poly::VirtualPolynomial};
 use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
-use transcript::Transcript;
+use transcript::{BasicTranscript, Transcript};
 
 use crate::{
     structs::{IOPProverState, IOPVerifierState},
@@ -21,7 +21,7 @@ fn test_sumcheck<E: ExtensionField>(
     num_products: usize,
 ) {
     let mut rng = test_rng();
-    let mut transcript = Transcript::new(b"test");
+    let mut transcript = BasicTranscript::new(b"test");
 
     let (poly, asserted_sum) =
         VirtualPolynomial::<E>::random(nv, num_multiplicands_range, num_products, &mut rng);
@@ -29,7 +29,7 @@ fn test_sumcheck<E: ExtensionField>(
     #[allow(deprecated)]
     let (proof, _) = IOPProverState::<E>::prove_parallel(poly.clone(), &mut transcript);
 
-    let mut transcript = Transcript::new(b"test");
+    let mut transcript = BasicTranscript::new(b"test");
     let subclaim = IOPVerifierState::<E>::verify(asserted_sum, &proof, &poly_info, &mut transcript);
     assert!(
         poly.evaluate(
@@ -58,7 +58,7 @@ fn test_sumcheck_internal<E: ExtensionField>(
     let mut verifier_state = IOPVerifierState::verifier_init(&poly_info);
     let mut challenge = None;
 
-    let mut transcript = Transcript::new(b"test");
+    let mut transcript = BasicTranscript::new(b"test");
 
     transcript.append_message(b"initializing transcript for testing");
 
@@ -145,7 +145,7 @@ fn test_extract_sum() {
 
 fn test_extract_sum_helper<E: ExtensionField>() {
     let mut rng = test_rng();
-    let mut transcript = Transcript::<E>::new(b"test");
+    let mut transcript = BasicTranscript::<E>::new(b"test");
     let (poly, asserted_sum) = VirtualPolynomial::<E>::random(8, (2, 3), 3, &mut rng);
     #[allow(deprecated)]
     let (proof, _) = IOPProverState::<E>::prove_parallel(poly, &mut transcript);

--- a/sumcheck/src/verifier.rs
+++ b/sumcheck/src/verifier.rs
@@ -13,7 +13,7 @@ impl<E: ExtensionField> IOPVerifierState<E> {
         claimed_sum: E,
         proof: &IOPProof<E>,
         aux_info: &VPAuxInfo<E>,
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
     ) -> SumCheckSubClaim<E> {
         if aux_info.num_variables == 0 {
             return SumCheckSubClaim {
@@ -66,7 +66,7 @@ impl<E: ExtensionField> IOPVerifierState<E> {
     pub(crate) fn verify_round_and_update_state(
         &mut self,
         prover_msg: &IOPProverMessage<E>,
-        transcript: &mut Transcript<E>,
+        transcript: &mut impl Transcript<E>,
     ) -> Challenge<E> {
         let start =
             start_timer!(|| format!("sum check verify {}-th round and update state", self.round));

--- a/transcript/src/basic.rs
+++ b/transcript/src/basic.rs
@@ -5,64 +5,45 @@ use poseidon::poseidon_permutation::PoseidonPermutation;
 
 use crate::Challenge;
 
-#[derive(Clone)]
-pub struct Transcript<E: ExtensionField> {
-    permutation: PoseidonPermutation<E::BaseField>,
-}
-
-impl<E: ExtensionField> Transcript<E> {
-    /// Create a new IOP transcript.
-    pub fn new(label: &'static [u8]) -> Self {
-        let mut perm = PoseidonPermutation::new(core::iter::repeat(E::BaseField::ZERO));
-        let label_f = E::BaseField::bytes_to_field_elements(label);
-        perm.set_from_slice(label_f.as_slice(), 0);
-        perm.permute();
-        Self { permutation: perm }
-    }
-}
-
-impl<E: ExtensionField> Transcript<E> {
-    /// Fork this transcript into n different threads.
-    pub fn fork(self, n: usize) -> Vec<Self> {
-        let mut forks = Vec::with_capacity(n);
-        for i in 0..n {
-            let mut fork = self.clone();
-            fork.append_field_element(&(i as u64).into());
-            forks.push(fork);
+/// The Transcript trait
+pub trait Transcript<E: ExtensionField> {
+    /// Append slice of base field elemets to the transcript. Implement
+    /// has to override at least one of append_field_elements / append_field_element
+    fn append_field_elements(&mut self, elements: &[E::BaseField]) {
+        for e in elements {
+            self.append_field_element(e);
         }
-        forks
     }
 
-    // Append the message to the transcript.
-    pub fn append_message(&mut self, msg: &[u8]) {
+    // Append a single field element to the transcript. Implement
+    /// has to override at least one of append_field_elements / append_field_element
+    fn append_field_element(&mut self, element: &E::BaseField) {
+        self.append_field_elements(&[*element])
+    }
+
+    /// Append the message to the transcript.
+    fn append_message(&mut self, msg: &[u8]) {
         let msg_f = E::BaseField::bytes_to_field_elements(msg);
-        self.permutation.set_from_slice(&msg_f, 0);
-        self.permutation.permute();
+        self.append_field_elements(&msg_f);
     }
 
-    // Append the field extension element to the transcript.
-    pub fn append_field_element_ext(&mut self, element: &E) {
-        self.permutation.set_from_slice(element.as_bases(), 0);
-        self.permutation.permute();
+    /// Append the field extension element to the transcript.Implement
+    /// has to override at least one of append_field_element_ext / append_field_element_exts
+    fn append_field_element_ext(&mut self, element: &E) {
+        self.append_field_element_exts(&[*element])
     }
 
-    pub fn append_field_element_exts(&mut self, element: &[E]) {
+    /// Append slice of field extension elements to the transcript. Implement
+    /// has to override at least one of append_field_element_ext / append_field_element_exts
+    fn append_field_element_exts(&mut self, element: &[E]) {
         for e in element {
             self.append_field_element_ext(e);
         }
     }
 
-    // Append the field elemetn to the transcript.
-    pub fn append_field_element(&mut self, element: &E::BaseField) {
-        self.permutation.set_from_slice(&[*element], 0);
-        self.permutation.permute();
-    }
-
-    // Append the challenge to the transcript.
-    pub fn append_challenge(&mut self, challenge: Challenge<E>) {
-        self.permutation
-            .set_from_slice(challenge.elements.as_bases(), 0);
-        self.permutation.permute();
+    /// Append the challenge to the transcript.
+    fn append_challenge(&mut self, challenge: Challenge<E>) {
+        self.append_field_element_ext(&challenge.elements)
     }
 
     // // Append the message to the transcript.
@@ -74,43 +55,89 @@ impl<E: ExtensionField> Transcript<E> {
     //     unimplemented!()
     // }
 
-    // Generate the challenge from the current transcript
-    // and append it to the transcript.
-    //
-    // The output field element is statistical uniform as long
-    // as the field has a size less than 2^384.
-    pub fn get_and_append_challenge(&mut self, label: &'static [u8]) -> Challenge<E> {
+    /// Generate the challenge from the current transcript
+    /// and append it to the transcript.
+    ///
+    /// The output field element is statistical uniform as long
+    /// as the field has a size less than 2^384.
+    fn get_and_append_challenge(&mut self, label: &'static [u8]) -> Challenge<E> {
         self.append_message(label);
-
-        let challenge = Challenge {
-            elements: E::from_limbs(self.permutation.squeeze()),
-        };
-        challenge
+        self.read_challenge()
     }
 
-    pub fn commit_rolling(&mut self) {
+    fn read_field_element_ext(&self) -> E {
+        self.read_field_element_exts()[0]
+    }
+
+    fn read_field_element_exts(&self) -> Vec<E>;
+
+    fn read_field_element(&self) -> E::BaseField;
+
+    fn read_challenge(&mut self) -> Challenge<E>;
+
+    fn send_challenge(&self, challenge: E);
+
+    fn commit_rolling(&mut self) {
         // do nothing
     }
+}
 
-    pub fn read_field_element_ext(&self) -> E {
-        unimplemented!()
+pub trait ForkableTranscript<E: ExtensionField>: Transcript<E> + Sized + Clone {
+    /// Fork this transcript into n different threads.
+    fn fork(self, n: usize) -> Vec<Self> {
+        let mut forks = Vec::with_capacity(n);
+        for i in 0..n {
+            let mut fork = self.clone();
+            fork.append_field_element(&(i as u64).into());
+            forks.push(fork);
+        }
+        forks
+    }
+}
+
+#[derive(Clone)]
+pub struct BasicTranscript<E: ExtensionField> {
+    permutation: PoseidonPermutation<E::BaseField>,
+}
+
+impl<E: ExtensionField> BasicTranscript<E> {
+    /// Create a new IOP transcript.
+    pub fn new(label: &'static [u8]) -> Self {
+        let mut perm = PoseidonPermutation::new(core::iter::repeat(E::BaseField::ZERO));
+        let label_f = E::BaseField::bytes_to_field_elements(label);
+        perm.set_from_slice(label_f.as_slice(), 0);
+        perm.permute();
+        Self { permutation: perm }
+    }
+}
+
+impl<E: ExtensionField> Transcript<E> for BasicTranscript<E> {
+    fn append_field_elements(&mut self, elements: &[E::BaseField]) {
+        self.permutation.set_from_slice(elements, 0);
+        self.permutation.permute();
     }
 
-    pub fn read_field_element_exts(&self) -> Vec<E> {
-        unimplemented!()
+    fn append_field_element_ext(&mut self, element: &E) {
+        self.append_field_elements(element.as_bases())
     }
 
-    pub fn read_field_element(&self) -> E::BaseField {
-        unimplemented!()
-    }
-
-    pub fn read_challenge(&mut self) -> Challenge<E> {
-        let r = E::from_bases(&self.permutation.squeeze()[..2]);
+    fn read_challenge(&mut self) -> Challenge<E> {
+        let r = E::from_bases(self.permutation.squeeze());
 
         Challenge { elements: r }
     }
 
-    pub fn send_challenge(&self, _challenge: E) {
+    fn read_field_element_exts(&self) -> Vec<E> {
+        unimplemented!()
+    }
+
+    fn read_field_element(&self) -> E::BaseField {
+        unimplemented!()
+    }
+
+    fn send_challenge(&self, _challenge: E) {
         unimplemented!()
     }
 }
+
+impl<E: ExtensionField> ForkableTranscript<E> for BasicTranscript<E> {}

--- a/transcript/src/lib.rs
+++ b/transcript/src/lib.rs
@@ -5,7 +5,7 @@
 
 pub mod basic;
 pub mod syncronized;
-pub use basic::Transcript;
+pub use basic::{BasicTranscript, ForkableTranscript, Transcript};
 pub use syncronized::TranscriptSyncronized;
 
 mod hasher;

--- a/transcript/src/syncronized.rs
+++ b/transcript/src/syncronized.rs
@@ -2,9 +2,9 @@ use std::array;
 
 use crossbeam_channel::{Receiver, Sender, bounded};
 use ff_ext::ExtensionField;
-use goldilocks::SmallField;
+//use goldilocks::SmallField;
 
-use crate::Challenge;
+use crate::{Challenge, Transcript};
 
 #[derive(Clone)]
 pub struct TranscriptSyncronized<E: ExtensionField> {
@@ -42,36 +42,24 @@ impl<E: ExtensionField> TranscriptSyncronized<E> {
     }
 }
 
-impl<E: ExtensionField> TranscriptSyncronized<E> {
-    // Append the message to the transcript.
-    pub fn append_message(&mut self, msg: &[u8]) {
-        let msg_f = E::BaseField::bytes_to_field_elements(msg);
-        self.bf_append_tx[self.rolling_index].send(msg_f).unwrap();
-    }
-
-    pub fn append_field_element_ext(&mut self, element: &E) {
-        self.ef_append_tx[self.rolling_index]
-            .send(vec![*element])
-            .unwrap();
-    }
-
-    pub fn append_field_element_exts(&mut self, element: &[E]) {
-        self.ef_append_tx[self.rolling_index]
-            .send(element.to_vec())
-            .unwrap();
-    }
-
-    pub fn append_field_element(&mut self, element: &E::BaseField) {
+impl<E: ExtensionField> Transcript<E> for TranscriptSyncronized<E> {
+    fn append_field_element(&mut self, element: &E::BaseField) {
         self.bf_append_tx[self.rolling_index]
             .send(vec![*element])
             .unwrap();
     }
 
-    pub fn append_challenge(&mut self, _challenge: Challenge<E>) {
+    fn append_field_element_exts(&mut self, element: &[E]) {
+        self.ef_append_tx[self.rolling_index]
+            .send(element.to_vec())
+            .unwrap();
+    }
+
+    fn append_challenge(&mut self, _challenge: Challenge<E>) {
         unimplemented!()
     }
 
-    pub fn get_and_append_challenge(&mut self, _label: &'static [u8]) -> Challenge<E> {
+    fn get_and_append_challenge(&mut self, _label: &'static [u8]) -> Challenge<E> {
         Challenge {
             elements: self.challenge_rx[self.rolling_index].recv().unwrap(),
         }
@@ -91,29 +79,25 @@ impl<E: ExtensionField> TranscriptSyncronized<E> {
         // }
     }
 
-    pub fn read_field_element_ext(&self) -> E {
-        self.ef_append_rx[self.rolling_index].recv().unwrap()[0]
-    }
-
-    pub fn read_field_element_exts(&self) -> Vec<E> {
+    fn read_field_element_exts(&self) -> Vec<E> {
         self.ef_append_rx[self.rolling_index].recv().unwrap()
     }
 
-    pub fn read_field_element(&self) -> E::BaseField {
+    fn read_field_element(&self) -> E::BaseField {
         self.bf_append_rx[self.rolling_index].recv().unwrap()[0]
     }
 
-    pub fn read_challenge(&self, _challenge: Challenge<E>) {
+    fn read_challenge(&mut self) -> Challenge<E> {
         unimplemented!()
     }
 
-    pub fn send_challenge(&self, challenge: E) {
+    fn send_challenge(&self, challenge: E) {
         self.challenge_tx[self.rolling_index]
             .send(challenge)
             .unwrap();
     }
 
-    pub fn commit_rolling(&mut self) {
+    fn commit_rolling(&mut self) {
         self.rolling_index = (self.rolling_index + 1) % 2
     }
 }


### PR DESCRIPTION
This PR try to turn `Transcript` into a trait so we can apply different implenents (For example, the `TranscriptSyncronized`) in the future.

We try to split the trait into a basic `Transcript` trait and a extended `Forkable` (with the `fork` method being provided) one.
The original `Transcript` struct has been renamed into `BasicTranscript`.