### PR TITLE
Remove unnecessary partial eq for mpcs::Error

### DIFF
--- a/mpcs/src/lib.rs
+++ b/mpcs/src/lib.rs
@@ -299,7 +299,7 @@ impl<F> Evaluation<F> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub enum Error {
     InvalidSumcheck(String),
     InvalidPcsParam(String),


### PR DESCRIPTION
The `PartialEq` derivation is never used and prevents `mpcs::Error` from adding `whir::Error` as a variant.