### PR TITLE
Sorting with hints

### DIFF
--- a/ceno_host/tests/test_elf.rs
+++ b/ceno_host/tests/test_elf.rs
@@ -135,7 +135,7 @@ fn test_sorting() -> Result<()> {
     let mut rng = rand::thread_rng();
 
     // Provide some random numbers to sort.
-    hints.write(&(0..1000).map(|_| rng.gen::<u32>()).collect::<Vec<_>>())?;
+    hints.write(&(0..1_000).map(|_| rng.gen::<u32>()).collect::<Vec<_>>())?;
 
     let all_messages = ceno_host::run(CENO_PLATFORM, ceno_examples::sorting, &hints);
     for (i, msg) in enumerate(&all_messages) {
@@ -144,6 +144,11 @@ fn test_sorting() -> Result<()> {
     Ok(())
 }
 
+/// Sorting with hints
+///
+/// This is an example of using non-deterministic computation in the guest (ie hints) to
+/// sort faster.  For one million numbers of input, this takes 25_750_500 cycles to run.
+/// While `test_sorting` above takes around 302_674_458 cycles.  That's a 10x speedup!
 #[test]
 fn test_sorting_with_hints() -> Result<()> {
     use rand::Rng;
@@ -151,7 +156,7 @@ fn test_sorting_with_hints() -> Result<()> {
     let mut rng = rand::thread_rng();
 
     // Provide some random numbers to sort.
-    let nums = (0..1000).map(|_| rng.gen::<u32>()).collect::<Vec<_>>();
+    let nums = (0..1_000).map(|_| rng.gen::<u32>()).collect::<Vec<_>>();
     hints.write(&nums)?;
     // Provide both the sorted answer, and the places where you can find the original number.
     let (answer, places): (Vec<_>, Vec<_>) = enumerate(nums)

--- a/ceno_host/tests/test_elf.rs
+++ b/ceno_host/tests/test_elf.rs
@@ -1,4 +1,8 @@
-use std::{collections::{BTreeSet, HashSet}, iter::from_fn, sync::Arc};
+use std::{
+    collections::{BTreeSet, HashSet},
+    iter::from_fn,
+    sync::Arc,
+};
 
 use anyhow::Result;
 use ceno_emul::{
@@ -6,7 +10,7 @@ use ceno_emul::{
     host_utils::read_all_messages,
 };
 use ceno_host::CenoStdin;
-use itertools::enumerate;
+use itertools::{Itertools, enumerate};
 
 #[test]
 fn test_ceno_rt_mini() -> Result<()> {
@@ -134,6 +138,32 @@ fn test_sorting() -> Result<()> {
     hints.write(&(0..1000).map(|_| rng.gen::<u32>()).collect::<Vec<_>>())?;
 
     let all_messages = ceno_host::run(CENO_PLATFORM, ceno_examples::sorting, &hints);
+    for (i, msg) in enumerate(&all_messages) {
+        println!("{i}: {msg}");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_sorting_with_hints() -> Result<()> {
+    use rand::Rng;
+    let mut hints = CenoStdin::default();
+    let mut rng = rand::thread_rng();
+
+    // Provide some random numbers to sort.
+    let nums = (0..1000).map(|_| rng.gen::<u32>()).collect::<Vec<_>>();
+    hints.write(&nums)?;
+    // Provide both the sorted answer, and the places where you can find the original number.
+    let (answer, places): (Vec<_>, Vec<_>) = enumerate(nums)
+        .map(|(i, x)| (x, i as u32))
+        .sorted()
+        .collect::<Vec<_>>()
+        .into_iter()
+        .unzip();
+    hints.write(&answer)?;
+    hints.write(&places)?;
+
+    let all_messages = ceno_host::run(CENO_PLATFORM, ceno_examples::sorting_with_hints, &hints);
     for (i, msg) in enumerate(&all_messages) {
         println!("{i}: {msg}");
     }

--- a/examples-builder/build.rs
+++ b/examples-builder/build.rs
@@ -16,6 +16,7 @@ const EXAMPLES: &[&str] = &[
     "ceno_rt_panic",
     "hints",
     "sorting",
+    "sorting_with_hints",
     "median",
     "hashing",
 ];

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -39,6 +39,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +55,7 @@ name = "examples"
 version = "0.1.0"
 dependencies = [
  "ceno_rt",
+ "itertools",
  "rkyv",
 ]
 
@@ -66,6 +73,15 @@ checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,3 +15,4 @@ rkyv = { version = "0.8", default-features = false, features = [
   "alloc",
   "bytecheck",
 ] }
+itertools = "0.13"


### PR DESCRIPTION
This is an example of using non-deterministic computation in the guest (ie hints) to
sort faster.  For one million numbers of input, the new examples takes 25_750_500 cycles to run.

The old sorting example takes around 302_674_458 cycles. (With slight variations depending on how the input is shuffled.)

So hints give us a 10x speedup!