### PR TITLE
docs: Corrected naming of RISC-V architecture Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ceno: Non-uniform, Segment and Parallel Risc-V Zero-knowledge Virtual Machine
+# Ceno: Non-uniform, Segment and Parallel RISC-V Zero-knowledge Virtual Machine
 
 Please see [the slightly outdated paper](https://eprint.iacr.org/2024/387) for an introduction to Ceno.
 
@@ -14,7 +14,7 @@ Ceno is built in Rust, so [installing the Rust toolchain](https://www.rust-lang.
 cargo install cargo-make
 ```
 
-You will also need to install the Risc-V target for Rust. You can do this with the following command:
+You will also need to install the RISC-V target for Rust. You can do this with the following command:
 
 ```sh
 rustup target add riscv32im-unknown-none-elf


### PR DESCRIPTION
I noticed that the term "Risc-V" was used instead of the official "**RISC-V**" in several places, including the title and a section of the documentation.

I've updated these instances to ensure consistency with the official naming convention of the architecture.
