### PR TITLE
accelerate wit_infer_by_expr via grid-strde-loop + vector pool

### DIFF
--- a/ceno_zkvm/src/expression.rs
+++ b/ceno_zkvm/src/expression.rs
@@ -18,6 +18,7 @@ use crate::{
     circuit_builder::CircuitBuilder,
     error::ZKVMError,
     structs::{ChallengeId, RAMType, WitnessId},
+    uint::util::SimpleVecPool,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -134,6 +135,74 @@ impl<E: ExtensionField> Expression<E> {
                     fixed_in, wit_in, instance, constant, challenge, sum, product, scaled,
                 );
                 scaled(x, a, b)
+            }
+            Expression::Challenge(challenge_id, pow, scalar, offset) => {
+                challenge(*challenge_id, *pow, *scalar, *offset)
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn evaluate_with_instance_pool<T>(
+        &self,
+        fixed_in: &impl Fn(&Fixed) -> T,
+        wit_in: &impl Fn(WitnessId) -> T, // witin id
+        instance: &impl Fn(Instance) -> T,
+        constant: &impl Fn(E::BaseField) -> T,
+        challenge: &impl Fn(ChallengeId, usize, E, E) -> T,
+        sum: &impl Fn(T, T, &mut SimpleVecPool<Vec<E>>, &mut SimpleVecPool<Vec<E::BaseField>>) -> T,
+        product: &impl Fn(T, T, &mut SimpleVecPool<Vec<E>>, &mut SimpleVecPool<Vec<E::BaseField>>) -> T,
+        scaled: &impl Fn(
+            T,
+            T,
+            T,
+            &mut SimpleVecPool<Vec<E>>,
+            &mut SimpleVecPool<Vec<E::BaseField>>,
+        ) -> T,
+        pool_e: &mut SimpleVecPool<Vec<E>>,
+        pool_b: &mut SimpleVecPool<Vec<E::BaseField>>,
+    ) -> T {
+        match self {
+            Expression::Fixed(f) => fixed_in(f),
+            Expression::WitIn(witness_id) => wit_in(*witness_id),
+            Expression::Instance(i) => instance(*i),
+            Expression::Constant(scalar) => constant(*scalar),
+            Expression::Sum(a, b) => {
+                let a = a.evaluate_with_instance_pool(
+                    fixed_in, wit_in, instance, constant, challenge, sum, product, scaled, pool_e,
+                    pool_b,
+                );
+                let b = b.evaluate_with_instance_pool(
+                    fixed_in, wit_in, instance, constant, challenge, sum, product, scaled, pool_e,
+                    pool_b,
+                );
+                sum(a, b, pool_e, pool_b)
+            }
+            Expression::Product(a, b) => {
+                let a = a.evaluate_with_instance_pool(
+                    fixed_in, wit_in, instance, constant, challenge, sum, product, scaled, pool_e,
+                    pool_b,
+                );
+                let b = b.evaluate_with_instance_pool(
+                    fixed_in, wit_in, instance, constant, challenge, sum, product, scaled, pool_e,
+                    pool_b,
+                );
+                product(a, b, pool_e, pool_b)
+            }
+            Expression::ScaledSum(x, a, b) => {
+                let x = x.evaluate_with_instance_pool(
+                    fixed_in, wit_in, instance, constant, challenge, sum, product, scaled, pool_e,
+                    pool_b,
+                );
+                let a = a.evaluate_with_instance_pool(
+                    fixed_in, wit_in, instance, constant, challenge, sum, product, scaled, pool_e,
+                    pool_b,
+                );
+                let b = b.evaluate_with_instance_pool(
+                    fixed_in, wit_in, instance, constant, challenge, sum, product, scaled, pool_e,
+                    pool_b,
+                );
+                scaled(x, a, b, pool_e, pool_b)
             }
             Expression::Challenge(challenge_id, pow, scalar, offset) => {
                 challenge(*challenge_id, *pow, *scalar, *offset)

--- a/ceno_zkvm/src/lib.rs
+++ b/ceno_zkvm/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(stmt_expr_attributes)]
 #![feature(variant_count)]
 #![feature(strict_overflow_ops)]
+#![feature(sync_unsafe_cell)]
 
 pub mod error;
 pub mod instructions;

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -28,7 +28,7 @@ use crate::{
         constants::{MAINCONSTRAIN_SUMCHECK_BATCH_SIZE, NUM_FANIN, NUM_FANIN_LOGUP},
         utils::{
             infer_tower_logup_witness, infer_tower_product_witness, interleaving_mles_to_mles,
-            wit_infer_by_expr, wit_infer_by_expr_in_pool,
+            wit_infer_by_expr,
         },
     },
     structs::{
@@ -246,7 +246,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
             .chain(cs.lk_expressions.iter())
             .map(|expr| {
                 assert_eq!(expr.degree(), 1);
-                wit_infer_by_expr_in_pool(&[], &witnesses, pi, challenges, expr, n_threads)
+                wit_infer_by_expr(&[], &witnesses, pi, challenges, expr, n_threads)
             })
             .collect();
         let (r_records_wit, w_lk_records_wit) = records_wit.split_at(cs.r_expressions.len());
@@ -526,7 +526,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
                 // sanity check in debug build and output != instance index for zero check sumcheck poly
                 if cfg!(debug_assertions) {
                     let expected_zero_poly =
-                        wit_infer_by_expr_in_pool(&[], &witnesses, pi, challenges, expr, n_threads);
+                        wit_infer_by_expr(&[], &witnesses, pi, challenges, expr, n_threads);
                     let top_100_errors = expected_zero_poly
                         .get_base_field_vec()
                         .iter()
@@ -716,7 +716,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
             .chain(cs.lk_table_expressions.par_iter().map(|lk| &lk.values))
             .map(|expr| {
                 assert_eq!(expr.degree(), 1);
-                wit_infer_by_expr_in_pool(&fixed, &witnesses, pi, challenges, expr, n_threads)
+                wit_infer_by_expr(&fixed, &witnesses, pi, challenges, expr, n_threads)
             })
             .collect();
         let max_log2_num_instance = records_wit.iter().map(|mle| mle.num_vars()).max().unwrap();

--- a/ceno_zkvm/src/scheme/utils.rs
+++ b/ceno_zkvm/src/scheme/utils.rs
@@ -382,6 +382,7 @@ fn try_recycle_arcpoly<E: ExtensionField>(
     ) -> DenseMultilinearExtension<E> {
         unsafe {
             // get the raw pointer from the Arc
+            assert_eq!(Arc::strong_count(&arc), 1);
             let raw = Arc::into_raw(arc);
             // cast the raw pointer to the desired concrete type
             let typed_ptr = raw as *const DenseMultilinearExtension<E>;
@@ -625,6 +626,7 @@ pub(crate) fn wit_infer_by_expr_in_place<'a, E: ExtensionField, const N: usize>(
             &mut pool_e,
             &mut pool_b,
         );
+    println!("??");
     match poly {
         Cow::Borrowed(poly) => poly.clone(),
         Cow::Owned(_) => poly.into_owned(),

--- a/ceno_zkvm/src/uint/util.rs
+++ b/ceno_zkvm/src/uint/util.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 // calculate the maximum number of combinations for stars and bars formula
 const fn max_combinations(degree: usize, num_cells: usize) -> usize {
     // compute factorial of n using usize
@@ -64,5 +66,39 @@ mod tests {
     #[test]
     fn test_max_word_of_limb_degree() {
         assert_eq!(131070, max_carry_word_for_multiplication(2, 32, 16));
+    }
+}
+
+pub struct SimpleVecPool<T> {
+    pool: VecDeque<T>,
+}
+
+impl<T> SimpleVecPool<T> {
+    // Create a new pool with a factory closure
+    pub fn new<F: Fn() -> T>(cap: usize, init: F) -> Self {
+        let mut pool = SimpleVecPool {
+            pool: VecDeque::new(),
+        };
+        (0..cap).for_each(|_| {
+            pool.add(init());
+        });
+        pool
+    }
+
+    // Add a new item to the pool
+    pub fn add(&mut self, item: T) {
+        self.pool.push_back(item);
+    }
+
+    // Borrow an item from the pool, or create a new one if empty
+    pub fn borrow(&mut self) -> T {
+        self.pool
+            .pop_front()
+            .expect("pool is empty, consider increase cap size")
+    }
+
+    // Return an item to the pool
+    pub fn return_to_pool(&mut self, item: T) {
+        self.pool.push_back(item);
     }
 }

--- a/ceno_zkvm/src/uint/util.rs
+++ b/ceno_zkvm/src/uint/util.rs
@@ -80,6 +80,7 @@ impl<T> SimpleVecPool<T> {
 
     // Return an item to the pool
     pub fn return_to_pool(&mut self, item: T) {
+        println!("got return!");
         self.pool.push_back(item);
     }
 }

--- a/ceno_zkvm/src/uint/util.rs
+++ b/ceno_zkvm/src/uint/util.rs
@@ -50,25 +50,6 @@ pub(crate) const fn max_carry_word_for_multiplication(n: usize, m: usize, c: usi
     max_carry_value_gt as u64
 }
 
-#[cfg(test)]
-mod tests {
-    use crate::uint::util::{max_carry_word_for_multiplication, max_combinations};
-
-    #[test]
-    fn test_max_combinations_degree() {
-        // degree=1 is pure add, therefore only one term
-        assert_eq!(1, max_combinations(1, 4));
-        // for degree=2 mul, we have u[0]*v[3], u[1]*v[2], u[2]*v[1], u[3]*v[0]
-        // thus 4 terms
-        assert_eq!(4, max_combinations(2, 4));
-    }
-
-    #[test]
-    fn test_max_word_of_limb_degree() {
-        assert_eq!(131070, max_carry_word_for_multiplication(2, 32, 16));
-    }
-}
-
 pub struct SimpleVecPool<T> {
     pool: VecDeque<T>,
 }
@@ -100,5 +81,24 @@ impl<T> SimpleVecPool<T> {
     // Return an item to the pool
     pub fn return_to_pool(&mut self, item: T) {
         self.pool.push_back(item);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::uint::util::{max_carry_word_for_multiplication, max_combinations};
+
+    #[test]
+    fn test_max_combinations_degree() {
+        // degree=1 is pure add, therefore only one term
+        assert_eq!(1, max_combinations(1, 4));
+        // for degree=2 mul, we have u[0]*v[3], u[1]*v[2], u[2]*v[1], u[3]*v[0]
+        // thus 4 terms
+        assert_eq!(4, max_combinations(2, 4));
+    }
+
+    #[test]
+    fn test_max_word_of_limb_degree() {
+        assert_eq!(131070, max_carry_word_for_multiplication(2, 32, 16));
     }
 }

--- a/multilinear_extensions/src/mle.rs
+++ b/multilinear_extensions/src/mle.rs
@@ -1052,45 +1052,6 @@ macro_rules! op_mle3_range {
     }};
 }
 
-/// deal with x * a + b
-#[macro_export]
-macro_rules! op_mle_xa_b {
-    (|$x:ident, $a:ident, $b:ident| $op:expr, |$bb_out:ident| $op_bb_out:expr) => {
-        match (&$x.evaluations(), &$a.evaluations(), &$b.evaluations()) {
-            (
-                $crate::mle::FieldType::Base(x_vec),
-                $crate::mle::FieldType::Base(a_vec),
-                $crate::mle::FieldType::Base(b_vec),
-            ) => {
-                op_mle3_range!($x, $a, $b, x_vec, a_vec, b_vec, $op, |$bb_out| $op_bb_out)
-            }
-            (
-                $crate::mle::FieldType::Base(x_vec),
-                $crate::mle::FieldType::Ext(a_vec),
-                $crate::mle::FieldType::Base(b_vec),
-            ) => {
-                op_mle3_range!($x, $a, $b, x_vec, a_vec, b_vec, $op, |$bb_out| $op_bb_out)
-            }
-            (
-                $crate::mle::FieldType::Base(x_vec),
-                $crate::mle::FieldType::Ext(a_vec),
-                $crate::mle::FieldType::Ext(b_vec),
-            ) => {
-                op_mle3_range!($x, $a, $b, x_vec, a_vec, b_vec, $op, |$bb_out| $op_bb_out)
-            }
-            (x, a, b) => unreachable!(
-                "unmatched pattern {:?} {:?} {:?}",
-                x.variant_name(),
-                a.variant_name(),
-                b.variant_name()
-            ),
-        }
-    };
-    (|$x:ident, $a:ident, $b:ident| $op:expr) => {
-        op_mle_xa_b!(|$x, $a, $b| $op, |out| out)
-    };
-}
-
 #[macro_export]
 macro_rules! op_mle3_range_pool {
     ($x:ident, $a:ident, $b:ident, $res:ident, $x_vec:ident, $a_vec:ident, $b_vec:ident, $res_vec:ident, $op:expr, |$bb_out:ident| $op_bb_out:expr) => {{

--- a/multilinear_extensions/src/mle.rs
+++ b/multilinear_extensions/src/mle.rs
@@ -1091,6 +1091,45 @@ macro_rules! op_mle_xa_b {
     };
 }
 
+/// deal with x * a + b
+#[macro_export]
+macro_rules! op_mle_xa_b_pool {
+    (|$x:ident, $a:ident, $b:ident| $op:expr, $pool_e:ident, $pool_b:ident, |$bb_out:ident| $op_bb_out:expr) => {
+        match (&$x.evaluations(), &$a.evaluations(), &$b.evaluations()) {
+            (
+                $crate::mle::FieldType::Base(x_vec),
+                $crate::mle::FieldType::Base(a_vec),
+                $crate::mle::FieldType::Base(b_vec),
+            ) => {
+                op_mle3_range!($x, $a, $b, x_vec, a_vec, b_vec, $op, |$bb_out| $op_bb_out)
+            }
+            (
+                $crate::mle::FieldType::Base(x_vec),
+                $crate::mle::FieldType::Ext(a_vec),
+                $crate::mle::FieldType::Base(b_vec),
+            ) => {
+                op_mle3_range!($x, $a, $b, x_vec, a_vec, b_vec, $op, |$bb_out| $op_bb_out)
+            }
+            (
+                $crate::mle::FieldType::Base(x_vec),
+                $crate::mle::FieldType::Ext(a_vec),
+                $crate::mle::FieldType::Ext(b_vec),
+            ) => {
+                op_mle3_range!($x, $a, $b, x_vec, a_vec, b_vec, $op, |$bb_out| $op_bb_out)
+            }
+            (x, a, b) => unreachable!(
+                "unmatched pattern {:?} {:?} {:?}",
+                x.variant_name(),
+                a.variant_name(),
+                b.variant_name()
+            ),
+        }
+    };
+    (|$x:ident, $a:ident, $b:ident| $op:expr, $pool_e:ident, $pool_b:ident) => {
+        op_mle_xa_b_pool!(|$x, $a, $b| $op, $pool_e, $pool_b, |out| out)
+    };
+}
+
 /// deal with f1 * f2 * f3
 /// applying cumulative rule for f1, f2, f3 to canonical form: Ext field comes first following by Base Field
 #[macro_export]


### PR DESCRIPTION
related #772 

This PR re-design `wit_infer_by_expr` to try grid-strde-loop traverse + reuse a simple vector pool to make vector reuse across closure across type boundary. The design is complex, since we need to deal with base/extension field and maximized code reuse.