### PR TITLE
[Mock data to support #702] experiment latency improvement for lookup reduce to half

### DIFF
--- a/ceno_zkvm/benches/riscv_add.rs
+++ b/ceno_zkvm/benches/riscv_add.rs
@@ -95,6 +95,11 @@ fn bench_add(c: &mut Criterion) {
                             transcript.read_challenge().elements,
                             transcript.read_challenge().elements,
                         ];
+                        println!(
+                            "AddInstruction::batch_commit_and_write, instance_num_vars = {}, time = {}",
+                            instance_num_vars,
+                            timer.elapsed().as_secs_f64()
+                        );
 
                         let _ = prover
                             .create_opcode_proof(

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -175,6 +175,17 @@ impl<E: ExtensionField> ZKVMConstraintSystem<E> {
         let mut circuit_builder =
             CircuitBuilder::<E>::new_with_params(&mut cs, self.params.clone());
         let config = OC::construct_circuit(&mut circuit_builder).unwrap();
+        println!(
+            "before lk expression {} lk len {}",
+            OC::name(),
+            cs.lk_expressions.len()
+        );
+        cs.lk_expressions = cs.lk_expressions.split_off(cs.lk_expressions.len() / 2);
+        println!(
+            "after lk expression {} lk len {}",
+            OC::name(),
+            cs.lk_expressions.len()
+        );
         assert!(self.circuit_css.insert(OC::name(), cs).is_none());
 
         config


### PR DESCRIPTION
Preliminary to have some data to support #702 

With command on riscv add 2^20 instance
```
cargo bench --bench riscv_add --package ceno_zkvm -- --baseline baseline
```

the results 
```
add_op_20/prove_add/prove_add_log2_20
                        time:   [1.2830 s 1.2933 s 1.3040 s]
                        change: [-20.159% -18.206% -16.240%] (p = 0.00 < 0.05)
                        Performance has improved.
```

The 1.293s latency include mpcs part, and mpcs latency in bench occupied ~0.634s
If we only talk about basic proof improvement excluded mpcs, it will be (0.67 - 1.29 * 0.18) / 0.67 ~ `-65.3%`  improvement.

Note, this PR does not estimate the reduce witness overhead. Besides simulate SPARK protocol overhead (happened on table proof). So the improvement on mpcs (due to less `witin`) will boost overall eventually.