### PR TITLE
Remove unnecessary `_stack_start` from Rust code

### DIFF
--- a/ceno_rt/ceno_link.x
+++ b/ceno_rt/ceno_link.x
@@ -1,4 +1,5 @@
 
+/* The address of this variable is the start of the stack (growing downwards). */
 _stack_start = ORIGIN(REGION_STACK) + LENGTH(REGION_STACK);
 _hints_start = ORIGIN(REGION_HINTS);
 _hints_length = LENGTH(REGION_HINTS);

--- a/ceno_rt/src/lib.rs
+++ b/ceno_rt/src/lib.rs
@@ -84,8 +84,3 @@ unsafe extern "C" fn _start_rust() -> ! {
     bespoke_entrypoint();
     halt(0)
 }
-
-extern "C" {
-    // The address of this variable is the start of the stack (growing downwards).
-    static _stack_start: u8;
-}


### PR DESCRIPTION
Just like `__global_pointer` or `_start`, we don't need to mention `_stack_start` in Rust to make use of it in the assembly.