### PR TITLE
Less spam when running `e2e`

### DIFF
--- a/ceno_emul/src/platform.rs
+++ b/ceno_emul/src/platform.rs
@@ -1,4 +1,5 @@
-use std::{collections::BTreeSet, ops::Range};
+use core::fmt::{self, Formatter};
+use std::{collections::BTreeSet, fmt::Display, ops::Range};
 
 use crate::addr::{Addr, RegIdx};
 
@@ -17,6 +18,26 @@ pub struct Platform {
     pub hints: Range<Addr>,
     /// If true, ecall instructions are no-op instead of trap. Testing only.
     pub unsafe_ecall_nop: bool,
+}
+
+impl Display for Platform {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let prog_data: Option<Range<Addr>> = match (self.prog_data.first(), self.prog_data.last()) {
+            (Some(first), Some(last)) => Some(*first..*last),
+            _ => None,
+        };
+        write!(
+            f,
+            "Platform {{ rom: {:?}, prog_data: {:?}, stack: {:?}, heap: {:?}, public_io: {:?}, hints: {:?}, unsafe_ecall_nop: {} }}",
+            self.rom,
+            prog_data,
+            self.stack,
+            self.heap,
+            self.public_io,
+            self.hints,
+            self.unsafe_ecall_nop
+        )
+    }
 }
 
 pub const CENO_PLATFORM: Platform = Platform {

--- a/ceno_zkvm/src/bin/e2e.rs
+++ b/ceno_zkvm/src/bin/e2e.rs
@@ -113,7 +113,7 @@ fn main() {
         args.heap_size,
         pub_io_size,
     );
-    tracing::info!("Running on platform {:?} {:?}", args.platform, platform);
+    tracing::info!("Running on platform {:?} {}", args.platform, platform);
     tracing::info!(
         "Stack: {} bytes. Heap: {} bytes.",
         args.stack_size,


### PR DESCRIPTION
This avoids spam like the following going on for thousands of lines:

```
 INFO e2e: Running on platform Ceno Platform { rom: 536870912..538373056, prog_data: {536870912, [...]
 ```