### PR TITLE
Fix `DynVolatileRamTable::max_len`

### DIFF
--- a/ceno_zkvm/src/tables/ram.rs
+++ b/ceno_zkvm/src/tables/ram.rs
@@ -31,6 +31,15 @@ impl DynVolatileRamTable for DynMemTable {
     }
 }
 
+#[test]
+fn test_dyn_mem_table() {
+    let mut params = ProgramParams::default();
+    params.platform.ram.start = 0;
+    params.platform.ram.end = 100;
+    let max_len_bytes = 4 * DynMemTable::max_len(&params);
+    assert_eq!(max_len_bytes, 128);
+}
+
 pub type DynMemCircuit<E> = DynVolatileRamCircuit<E, DynMemTable>;
 
 #[derive(Clone)]

--- a/ceno_zkvm/src/tables/ram/ram_circuit.rs
+++ b/ceno_zkvm/src/tables/ram/ram_circuit.rs
@@ -163,7 +163,12 @@ pub trait DynVolatileRamTable {
     fn max_len(params: &ProgramParams) -> usize {
         let max_size =
             (Self::end_addr(params) - Self::offset_addr(params)).div_ceil(WORD_SIZE as u32) as Addr;
-        1 << (u32::BITS - 1 - max_size.leading_zeros()) // prev_power_of_2
+        let max_len = 1 << (u32::BITS - 1 - max_size.leading_zeros()); // prev_power_of_2
+        assert!(
+            max_size as usize <= max_len,
+            "Did not round up {max_size} correctly, got {max_len}, which is smaller."
+        );
+        max_len
     }
 
     fn addr(params: &ProgramParams, entry_index: usize) -> Addr {

--- a/ceno_zkvm/src/tables/ram/ram_circuit.rs
+++ b/ceno_zkvm/src/tables/ram/ram_circuit.rs
@@ -163,12 +163,7 @@ pub trait DynVolatileRamTable {
     fn max_len(params: &ProgramParams) -> usize {
         let max_size = (Self::end_addr(params) as usize).div_ceil(WORD_SIZE)
             - (Self::offset_addr(params) as usize) / WORD_SIZE;
-        let max_len: usize = max_size.next_power_of_two();
-        assert!(
-            max_size <= max_len,
-            "Did not round up {max_size} correctly, got {max_len}, which is smaller."
-        );
-        max_len
+        max_size.next_power_of_two()
     }
 
     fn addr(params: &ProgramParams, entry_index: usize) -> Addr {

--- a/ceno_zkvm/src/tables/ram/ram_circuit.rs
+++ b/ceno_zkvm/src/tables/ram/ram_circuit.rs
@@ -161,11 +161,10 @@ pub trait DynVolatileRamTable {
     fn name() -> &'static str;
 
     fn max_len(params: &ProgramParams) -> usize {
-        let max_size =
-            (Self::end_addr(params) - Self::offset_addr(params)).div_ceil(WORD_SIZE as u32) as Addr;
-        let max_len = 1 << (u32::BITS - 1 - max_size.leading_zeros()); // prev_power_of_2
+        let max_size = (Self::end_addr(params) - Self::offset_addr(params)) as usize;
+        let max_len: usize = max_size.next_power_of_two().div_ceil(WORD_SIZE);
         assert!(
-            max_size as usize <= max_len,
+            max_size <= max_len,
             "Did not round up {max_size} correctly, got {max_len}, which is smaller."
         );
         max_len

--- a/ceno_zkvm/src/tables/ram/ram_circuit.rs
+++ b/ceno_zkvm/src/tables/ram/ram_circuit.rs
@@ -161,8 +161,9 @@ pub trait DynVolatileRamTable {
     fn name() -> &'static str;
 
     fn max_len(params: &ProgramParams) -> usize {
-        let max_size = (Self::end_addr(params) - Self::offset_addr(params)) as usize;
-        let max_len: usize = max_size.next_power_of_two().div_ceil(WORD_SIZE);
+        let max_size = (Self::end_addr(params) as usize).div_ceil(WORD_SIZE)
+            - (Self::offset_addr(params) as usize) / WORD_SIZE;
+        let max_len: usize = max_size.next_power_of_two();
         assert!(
             max_size <= max_len,
             "Did not round up {max_size} correctly, got {max_len}, which is smaller."


### PR DESCRIPTION
The previous logic only ever worked for powers of two.