### PR TITLE
chore: fix several typos in docs and comments

### DIFF
--- a/ceno_emul/src/disassemble/mod.rs
+++ b/ceno_emul/src/disassemble/mod.rs
@@ -272,7 +272,7 @@ impl InstructionProcessor for InstructionTranspiler {
 
     /// Convert AUIPC to ADDI.
     ///
-    /// RiscV's instructions are designed to be (mosty) position-independent.  AUIPC is used
+    /// RiscV's instructions are designed to be (mostly) position-independent.  AUIPC is used
     /// to get access to the current program counter, even if the code has been moved around
     /// by the linker.
     ///

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -365,7 +365,7 @@ pub type IntermediateState<E, PCS> = (ZKVMProof<E, PCS>, ZKVMVerifier<E, PCS>);
 //
 // The return type is a pair of:
 // 1. Explicit state
-// 2. A no-input-no-ouptut closure
+// 2. A no-input-no-output closure
 //
 // (2.) is useful when you want to setup a certain action and run it
 // elsewhere (i.e, in a benchmark)

--- a/ceno_zkvm/src/instructions/riscv/div.rs
+++ b/ceno_zkvm/src/instructions/riscv/div.rs
@@ -7,7 +7,7 @@
 //!
 //! where `remainder` is constrained to be between 0 and the divisor in a way
 //! that suitably respects signed values, except for the case of division by 0.
-//! Of particular note for this implememntation is the fact that in the
+//! Of particular note for this implementation is the fact that in the
 //! Goldilocks field, the right hand side of (1) does not wrap around under
 //! modular arithmetic for either unsigned or signed 32-bit range-checked
 //! values of `divisor`, `quotient`, and `remainder`, taking values between `0`

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -614,7 +614,7 @@ impl<'a, E: ExtensionField + Hash> MockProver<E> {
                     })
                     .collect();
 
-                // Count lookups infered from ConstraintSystem from all instances into lkm_from_cs.
+                // Count lookups inferred from ConstraintSystem from all instances into lkm_from_cs.
                 for inst_id in 0..num_instances {
                     match rom_type {
                         ROMType::U5 => lkm_from_cs.assert_ux::<5>(args_eval[0][inst_id]),

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -774,7 +774,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         if circuit_vk.fixed_commit.is_some() {
             let Some(fixed_opening_proof) = &proof.fixed_opening_proof else {
                 return Err(ZKVMError::VerifyError(
-                    "fixed openning proof shoudn't be none".into(),
+                    "fixed opening proof shouldn't be none".into(),
                 ));
             };
             PCS::simple_batch_verify(

--- a/mpcs/src/basefold.rs
+++ b/mpcs/src/basefold.rs
@@ -137,7 +137,7 @@ where
         // endian, so the left half of the evaluation vector are evaluated
         // at 0 for the first variable, and the right half are evaluated at
         // 1 for the first variable.
-        // In each step of sum-check, we subsitute the first variable of the
+        // In each step of sum-check, we substitute the first variable of the
         // current polynomial with the random challenge, which is equivalent
         // to a left-right folding of the evaluation vector.
         // However, the algorithms that we will use are applying even-odd

--- a/multilinear_extensions/src/mle.rs
+++ b/multilinear_extensions/src/mle.rs
@@ -740,7 +740,7 @@ impl<E: ExtensionField> MultilinearExtension<E> for DenseMultilinearExtension<E>
                 self.evaluations = b;
             }
             (a, b) => panic!(
-                "do not support merge differnt field type DME a: {:?} b: {:?}",
+                "do not support merge different field type DME a: {:?} b: {:?}",
                 a, b
             ),
         }

--- a/sumcheck_macro/src/lib.rs
+++ b/sumcheck_macro/src/lib.rs
@@ -73,7 +73,7 @@ pub fn sumcheck_code_gen(input: proc_macro::TokenStream) -> proc_macro::TokenStr
     }
 
     // Part 2 - Sort f vars based on FieldType.
-    // match (&f0.evaluations(), &f1.evalutations(), ...) {
+    // match (&f0.evaluations(), &f1.evaluations(), ...) {
     //     (FieldType::Base(base1), FieldType::Base(base2), ...) => {...}
     //     ...
     // }


### PR DESCRIPTION
Simply fixes some typos I have encountered while exploring the codebase.