### PR TITLE
upgrade to latest plonky3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,6 +771,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "forward_ref"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,6 +969,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1314,7 +1329,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p3-challenger"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=b0591e9b#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -1326,9 +1341,9 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=b0591e9b#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "p3-field",
  "p3-matrix",
  "p3-maybe-rayon",
@@ -1339,15 +1354,17 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=b0591e9b#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
 dependencies = [
- "itertools 0.13.0",
+ "forward_ref",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
  "nums",
  "p3-maybe-rayon",
  "p3-util",
+ "paste",
  "rand",
  "serde",
  "tracing",
@@ -1356,7 +1373,7 @@ dependencies = [
 [[package]]
 name = "p3-goldilocks"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=b0591e9b#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
 dependencies = [
  "num-bigint",
  "p3-dft",
@@ -1366,6 +1383,7 @@ dependencies = [
  "p3-poseidon2",
  "p3-symmetric",
  "p3-util",
+ "paste",
  "rand",
  "serde",
 ]
@@ -1373,9 +1391,9 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=b0591e9b#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "p3-field",
  "p3-maybe-rayon",
  "p3-util",
@@ -1388,14 +1406,14 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=b0591e9b#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
 
 [[package]]
 name = "p3-mds"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=b0591e9b#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "p3-dft",
  "p3-field",
  "p3-matrix",
@@ -1407,7 +1425,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=b0591e9b#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -1418,7 +1436,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=b0591e9b#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
 dependencies = [
  "gcd",
  "p3-field",
@@ -1430,9 +1448,9 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=b0591e9b#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "p3-field",
  "serde",
 ]
@@ -1440,7 +1458,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=b0591e9b#b0591e9b82d58d10f86359875b5d5fa96433b4cf"
+source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,13 +33,13 @@ crossbeam-channel = "0.5"
 itertools = "0.13"
 num-derive = "0.4"
 num-traits = "0.2"
-p3-challenger = { git = "https://github.com/plonky3/plonky3", rev = "b0591e9b" }
-p3-field = { git = "https://github.com/plonky3/plonky3", rev = "b0591e9b" }
-p3-goldilocks = { git = "https://github.com/plonky3/plonky3", rev = "b0591e9b" }
-p3-mds = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9b" }
-p3-poseidon = { git = "https://github.com/plonky3/plonky3", rev = "b0591e9b" }
-p3-poseidon2 = { git = "https://github.com/plonky3/plonky3", rev = "b0591e9b" }
-p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "b0591e9b" }
+p3-challenger = { git = "https://github.com/plonky3/plonky3", rev = "00da91c" }
+p3-field = { git = "https://github.com/plonky3/plonky3", rev = "00da91c" }
+p3-goldilocks = { git = "https://github.com/plonky3/plonky3", rev = "00da91c" }
+p3-mds = { git = "https://github.com/Plonky3/Plonky3.git", rev = "00da91c" }
+p3-poseidon = { git = "https://github.com/plonky3/plonky3", rev = "00da91c" }
+p3-poseidon2 = { git = "https://github.com/plonky3/plonky3", rev = "00da91c" }
+p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "00da91c" }
 paste = "1"
 plonky2 = "0.2"
 poseidon = { path = "./poseidon" }

--- a/ceno_zkvm/examples/riscv_opcodes.rs
+++ b/ceno_zkvm/examples/riscv_opcodes.rs
@@ -9,7 +9,7 @@ use ceno_zkvm::{
     with_panic_hook,
 };
 use clap::Parser;
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 
 use ceno_emul::{
     CENO_PLATFORM, EmuContext,

--- a/ceno_zkvm/src/bin/e2e.rs
+++ b/ceno_zkvm/src/bin/e2e.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 use ff_ext::GoldilocksExt2;
 use itertools::Itertools;
 use mpcs::{Basefold, BasefoldRSParams};
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use p3_goldilocks::Goldilocks;
 use std::{fs, panic};
 use tracing::level_filters::LevelFilter;

--- a/ceno_zkvm/src/chip_handler/global_state.rs
+++ b/ceno_zkvm/src/chip_handler/global_state.rs
@@ -4,14 +4,12 @@ use super::GlobalStateRegisterMachineChipOperations;
 use crate::{
     circuit_builder::CircuitBuilder, error::ZKVMError, expression::Expression, structs::RAMType,
 };
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 
 impl<E: ExtensionField> GlobalStateRegisterMachineChipOperations<E> for CircuitBuilder<'_, E> {
     fn state_in(&mut self, pc: Expression<E>, ts: Expression<E>) -> Result<(), ZKVMError> {
         let record: Vec<Expression<E>> = vec![
-            Expression::Constant(E::BaseField::from_canonical_u64(
-                RAMType::GlobalState as u64,
-            )),
+            Expression::Constant(E::BaseField::from_u64(RAMType::GlobalState as u64)),
             pc,
             ts,
         ];
@@ -21,9 +19,7 @@ impl<E: ExtensionField> GlobalStateRegisterMachineChipOperations<E> for CircuitB
 
     fn state_out(&mut self, pc: Expression<E>, ts: Expression<E>) -> Result<(), ZKVMError> {
         let record: Vec<Expression<E>> = vec![
-            Expression::Constant(E::BaseField::from_canonical_u64(
-                RAMType::GlobalState as u64,
-            )),
+            Expression::Constant(E::BaseField::from_u64(RAMType::GlobalState as u64)),
             pc,
             ts,
         ];

--- a/ceno_zkvm/src/chip_handler/utils.rs
+++ b/ceno_zkvm/src/chip_handler/utils.rs
@@ -3,7 +3,7 @@ use std::iter::successors;
 use crate::expression::Expression;
 use ff_ext::ExtensionField;
 use itertools::izip;
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 
 pub fn rlc_chip_record<E: ExtensionField>(
     records: Vec<Expression<E>>,

--- a/ceno_zkvm/src/circuit_builder.rs
+++ b/ceno_zkvm/src/circuit_builder.rs
@@ -12,7 +12,7 @@ use crate::{
     structs::{ProgramParams, ProvingKey, RAMType, VerifyingKey, WitnessId},
     witness::RowMajorMatrix,
 };
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 
 /// namespace used for annotation, preserve meta info during circuit construction
 #[derive(Clone, Debug, Default, serde::Serialize)]
@@ -269,7 +269,7 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         record: Vec<Expression<E>>,
     ) -> Result<(), ZKVMError> {
         let rlc_record = self.rlc_chip_record(
-            std::iter::once(Expression::Constant(E::BaseField::from_canonical_u64(
+            std::iter::once(Expression::Constant(E::BaseField::from_u64(
                 rom_type as u64,
             )))
             .chain(record.clone())

--- a/ceno_zkvm/src/expression.rs
+++ b/ceno_zkvm/src/expression.rs
@@ -9,7 +9,7 @@ use std::{
 
 use ceno_emul::InsnKind;
 use ff_ext::{ExtensionField, SmallField};
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 
 use multilinear_extensions::virtual_poly::ArcMultilinearExtension;
 
@@ -913,7 +913,7 @@ macro_rules! impl_from_unsigned {
         $(
             impl<F: SmallField, E: ExtensionField<BaseField = F>> From<$t> for Expression<E> {
                 fn from(value: $t) -> Self {
-                    Expression::Constant(F::from_canonical_u64(value as u64))
+                    Expression::Constant(F::from_u64(value as u64))
                 }
             }
         )*
@@ -928,7 +928,7 @@ macro_rules! impl_from_signed {
             impl<F: SmallField, E: ExtensionField<BaseField = F>> From<$t> for Expression<E> {
                 fn from(value: $t) -> Self {
                     let reduced = (value as i128).rem_euclid(F::MODULUS_U64 as i128) as u64;
-                    Expression::Constant(F::from_canonical_u64(reduced))
+                    Expression::Constant(F::from_u64(reduced))
                 }
             }
         )*
@@ -1088,7 +1088,7 @@ mod tests {
     use super::{Expression, ToExpr, fmt};
     use crate::circuit_builder::{CircuitBuilder, ConstraintSystem};
     use ff_ext::{FieldInto, GoldilocksExt2};
-    use p3_field::FieldAlgebra;
+    use p3_field::PrimeCharacteristicRing;
 
     #[test]
     fn test_expression_arithmetics() {

--- a/ceno_zkvm/src/expression/monomial.rs
+++ b/ceno_zkvm/src/expression/monomial.rs
@@ -82,7 +82,7 @@ mod tests {
 
     use super::*;
     use ff_ext::{FieldInto, FromUniformBytes, GoldilocksExt2 as E};
-    use p3_field::FieldAlgebra;
+    use p3_field::PrimeCharacteristicRing;
     use p3_goldilocks::Goldilocks as F;
     use rand_chacha::{ChaChaRng, rand_core::SeedableRng};
 
@@ -99,7 +99,7 @@ mod tests {
         let y = || WitIn(1);
         let z = || WitIn(2);
         let n = || Constant(104u64.into_f());
-        let m = || Constant(-F::from_canonical_u64(599));
+        let m = || Constant(-F::from_u64(599));
         let r = || Challenge(0, 1, E::ONE, E::ZERO);
 
         let test_exprs: &[Expression<E>] = &[

--- a/ceno_zkvm/src/gadgets/is_lt.rs
+++ b/ceno_zkvm/src/gadgets/is_lt.rs
@@ -242,13 +242,7 @@ impl InnerLtConfig {
         lhs: u64,
         rhs: u64,
     ) -> Result<(), ZKVMError> {
-        self.assign_instance_field(
-            instance,
-            lkm,
-            F::from_canonical_u64(lhs),
-            F::from_canonical_u64(rhs),
-            lhs < rhs,
-        )
+        self.assign_instance_field(instance, lkm, F::from_u64(lhs), F::from_u64(rhs), lhs < rhs)
     }
 
     /// Assign instance values to this configuration where the ordering is

--- a/ceno_zkvm/src/gadgets/signed_ext.rs
+++ b/ceno_zkvm/src/gadgets/signed_ext.rs
@@ -7,7 +7,7 @@ use crate::{
     witness::LkMultiplicity,
 };
 use ff_ext::{ExtensionField, FieldInto};
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use std::marker::PhantomData;
 
 /// Extract the most significant bit from an expression previously constrained
@@ -103,7 +103,7 @@ impl<E: ExtensionField> SignedExtendConfig<E> {
         };
 
         assert_ux(lk_multiplicity, 2 * val - (msb << self.n_bits));
-        set_val!(instance, self.msb, E::BaseField::from_canonical_u64(msb));
+        set_val!(instance, self.msb, E::BaseField::from_u64(msb));
 
         Ok(())
     }

--- a/ceno_zkvm/src/instructions/riscv/branch/branch_circuit.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch/branch_circuit.rs
@@ -19,7 +19,7 @@ use crate::{
     },
     witness::LkMultiplicity,
 };
-pub use p3_field::FieldAlgebra;
+pub use p3_field::PrimeCharacteristicRing;
 
 pub struct BranchCircuit<E, I>(PhantomData<(E, I)>);
 
@@ -151,8 +151,8 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BranchCircuit<E, I
         if let Some(equal) = &config.is_equal {
             equal.assign_instance(
                 instance,
-                E::BaseField::from_canonical_u64(rs2.as_u64()),
-                E::BaseField::from_canonical_u64(rs1.as_u64()),
+                E::BaseField::from_u64(rs2.as_u64()),
+                E::BaseField::from_u64(rs1.as_u64()),
             )?;
         }
 

--- a/ceno_zkvm/src/instructions/riscv/ecall/halt.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/halt.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use ceno_emul::{StepRecord, Tracer};
 use ff_ext::{ExtensionField, FieldInto};
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use std::marker::PhantomData;
 
 pub struct HaltConfig {
@@ -51,7 +51,7 @@ impl<E: ExtensionField> Instruction<E> for HaltInstruction<E> {
         // read exit_code from arg0 (X10 register)
         let (_, lt_x10_cfg) = cb.register_read(
             || "read x10",
-            E::BaseField::from_canonical_u64(ceno_emul::Platform::reg_arg0() as u64),
+            E::BaseField::from_u64(ceno_emul::Platform::reg_arg0() as u64),
             prev_x10_ts.expr(),
             ecall_cfg.ts.expr() + Tracer::SUBCYCLE_RS2,
             exit_code,

--- a/ceno_zkvm/src/instructions/riscv/ecall_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall_insn.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use ceno_emul::{InsnKind::ECALL, PC_STEP_SIZE, Platform, StepRecord, Tracer};
 use ff_ext::{ExtensionField, FieldInto};
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 
 pub struct EcallInstructionConfig {
     pub pc: WitIn,
@@ -51,7 +51,7 @@ impl EcallInstructionConfig {
         // read syscall_id from x5 and write return value to x5
         let (_, lt_x5_cfg) = cb.register_write(
             || "write x5",
-            E::BaseField::from_canonical_u64(Platform::reg_ecall() as u64),
+            E::BaseField::from_u64(Platform::reg_ecall() as u64),
             prev_x5_ts.expr(),
             ts.expr() + Tracer::SUBCYCLE_RS1,
             syscall_id.clone(),

--- a/ceno_zkvm/src/instructions/riscv/insn_base.rs
+++ b/ceno_zkvm/src/instructions/riscv/insn_base.rs
@@ -1,7 +1,7 @@
 use ceno_emul::{Cycle, StepRecord, Word, WriteOp};
 use ff_ext::{ExtensionField, FieldInto, SmallField};
 use itertools::Itertools;
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 
 use super::constants::{PC_STEP_SIZE, UINT_LIMBS, UInt};
 use crate::{
@@ -436,7 +436,7 @@ impl<E: ExtensionField> MemAddr<E> {
             .sum();
 
         // Range check the middle bits, that is the low limb excluding the low bits.
-        let shift_right = E::BaseField::from_canonical_u64(1 << Self::N_LOW_BITS)
+        let shift_right = E::BaseField::from_u64(1 << Self::N_LOW_BITS)
             .inverse()
             .expr();
         let mid_u14 = (&limbs[0] - low_sum) * shift_right;

--- a/ceno_zkvm/src/instructions/riscv/jump/jalr.rs
+++ b/ceno_zkvm/src/instructions/riscv/jump/jalr.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use ceno_emul::{InsnKind, PC_STEP_SIZE};
 use ff_ext::FieldInto;
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 
 pub struct JalrConfig<E: ExtensionField> {
     pub i_insn: IInstructionConfig<E>,

--- a/ceno_zkvm/src/instructions/riscv/memory/load.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/load.rs
@@ -19,7 +19,7 @@ use crate::{
 use ceno_emul::{ByteAddr, InsnKind, StepRecord};
 use ff_ext::{ExtensionField, FieldInto};
 use itertools::izip;
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use std::marker::PhantomData;
 
 pub struct LoadConfig<E: ExtensionField> {
@@ -226,11 +226,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for LoadInstruction<E,
             .memory_addr
             .assign_instance(instance, lk_multiplicity, unaligned_addr.into())?;
         if let Some(&limb) = config.target_limb.as_ref() {
-            set_val!(
-                instance,
-                limb,
-                E::BaseField::from_canonical_u16(target_limb)
-            );
+            set_val!(instance, limb, E::BaseField::from_u16(target_limb));
         }
         if let Some(limb_bytes) = config.target_limb_bytes.as_ref() {
             if addr_low_bits[0] == 1 {
@@ -240,7 +236,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for LoadInstruction<E,
             }
             for (&col, byte) in izip!(limb_bytes.iter(), target_limb_bytes.into_iter()) {
                 lk_multiplicity.assert_ux::<8>(byte as u64);
-                set_val!(instance, col, E::BaseField::from_canonical_u8(byte));
+                set_val!(instance, col, E::BaseField::from_u8(byte));
             }
         }
         let val = match I::INST_KIND {

--- a/ceno_zkvm/src/instructions/riscv/mul.rs
+++ b/ceno_zkvm/src/instructions/riscv/mul.rs
@@ -82,7 +82,7 @@ use std::marker::PhantomData;
 
 use ceno_emul::{InsnKind, StepRecord};
 use ff_ext::{ExtensionField, SmallField};
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use p3_goldilocks::Goldilocks;
 
 use crate::{
@@ -354,8 +354,8 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for MulhInstructionBas
             }
             MulhSignDependencies::UU { constrain_rd } => {
                 // assign nonzero value (u32::MAX - rd)
-                let rd_f = E::BaseField::from_canonical_u64(rd as u64);
-                let avoid_f = E::BaseField::from_canonical_u32(u32::MAX);
+                let rd_f = E::BaseField::from_u64(rd as u64);
+                let avoid_f = E::BaseField::from_u32(u32::MAX);
                 constrain_rd.assign_instance(instance, rd_f, avoid_f)?;
 
                 // only take the low part of the product
@@ -367,12 +367,8 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for MulhInstructionBas
                 assert_eq!(prod_lo, rd);
 
                 let prod_hi = prod >> BIT_WIDTH;
-                let avoid_f = E::BaseField::from_canonical_u32(u32::MAX);
-                constrain_rd.assign_instance(
-                    instance,
-                    E::BaseField::from_canonical_u64(prod_hi),
-                    avoid_f,
-                )?;
+                let avoid_f = E::BaseField::from_u32(u32::MAX);
+                constrain_rd.assign_instance(instance, E::BaseField::from_u64(prod_hi), avoid_f)?;
                 prod_hi as u32
             }
             MulhSignDependencies::SU {

--- a/ceno_zkvm/src/scheme.rs
+++ b/ceno_zkvm/src/scheme.rs
@@ -1,7 +1,7 @@
 use ff_ext::ExtensionField;
 use itertools::Itertools;
 use mpcs::PolynomialCommitmentScheme;
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::{collections::BTreeMap, fmt::Debug};
 use sumcheck::structs::IOPProverMessage;
@@ -103,19 +103,17 @@ impl PublicValues<u32> {
     }
     pub fn to_vec<E: ExtensionField>(&self) -> Vec<Vec<E::BaseField>> {
         vec![
-            vec![E::BaseField::from_canonical_u64(
-                (self.exit_code & 0xffff) as u64,
-            )],
-            vec![E::BaseField::from_canonical_u64(
+            vec![E::BaseField::from_u64((self.exit_code & 0xffff) as u64)],
+            vec![E::BaseField::from_u64(
                 ((self.exit_code >> 16) & 0xffff) as u64,
             )],
-            vec![E::BaseField::from_canonical_u64(self.init_pc as u64)],
-            vec![E::BaseField::from_canonical_u64(self.init_cycle as u64)],
-            vec![E::BaseField::from_canonical_u64(self.end_pc as u64)],
-            vec![E::BaseField::from_canonical_u64(self.end_cycle as u64)],
+            vec![E::BaseField::from_u64(self.init_pc as u64)],
+            vec![E::BaseField::from_u64(self.init_cycle as u64)],
+            vec![E::BaseField::from_u64(self.end_pc as u64)],
+            vec![E::BaseField::from_u64(self.end_cycle as u64)],
             self.public_io
                 .iter()
-                .map(|e| E::BaseField::from_canonical_u64(*e as u64))
+                .map(|e| E::BaseField::from_u64(*e as u64))
                 .collect(),
         ]
     }

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -22,7 +22,7 @@ use ff_ext::{ExtensionField, GoldilocksExt2, SmallField};
 use generic_static::StaticTypeMap;
 use itertools::{Itertools, chain, enumerate, izip};
 use multilinear_extensions::{mle::IntoMLEs, virtual_poly::ArcMultilinearExtension};
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use rand::thread_rng;
 use std::{
     cmp::max,
@@ -1328,12 +1328,9 @@ mod tests {
         let _ = RangeCheckCircuit::construct_circuit(&mut builder).unwrap();
 
         let wits_in = vec![
-            vec![
-                Goldilocks::from_canonical_u64(3u64),
-                Goldilocks::from_canonical_u64(5u64),
-            ]
-            .into_mle()
-            .into(),
+            vec![Goldilocks::from_u64(3u64), Goldilocks::from_u64(5u64)]
+                .into_mle()
+                .into(),
         ];
 
         let challenge = [1.into_f(), 1000.into_f()];
@@ -1365,9 +1362,7 @@ mod tests {
                         GoldilocksExt2::ONE,
                         GoldilocksExt2::ZERO,
                     )),
-                    Box::new(Expression::Constant(Goldilocks::from_canonical_u64(
-                        U5 as u64
-                    ))),
+                    Box::new(Expression::Constant(Goldilocks::from_u64(U5 as u64))),
                 )),
                 Box::new(Expression::Challenge(
                     0,

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -11,7 +11,7 @@ use multilinear_extensions::{
     util::ceil_log2,
     virtual_poly::{ArcMultilinearExtension, build_eq_x_r_vec},
 };
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use sumcheck::{
     macros::{entered_span, exit_span},

--- a/ceno_zkvm/src/scheme/tests.rs
+++ b/ceno_zkvm/src/scheme/tests.rs
@@ -28,7 +28,7 @@ use mpcs::{Basefold, BasefoldDefault, BasefoldRSParams, PolynomialCommitmentSche
 use multilinear_extensions::{
     mle::IntoMLE, util::ceil_log2, virtual_poly::ArcMultilinearExtension,
 };
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use transcript::{BasicTranscript, BasicTranscriptWithStat, StatisticRecorder, Transcript};
 
 use super::{

--- a/ceno_zkvm/src/scheme/utils.rs
+++ b/ceno_zkvm/src/scheme/utils.rs
@@ -416,7 +416,7 @@ mod tests {
         util::ceil_log2,
         virtual_poly::ArcMultilinearExtension,
     };
-    use p3_field::{FieldAlgebra, FieldExtensionAlgebra};
+    use p3_field::PrimeCharacteristicRing;
 
     use crate::{
         circuit_builder::{CircuitBuilder, ConstraintSystem},
@@ -433,10 +433,8 @@ mod tests {
         type E = GoldilocksExt2;
         let num_product_fanin = 2;
         let last_layer: Vec<ArcMultilinearExtension<E>> = vec![
-            vec![E::ONE, E::from_canonical_u64(2u64)].into_mle().into(),
-            vec![E::from_canonical_u64(3u64), E::from_canonical_u64(4u64)]
-                .into_mle()
-                .into(),
+            vec![E::ONE, E::from_u64(2u64)].into_mle().into(),
+            vec![E::from_u64(3u64), E::from_u64(4u64)].into_mle().into(),
         ];
         let num_vars = ceil_log2(last_layer[0].evaluations().len()) + 1;
         let res = infer_tower_product_witness(num_vars, last_layer.clone(), 2);
@@ -446,7 +444,7 @@ mod tests {
                 assert!(left.len() == 1 && right.len() == 1);
                 left[0] * right[0]
             },
-            |out| E::from_base(out)
+            |out| out.into()
         );
         let expected_final_product: E = last_layer
             .iter()
@@ -469,30 +467,24 @@ mod tests {
         let num_product_fanin = 2;
         // [[1, 2], [3, 4], [5, 6], [7, 8]]
         let input_mles: Vec<ArcMultilinearExtension<E>> = vec![
-            vec![E::ONE, E::from_canonical_u64(2u64)].into_mle().into(),
-            vec![E::from_canonical_u64(3u64), E::from_canonical_u64(4u64)]
-                .into_mle()
-                .into(),
-            vec![E::from_canonical_u64(5u64), E::from_canonical_u64(6u64)]
-                .into_mle()
-                .into(),
-            vec![E::from_canonical_u64(7u64), E::from_canonical_u64(8u64)]
-                .into_mle()
-                .into(),
+            vec![E::ONE, E::from_u64(2u64)].into_mle().into(),
+            vec![E::from_u64(3u64), E::from_u64(4u64)].into_mle().into(),
+            vec![E::from_u64(5u64), E::from_u64(6u64)].into_mle().into(),
+            vec![E::from_u64(7u64), E::from_u64(8u64)].into_mle().into(),
         ];
         let res = interleaving_mles_to_mles(&input_mles, 2, num_product_fanin, E::ONE);
         // [[1, 3, 5, 7], [2, 4, 6, 8]]
         assert_eq!(res[0].get_ext_field_vec(), vec![
             E::ONE,
-            E::from_canonical_u64(3u64),
-            E::from_canonical_u64(5u64),
-            E::from_canonical_u64(7u64)
+            E::from_u64(3u64),
+            E::from_u64(5u64),
+            E::from_u64(7u64)
         ],);
         assert_eq!(res[1].get_ext_field_vec(), vec![
-            E::from_canonical_u64(2u64),
-            E::from_canonical_u64(4u64),
-            E::from_canonical_u64(6u64),
-            E::from_canonical_u64(8u64)
+            E::from_u64(2u64),
+            E::from_u64(4u64),
+            E::from_u64(6u64),
+            E::from_u64(8u64)
         ],);
     }
 
@@ -504,46 +496,38 @@ mod tests {
         // case 1: test limb level padding
         // [[1,2],[3,4],[5,6]]]
         let input_mles: Vec<ArcMultilinearExtension<E>> = vec![
-            vec![E::ONE, E::from_canonical_u64(2u64)].into_mle().into(),
-            vec![E::from_canonical_u64(3u64), E::from_canonical_u64(4u64)]
-                .into_mle()
-                .into(),
-            vec![E::from_canonical_u64(5u64), E::from_canonical_u64(6u64)]
-                .into_mle()
-                .into(),
+            vec![E::ONE, E::from_u64(2u64)].into_mle().into(),
+            vec![E::from_u64(3u64), E::from_u64(4u64)].into_mle().into(),
+            vec![E::from_u64(5u64), E::from_u64(6u64)].into_mle().into(),
         ];
         let res = interleaving_mles_to_mles(&input_mles, 2, num_product_fanin, E::ZERO);
         // [[1, 3, 5, 0], [2, 4, 6, 0]]
         assert_eq!(res[0].get_ext_field_vec(), vec![
             E::ONE,
-            E::from_canonical_u64(3u64),
-            E::from_canonical_u64(5u64),
-            E::from_canonical_u64(0u64)
+            E::from_u64(3u64),
+            E::from_u64(5u64),
+            E::from_u64(0u64)
         ],);
         assert_eq!(res[1].get_ext_field_vec(), vec![
-            E::from_canonical_u64(2u64),
-            E::from_canonical_u64(4u64),
-            E::from_canonical_u64(6u64),
-            E::from_canonical_u64(0u64)
+            E::from_u64(2u64),
+            E::from_u64(4u64),
+            E::from_u64(6u64),
+            E::from_u64(0u64)
         ],);
 
         // case 2: test instance level padding
         // [[1,0],[3,0],[5,0]]]
         let input_mles: Vec<ArcMultilinearExtension<E>> = vec![
-            vec![E::ONE, E::from_canonical_u64(0u64)].into_mle().into(),
-            vec![E::from_canonical_u64(3u64), E::from_canonical_u64(0u64)]
-                .into_mle()
-                .into(),
-            vec![E::from_canonical_u64(5u64), E::from_canonical_u64(0u64)]
-                .into_mle()
-                .into(),
+            vec![E::ONE, E::from_u64(0u64)].into_mle().into(),
+            vec![E::from_u64(3u64), E::from_u64(0u64)].into_mle().into(),
+            vec![E::from_u64(5u64), E::from_u64(0u64)].into_mle().into(),
         ];
         let res = interleaving_mles_to_mles(&input_mles, 1, num_product_fanin, E::ONE);
         // [[1, 3, 5, 1], [1, 1, 1, 1]]
         assert_eq!(res[0].get_ext_field_vec(), vec![
             E::ONE,
-            E::from_canonical_u64(3u64),
-            E::from_canonical_u64(5u64),
+            E::from_u64(3u64),
+            E::from_u64(5u64),
             E::ONE
         ],);
         assert_eq!(res[1].get_ext_field_vec(), vec![E::ONE; 4],);
@@ -555,14 +539,14 @@ mod tests {
         let num_product_fanin = 2;
         // one instance, 2 mles: [[2], [3]]
         let input_mles: Vec<ArcMultilinearExtension<E>> = vec![
-            vec![E::from_canonical_u64(2u64)].into_mle().into(),
-            vec![E::from_canonical_u64(3u64)].into_mle().into(),
+            vec![E::from_u64(2u64)].into_mle().into(),
+            vec![E::from_u64(3u64)].into_mle().into(),
         ];
         let res = interleaving_mles_to_mles(&input_mles, 1, num_product_fanin, E::ONE);
         // [[2, 3], [1, 1]]
         assert_eq!(res[0].get_ext_field_vec(), vec![
-            E::from_canonical_u64(2u64),
-            E::from_canonical_u64(3u64)
+            E::from_u64(2u64),
+            E::from_u64(3u64)
         ],);
         assert_eq!(res[1].get_ext_field_vec(), vec![E::ONE, E::ONE],);
     }
@@ -574,13 +558,13 @@ mod tests {
         let q: Vec<ArcMultilinearExtension<E>> = vec![
             vec![1, 2, 3, 4]
                 .into_iter()
-                .map(E::from_canonical_u64)
+                .map(E::from_u64)
                 .collect_vec()
                 .into_mle()
                 .into(),
             vec![5, 6, 7, 8]
                 .into_iter()
-                .map(E::from_canonical_u64)
+                .map(E::from_u64)
                 .collect_vec()
                 .into_mle()
                 .into(),
@@ -614,53 +598,32 @@ mod tests {
         assert_eq!(
             layer[0].evaluations().clone(),
             FieldType::<E>::Ext(vec![
-                vec![1 + 5]
-                    .into_iter()
-                    .map(E::from_canonical_u64)
-                    .sum::<E>(),
-                vec![2 + 6]
-                    .into_iter()
-                    .map(E::from_canonical_u64)
-                    .sum::<E>()
+                vec![1 + 5].into_iter().map(E::from_u64).sum::<E>(),
+                vec![2 + 6].into_iter().map(E::from_u64).sum::<E>()
             ])
         );
         // next layer p2
         assert_eq!(
             layer[1].evaluations().clone(),
             FieldType::<E>::Ext(vec![
-                vec![3 + 7]
-                    .into_iter()
-                    .map(E::from_canonical_u64)
-                    .sum::<E>(),
-                vec![4 + 8]
-                    .into_iter()
-                    .map(E::from_canonical_u64)
-                    .sum::<E>()
+                vec![3 + 7].into_iter().map(E::from_u64).sum::<E>(),
+                vec![4 + 8].into_iter().map(E::from_u64).sum::<E>()
             ])
         );
         // next layer q1
         assert_eq!(
             layer[2].evaluations().clone(),
             FieldType::<E>::Ext(vec![
-                vec![5].into_iter().map(E::from_canonical_u64).sum::<E>(),
-                vec![2 * 6]
-                    .into_iter()
-                    .map(E::from_canonical_u64)
-                    .sum::<E>()
+                vec![5].into_iter().map(E::from_u64).sum::<E>(),
+                vec![2 * 6].into_iter().map(E::from_u64).sum::<E>()
             ])
         );
         // next layer q2
         assert_eq!(
             layer[3].evaluations().clone(),
             FieldType::<E>::Ext(vec![
-                vec![3 * 7]
-                    .into_iter()
-                    .map(E::from_canonical_u64)
-                    .sum::<E>(),
-                vec![4 * 8]
-                    .into_iter()
-                    .map(E::from_canonical_u64)
-                    .sum::<E>()
+                vec![3 * 7].into_iter().map(E::from_u64).sum::<E>(),
+                vec![4 * 8].into_iter().map(E::from_u64).sum::<E>()
             ])
         );
 
@@ -673,7 +636,7 @@ mod tests {
             FieldType::<E>::Ext(vec![
                 vec![(1 + 5) * (3 * 7) + (3 + 7) * 5]
                     .into_iter()
-                    .map(E::from_canonical_u64)
+                    .map(E::from_u64)
                     .sum::<E>(),
             ])
         );
@@ -684,7 +647,7 @@ mod tests {
             FieldType::<E>::Ext(vec![
                 vec![(2 + 6) * (4 * 8) + (4 + 8) * (2 * 6)]
                     .into_iter()
-                    .map(E::from_canonical_u64)
+                    .map(E::from_u64)
                     .sum::<E>(),
             ])
         );
@@ -693,10 +656,7 @@ mod tests {
             layer[2].evaluations().clone(),
             // q12 * q11
             FieldType::<E>::Ext(vec![
-                vec![(3 * 7) * 5]
-                    .into_iter()
-                    .map(E::from_canonical_u64)
-                    .sum::<E>(),
+                vec![(3 * 7) * 5].into_iter().map(E::from_u64).sum::<E>(),
             ])
         );
         // q2
@@ -706,7 +666,7 @@ mod tests {
             FieldType::<E>::Ext(vec![
                 vec![(4 * 8) * (2 * 6)]
                     .into_iter()
-                    .map(E::from_canonical_u64)
+                    .map(E::from_u64)
                     .sum::<E>(),
             ])
         );
@@ -727,9 +687,9 @@ mod tests {
         let res = wit_infer_by_expr(
             &[],
             &[
-                vec![B::from_canonical_u64(1)].into_mle().into(),
-                vec![B::from_canonical_u64(2)].into_mle().into(),
-                vec![B::from_canonical_u64(3)].into_mle().into(),
+                vec![B::from_u64(1)].into_mle().into(),
+                vec![B::from_u64(2)].into_mle().into(),
+                vec![B::from_u64(3)].into_mle().into(),
             ],
             &[],
             &[],
@@ -758,9 +718,9 @@ mod tests {
         let res = wit_infer_by_expr(
             &[],
             &[
-                vec![B::from_canonical_u64(1)].into_mle().into(),
-                vec![B::from_canonical_u64(2)].into_mle().into(),
-                vec![B::from_canonical_u64(3)].into_mle().into(),
+                vec![B::from_u64(1)].into_mle().into(),
+                vec![B::from_u64(2)].into_mle().into(),
+                vec![B::from_u64(3)].into_mle().into(),
             ],
             &[],
             &[],

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -225,8 +225,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
                 .copied()
                 .product::<E>();
         }
-        logup_sum -= E::from_canonical_u64(dummy_table_item_multiplicity as u64)
-            * dummy_table_item.inverse();
+        logup_sum -= E::from_u64(dummy_table_item_multiplicity as u64) * dummy_table_item.inverse();
 
         // check logup relation across all proofs
         if logup_sum != E::ZERO {

--- a/ceno_zkvm/src/state.rs
+++ b/ceno_zkvm/src/state.rs
@@ -6,7 +6,7 @@ use crate::{
     expression::{Expression, ToExpr},
     structs::RAMType,
 };
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 
 pub trait StateCircuit<E: ExtensionField> {
     fn initial_global_state(
@@ -24,9 +24,7 @@ impl<E: ExtensionField> StateCircuit<E> for GlobalState {
         circuit_builder: &mut crate::circuit_builder::CircuitBuilder<E>,
     ) -> Result<Expression<E>, ZKVMError> {
         let states: Vec<Expression<E>> = vec![
-            Expression::Constant(E::BaseField::from_canonical_u64(
-                RAMType::GlobalState as u64,
-            )),
+            Expression::Constant(E::BaseField::from_u64(RAMType::GlobalState as u64)),
             circuit_builder.query_init_pc()?.expr(),
             circuit_builder.query_init_cycle()?.expr(),
         ];
@@ -38,9 +36,7 @@ impl<E: ExtensionField> StateCircuit<E> for GlobalState {
         circuit_builder: &mut crate::circuit_builder::CircuitBuilder<E>,
     ) -> Result<crate::expression::Expression<E>, crate::error::ZKVMError> {
         let states: Vec<Expression<E>> = vec![
-            Expression::Constant(E::BaseField::from_canonical_u64(
-                RAMType::GlobalState as u64,
-            )),
+            Expression::Constant(E::BaseField::from_u64(RAMType::GlobalState as u64)),
             circuit_builder.query_end_pc()?.expr(),
             circuit_builder.query_end_cycle()?.expr(),
         ];

--- a/ceno_zkvm/src/tables/program.rs
+++ b/ceno_zkvm/src/tables/program.rs
@@ -17,7 +17,7 @@ use ceno_emul::{
 };
 use ff_ext::{ExtensionField, FieldInto, SmallField};
 use itertools::Itertools;
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
 
 /// This structure establishes the order of the fields in instruction records, common to the program table and circuit fetches.
@@ -189,11 +189,7 @@ impl<E: ExtensionField> TableCircuit<E> for ProgramTableCircuit<E> {
             .with_min_len(MIN_PAR_SIZE)
             .zip(prog_mlt.into_par_iter())
             .for_each(|(row, mlt)| {
-                set_val!(
-                    row,
-                    config.mlt,
-                    E::BaseField::from_canonical_u64(mlt as u64)
-                );
+                set_val!(row, config.mlt, E::BaseField::from_u64(mlt as u64));
             });
 
         Ok(witness)

--- a/ceno_zkvm/src/tables/ram/ram_impl.rs
+++ b/ceno_zkvm/src/tables/ram/ram_impl.rs
@@ -454,7 +454,7 @@ mod tests {
     use ceno_emul::WORD_SIZE;
     use ff_ext::GoldilocksExt2 as E;
     use itertools::Itertools;
-    use p3_field::FieldAlgebra;
+    use p3_field::PrimeCharacteristicRing;
     use p3_goldilocks::Goldilocks as F;
 
     #[test]
@@ -494,7 +494,7 @@ mod tests {
         let addr_padded_view = wit.column_padded(addr_column + cb.cs.num_witin as usize);
         // Expect addresses to proceed consecutively inside the padding as well
         let expected = successors(Some(addr_padded_view[0]), |idx| {
-            Some(*idx + F::from_canonical_u64(WORD_SIZE as u64))
+            Some(*idx + F::from_u64(WORD_SIZE as u64))
         })
         .take(next_pow2_instance_padding(wit.num_instances()))
         .collect::<Vec<_>>();

--- a/ceno_zkvm/src/tables/range/range_impl.rs
+++ b/ceno_zkvm/src/tables/range/range_impl.rs
@@ -76,8 +76,8 @@ impl RangeTableConfig {
             .zip(mlts.into_par_iter())
             .zip(content.into_par_iter())
             .for_each(|((row, mlt), i)| {
-                set_val!(row, self.mlt, F::from_canonical_u64(mlt as u64));
-                set_val!(row, offset_range, F::from_canonical_u64(i));
+                set_val!(row, self.mlt, F::from_u64(mlt as u64));
+                set_val!(row, offset_range, F::from_u64(i));
             });
 
         Ok(witness)

--- a/ceno_zkvm/src/uint.rs
+++ b/ceno_zkvm/src/uint.rs
@@ -16,7 +16,7 @@ use crate::{
 use ark_std::iterable::Iterable;
 use ff_ext::{ExtensionField, SmallField};
 use itertools::{Itertools, enumerate};
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use std::{
     borrow::Cow,
     mem::{self},
@@ -157,7 +157,7 @@ impl<const M: usize, const C: usize, E: ExtensionField> UIntLimbs<M, C, E> {
                 limbs
                     .into_iter()
                     .take(Self::NUM_LIMBS)
-                    .map(|limb| Expression::Constant(E::BaseField::from_canonical_u64(limb.into())))
+                    .map(|limb| Expression::Constant(E::BaseField::from_u64(limb.into())))
                     .collect::<Vec<Expression<E>>>(),
             ),
             carries: None,
@@ -234,7 +234,7 @@ impl<const M: usize, const C: usize, E: ExtensionField> UIntLimbs<M, C, E> {
             for (wire, limb) in wires.iter().zip(
                 limbs_values
                     .iter()
-                    .map(|v| E::BaseField::from_canonical_u64(*v as u64))
+                    .map(|v| E::BaseField::from_u64(*v as u64))
                     .chain(std::iter::repeat(E::BaseField::ZERO)),
             ) {
                 instance[wire.id as usize] = limb;
@@ -260,7 +260,7 @@ impl<const M: usize, const C: usize, E: ExtensionField> UIntLimbs<M, C, E> {
             for (wire, carry) in carries.iter().zip(
                 carry_values
                     .iter()
-                    .map(|v| E::BaseField::from_canonical_u64(Into::<u64>::into(*v)))
+                    .map(|v| E::BaseField::from_u64(Into::<u64>::into(*v)))
                     .chain(std::iter::repeat(E::BaseField::ZERO)),
             ) {
                 instance[wire.id as usize] = carry;
@@ -445,7 +445,7 @@ impl<const M: usize, const C: usize, E: ExtensionField> UIntLimbs<M, C, E> {
     pub fn counter_vector<F: SmallField>(size: usize) -> Vec<Vec<F>> {
         let num_vars = ceil_log2(size);
         let number_of_limbs = num_vars.div_ceil(C);
-        let cell_modulo = F::from_canonical_u64(1 << C);
+        let cell_modulo = F::from_u64(1 << C);
 
         let mut res = vec![vec![F::ZERO; number_of_limbs]];
 
@@ -712,7 +712,7 @@ impl<'a, T: Into<u64> + From<u32> + Copy + Default> Value<'a, T> {
     pub fn u16_fields<F: SmallField>(&self) -> Vec<F> {
         self.limbs
             .iter()
-            .map(|v| F::from_canonical_u64(*v as u64))
+            .map(|v| F::from_u64(*v as u64))
             .collect_vec()
     }
 

--- a/ceno_zkvm/src/uint/arithmetic.rs
+++ b/ceno_zkvm/src/uint/arithmetic.rs
@@ -9,7 +9,7 @@ use crate::{
     gadgets::AssertLtConfig,
     instructions::riscv::config::IsEqualConfig,
 };
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 
 impl<const M: usize, const C: usize, E: ExtensionField> UIntLimbs<M, C, E> {
     const POW_OF_C: usize = 2_usize.pow(C as u32);
@@ -83,7 +83,7 @@ impl<const M: usize, const C: usize, E: ExtensionField> UIntLimbs<M, C, E> {
             // convert Expression::Constant to limbs
             let b_limbs = (0..Self::NUM_LIMBS)
                 .map(|i| {
-                    Expression::Constant(E::BaseField::from_canonical_u64(
+                    Expression::Constant(E::BaseField::from_u64(
                         (b >> (C * i)) & Self::LIMB_BIT_MASK,
                     ))
                 })
@@ -486,13 +486,10 @@ mod tests {
             let wit: Vec<E> = witness_values
                 .iter()
                 .cloned()
-                .map(E::from_canonical_u64)
+                .map(E::from_u64)
                 .collect_vec();
             uint_c.expr().iter().zip(result).for_each(|(c, ret)| {
-                assert_eq!(
-                    eval_by_expr(&wit, &[], &challenges, c),
-                    E::from_canonical_u64(ret)
-                );
+                assert_eq!(eval_by_expr(&wit, &[], &challenges, c), E::from_u64(ret));
             });
 
             // overflow
@@ -666,13 +663,10 @@ mod tests {
             let wit: Vec<E> = witness_values
                 .iter()
                 .cloned()
-                .map(E::from_canonical_u64)
+                .map(E::from_u64)
                 .collect_vec();
             uint_c.expr().iter().zip(result).for_each(|(c, ret)| {
-                assert_eq!(
-                    eval_by_expr(&wit, &[], &challenges, c),
-                    E::from_canonical_u64(ret)
-                );
+                assert_eq!(eval_by_expr(&wit, &[], &challenges, c), E::from_u64(ret));
             });
 
             // overflow
@@ -700,7 +694,7 @@ mod tests {
         use multilinear_extensions::{
             mle::DenseMultilinearExtension, virtual_poly::ArcMultilinearExtension,
         };
-        use p3_field::FieldAlgebra;
+        use p3_field::PrimeCharacteristicRing;
 
         type E = GoldilocksExt2; // 18446744069414584321
 
@@ -715,7 +709,7 @@ mod tests {
                     .map(|a| {
                         let mle: ArcMultilinearExtension<E> =
                             DenseMultilinearExtension::from_evaluation_vec_smart(0, vec![
-                                E::BaseField::from_canonical_u64(*a),
+                                E::BaseField::from_u64(*a),
                             ])
                             .into();
                         mle

--- a/ceno_zkvm/src/utils.rs
+++ b/ceno_zkvm/src/utils.rs
@@ -13,9 +13,9 @@ use transcript::Transcript;
 
 pub fn i64_to_base<F: SmallField>(x: i64) -> F {
     if x >= 0 {
-        F::from_canonical_u64(x as u64)
+        F::from_u64(x as u64)
     } else {
-        -F::from_canonical_u64((-x) as u64)
+        -F::from_u64((-x) as u64)
     }
 }
 
@@ -124,7 +124,7 @@ pub(crate) fn eq_eval_less_or_equal_than<E: ExtensionField>(max_idx: usize, a: &
         let mut running_product = vec![E::ZERO; b.len() + 1];
         running_product[b.len()] = E::ONE;
         for i in (0..b.len()).rev() {
-            let bit = E::from_canonical_u64(((max_idx >> i) & 1) as u64);
+            let bit = E::from_u64(((max_idx >> i) & 1) as u64);
             running_product[i] = running_product[i + 1]
                 * (a[i] * b[i] * bit + (E::ONE - a[i]) * (E::ONE - b[i]) * (E::ONE - bit));
         }
@@ -155,13 +155,13 @@ pub(crate) fn eq_eval_less_or_equal_than<E: ExtensionField>(max_idx: usize, a: &
 /// a, b, is constant
 /// the result M(r0, r1,... rn) = r0 + r1 * 2 + r2 * 2^2 + .... rn * 2^n
 pub fn eval_wellform_address_vec<E: ExtensionField>(offset: u64, scaled: u64, r: &[E]) -> E {
-    let (offset, scaled) = (E::from_canonical_u64(offset), E::from_canonical_u64(scaled));
+    let (offset, scaled) = (E::from_u64(offset), E::from_u64(scaled));
     offset
         + scaled
             * r.iter()
                 .scan(E::ONE, |state, x| {
                     let result = *x * *state;
-                    *state *= E::from_canonical_u64(2); // Update the state for the next power of 2
+                    *state *= E::from_u64(2); // Update the state for the next power of 2
                     Some(result)
                 })
                 .sum::<E>()

--- a/ceno_zkvm/src/virtual_polys.rs
+++ b/ceno_zkvm/src/virtual_polys.rs
@@ -176,7 +176,7 @@ mod tests {
         mle::IntoMLE,
         virtual_poly::{ArcMultilinearExtension, VPAuxInfo, VirtualPolynomial},
     };
-    use p3_field::FieldAlgebra;
+    use p3_field::PrimeCharacteristicRing;
     use p3_goldilocks::Goldilocks;
     use sumcheck::structs::{IOPProverState, IOPVerifierState};
     use transcript::BasicTranscript as Transcript;
@@ -196,7 +196,7 @@ mod tests {
         let y = cb.create_witin(|| "y");
 
         let wits_in: Vec<ArcMultilinearExtension<E>> = (0..cs.num_witin as usize)
-            .map(|_| vec![Goldilocks::from_canonical_u64(1)].into_mle().into())
+            .map(|_| vec![Goldilocks::from_u64(1)].into_mle().into())
             .collect();
 
         let mut virtual_polys = VirtualPolynomials::new(1, 0);
@@ -231,7 +231,7 @@ mod tests {
     fn test_sumcheck_different_degree() {
         let max_num_vars = 3;
         let fn_eval = |fs: &[ArcMultilinearExtension<E>]| -> E {
-            let base_2 = Goldilocks::from_canonical_u64(2);
+            let base_2 = Goldilocks::from_u64(2);
 
             let evals = fs.iter().fold(
                 vec![Goldilocks::ONE; 1 << fs[0].num_vars()],

--- a/ceno_zkvm/src/witness.rs
+++ b/ceno_zkvm/src/witness.rs
@@ -1,6 +1,6 @@
 use itertools::izip;
 use multilinear_extensions::mle::{DenseMultilinearExtension, IntoMLE};
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 use rayon::{
     iter::{IntoParallelIterator, ParallelIterator},
     slice::ParallelSliceMut,
@@ -46,7 +46,7 @@ pub struct RowMajorMatrix<T: Sized + Sync + Clone + Send + Copy> {
     padding_strategy: InstancePaddingStrategy,
 }
 
-impl<T: Sized + Sync + Clone + Send + Copy + Default + FieldAlgebra> RowMajorMatrix<T> {
+impl<T: Sized + Sync + Clone + Send + Copy + Default + PrimeCharacteristicRing> RowMajorMatrix<T> {
     pub fn new(num_rows: usize, num_col: usize, padding_strategy: InstancePaddingStrategy) -> Self {
         RowMajorMatrix {
             values: (0..num_rows * num_col)
@@ -89,9 +89,7 @@ impl<T: Sized + Sync + Clone + Send + Copy + Default + FieldAlgebra> RowMajorMat
 
         let padding_iter = (num_instances..num_instances + num_padding_instances).map(|i| {
             match &self.padding_strategy {
-                InstancePaddingStrategy::Custom(fun) => {
-                    T::from_canonical_u64(fun(i as u64, column as u64))
-                }
+                InstancePaddingStrategy::Custom(fun) => T::from_u64(fun(i as u64, column as u64)),
                 InstancePaddingStrategy::RepeatLast if num_instances > 0 => {
                     self[num_instances - 1][column]
                 }
@@ -109,7 +107,7 @@ impl<T: Sized + Sync + Clone + Send + Copy + Default + FieldAlgebra> RowMajorMat
     }
 }
 
-impl<F: Field + FieldAlgebra> RowMajorMatrix<F> {
+impl<F: Field + PrimeCharacteristicRing> RowMajorMatrix<F> {
     pub fn into_mles<E: ff_ext::ExtensionField<BaseField = F>>(
         self,
     ) -> Vec<DenseMultilinearExtension<E>> {

--- a/ff_ext/src/lib.rs
+++ b/ff_ext/src/lib.rs
@@ -56,7 +56,7 @@ macro_rules! impl_from_uniform_bytes_for_binomial_extension {
             type Bytes = [u8; <$base as FromUniformBytes>::Bytes::WIDTH * $degree];
 
             fn try_from_uniform_bytes(bytes: Self::Bytes) -> Option<Self> {
-                Some(p3_field::FieldExtensionAlgebra::from_base_slice(
+                Some(p3_field::BasedVectorSpace::from_basis_coefficients_slice(
                     &array_try_from_uniform_bytes::<
                         $base,
                         { <$base as FromUniformBytes>::Bytes::WIDTH },
@@ -121,7 +121,7 @@ mod impl_goldilocks {
         ExtensionField, FieldFrom, FieldInto, FromUniformBytes, GoldilocksExt2, SmallField,
         poseidon::{PoseidonField, new_array},
     };
-    use p3_field::{FieldAlgebra, FieldExtensionAlgebra, PrimeField64};
+    use p3_field::{BasedVectorSpace, PrimeCharacteristicRing, PrimeField64};
     use p3_goldilocks::{
         Goldilocks, HL_GOLDILOCKS_8_EXTERNAL_ROUND_CONSTANTS,
         HL_GOLDILOCKS_8_INTERNAL_ROUND_CONSTANTS, Poseidon2GoldilocksHL,
@@ -130,13 +130,13 @@ mod impl_goldilocks {
 
     impl FieldFrom<u64> for Goldilocks {
         fn from_v(v: u64) -> Self {
-            Self::from_canonical_u64(v)
+            Self::from_u64(v)
         }
     }
 
     impl FieldFrom<u64> for GoldilocksExt2 {
         fn from_v(v: u64) -> Self {
-            Self::from_canonical_u64(v)
+            Self::from_u64(v)
         }
     }
 
@@ -174,7 +174,7 @@ mod impl_goldilocks {
         fn try_from_uniform_bytes(bytes: [u8; 8]) -> Option<Self> {
             let value = u64::from_le_bytes(bytes);
             let is_canonical = value < Self::ORDER_U64;
-            is_canonical.then(|| Self::from_canonical_u64(value))
+            is_canonical.then(|| Self::from_u64(value))
         }
     }
 
@@ -192,7 +192,7 @@ mod impl_goldilocks {
                     array[..chunk.len()].copy_from_slice(chunk);
                     unsafe { std::ptr::read_unaligned(array.as_ptr() as *const u64) }
                 })
-                .map(Self::from_canonical_u64)
+                .map(Self::from_u64)
                 .collect::<Vec<_>>()
         }
 
@@ -214,20 +214,20 @@ mod impl_goldilocks {
 
         fn from_bases(bases: &[Goldilocks]) -> Self {
             debug_assert_eq!(bases.len(), 2);
-            Self::from_base_slice(bases)
+            Self::from_basis_coefficients_slice(bases)
         }
 
         fn as_bases(&self) -> &[Goldilocks] {
-            self.as_base_slice()
+            self.as_basis_coefficients_slice()
         }
 
         /// Convert limbs into self
         fn from_limbs(limbs: &[Self::BaseField]) -> Self {
-            Self::from_base_slice(&limbs[0..2])
+            Self::from_bases(&limbs[0..2])
         }
 
         fn to_canonical_u64_vec(&self) -> Vec<u64> {
-            self.as_base_slice()
+            self.as_basis_coefficients_slice()
                 .iter()
                 .map(|v: &Self::BaseField| v.as_canonical_u64())
                 .collect()

--- a/ff_ext/src/poseidon.rs
+++ b/ff_ext/src/poseidon.rs
@@ -1,4 +1,4 @@
-use p3_field::{FieldAlgebra, PrimeField};
+use p3_field::PrimeField;
 use p3_symmetric::CryptographicPermutation;
 
 use crate::SmallField;
@@ -8,11 +8,11 @@ pub trait PoseidonField: PrimeField + SmallField {
     fn get_perm() -> Self::T;
 }
 
-pub(crate) fn new_array<const N: usize, F: FieldAlgebra>(input: [u64; N]) -> [F; N] {
+pub(crate) fn new_array<const N: usize, F: PrimeField>(input: [u64; N]) -> [F; N] {
     let mut output = [F::ZERO; N];
     let mut i = 0;
     while i < N {
-        output[i] = F::from_canonical_u64(input[i]);
+        output[i] = F::from_u64(input[i]);
         i += 1;
     }
     output

--- a/mpcs/src/basefold.rs
+++ b/mpcs/src/basefold.rs
@@ -594,7 +594,7 @@ where
             evals.iter().map(Evaluation::value),
             &evals
                 .iter()
-                .map(|eval| E::from_canonical_u64(1 << (num_vars - points[eval.point()].len())))
+                .map(|eval| E::from_u64(1 << (num_vars - points[eval.point()].len())))
                 .collect_vec(),
             &poly_iter_ext(&eq_xt).take(evals.len()).collect_vec(),
         );
@@ -646,7 +646,7 @@ where
                         &poly_iter_ext(poly).collect_vec(),
                         build_eq_x_r_vec(point).iter(),
                     ) * *scalar
-                        * E::from_canonical_u64(1 << (num_vars - poly.num_vars))
+                        * E::from_u64(1 << (num_vars - poly.num_vars))
                     // When this polynomial is smaller, it will be repeatedly summed over the cosets of the hypercube
                 })
                 .sum::<E>();
@@ -977,7 +977,7 @@ where
             evals.iter().map(Evaluation::value),
             &evals
                 .iter()
-                .map(|eval| E::from_canonical_u64(1 << (num_vars - points[eval.point()].len())))
+                .map(|eval| E::from_u64(1 << (num_vars - points[eval.point()].len())))
                 .collect_vec(),
             &poly_iter_ext(&eq_xt).take(evals.len()).collect_vec(),
         );

--- a/mpcs/src/basefold/encoding.rs
+++ b/mpcs/src/basefold/encoding.rs
@@ -173,9 +173,7 @@ pub(crate) mod test_util {
     pub fn test_codeword_folding<E: ExtensionField, Code: EncodingScheme<E>>() {
         let num_vars = 12;
 
-        let poly: Vec<E> = (0..(1 << num_vars))
-            .map(|i| E::from_canonical_u64(i))
-            .collect();
+        let poly: Vec<E> = (0..(1 << num_vars)).map(|i| E::from_u64(i)).collect();
         let mut poly = FieldType::Ext(poly);
 
         let pp: Code::PublicParameters = Code::setup(num_vars);

--- a/mpcs/src/basefold/encoding/basecode.rs
+++ b/mpcs/src/basefold/encoding/basecode.rs
@@ -13,7 +13,7 @@ use ark_std::{end_timer, start_timer};
 use ff_ext::ExtensionField;
 use generic_array::GenericArray;
 use multilinear_extensions::mle::FieldType;
-use p3_field::{Field, FieldAlgebra, batch_multiplicative_inverse};
+use p3_field::{Field, PrimeCharacteristicRing, batch_multiplicative_inverse};
 use rand::SeedableRng;
 use rayon::prelude::{ParallelIterator, ParallelSlice, ParallelSliceMut};
 

--- a/mpcs/src/basefold/encoding/rs.rs
+++ b/mpcs/src/basefold/encoding/rs.rs
@@ -9,7 +9,7 @@ use crate::{
 use ark_std::{end_timer, start_timer};
 use ff_ext::ExtensionField;
 use multilinear_extensions::mle::FieldType;
-use p3_field::{Field, FieldAlgebra, PrimeField, TwoAdicField};
+use p3_field::{Field, PrimeCharacteristicRing, PrimeField, TwoAdicField};
 
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
@@ -317,7 +317,7 @@ where
             gamma_powers.push(gamma_powers[i - 1].square());
             gamma_powers_inv.push(gamma_powers_inv[i - 1].square());
         }
-        let inv_of_two = E::BaseField::from_canonical_u64(2).inverse();
+        let inv_of_two = E::BaseField::from_u64(2).inverse();
         gamma_powers_inv.iter_mut().for_each(|x| *x *= inv_of_two);
         pp.fft_root_table
             .truncate(max_message_size_log + Spec::get_rate_log());
@@ -559,9 +559,8 @@ mod tests {
     fn test_naive_fft() {
         let num_vars = 5;
 
-        let poly: Vec<GoldilocksExt2> = (0..(1 << num_vars))
-            .map(GoldilocksExt2::from_canonical_u64)
-            .collect();
+        let poly: Vec<GoldilocksExt2> =
+            (0..(1 << num_vars)).map(GoldilocksExt2::from_u64).collect();
         let mut poly2 = FieldType::Ext(poly.clone());
 
         let naive = naive_fft::<GoldilocksExt2>(&poly, 1, Goldilocks::ONE);
@@ -627,9 +626,8 @@ mod tests {
     fn test_ifft() {
         let num_vars = 5;
 
-        let poly: Vec<GoldilocksExt2> = (0..(1 << num_vars))
-            .map(GoldilocksExt2::from_canonical_u64)
-            .collect();
+        let poly: Vec<GoldilocksExt2> =
+            (0..(1 << num_vars)).map(GoldilocksExt2::from_u64).collect();
         let mut poly = FieldType::Ext(poly);
         let original = poly.clone();
 
@@ -677,14 +675,14 @@ mod tests {
     pub fn test_colinearity() {
         let num_vars = 10;
 
-        let poly: Vec<E> = (0..(1 << num_vars)).map(E::from_canonical_u64).collect();
+        let poly: Vec<E> = (0..(1 << num_vars)).map(E::from_u64).collect();
         let poly = FieldType::Ext(poly);
 
         let pp = <Code as EncodingScheme<E>>::setup(num_vars);
         let (pp, _) = Code::trim(pp, num_vars).unwrap();
         let mut codeword = Code::encode(&pp, &poly);
         reverse_index_bits_in_place_field_type(&mut codeword);
-        let challenge = E::from_canonical_u64(2);
+        let challenge = E::from_u64(2);
         let folded_codeword = Code::fold_bitreversed_codeword(&pp, &codeword, challenge);
         let codeword = match codeword {
             FieldType::Ext(coeffs) => coeffs,
@@ -715,7 +713,7 @@ mod tests {
     pub fn test_low_degree() {
         let num_vars = 10;
 
-        let poly: Vec<E> = (0..(1 << num_vars)).map(E::from_canonical_u64).collect();
+        let poly: Vec<E> = (0..(1 << num_vars)).map(E::from_u64).collect();
         let poly = FieldType::Ext(poly);
 
         let pp = <Code as EncodingScheme<E>>::setup(num_vars);
@@ -781,7 +779,7 @@ mod tests {
             "check low degree of (left-right)*omega^(-i)",
         );
 
-        let challenge = E::from_canonical_u64(2);
+        let challenge = E::from_u64(2);
         let folded_codeword = Code::fold_bitreversed_codeword(&pp, &codeword, challenge);
         let c_fold = folded_codeword[0];
         let c_fold1 = folded_codeword[folded_codeword.len() >> 1];
@@ -807,15 +805,15 @@ mod tests {
         // So the folded value should be equal to
         // (gamma^{-1} * alpha * (c0 - c_mid) + (c0 + c_mid)) / 2
         assert_eq!(
-            c_fold * F::GENERATOR * F::from_canonical_u64(2),
+            c_fold * F::GENERATOR * F::from_u64(2),
             challenge * (c0 - c_mid) + (c0 + c_mid) * F::GENERATOR
         );
         assert_eq!(
-            c_fold * F::GENERATOR * F::from_canonical_u64(2),
+            c_fold * F::GENERATOR * F::from_u64(2),
             challenge * left_right_diff[0] + left_right_sum[0] * F::GENERATOR
         );
         assert_eq!(
-            c_fold * F::from_canonical_u64(2),
+            c_fold * F::from_u64(2),
             challenge * left_right_diff[0] * F::GENERATOR.inverse() + left_right_sum[0]
         );
 
@@ -845,7 +843,7 @@ mod tests {
             _ => panic!("Wrong field type"),
         };
         assert_eq!(
-            c_fold * F::from_canonical_u64(2),
+            c_fold * F::from_u64(2),
             left_right_diff[0] * b + left_right_sum[0]
         );
         for (i, (c, (diff, sum))) in folded_codeword_vec

--- a/mpcs/src/sum_check.rs
+++ b/mpcs/src/sum_check.rs
@@ -135,8 +135,5 @@ pub fn eq_xy_eval<F: Field>(x: &[F], y: &[F]) -> F {
 }
 
 fn identity_eval<F: Field>(x: &[F]) -> F {
-    inner_product(
-        x,
-        &powers(F::from_canonical_u64(2)).take(x.len()).collect_vec(),
-    )
+    inner_product(x, &powers(F::from_u64(2)).take(x.len()).collect_vec())
 }

--- a/mpcs/src/sum_check/classic.rs
+++ b/mpcs/src/sum_check/classic.rs
@@ -23,7 +23,7 @@ use multilinear_extensions::{
 
 pub(crate) use coeff::Coefficients;
 pub use coeff::CoefficientsProver;
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 
 #[derive(Debug)]
 pub struct ProverState<'a, E: ExtensionField> {
@@ -99,7 +99,7 @@ impl<'a, E: ExtensionField> ProverState<'a, E> {
 
     fn next_round(&mut self, sum: E, challenge: &E) {
         self.sum = sum;
-        self.identity += E::from_canonical_u64(1 << self.round) * *challenge;
+        self.identity += E::from_u64(1 << self.round) * *challenge;
         self.lagranges.values_mut().for_each(|(b, value)| {
             if b.is_even() {
                 *value *= E::ONE - *challenge;
@@ -331,50 +331,47 @@ mod tests {
     fn test_sum_check_protocol() {
         let polys = [
             DenseMultilinearExtension::<E>::from_evaluations_vec(2, vec![
-                Fr::from_canonical_u64(1),
-                Fr::from_canonical_u64(2),
-                Fr::from_canonical_u64(3),
-                Fr::from_canonical_u64(4),
+                Fr::from_u64(1),
+                Fr::from_u64(2),
+                Fr::from_u64(3),
+                Fr::from_u64(4),
             ]),
             DenseMultilinearExtension::from_evaluations_vec(2, vec![
-                Fr::from_canonical_u64(0),
-                Fr::from_canonical_u64(1),
-                Fr::from_canonical_u64(1),
-                Fr::from_canonical_u64(0),
+                Fr::from_u64(0),
+                Fr::from_u64(1),
+                Fr::from_u64(1),
+                Fr::from_u64(0),
             ]),
             DenseMultilinearExtension::from_evaluations_vec(1, vec![
-                Fr::from_canonical_u64(0),
-                Fr::from_canonical_u64(1),
+                Fr::from_u64(0),
+                Fr::from_u64(1),
             ]),
         ];
-        let points = vec![
-            vec![E::from_canonical_u64(1), E::from_canonical_u64(2)],
-            vec![E::from_canonical_u64(1)],
-        ];
+        let points = vec![vec![E::from_u64(1), E::from_u64(2)], vec![E::from_u64(1)]];
         let expression = Expression::<E>::eq_xy(0)
             * Expression::Polynomial(Query::new(0, Rotation::cur()))
-            * E::from(Fr::from_canonical_u64(2))
+            * E::from(Fr::from_u64(2))
             + Expression::<E>::eq_xy(0)
                 * Expression::Polynomial(Query::new(1, Rotation::cur()))
-                * E::from(Fr::from_canonical_u64(3))
+                * E::from(Fr::from_u64(3))
             + Expression::<E>::eq_xy(1)
                 * Expression::Polynomial(Query::new(2, Rotation::cur()))
-                * E::from(Fr::from_canonical_u64(4));
+                * E::from(Fr::from_u64(4));
         let virtual_poly =
             VirtualPolynomial::<E>::new(&expression, polys.iter(), &[], points.as_slice());
         let sum = inner_product(
             &poly_iter_ext(&polys[0]).collect_vec(),
             &build_eq_x_r_vec(&points[0]),
-        ) * Fr::from_canonical_u64(2)
+        ) * Fr::from_u64(2)
             + inner_product(
                 &poly_iter_ext(&polys[1]).collect_vec(),
                 &build_eq_x_r_vec(&points[0]),
-            ) * Fr::from_canonical_u64(3)
+            ) * Fr::from_u64(3)
             + inner_product(
                 &poly_iter_ext(&polys[2]).collect_vec(),
                 &build_eq_x_r_vec(&points[1]),
-            ) * Fr::from_canonical_u64(4)
-                * Fr::from_canonical_u64(2); // The third polynomial is summed twice because the hypercube is larger
+            ) * Fr::from_u64(4)
+                * Fr::from_u64(2); // The third polynomial is summed twice because the hypercube is larger
         let mut transcript = BasicTranscript::new(b"sumcheck");
         let (challenges, evals, proof) =
             <ClassicSumCheck<CoefficientsProver<E>> as SumCheck<E>>::prove(
@@ -402,9 +399,9 @@ mod tests {
         assert_eq!(verifier_challenges, challenges);
         assert_eq!(
             new_sum,
-            evals[0] * eq_xy_eval(&points[0], &challenges[..2]) * Fr::from_canonical_u64(2)
-                + evals[1] * eq_xy_eval(&points[0], &challenges[..2]) * Fr::from_canonical_u64(3)
-                + evals[2] * eq_xy_eval(&points[1], &challenges[..1]) * Fr::from_canonical_u64(4)
+            evals[0] * eq_xy_eval(&points[0], &challenges[..2]) * Fr::from_u64(2)
+                + evals[1] * eq_xy_eval(&points[0], &challenges[..2]) * Fr::from_u64(3)
+                + evals[2] * eq_xy_eval(&points[1], &challenges[..1]) * Fr::from_u64(4)
         );
 
         let mut transcript = BasicTranscript::new(b"sumcheck");

--- a/mpcs/src/sum_check/classic/coeff.rs
+++ b/mpcs/src/sum_check/classic/coeff.rs
@@ -198,7 +198,7 @@ impl<E: ExtensionField> ClassicSumCheckProver<E> for CoefficientsProver<E> {
         // Initialize h(X) to zero
         let mut coeffs = Coefficients(FieldType::Ext(vec![E::ZERO; state.expression.degree() + 1]));
         // First, sum the constant over the hypercube and add to h(X)
-        coeffs += &(E::from_canonical_u64(state.size() as u64) * self.0);
+        coeffs += &(E::from_u64(state.size() as u64) * self.0);
         // Next, for every product of polynomials, where each product is assumed to be exactly 2
         // put this into h(X).
         if self.1.iter().all(|(_, products)| products.len() == 2) {

--- a/mpcs/src/util.rs
+++ b/mpcs/src/util.rs
@@ -9,7 +9,7 @@ use multilinear_extensions::mle::{DenseMultilinearExtension, FieldType};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 pub mod merkle_tree;
 use crate::{Error, util::parallel::parallelize};
-use p3_field::{FieldAlgebra, PrimeField};
+use p3_field::{PrimeCharacteristicRing, PrimeField};
 pub use plonky2_util::log2_strict;
 
 pub fn ext_to_usize<E: ExtensionField>(x: &E) -> usize {
@@ -22,7 +22,7 @@ pub fn base_to_usize<E: ExtensionField>(x: &E::BaseField) -> usize {
 }
 
 pub fn u32_to_field<E: ExtensionField>(x: u32) -> E::BaseField {
-    E::BaseField::from_canonical_u32(x)
+    E::BaseField::from_u32(x)
 }
 
 pub trait BitIndex {
@@ -320,7 +320,7 @@ pub mod test {
     #[cfg(test)]
     use crate::util::{base_to_usize, u32_to_field};
     use ff_ext::FromUniformBytes;
-    use p3_field::FieldAlgebra;
+    use p3_field::PrimeCharacteristicRing;
     #[cfg(test)]
     type E = ff_ext::GoldilocksExt2;
     #[cfg(test)]
@@ -353,10 +353,7 @@ pub mod test {
 
     #[test]
     pub fn test_field_transform() {
-        assert_eq!(
-            F::from_canonical_u64(2) * F::from_canonical_u64(3),
-            F::from_canonical_u64(6)
-        );
+        assert_eq!(F::from_u64(2) * F::from_u64(3), F::from_u64(6));
         assert_eq!(base_to_usize::<E>(&u32_to_field::<E>(1u32)), 1);
         assert_eq!(base_to_usize::<E>(&u32_to_field::<E>(10u32)), 10);
     }

--- a/mpcs/src/util/arithmetic.rs
+++ b/mpcs/src/util/arithmetic.rs
@@ -10,7 +10,7 @@ pub use bh::BooleanHypercube;
 pub use hypercube::{
     interpolate_field_type_over_boolean_hypercube, interpolate_over_boolean_hypercube,
 };
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 
 use itertools::Itertools;
 
@@ -159,7 +159,7 @@ pub fn degree_2_eval<F: Field>(poly: &[F], point: F) -> F {
 pub fn base_from_raw_bytes<E: ExtensionField>(bytes: &[u8]) -> E::BaseField {
     let mut res = E::BaseField::ZERO;
     bytes.iter().for_each(|b| {
-        res += E::BaseField::from_canonical_u8(*b);
+        res += E::BaseField::from_u8(*b);
     });
     res
 }

--- a/multilinear_extensions/src/mle.rs
+++ b/multilinear_extensions/src/mle.rs
@@ -4,7 +4,7 @@ use crate::{op_mle, util::ceil_log2};
 use ark_std::{end_timer, rand::RngCore, start_timer};
 use core::hash::Hash;
 use ff_ext::{ExtensionField, FromUniformBytes};
-use p3_field::{Field, FieldAlgebra};
+use p3_field::{Field, PrimeCharacteristicRing};
 use rayon::iter::{
     IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
 };

--- a/multilinear_extensions/src/test.rs
+++ b/multilinear_extensions/src/test.rs
@@ -1,6 +1,6 @@
 use ark_std::test_rng;
 use ff_ext::{ExtensionField, FromUniformBytes};
-use p3_field::{FieldAlgebra, extension::BinomialExtensionField};
+use p3_field::{PrimeCharacteristicRing, extension::BinomialExtensionField};
 use p3_goldilocks::Goldilocks;
 
 type F = Goldilocks;
@@ -47,30 +47,30 @@ fn test_eq_xr() {
 fn test_fix_high_variables() {
     let poly: DenseMultilinearExtension<E> =
         DenseMultilinearExtension::from_evaluations_vec(3, vec![
-            F::from_canonical_u64(13),
-            F::from_canonical_u64(97),
-            F::from_canonical_u64(11),
-            F::from_canonical_u64(101),
-            F::from_canonical_u64(7),
-            F::from_canonical_u64(103),
-            F::from_canonical_u64(5),
-            F::from_canonical_u64(107),
+            F::from_u64(13),
+            F::from_u64(97),
+            F::from_u64(11),
+            F::from_u64(101),
+            F::from_u64(7),
+            F::from_u64(103),
+            F::from_u64(5),
+            F::from_u64(107),
         ]);
 
-    let partial_point = vec![E::from_canonical_u64(3), E::from_canonical_u64(5)];
+    let partial_point = vec![E::from_u64(3), E::from_u64(5)];
 
     let expected1 = DenseMultilinearExtension::from_evaluations_ext_vec(2, vec![
-        -E::from_canonical_u64(17),
-        E::from_canonical_u64(127),
-        -E::from_canonical_u64(19),
-        E::from_canonical_u64(131),
+        -E::from_u64(17),
+        E::from_u64(127),
+        -E::from_u64(19),
+        E::from_u64(131),
     ]);
     let result1 = poly.fix_high_variables(&partial_point[1..]);
     assert_eq!(result1, expected1);
 
     let expected2 = DenseMultilinearExtension::from_evaluations_ext_vec(1, vec![
-        -E::from_canonical_u64(23),
-        E::from_canonical_u64(139),
+        -E::from_u64(23),
+        E::from_u64(139),
     ]);
     let result2 = poly.fix_high_variables(&partial_point);
     assert_eq!(result2, expected2);

--- a/poseidon/benches/hashing.rs
+++ b/poseidon/benches/hashing.rs
@@ -1,7 +1,7 @@
 use ark_std::test_rng;
 use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
 use ff_ext::FromUniformBytes;
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use p3_goldilocks::Goldilocks;
 use plonky2::{
     field::{goldilocks_field::GoldilocksField, types::Sample},

--- a/poseidon/src/challenger.rs
+++ b/poseidon/src/challenger.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 use ff_ext::ExtensionField;
-use p3_field::{FieldExtensionAlgebra, PrimeField};
+use p3_field::PrimeField;
 use p3_symmetric::CryptographicPermutation;
 use std::ops::{Deref, DerefMut};
 
@@ -67,11 +67,11 @@ where
 pub trait FieldChallengerExt<F: PoseidonField>: FieldChallenger<F> {
     fn observe_ext_slice<E: ExtensionField<BaseField = F>>(&mut self, exts: &[E]) {
         exts.iter()
-            .for_each(|ext| self.observe_slice(ext.as_base_slice()));
+            .for_each(|ext| self.observe_slice(ext.as_basis_coefficients_slice()));
     }
 
-    fn sample_ext_vec<EF: FieldExtensionAlgebra<F>>(&mut self, n: usize) -> Vec<EF> {
-        (0..n).map(|_| self.sample_ext_element()).collect()
+    fn sample_ext_vec<E: ExtensionField<BaseField = F>>(&mut self, n: usize) -> Vec<E> {
+        (0..n).map(|_| self.sample_algebra_element()).collect()
     }
 }
 

--- a/sumcheck/src/prover.rs
+++ b/sumcheck/src/prover.rs
@@ -26,7 +26,7 @@ use crate::{
         merge_sumcheck_polys, serial_extrapolate,
     },
 };
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 
 impl<'a, E: ExtensionField> IOPProverState<'a, E> {
     /// Given a virtual polynomial, generate an IOP proof.
@@ -72,9 +72,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         // extrapolation_aux only need to init once
         let extrapolation_aux = (1..max_degree)
             .map(|degree| {
-                let points = (0..1 + degree as u64)
-                    .map(E::from_canonical_u64)
-                    .collect::<Vec<_>>();
+                let points = (0..1 + degree as u64).map(E::from_u64).collect::<Vec<_>>();
                 let weights = barycentric_weights(&points);
                 (points, weights)
             })
@@ -447,7 +445,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                 let extrapolation = (0..self.poly.aux_info.max_degree - products.len())
                     .map(|i| {
                         let (points, weights) = &self.extrapolation_aux[products.len() - 1];
-                        let at = E::from_canonical_u64((products.len() + 1 + i) as u64);
+                        let at = E::from_u64((products.len() + 1 + i) as u64);
                         serial_extrapolate(points, weights, &sum, &at)
                     })
                     .collect::<Vec<_>>();
@@ -595,9 +593,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
             poly: polynomial,
             extrapolation_aux: (1..max_degree)
                 .map(|degree| {
-                    let points = (0..1 + degree as u64)
-                        .map(E::from_canonical_u64)
-                        .collect::<Vec<_>>();
+                    let points = (0..1 + degree as u64).map(E::from_u64).collect::<Vec<_>>();
                     let weights = barycentric_weights(&points);
                     (points, weights)
                 })
@@ -709,7 +705,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                         .into_par_iter()
                         .map(|i| {
                             let (points, weights) = &self.extrapolation_aux[products.len() - 1];
-                            let at = E::from_canonical_u64((products.len() + 1 + i) as u64);
+                            let at = E::from_u64((products.len() + 1 + i) as u64);
                             extrapolate(points, weights, &sum, &at)
                         })
                         .collect::<Vec<_>>();

--- a/sumcheck/src/test.rs
+++ b/sumcheck/src/test.rs
@@ -7,7 +7,7 @@ use crate::{
 use ark_std::{rand::RngCore, test_rng};
 use ff_ext::{ExtensionField, FromUniformBytes, GoldilocksExt2};
 use multilinear_extensions::{mle::DenseMultilinearExtension, virtual_poly::VirtualPolynomial};
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 use transcript::{BasicTranscript, Transcript};
 
@@ -192,7 +192,7 @@ fn test_interpolation() {
     // test a polynomial with 20 known points, i.e., with degree 19
     let poly = DensePolynomial::rand(20 - 1, &mut prng);
     let evals = (0..20)
-        .map(|i| poly.evaluate(&GoldilocksExt2::from_canonical_u64(i as u64)))
+        .map(|i| poly.evaluate(&GoldilocksExt2::from_u64(i as u64)))
         .collect::<Vec<GoldilocksExt2>>();
     let query = GoldilocksExt2::random(&mut prng);
 
@@ -201,7 +201,7 @@ fn test_interpolation() {
     // test a polynomial with 33 known points, i.e., with degree 32
     let poly = DensePolynomial::rand(33 - 1, &mut prng);
     let evals = (0..33)
-        .map(|i| poly.evaluate(&GoldilocksExt2::from_canonical_u64(i as u64)))
+        .map(|i| poly.evaluate(&GoldilocksExt2::from_u64(i as u64)))
         .collect::<Vec<GoldilocksExt2>>();
     let query = GoldilocksExt2::random(&mut prng);
 
@@ -210,7 +210,7 @@ fn test_interpolation() {
     // test a polynomial with 64 known points, i.e., with degree 63
     let poly = DensePolynomial::rand(64 - 1, &mut prng);
     let evals = (0..64)
-        .map(|i| poly.evaluate(&GoldilocksExt2::from_canonical_u64(i as u64)))
+        .map(|i| poly.evaluate(&GoldilocksExt2::from_u64(i as u64)))
         .collect::<Vec<GoldilocksExt2>>();
     let query = GoldilocksExt2::random(&mut prng);
 

--- a/sumcheck/src/util.rs
+++ b/sumcheck/src/util.rs
@@ -155,7 +155,7 @@ pub(crate) fn interpolate_uni_poly<F: Field>(p_i: &[F], eval_at: F) -> F {
 
     // `prod = \prod_{j} (eval_at - j)`
     for e in 1..len {
-        let tmp = eval_at - F::from_canonical_u64(e as u64);
+        let tmp = eval_at - F::from_u64(e as u64);
         evals.push(tmp);
         prod *= tmp;
     }
@@ -186,8 +186,8 @@ pub(crate) fn interpolate_uni_poly<F: Field>(p_i: &[F], eval_at: F) -> F {
 
         // compute denom for the next step is current_denom * (len-i)/i
         if i != 0 {
-            denom_up *= -F::from_canonical_u64((len - i) as u64);
-            denom_down *= F::from_canonical_u64(i as u64);
+            denom_up *= -F::from_u64((len - i) as u64);
+            denom_down *= F::from_u64(i as u64);
         }
     }
     end_timer!(start);
@@ -199,7 +199,7 @@ pub(crate) fn interpolate_uni_poly<F: Field>(p_i: &[F], eval_at: F) -> F {
 fn field_factorial<F: Field>(a: usize) -> F {
     let mut res = F::ONE;
     for i in 2..=a {
-        res *= F::from_canonical_u64(i as u64);
+        res *= F::from_u64(i as u64);
     }
     res
 }

--- a/sumcheck_macro/examples/expand.rs
+++ b/sumcheck_macro/examples/expand.rs
@@ -7,7 +7,7 @@ use ff_ext::GoldilocksExt2;
 use multilinear_extensions::{
     mle::FieldType, util::largest_even_below, virtual_poly::VirtualPolynomial,
 };
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 use sumcheck::util::{AdditiveArray, ceil_log2};
 
 #[derive(Default)]

--- a/sumcheck_macro/src/lib.rs
+++ b/sumcheck_macro/src/lib.rs
@@ -241,7 +241,7 @@ pub fn sumcheck_code_gen(input: proc_macro::TokenStream) -> proc_macro::TokenStr
             };
             let num_vars_multiplicity = self.poly.aux_info.max_num_variables - (ceil_log2(v1.len()).max(1) + self.round - 1);
             if num_vars_multiplicity > 0 {
-                AdditiveArray(res.0.map(|e| e * E::BaseField::from_canonical_u64(1 << num_vars_multiplicity)))
+                AdditiveArray(res.0.map(|e| e * E::BaseField::from_u64(1 << num_vars_multiplicity)))
             } else {
                 res
             }
@@ -295,7 +295,7 @@ pub fn sumcheck_code_gen(input: proc_macro::TokenStream) -> proc_macro::TokenStr
             quote! {
                 #arm_body
                 let result = {#additive_converter};
-                AdditiveArray(result.0.map(E::from_base))
+                AdditiveArray(result.0.map(|b| b.into()))
             }
         } else {
             quote! {

--- a/transcript/src/basic.rs
+++ b/transcript/src/basic.rs
@@ -25,12 +25,12 @@ impl<E: ExtensionField> Transcript<E> for BasicTranscript<E> {
     }
 
     fn append_field_element_ext(&mut self, element: &E) {
-        self.challenger.observe_ext_element(*element);
+        self.challenger.observe_algebra_element(*element);
     }
 
     fn read_challenge(&mut self) -> Challenge<E> {
         Challenge {
-            elements: self.challenger.sample_ext_element(),
+            elements: self.challenger.sample_algebra_element(),
         }
     }
 

--- a/transcript/src/lib.rs
+++ b/transcript/src/lib.rs
@@ -8,7 +8,7 @@ mod statistics;
 pub mod syncronized;
 pub use basic::BasicTranscript;
 use ff_ext::SmallField;
-use p3_field::FieldAlgebra;
+use p3_field::PrimeCharacteristicRing;
 pub use statistics::{BasicTranscriptWithStat, StatisticRecorder};
 pub use syncronized::TranscriptSyncronized;
 #[derive(Default, Copy, Clone, Eq, PartialEq, Debug)]
@@ -98,7 +98,7 @@ pub trait ForkableTranscript<E: ExtensionField>: Transcript<E> + Sized + Clone {
         (0..n)
             .map(|i| {
                 let mut fork = self.clone();
-                fork.append_field_element(&E::BaseField::from_canonical_u64(i as u64));
+                fork.append_field_element(&E::BaseField::from_u64(i as u64));
                 fork
             })
             .collect()


### PR DESCRIPTION
Follow the new plonly3 [PR](https://github.com/Plonky3/Plonky3/pull/640) to use new api: "from_canonical_XXX" =>  "from_XXX"

Notes we can't update to latest p3 after this PR https://github.com/Plonky3/Plonky3/pull/653 because `rand~=0.9.x` version conflict with ark-std `rand~=0.8.x` https://github.com/arkworks-rs/std/blob/master/Cargo.toml#L16