### PR TITLE
Heap and stack sizes in kiB and MiB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,7 @@ dependencies = [
  "mpcs",
  "multilinear_extensions",
  "num-traits",
+ "parse-size",
  "paste",
  "pprof2",
  "prettytable-rs",
@@ -1363,6 +1364,12 @@ dependencies = [
  "smallvec",
  "windows-targets",
 ]
+
+[[package]]
+name = "parse-size"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
 
 [[package]]
 name = "pasta_curves"

--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -40,6 +40,7 @@ tracing-subscriber.workspace = true
 bincode = "1"
 clap = { version = "4.5", features = ["derive"] }
 generic_static = "0.2"
+parse-size = "1.1"
 rand.workspace = true
 tempfile = "3.14"
 thread_local = "1.1"

--- a/ceno_zkvm/src/bin/e2e.rs
+++ b/ceno_zkvm/src/bin/e2e.rs
@@ -18,6 +18,13 @@ use transcript::{
     BasicTranscript as Transcript, BasicTranscriptWithStat as TranscriptWithStat, StatisticRecorder,
 };
 
+fn parse_size(s: &str) -> Result<u32, parse_size::Error> {
+    parse_size::Config::new()
+        .with_binary()
+        .parse_size(s)
+        .map(|size| size as u32)
+}
+
 /// Prove the execution of a fixed RISC-V program.
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -45,11 +52,11 @@ struct Args {
     hints: Option<String>,
 
     /// Stack size in bytes.
-    #[arg(long, default_value = "32768")]
+    #[arg(long, default_value = "32k", value_parser = parse_size)]
     stack_size: u32,
 
     /// Heap size in bytes.
-    #[arg(long, default_value = "2097152")]
+    #[arg(long, default_value = "2M", value_parser = parse_size)]
     heap_size: u32,
 }
 


### PR DESCRIPTION
Allow specification of guest heap and stack sizes on the command line in more convenient units than just raw bytes.