### PR TITLE
[FIX] Broken integration test caused by transcript (#715)

### DIFF
--- a/transcript/src/basic.rs
+++ b/transcript/src/basic.rs
@@ -32,7 +32,7 @@ impl<E: ExtensionField> Transcript<E> for BasicTranscript<E> {
     }
 
     fn read_challenge(&mut self) -> Challenge<E> {
-        let r = E::from_bases(self.permutation.squeeze());
+        let r = E::from_bases(&self.permutation.squeeze()[..2]);
 
         Challenge { elements: r }
     }

--- a/transcript/src/basic.rs
+++ b/transcript/src/basic.rs
@@ -32,11 +32,11 @@ impl<E: ExtensionField> Transcript<E> for BasicTranscript<E> {
     }
 
     fn read_challenge(&mut self) -> Challenge<E> {
-        // notice `from_bases` and `from_limbs` has the same behavior but 
+        // notice `from_bases` and `from_limbs` has the same behavior but
         // `from_bases` has a sanity check for length of input slices
         // while `from_limbs` use the first two fields silently
         // we select `from_base` here to make it being more clear that
-        // we only use the first 2 fields here to construct the 
+        // we only use the first 2 fields here to construct the
         // extension field (i.e. the challenge)
         let r = E::from_bases(&self.permutation.squeeze()[..2]);
 

--- a/transcript/src/basic.rs
+++ b/transcript/src/basic.rs
@@ -32,6 +32,12 @@ impl<E: ExtensionField> Transcript<E> for BasicTranscript<E> {
     }
 
     fn read_challenge(&mut self) -> Challenge<E> {
+        // notice `from_bases` and `from_limbs` has the same behavior but 
+        // `from_bases` has a sanity check for length of input slices
+        // while `from_limbs` use the first two fields silently
+        // we select `from_base` here to make it being more clear that
+        // we only use the first 2 fields here to construct the 
+        // extension field (i.e. the challenge)
         let r = E::from_bases(&self.permutation.squeeze()[..2]);
 
         Challenge { elements: r }


### PR DESCRIPTION
This PR has fixed issue #715 by respect the assertion in `from_base` method of the Godilock extension field

Notice there is two method `from_base` and `form_limbs` in the `ExtensionField` trait which is not well illustrated and maybe we should update them later.

The two running mentioned in #715 have been success under this PR

`cargo run --package ceno_zkvm --bin e2e -- --platform=sp1 ceno_zkvm/examples/fibonacci.elf`

`RUST_BACKTRACE=1 cargo run --package ceno_zkvm --example riscv_opcodes -- --start 10 --end 11`