### PR TITLE
Remove redundant format Make targets

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           cargo make --version || cargo install cargo-make
       - name: Check code format
-        run: cargo make fmt-all-check
+        run: cargo fmt --all --check
 
       - name: Run clippy
         env:

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -33,11 +33,6 @@ args = [
 command = "cargo"
 workspace = false
 
-[tasks.fmt-all-check]
-args = ["fmt", "--all", "--", "--check"]
-command = "cargo"
-workspace = false
-
 [tasks.clippy-all]
 args = ["clippy", "--all-features", "--all-targets", "--", "-D", "warnings"]
 command = "cargo"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -38,18 +38,8 @@ args = ["fmt", "--all", "--", "--check"]
 command = "cargo"
 workspace = false
 
-[tasks.fmt-all]
-args = ["fmt", "--all"]
-command = "cargo"
-workspace = false
-
 [tasks.clippy-all]
 args = ["clippy", "--all-features", "--all-targets", "--", "-D", "warnings"]
-command = "cargo"
-workspace = false
-
-[tasks.fmt]
-args = ["fmt", "-p", "ceno_zkvm", "--", "--check"]
 command = "cargo"
 workspace = false
 


### PR DESCRIPTION
Just use `cargo fmt` or `cargo fmt --all` for the same effect.

Especially the `fmt` target was obsolote: why would you want to format specifically only `ceno_zkvm`?