### PR TITLE
Remove `riscv` crate dependency

### DIFF
--- a/guest/Cargo.lock
+++ b/guest/Cargo.lock
@@ -5,21 +5,6 @@ version = 4
 [[package]]
 name = "ceno_rt"
 version = "0.1.0"
-dependencies = [
- "riscv",
-]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "embedded-hal"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
 name = "examples"
@@ -27,74 +12,3 @@ version = "0.1.0"
 dependencies = [
  "ceno_rt",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
-dependencies = [
- "proc-macro2",
-]
-
-[[package]]
-name = "riscv"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea8ff73d3720bdd0a97925f0bf79ad2744b6da8ff36be3840c48ac81191d7a7"
-dependencies = [
- "critical-section",
- "embedded-hal",
- "paste",
- "riscv-macros",
- "riscv-pac",
-]
-
-[[package]]
-name = "riscv-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f265be5d634272320a7de94cea15c22a3bfdd4eb42eb43edc528415f066a1f25"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "riscv-pac"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8188909339ccc0c68cfb5a04648313f09621e8b87dc03095454f1a11f6c5d436"
-
-[[package]]
-name = "syn"
-version = "2.0.90"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "unicode-ident"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"

--- a/guest/ceno_rt/Cargo.toml
+++ b/guest/ceno_rt/Cargo.toml
@@ -8,6 +8,3 @@ name = "ceno_rt"
 readme = "README.md"
 repository.workspace = true
 version.workspace = true
-
-[dependencies]
-riscv = "0.12"

--- a/guest/ceno_rt/src/lib.rs
+++ b/guest/ceno_rt/src/lib.rs
@@ -27,16 +27,12 @@ mod panic_handler {
 pub fn halt(exit_code: u32) -> ! {
     unsafe {
         asm!(
-            // Set the first argument.
-            "mv a0, {}",
-            // Set the ecall code HALT.
-            "li t0, 0x0",
-            in(reg) exit_code,
+            "ecall",
+            in ("a0") exit_code,
+            in ("t0") 0,
         );
-        riscv::asm::ecall();
     }
-    #[allow(clippy::empty_loop)]
-    loop {}
+    unreachable!();
 }
 
 global_asm!(


### PR DESCRIPTION
Extracted for ease of review from the work on introducing Rust standard library support for guests.