### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   skip_check:
     runs-on: [self-hosted, Linux, X64]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,9 +33,9 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   lints:
     name: Various lints

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -9,31 +9,13 @@ on:
       - master
 
 jobs:
-  skip_check:
-    runs-on: [self-hosted, Linux, X64]
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
-        with:
-          cancel_others: 'true'
-          concurrent_skipping: 'same_content_newer'
-          paths_ignore: '["**/README.md"]'
-          do_not_skip: '["pull_request", "workflow_dispatch", "schedule", "merge_group"]'
-
   lints:
-    needs: [skip_check]
-    if: |
-      github.event.pull_request.draft == false &&
-      (github.event.action == 'ready_for_review' || needs.skip_check.outputs.should_skip != 'true')
-
     name: Various lints
     timeout-minutes: 30
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt, clippy
@@ -41,7 +23,7 @@ jobs:
           # TODO(Matthias): see whether we can keep this in sync with rust-toolchain.toml automatically?
           toolchain: nightly-2024-12-06
       - name: Cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -51,6 +33,7 @@ jobs:
             target/
             guest/target/
           key: lint-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: lint-${{ runner.os }}-cargo-
 
       - name: Install cargo make
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,28 +8,15 @@ on:
     branches:
       - master
 
-jobs:
-  skip_check:
-    runs-on: [self-hosted, Linux, X64]
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
-        with:
-          cancel_others: 'true'
-          concurrent_skipping: 'same_content_newer'
-          paths_ignore: '["**/README.md"]'
-          do_not_skip: '["pull_request", "workflow_dispatch", "schedule", "merge_group"]'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
+jobs:
   tests:
-    needs: [skip_check]
-    if: |
-      github.event.pull_request.draft == false &&
-      (github.event.action == 'ready_for_review' || needs.skip_check.outputs.should_skip != 'true')
     name: Run Tests
     timeout-minutes: 30
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -49,6 +36,7 @@ jobs:
             target/
             guest/target/
           key: tests-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: tests-${{ runner.os }}-cargo-
 
       - name: Install cargo make
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,14 +32,14 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           targets: riscv32im-unknown-none-elf
           # TODO(Matthias): see whether we can keep this in sync with rust-toolchain.toml automatically?
           toolchain: nightly-2024-12-06
       - name: Cargo cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
We are spending a lot of time restoring our cache on our self-hosted runners.  So let's try offloading some of the CI work back to GitHub, specifically hand back lints and tests, but keep integration tests with our runner.

Also:
- upgrade our actions
- cancel previous runs, when new commits are pushed