### PR TITLE
WIP upgrade plonky3 with dependency cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,11 +35,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "const-random",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -93,35 +92,25 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
- "windows-sys 0.59.0",
+ "once_cell",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
-
-[[package]]
-name = "ark-std"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
-dependencies = [
- "colored",
- "num-traits",
- "rand",
-]
+checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
 
 [[package]]
 name = "arrayvec"
@@ -204,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bitvec"
@@ -222,15 +211,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytecheck"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c8f430744b23b54ad15161fcbc22d82a29b73eacbe425fea23ec822600bc6f"
+checksum = "50690fb3370fb9fe3550372746084c46f2ac8c9685c583d2be10eefd89d3d1a3"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
@@ -240,20 +229,20 @@ dependencies = [
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523363cbe1df49b68215efdf500b103ac3b0fb4836aed6d15689a076eadb8fff"
+checksum = "efb7846e0cb180355c2dec69e721edafa36919850f1a9f52ffba4ebc0393cb71"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "bytemuck"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
+checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
 name = "byteorder"
@@ -263,9 +252,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "cast"
@@ -275,9 +264,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.4"
+version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
+checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
 dependencies = [
  "shlex",
 ]
@@ -315,7 +304,7 @@ dependencies = [
  "ceno-examples",
  "ceno_emul",
  "itertools 0.13.0",
- "rand",
+ "rand 0.9.0",
  "rkyv",
  "tiny-keccak",
 ]
@@ -324,7 +313,7 @@ dependencies = [
 name = "ceno_rt"
 version = "0.1.0"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.1",
  "rkyv",
 ]
 
@@ -332,7 +321,6 @@ dependencies = [
 name = "ceno_zkvm"
 version = "0.1.0"
 dependencies = [
- "ark-std",
  "base64",
  "bincode",
  "ceno_emul",
@@ -355,8 +343,8 @@ dependencies = [
  "pprof2",
  "prettytable-rs",
  "proptest",
- "rand",
- "rand_chacha",
+ "rand 0.9.0",
+ "rand_chacha 0.9.0",
  "rayon",
  "serde",
  "serde_json",
@@ -417,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -427,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -439,14 +427,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -462,36 +450,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
-name = "colored"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
-dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom",
- "once_cell",
- "tiny-keccak",
-]
-
-[[package]]
 name = "cpp_demangle"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -581,9 +539,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -609,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
 dependencies = [
  "memchr",
 ]
@@ -663,9 +621,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 
 [[package]]
 name = "elf"
@@ -681,9 +639,9 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_filter"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
  "regex",
@@ -704,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -715,7 +673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -740,7 +698,7 @@ dependencies = [
  "p3-goldilocks",
  "p3-poseidon2",
  "p3-symmetric",
- "rand_core",
+ "rand 0.9.0",
  "serde",
 ]
 
@@ -754,15 +712,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
-dependencies = [
- "static_assertions",
 ]
 
 [[package]]
@@ -782,12 +731,6 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "gcd"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
 name = "generic-array"
@@ -816,10 +759,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
- "wasi",
- "wasm-bindgen",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -846,17 +799,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "rayon",
- "serde",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
@@ -872,12 +814,6 @@ name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hex-conservative"
@@ -896,19 +832,19 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown",
 ]
 
 [[package]]
 name = "inferno"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a5d75fee4d36809e6b021e4b96b686e763d365ffdb03af2bd00786353f84fe"
+checksum = "692eda1cc790750b9f5a5e3921ef9c117fd5498b97cfacbc910693e5b29002dc"
 dependencies = [
  "ahash",
  "indexmap",
@@ -923,22 +859,22 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -952,15 +888,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -991,22 +918,12 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "keccak-hash"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2bd4c29270e724d3eaadf7bdc8700af4221fc0ed771b855eadcd1b98d52851"
-dependencies = [
- "primitive-types",
- "tiny-keccak",
 ]
 
 [[package]]
@@ -1017,9 +934,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 
 [[package]]
 name = "libredox"
@@ -1033,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "lock_api"
@@ -1049,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "matchers"
@@ -1079,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -1091,7 +1008,6 @@ name = "mpcs"
 version = "0.1.0"
 dependencies = [
  "aes",
- "ark-std",
  "bitvec",
  "criterion",
  "ctr",
@@ -1105,10 +1021,9 @@ dependencies = [
  "p3-goldilocks",
  "p3-mds",
  "p3-symmetric",
- "plonky2",
  "poseidon",
- "rand",
- "rand_chacha",
+ "rand 0.9.0",
+ "rand_chacha 0.9.0",
  "rayon",
  "serde",
  "transcript",
@@ -1118,13 +1033,13 @@ dependencies = [
 name = "multilinear_extensions"
 version = "0.1.0"
 dependencies = [
- "ark-std",
  "env_logger",
  "ff_ext",
  "itertools 0.13.0",
  "log",
  "p3-field",
  "p3-goldilocks",
+ "rand 0.9.0",
  "rayon",
  "serde",
  "tracing",
@@ -1132,22 +1047,22 @@ dependencies = [
 
 [[package]]
 name = "munge"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64142d38c84badf60abf06ff9bd80ad2174306a5b11bd4706535090a30a419df"
+checksum = "8743b8dfaf66acac79aca9ff2440e8680fef745b6260e6a31d1772b14cfa2862"
 dependencies = [
  "munge_macro",
 ]
 
 [[package]]
 name = "munge_macro"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb5c1d8184f13f7d0ccbeeca0def2f9a181bce2624302793005f5ca8aa62e5e"
+checksum = "66191390a55bb9830fa8468c12634442ea4199c6e390ddf08ddcace35b3cd5da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1172,20 +1087,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,17 +1094,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1214,7 +1105,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1233,28 +1124,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 
@@ -1297,23 +1166,23 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "oorandom"
@@ -1330,7 +1199,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "p3-challenger"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
+source = "git+https://github.com/plonky3/plonky3?rev=973088b#973088b58914a7128abe04ca646762f294ed4c5e"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -1342,7 +1211,7 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
+source = "git+https://github.com/plonky3/plonky3?rev=973088b#973088b58914a7128abe04ca646762f294ed4c5e"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -1355,7 +1224,7 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
+source = "git+https://github.com/plonky3/plonky3?rev=973088b#973088b58914a7128abe04ca646762f294ed4c5e"
 dependencies = [
  "forward_ref",
  "itertools 0.14.0",
@@ -1366,7 +1235,7 @@ dependencies = [
  "p3-maybe-rayon",
  "p3-util",
  "paste",
- "rand",
+ "rand 0.9.0",
  "serde",
  "tracing",
 ]
@@ -1374,7 +1243,7 @@ dependencies = [
 [[package]]
 name = "p3-goldilocks"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
+source = "git+https://github.com/plonky3/plonky3?rev=973088b#973088b58914a7128abe04ca646762f294ed4c5e"
 dependencies = [
  "num-bigint",
  "p3-dft",
@@ -1385,20 +1254,20 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "paste",
- "rand",
+ "rand 0.9.0",
  "serde",
 ]
 
 [[package]]
 name = "p3-matrix"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
+source = "git+https://github.com/plonky3/plonky3?rev=973088b#973088b58914a7128abe04ca646762f294ed4c5e"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
  "p3-maybe-rayon",
  "p3-util",
- "rand",
+ "rand 0.9.0",
  "serde",
  "tracing",
  "transpose",
@@ -1407,12 +1276,12 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
+source = "git+https://github.com/plonky3/plonky3?rev=973088b#973088b58914a7128abe04ca646762f294ed4c5e"
 
 [[package]]
 name = "p3-mds"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
+source = "git+https://github.com/plonky3/plonky3?rev=973088b#973088b58914a7128abe04ca646762f294ed4c5e"
 dependencies = [
  "itertools 0.14.0",
  "p3-dft",
@@ -1420,36 +1289,36 @@ dependencies = [
  "p3-matrix",
  "p3-symmetric",
  "p3-util",
- "rand",
+ "rand 0.9.0",
 ]
 
 [[package]]
 name = "p3-poseidon"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
+source = "git+https://github.com/plonky3/plonky3?rev=973088b#973088b58914a7128abe04ca646762f294ed4c5e"
 dependencies = [
  "p3-field",
  "p3-mds",
  "p3-symmetric",
- "rand",
+ "rand 0.9.0",
 ]
 
 [[package]]
 name = "p3-poseidon2"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
+source = "git+https://github.com/plonky3/plonky3?rev=973088b#973088b58914a7128abe04ca646762f294ed4c5e"
 dependencies = [
- "gcd",
  "p3-field",
  "p3-mds",
  "p3-symmetric",
- "rand",
+ "p3-util",
+ "rand 0.9.0",
 ]
 
 [[package]]
 name = "p3-symmetric"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
+source = "git+https://github.com/plonky3/plonky3?rev=973088b#973088b58914a7128abe04ca646762f294ed4c5e"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -1459,7 +1328,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.1.0"
-source = "git+https://github.com/plonky3/plonky3?rev=00da91c#00da91ca9e6fd8a14242dd58b98294c0b828239e"
+source = "git+https://github.com/plonky3/plonky3?rev=973088b#973088b58914a7128abe04ca646762f294ed4c5e"
 dependencies = [
  "serde",
 ]
@@ -1501,65 +1370,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
-
-[[package]]
-name = "plonky2"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f26b090b989aebdeaf6a4eed748c1fbcabf67e7273a22e4e0c877b63846d0f"
-dependencies = [
- "ahash",
- "anyhow",
- "getrandom",
- "hashbrown 0.14.5",
- "itertools 0.11.0",
- "keccak-hash",
- "log",
- "num",
- "plonky2_field",
- "plonky2_maybe_rayon",
- "plonky2_util",
- "rand",
- "rand_chacha",
- "serde",
- "static_assertions",
- "unroll",
- "web-time",
-]
-
-[[package]]
-name = "plonky2_field"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1dca60ad900d81b1fe2df3d0b88d43345988e2935e6709176e96573f4bcf5d"
-dependencies = [
- "anyhow",
- "itertools 0.11.0",
- "num",
- "plonky2_util",
- "rand",
- "serde",
- "static_assertions",
- "unroll",
-]
-
-[[package]]
-name = "plonky2_maybe_rayon"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ff44a90aaca13e10e7ddf8fab815ba1b404c3f7c3ca82aaf11c46beabaa923"
-dependencies = [
- "rayon",
-]
-
-[[package]]
-name = "plonky2_util"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16136f5f3019c1e83035af76cccddd56d789a5e2933306270185c3f99f12259"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "plotters"
@@ -1593,7 +1406,6 @@ dependencies = [
 name = "poseidon"
 version = "0.1.0"
 dependencies = [
- "ark-std",
  "criterion",
  "ff_ext",
  "p3-challenger",
@@ -1602,8 +1414,7 @@ dependencies = [
  "p3-mds",
  "p3-poseidon2",
  "p3-symmetric",
- "plonky2",
- "rand",
+ "rand 0.9.0",
  "serde",
  "unroll",
 ]
@@ -1627,7 +1438,7 @@ dependencies = [
  "smallvec",
  "symbolic-demangle",
  "tempfile",
- "thiserror 2.0.8",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -1636,7 +1447,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -1654,16 +1465,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "primitive-types"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
-dependencies = [
- "fixed-hash",
- "uint",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -1693,8 +1494,8 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "rusty-fork",
@@ -1719,7 +1520,7 @@ checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1730,18 +1531,18 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.1"
+version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22f29bdff3987b4d8632ef95fd6424ec7e4e0a57e2f4fc63e489e75357f6a03"
+checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1768,8 +1569,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.2",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -1779,8 +1591,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
- "serde",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.2",
 ]
 
 [[package]]
@@ -1789,7 +1610,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a509b1a2ffbe92afab0e55c8fd99dea1c280e8171bd2d88682bb20bc41cbc2c"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -1798,7 +1629,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1823,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
  "bitflags",
 ]
@@ -1836,7 +1667,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -1905,13 +1736,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b11a153aec4a6ab60795f8ebe2923c597b16b05bb1504377451e705ef1a45323"
+checksum = "1e147371c75553e1e2fcdb483944a8540b8438c31426279553b9a8182a9b7b65"
 dependencies = [
  "bytecheck",
  "bytes",
- "hashbrown 0.15.2",
+ "hashbrown",
  "indexmap",
  "munge",
  "ptr_meta",
@@ -1924,13 +1755,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb382a4d9f53bd5c0be86b10d8179c3f8a14c30bf774ff77096ed6581e35981"
+checksum = "246b40ac189af6c675d124b802e8ef6d5246c53e17367ce9501f8f66a81abb7a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1952,22 +1783,22 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "rusty-fork"
@@ -1983,9 +1814,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "same-file"
@@ -2021,7 +1852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
- "rand",
+ "rand 0.8.5",
  "secp256k1-sys",
 ]
 
@@ -2036,29 +1867,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
  "itoa",
  "memchr",
@@ -2089,21 +1920,15 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str_stack"
@@ -2139,7 +1964,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.90",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2152,7 +1977,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 name = "sumcheck"
 version = "0.1.0"
 dependencies = [
- "ark-std",
  "criterion",
  "crossbeam-channel",
  "ff_ext",
@@ -2181,14 +2005,14 @@ dependencies = [
  "quote",
  "rayon",
  "sumcheck",
- "syn 2.0.90",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "symbolic-common"
-version = "12.12.3"
+version = "12.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ba5365997a4e375660bed52f5b42766475d5bc8ceb1bb13fea09c469ea0f49"
+checksum = "b6189977df1d6ec30c920647919d76f29fb8d8f25e8952e835b0fcda25e8f792"
 dependencies = [
  "debugid",
  "memmap2",
@@ -2198,9 +2022,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.12.3"
+version = "12.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beff338b2788519120f38c59ff4bb15174f52a183e547bac3d6072c2c0aa48aa"
+checksum = "d234917f7986498e7f62061438cee724bafb483fe84cfbe2486f68dce48240d7"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -2220,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2237,15 +2061,16 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2270,11 +2095,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.8"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f5383f3e0071702bf93ab5ee99b52d26936be9dedd9413067cbdcddcb6141a"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.8",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -2285,18 +2110,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.8"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f357fcec90b3caef6623a099691be676d033b40a058ac95d2a6ade6fa0c943"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2330,9 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2379,7 +2204,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2459,21 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unarray"
@@ -2483,9 +2296,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "unicode-width"
@@ -2511,15 +2324,15 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "93d59ca99a559661b96bf898d8fce28ed87935fd2bea9f05983c1464dd6c71b1"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -2529,9 +2342,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
@@ -2553,35 +2366,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.99"
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2589,38 +2412,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
-
-[[package]]
-name = "web-sys"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
- "js-sys",
- "wasm-bindgen",
+ "unicode-ident",
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
+name = "web-sys"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2648,7 +2464,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2656,15 +2472,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"
@@ -2749,6 +2556,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2764,7 +2580,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
+dependencies = [
+ "zerocopy-derive 0.8.20",
 ]
 
 [[package]]
@@ -2775,5 +2600,16 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.90",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,30 +26,28 @@ version = "0.1.0"
 
 [workspace.dependencies]
 anyhow = { version = "1.0", default-features = false }
-ark-std = "0.4"
 cfg-if = "1.0"
 criterion = { version = "0.5", features = ["html_reports"] }
 crossbeam-channel = "0.5"
 itertools = "0.13"
 num-derive = "0.4"
 num-traits = "0.2"
-p3-challenger = { git = "https://github.com/plonky3/plonky3", rev = "00da91c" }
-p3-field = { git = "https://github.com/plonky3/plonky3", rev = "00da91c" }
-p3-goldilocks = { git = "https://github.com/plonky3/plonky3", rev = "00da91c" }
-p3-mds = { git = "https://github.com/Plonky3/Plonky3.git", rev = "00da91c" }
-p3-poseidon = { git = "https://github.com/plonky3/plonky3", rev = "00da91c" }
-p3-poseidon2 = { git = "https://github.com/plonky3/plonky3", rev = "00da91c" }
-p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "00da91c" }
+num-bigint = { version = "0.4", default-features = false }
+p3-challenger = { git = "https://github.com/plonky3/plonky3", rev = "973088b" }
+p3-field = { git = "https://github.com/plonky3/plonky3", rev = "973088b" }
+p3-goldilocks = { git = "https://github.com/plonky3/plonky3", rev = "973088b" }
+p3-mds = { git = "https://github.com/Plonky3/Plonky3.git", rev = "973088b" }
+p3-poseidon = { git = "https://github.com/plonky3/plonky3", rev = "973088b" }
+p3-poseidon2 = { git = "https://github.com/plonky3/plonky3", rev = "973088b" }
+p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "973088b" }
 paste = "1"
-plonky2 = "0.2"
 poseidon = { path = "./poseidon" }
 pprof2 = { version = "0.13", features = ["flamegraph"] }
 prettytable-rs = "^0.10"
 proptest = "1"
-rand = "0.8"
-rand_chacha = { version = "0.3", features = ["serde1"] }
-rand_core = "0.6"
 rand_xorshift = "0.3"
+rand = "0.9"
+rand_chacha = "0.9"
 rayon = "1.10"
 secp = "0.4.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/ceno_rt/Cargo.toml
+++ b/ceno_rt/Cargo.toml
@@ -10,5 +10,5 @@ repository = "https://github.com/scroll-tech/ceno"
 version = "0.1.0"
 
 [dependencies]
-getrandom = { version = "*", features = ["custom"], default-features = false }
+getrandom = { version = "0.3.1", default-features = false }
 rkyv = { version = "0.8", features = ["pointer_width_32"] }

--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-ark-std.workspace = true
 rand_chacha.workspace = true
 rayon.workspace = true
 serde.workspace = true

--- a/ceno_zkvm/benches/riscv_add.rs
+++ b/ceno_zkvm/benches/riscv_add.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use ark_std::test_rng;
 use ceno_zkvm::{
     self,
     instructions::{Instruction, riscv::arith::AddInstruction},
@@ -8,6 +7,7 @@ use ceno_zkvm::{
     structs::{ZKVMConstraintSystem, ZKVMFixedTraces},
 };
 use criterion::*;
+use rand::rng;
 
 use ceno_zkvm::scheme::constants::MAX_NUM_VARIABLES;
 use ff_ext::{FromUniformBytes, GoldilocksExt2};
@@ -74,7 +74,7 @@ fn bench_add(c: &mut Criterion) {
                     let mut time = Duration::new(0, 0);
                     for _ in 0..iters {
                         // generate mock witness
-                        let mut rng = test_rng();
+                        let mut rng = rng();
                         let num_instances = 1 << instance_num_vars;
                         let wits_in = (0..num_witin as usize)
                             .map(|_| {

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -15,7 +15,6 @@ use crate::{
     },
     witness::{LkMultiplicity, LkMultiplicityRaw, RowMajorMatrix},
 };
-use ark_std::test_rng;
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use ceno_emul::{ByteAddr, CENO_PLATFORM, Platform, Program};
 use ff_ext::{ExtensionField, GoldilocksExt2, SmallField};
@@ -23,7 +22,7 @@ use generic_static::StaticTypeMap;
 use itertools::{Itertools, chain, enumerate, izip};
 use multilinear_extensions::{mle::IntoMLEs, virtual_poly::ArcMultilinearExtension};
 use p3_field::PrimeCharacteristicRing;
-use rand::thread_rng;
+use rand::rng;
 use std::{
     cmp::max,
     collections::{BTreeSet, HashMap, HashSet},
@@ -404,7 +403,7 @@ fn load_once_tables<E: ExtensionField + 'static + Sync + Send>(
     let cache = CACHE.get_or_init(StaticTypeMap::new);
 
     let (challenges_repr, table) = cache.call_once::<E, _>(|| {
-        let mut rng = test_rng();
+        let mut rng = rng();
         let challenge = [E::random(&mut rng), E::random(&mut rng)];
         let mut keccak = Keccak::v256();
         let mut filename_digest = [0u8; 32];
@@ -785,7 +784,7 @@ Hints:
             .into_iter()
             .map(|v| v.into())
             .collect_vec();
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let challenges = [0u8; 2].map(|_| E::random(&mut rng));
 
         // Load lookup table.

--- a/ceno_zkvm/src/scheme/tests.rs
+++ b/ceno_zkvm/src/scheme/tests.rs
@@ -16,7 +16,6 @@ use crate::{
     tables::{ProgramTableCircuit, U16TableCircuit},
     witness::LkMultiplicity,
 };
-use ark_std::test_rng;
 use ceno_emul::{
     CENO_PLATFORM,
     InsnKind::{ADD, ECALL},
@@ -29,6 +28,7 @@ use multilinear_extensions::{
     mle::IntoMLE, util::ceil_log2, virtual_poly::ArcMultilinearExtension,
 };
 use p3_field::PrimeCharacteristicRing;
+use rand::rng;
 use transcript::{BasicTranscript, BasicTranscriptWithStat, StatisticRecorder, Transcript};
 
 use super::{
@@ -315,7 +315,7 @@ fn test_single_add_instance_e2e() {
 fn test_tower_proof_various_prod_size() {
     fn _test_tower_proof_prod_size_2(leaf_layer_size: usize) {
         let num_vars = ceil_log2(leaf_layer_size);
-        let mut rng = test_rng();
+        let mut rng = rng();
         type E = GoldilocksExt2;
         let mut transcript = BasicTranscript::new(b"test_tower_proof");
         let leaf_layer: ArcMultilinearExtension<E> = (0..leaf_layer_size)

--- a/ceno_zkvm/src/scheme/utils.rs
+++ b/ceno_zkvm/src/scheme/utils.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use ark_std::iterable::Iterable;
 use ff_ext::ExtensionField;
 use itertools::Itertools;
 use multilinear_extensions::{

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -1,6 +1,5 @@
 use std::marker::PhantomData;
 
-use ark_std::iterable::Iterable;
 use ff_ext::ExtensionField;
 
 use itertools::{Itertools, chain, interleave, izip};
@@ -458,6 +457,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
             },
         ]
         .iter()
+        .copied()
         .sum::<E>();
         if computed_evals != expected_evaluation {
             return Err(ZKVMError::VerifyError(
@@ -704,6 +704,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
                     .sum::<E>(),
             ]
             .iter()
+            .copied()
             .sum::<E>();
             if computed_evals != expected_evaluation {
                 return Err(ZKVMError::VerifyError(

--- a/ceno_zkvm/src/uint.rs
+++ b/ceno_zkvm/src/uint.rs
@@ -13,7 +13,7 @@ use crate::{
     utils::add_one_to_big_num,
     witness::LkMultiplicity,
 };
-use ark_std::iterable::Iterable;
+
 use ff_ext::{ExtensionField, SmallField};
 use itertools::{Itertools, enumerate};
 use p3_field::PrimeCharacteristicRing;

--- a/ceno_zkvm/src/virtual_polys.rs
+++ b/ceno_zkvm/src/virtual_polys.rs
@@ -4,7 +4,6 @@ use std::{
     sync::Arc,
 };
 
-use ark_std::iterable::Iterable;
 use ff_ext::ExtensionField;
 use itertools::Itertools;
 use multilinear_extensions::{
@@ -169,7 +168,6 @@ impl<'a, E: ExtensionField> VirtualPolynomials<'a, E> {
 #[cfg(test)]
 mod tests {
 
-    use ark_std::test_rng;
     use ff_ext::{FromUniformBytes, GoldilocksExt2};
     use itertools::Itertools;
     use multilinear_extensions::{
@@ -178,6 +176,7 @@ mod tests {
     };
     use p3_field::PrimeCharacteristicRing;
     use p3_goldilocks::Goldilocks;
+    use rand::rng;
     use sumcheck::structs::{IOPProverState, IOPVerifierState};
     use transcript::BasicTranscript as Transcript;
 
@@ -254,7 +253,7 @@ mod tests {
         let num_threads = 1;
         let mut transcript = Transcript::new(b"test");
 
-        let mut rng = test_rng();
+        let mut rng = rng();
 
         let f1: [ArcMultilinearExtension<E>; 2] = std::array::from_fn(|_| {
             (0..1 << (max_num_vars - 2))

--- a/examples/.cargo/config.toml
+++ b/examples/.cargo/config.toml
@@ -25,5 +25,7 @@ rustflags = [
   "-Zlocation-detail=none",
   "-C",
   "passes=lower-atomic",
+  "--cfg",
+  "getrandom_backend=\"custom\""
 ]
 target = "../ceno_rt/riscv32im-ceno-zkvm-elf.json"

--- a/ff_ext/Cargo.toml
+++ b/ff_ext/Cargo.toml
@@ -14,5 +14,5 @@ p3-field.workspace = true
 p3-goldilocks.workspace = true
 p3-poseidon2.workspace = true
 p3-symmetric.workspace = true
-rand_core.workspace = true
+rand.workspace = true
 serde.workspace = true

--- a/ff_ext/src/lib.rs
+++ b/ff_ext/src/lib.rs
@@ -5,7 +5,7 @@ use p3_field::{
     extension::BinomialExtensionField,
 };
 use p3_goldilocks::Goldilocks;
-use rand_core::RngCore;
+use rand::Rng;
 use serde::Serialize;
 use std::{array::from_fn, iter::repeat_with};
 mod poseidon;
@@ -41,11 +41,11 @@ pub trait FromUniformBytes: Sized {
 
     fn try_from_uniform_bytes(bytes: Self::Bytes) -> Option<Self>;
 
-    fn random(mut rng: impl RngCore) -> Self {
+    fn random(mut rng: impl Rng) -> Self {
         Self::from_uniform_bytes(|bytes| rng.fill_bytes(bytes.as_mut()))
     }
 
-    fn random_vec(n: usize, mut rng: impl RngCore) -> Vec<Self> {
+    fn random_vec(n: usize, mut rng: impl Rng) -> Vec<Self> {
         repeat_with(|| Self::random(&mut rng)).take(n).collect()
     }
 }

--- a/mpcs/Cargo.toml
+++ b/mpcs/Cargo.toml
@@ -11,7 +11,6 @@ version.workspace = true
 
 [dependencies]
 aes = "0.8"
-ark-std.workspace = true
 bitvec = "1.0"
 ctr = "0.9"
 ff_ext = { path = "../ff_ext" }
@@ -19,13 +18,12 @@ ff_ext = { path = "../ff_ext" }
 generic-array = { version = "0.14", features = ["serde"] }
 itertools.workspace = true
 multilinear_extensions = { path = "../multilinear_extensions" }
-num-bigint = "0.4"
+num-bigint.workspace = true
 num-integer = "0.1"
 p3-field.workspace = true
 p3-goldilocks.workspace = true
 p3-mds.workspace = true
 p3-symmetric.workspace = true
-plonky2.workspace = true
 poseidon.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
@@ -40,7 +38,6 @@ criterion.workspace = true
 benchmark = ["parallel"]
 default = ["parallel"] # Add "sanity-check" to debug
 parallel = ["dep:rayon"]
-print-trace = ["ark-std/print-trace"]
 sanity-check = []
 
 [[bench]]

--- a/mpcs/benches/hashing.rs
+++ b/mpcs/benches/hashing.rs
@@ -1,5 +1,5 @@
-use ark_std::test_rng;
 use criterion::{Criterion, criterion_group, criterion_main};
+use rand::rng;
 
 use ff_ext::FromUniformBytes;
 use mpcs::util::hash::{Digest, hash_two_digests};
@@ -7,7 +7,7 @@ use p3_goldilocks::Goldilocks;
 use poseidon::poseidon_hash::PoseidonHash;
 
 fn random_ceno_goldy() -> Goldilocks {
-    Goldilocks::random(&mut test_rng())
+    Goldilocks::random(&mut rng())
 }
 pub fn criterion_benchmark(c: &mut Criterion) {
     let left = Digest(vec![random_ceno_goldy(); 4].try_into().unwrap());

--- a/mpcs/src/basefold/commit_phase.rs
+++ b/mpcs/src/basefold/commit_phase.rs
@@ -13,7 +13,6 @@ use crate::util::{
     log2_strict,
     merkle_tree::MerkleTree,
 };
-use ark_std::{end_timer, start_timer};
 use ff_ext::ExtensionField;
 use itertools::Itertools;
 use serde::{Serialize, de::DeserializeOwned};
@@ -41,7 +40,6 @@ pub fn commit_phase<E: ExtensionField, Spec: BasefoldSpec<E>>(
 where
     E::BaseField: Serialize + DeserializeOwned,
 {
-    let timer = start_timer!(|| "Commit phase");
     #[cfg(feature = "sanity-check")]
     assert_eq!(point.len(), num_vars);
     let mut trees = Vec::with_capacity(num_vars);
@@ -57,14 +55,12 @@ where
     assert_eq!(running_evals.len(), 1 << num_vars);
 
     // eq is the evaluation representation of the eq(X,r) polynomial over the hypercube
-    let build_eq_timer = start_timer!(|| "Basefold::open");
+
     let mut eq = build_eq_x_r_vec(point);
-    end_timer!(build_eq_timer);
+
     reverse_index_bits_in_place(&mut eq);
 
-    let sumcheck_timer = start_timer!(|| "Basefold sumcheck first round");
     let mut last_sumcheck_message = sum_check_first_round_field_type(&mut eq, &mut running_evals);
-    end_timer!(sumcheck_timer);
 
     #[cfg(feature = "sanity-check")]
     assert_eq!(last_sumcheck_message.len(), 3);
@@ -80,7 +76,6 @@ where
     let mut final_message = Vec::new();
     let mut running_tree_inner = Vec::new();
     for i in 0..num_rounds {
-        let sumcheck_timer = start_timer!(|| format!("Basefold round {}", i));
         // For the first round, no need to send the running root, because this root is
         // committing to a vector that can be recovered from linearly combining other
         // already-committed vectors.
@@ -163,9 +158,7 @@ where
                 assert_eq!(basecode, new_running_oracle);
             }
         }
-        end_timer!(sumcheck_timer);
     }
-    end_timer!(timer);
 
     (trees, BasefoldCommitPhaseProof {
         sumcheck_messages,
@@ -188,12 +181,10 @@ pub fn batch_commit_phase<E: ExtensionField, Spec: BasefoldSpec<E>>(
 where
     E::BaseField: Serialize + DeserializeOwned,
 {
-    let timer = start_timer!(|| "Batch Commit phase");
     assert_eq!(point.len(), num_vars);
     let mut trees = Vec::with_capacity(num_vars);
     let mut running_oracle = vec![E::ZERO; 1 << (num_vars + Spec::get_rate_log())];
 
-    let build_oracle_timer = start_timer!(|| "Basefold build initial oracle");
     // Before the interaction, collect all the polynomials whose num variables match the
     // max num variables
     let running_oracle_len = running_oracle.len();
@@ -207,9 +198,7 @@ where
                 .zip_eq(field_type_iter_ext(&comm.get_codewords()[0]))
                 .for_each(|(r, a)| *r += a * coeffs[index]);
         });
-    end_timer!(build_oracle_timer);
 
-    let build_oracle_timer = start_timer!(|| "Basefold build initial sumcheck evals");
     // Unlike the FRI part, the sum-check part still follows the original procedure,
     // and linearly combine all the polynomials once for all
     let mut sum_of_all_evals_for_sumcheck = vec![E::ZERO; 1 << num_vars];
@@ -230,24 +219,20 @@ where
                 ) * coeffs[index]
             });
     });
-    end_timer!(build_oracle_timer);
 
     // eq is the evaluation representation of the eq(X,r) polynomial over the hypercube
     let mut eq = build_eq_x_r_vec(point);
     reverse_index_bits_in_place(&mut eq);
 
-    let sumcheck_timer = start_timer!(|| "Basefold first round");
     let mut sumcheck_messages = Vec::with_capacity(num_rounds + 1);
     let mut last_sumcheck_message =
         sum_check_first_round(&mut eq, &mut sum_of_all_evals_for_sumcheck);
     sumcheck_messages.push(last_sumcheck_message.clone());
-    end_timer!(sumcheck_timer);
 
     let mut roots = Vec::with_capacity(num_rounds - 1);
     let mut final_message = Vec::new();
     let mut running_tree_inner = Vec::new();
     for i in 0..num_rounds {
-        let sumcheck_timer = start_timer!(|| format!("Batch basefold round {}", i));
         // For the first round, no need to send the running root, because this root is
         // committing to a vector that can be recovered from linearly combining other
         // already-committed vectors.
@@ -334,9 +319,8 @@ where
                 assert_eq!(basecode, new_running_oracle);
             }
         }
-        end_timer!(sumcheck_timer);
     }
-    end_timer!(timer);
+
     (trees, BasefoldCommitPhaseProof {
         sumcheck_messages,
         roots,
@@ -358,14 +342,13 @@ pub fn simple_batch_commit_phase<E: ExtensionField, Spec: BasefoldSpec<E>>(
 where
     E::BaseField: Serialize + DeserializeOwned,
 {
-    let timer = start_timer!(|| "Simple batch commit phase");
     assert_eq!(point.len(), num_vars);
     assert_eq!(comm.num_polys, batch_coeffs.len());
-    let prepare_timer = start_timer!(|| "Prepare");
+
     let mut trees = Vec::with_capacity(num_vars);
-    let batch_codewords_timer = start_timer!(|| "Batch codewords");
+
     let mut running_oracle = comm.batch_codewords(batch_coeffs);
-    end_timer!(batch_codewords_timer);
+
     let mut running_evals = (0..(1 << num_vars))
         .into_par_iter()
         .map(|i| {
@@ -376,27 +359,20 @@ where
                 .sum()
         })
         .collect::<Vec<_>>();
-    end_timer!(prepare_timer);
 
     // eq is the evaluation representation of the eq(X,r) polynomial over the hypercube
-    let build_eq_timer = start_timer!(|| "Basefold::build eq");
+
     let mut eq = build_eq_x_r_vec(point);
-    end_timer!(build_eq_timer);
 
-    let reverse_bits_timer = start_timer!(|| "Basefold::reverse bits");
     reverse_index_bits_in_place(&mut eq);
-    end_timer!(reverse_bits_timer);
 
-    let sumcheck_timer = start_timer!(|| "Basefold sumcheck first round");
     let mut last_sumcheck_message = sum_check_first_round(&mut eq, &mut running_evals);
-    end_timer!(sumcheck_timer);
 
     let mut sumcheck_messages = Vec::with_capacity(num_rounds);
     let mut roots = Vec::with_capacity(num_rounds - 1);
     let mut final_message = Vec::new();
     let mut running_tree_inner = Vec::new();
     for i in 0..num_rounds {
-        let sumcheck_timer = start_timer!(|| format!("Basefold round {}", i));
         // For the first round, no need to send the running root, because this root is
         // committing to a vector that can be recovered from linearly combining other
         // already-committed vectors.
@@ -473,9 +449,8 @@ where
                 assert_eq!(basecode, new_running_oracle);
             }
         }
-        end_timer!(sumcheck_timer);
     }
-    end_timer!(timer);
+
     (trees, BasefoldCommitPhaseProof {
         sumcheck_messages,
         roots,

--- a/mpcs/src/basefold/encoding.rs
+++ b/mpcs/src/basefold/encoding.rs
@@ -7,7 +7,6 @@ mod basecode;
 pub use basecode::{Basecode, BasecodeDefaultSpec};
 
 mod rs;
-use plonky2::util::log2_strict;
 use rayon::{
     iter::{IndexedParallelIterator, ParallelIterator},
     slice::ParallelSlice,
@@ -16,7 +15,10 @@ pub use rs::{RSCode, RSCodeDefaultSpec, coset_fft, fft, fft_root_table};
 
 use serde::{Serialize, de::DeserializeOwned};
 
-use crate::{Error, util::arithmetic::interpolate2_weights};
+use crate::{
+    Error,
+    util::{arithmetic::interpolate2_weights, log2_strict},
+};
 
 pub trait EncodingProverParameters {
     fn get_max_message_size_log(&self) -> usize;

--- a/mpcs/src/basefold/encoding/basecode.rs
+++ b/mpcs/src/basefold/encoding/basecode.rs
@@ -9,7 +9,6 @@ use crate::{
     vec_mut,
 };
 use aes::cipher::{KeyIvInit, StreamCipher, StreamCipherSeek};
-use ark_std::{end_timer, start_timer};
 use ff_ext::ExtensionField;
 use generic_array::GenericArray;
 use multilinear_extensions::mle::FieldType;
@@ -244,7 +243,6 @@ fn encode_field_type_rs_basecode<E: ExtensionField>(
 // FIXME: It is expensive for now because it is using naive FFT (although it is
 // over a small domain)
 fn get_basecode<F: Field>(poly: &[F], rate: usize, message_size: usize) -> Vec<Vec<F>> {
-    let timer = start_timer!(|| "Encode basecode");
     // The domain is just counting 1, 2, 3, ... , domain_size
     let domain: Vec<F> = steps(F::ONE).take(message_size * rate).collect();
     let res = poly
@@ -259,7 +257,6 @@ fn get_basecode<F: Field>(poly: &[F], rate: usize, message_size: usize) -> Vec<V
             target
         })
         .collect::<Vec<Vec<F>>>();
-    end_timer!(timer);
 
     res
 }
@@ -272,7 +269,6 @@ pub fn evaluate_over_foldable_domain_generic_basecode<E: ExtensionField>(
     base_codewords: Vec<FieldType<E>>,
     table: &[Vec<E::BaseField>],
 ) -> FieldType<E> {
-    let timer = start_timer!(|| "evaluate over foldable domain");
     let k = num_coeffs;
     let logk = log2_strict(k);
     let base_log_k = log2_strict(base_message_length);
@@ -306,7 +302,7 @@ pub fn evaluate_over_foldable_domain_generic_basecode<E: ExtensionField>(
             });
         });
     }
-    end_timer!(timer);
+
     coeffs_with_bc
 }
 

--- a/mpcs/src/basefold/encoding/rs.rs
+++ b/mpcs/src/basefold/encoding/rs.rs
@@ -6,7 +6,6 @@ use crate::{
     util::{field_type_index_mul_base, log2_strict, plonky2_util::reverse_bits},
     vec_mut,
 };
-use ark_std::{end_timer, start_timer};
 use ff_ext::ExtensionField;
 use multilinear_extensions::mle::FieldType;
 use p3_field::{Field, PrimeCharacteristicRing, PrimeField, TwoAdicField};
@@ -522,7 +521,6 @@ impl<Spec: RSCodeSpec> RSCode<Spec> {
 
 #[allow(unused)]
 fn naive_fft<E: ExtensionField>(poly: &[E], rate: usize, shift: E::BaseField) -> Vec<E> {
-    let timer = start_timer!(|| "Encode RSCode");
     let message_size = poly.len();
     let domain_size_bit = log2_strict(message_size * rate);
     let root = E::BaseField::two_adic_generator(domain_size_bit);
@@ -537,7 +535,6 @@ fn naive_fft<E: ExtensionField>(poly: &[E], rate: usize, shift: E::BaseField) ->
     res.iter_mut()
         .enumerate()
         .for_each(|(i, target)| *target = horner(poly, &E::from(domain[i])));
-    end_timer!(timer);
 
     res
 }

--- a/mpcs/src/lib.rs
+++ b/mpcs/src/lib.rs
@@ -379,7 +379,7 @@ pub mod test_util {
     use multilinear_extensions::{
         mle::MultilinearExtension, virtual_poly::ArcMultilinearExtension,
     };
-    use rand::rngs::OsRng;
+    use rand::rng;
     #[cfg(test)]
     use transcript::BasicTranscript;
     use transcript::Transcript;
@@ -393,14 +393,16 @@ pub mod test_util {
     }
 
     pub fn gen_rand_poly_base<E: ExtensionField>(num_vars: usize) -> DenseMultilinearExtension<E> {
-        DenseMultilinearExtension::random(num_vars, &mut OsRng)
+        let mut rng = rng();
+        DenseMultilinearExtension::random(num_vars, &mut rng)
     }
 
     pub fn gen_rand_poly_ext<E: ExtensionField>(num_vars: usize) -> DenseMultilinearExtension<E> {
+        let mut rng = rng();
         DenseMultilinearExtension::from_evaluations_ext_vec(
             num_vars,
             (0..(1 << num_vars))
-                .map(|_| E::random(&mut OsRng))
+                .map(|_| E::random(&mut rng))
                 .collect_vec(),
         )
     }

--- a/mpcs/src/sum_check/classic.rs
+++ b/mpcs/src/sum_check/classic.rs
@@ -8,7 +8,6 @@ use crate::{
         poly_index_ext,
     },
 };
-use ark_std::{end_timer, start_timer};
 use ff_ext::ExtensionField;
 use itertools::Itertools;
 use num_integer::Integer;
@@ -236,11 +235,6 @@ where
         sum: E,
         transcript: &mut impl Transcript<E>,
     ) -> Result<(Vec<E>, Vec<E>, SumcheckProof<E, Self::RoundMessage>), Error> {
-        let _timer = start_timer!(|| {
-            let degree = virtual_poly.expression.degree();
-            format!("sum_check_prove-{num_vars}-{degree}")
-        });
-
         let mut state = ProverState::new(num_vars, sum, virtual_poly);
         let mut challenges = Vec::with_capacity(num_vars);
         let prover = P::new(&state);
@@ -254,9 +248,7 @@ where
         let mut prover_messages = Vec::with_capacity(num_vars);
 
         for _round in 0..num_vars {
-            let timer = start_timer!(|| format!("sum_check_prove_round-{_round}"));
             let msg = prover.prove_round(&state);
-            end_timer!(timer);
             msg.write(transcript)?;
 
             if cfg!(feature = "sanity-check") {
@@ -271,9 +263,7 @@ where
                 .elements;
             challenges.push(challenge);
 
-            let timer = start_timer!(|| format!("sum_check_next_round-{_round}"));
             state.next_round(msg.evaluate(&aux, &challenge), &challenge);
-            end_timer!(timer);
             prover_messages.push(msg);
         }
 

--- a/mpcs/src/util/arithmetic/hypercube.rs
+++ b/mpcs/src/util/arithmetic/hypercube.rs
@@ -14,7 +14,6 @@ pub fn interpolate_field_type_over_boolean_hypercube<E: ExtensionField>(evals: &
 }
 
 pub fn interpolate_over_boolean_hypercube<F: Field>(evals: &mut [F]) {
-    // let timer = start_timer!(|| "interpolate_over_hypercube");
     // iterate over array, replacing even indices with (evals[i] - evals[(i+1)])
     let n = log2_strict(evals.len());
 
@@ -33,5 +32,5 @@ pub fn interpolate_over_boolean_hypercube<F: Field>(evals: &mut [F]) {
             }
         });
     }
-    // end_timer!(timer);
+    //
 }

--- a/mpcs/src/util/merkle_tree.rs
+++ b/mpcs/src/util/merkle_tree.rs
@@ -18,8 +18,6 @@ use crate::util::{
 };
 use transcript::Transcript;
 
-use ark_std::{end_timer, start_timer};
-
 use super::hash::write_digest_to_transcript;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -258,7 +256,6 @@ fn merkelize<E: ExtensionField>(values: &[&FieldType<E>]) -> Vec<Vec<Digest<E::B
     for i in 0..(values.len() - 1) {
         assert_eq!(values[i].len(), values[i + 1].len());
     }
-    let timer = start_timer!(|| format!("merkelize {} values", values[0].len() * values.len()));
     let log_v = log2_strict(values[0].len());
     let mut tree = Vec::with_capacity(log_v);
     // The first layer of hashes, half the number of leaves
@@ -317,7 +314,7 @@ fn merkelize<E: ExtensionField>(values: &[&FieldType<E>]) -> Vec<Vec<Digest<E::B
 
         tree.push(oracle);
     }
-    end_timer!(timer);
+
     tree
 }
 
@@ -326,7 +323,6 @@ fn merkelize_base<E: ExtensionField>(values: &[&[E::BaseField]]) -> Vec<Vec<Dige
     for i in 0..(values.len() - 1) {
         assert_eq!(values[i].len(), values[i + 1].len());
     }
-    let timer = start_timer!(|| format!("merkelize {} values", values[0].len() * values.len()));
     let log_v = log2_strict(values[0].len());
     let mut tree = Vec::with_capacity(log_v);
     // The first layer of hashes, half the number of leaves
@@ -362,7 +358,6 @@ fn merkelize_base<E: ExtensionField>(values: &[&[E::BaseField]]) -> Vec<Vec<Dige
 
         tree.push(oracle);
     }
-    end_timer!(timer);
     tree
 }
 
@@ -371,7 +366,7 @@ fn merkelize_ext<E: ExtensionField>(values: &[&[E]]) -> Vec<Vec<Digest<E::BaseFi
     for i in 0..(values.len() - 1) {
         assert_eq!(values[i].len(), values[i + 1].len());
     }
-    let timer = start_timer!(|| format!("merkelize {} values", values[0].len() * values.len()));
+
     let log_v = log2_strict(values[0].len());
     let mut tree = Vec::with_capacity(log_v);
     // The first layer of hashes, half the number of leaves
@@ -407,7 +402,6 @@ fn merkelize_ext<E: ExtensionField>(values: &[&[E]]) -> Vec<Vec<Digest<E::BaseFi
 
         tree.push(oracle);
     }
-    end_timer!(timer);
     tree
 }
 

--- a/multilinear_extensions/Cargo.toml
+++ b/multilinear_extensions/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-ark-std.workspace = true
 ff_ext = { path = "../ff_ext" }
 itertools.workspace = true
 p3-field.workspace = true
@@ -18,6 +17,7 @@ p3-goldilocks.workspace = true
 rayon.workspace = true
 serde.workspace = true
 tracing.workspace = true
+rand.workspace = true
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/multilinear_extensions/src/mle.rs
+++ b/multilinear_extensions/src/mle.rs
@@ -1,10 +1,10 @@
 use std::{any::TypeId, borrow::Cow, mem, sync::Arc};
 
 use crate::{op_mle, util::ceil_log2};
-use ark_std::{end_timer, rand::RngCore, start_timer};
 use core::hash::Hash;
 use ff_ext::{ExtensionField, FromUniformBytes};
 use p3_field::{Field, PrimeCharacteristicRing};
+use rand::Rng;
 use rayon::iter::{
     IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
 };
@@ -267,7 +267,7 @@ impl<E: ExtensionField> DenseMultilinearExtension<E> {
     }
 
     /// Generate a random evaluation of a multilinear poly
-    pub fn random(nv: usize, mut rng: &mut impl RngCore) -> Self {
+    pub fn random(nv: usize, mut rng: &mut impl Rng) -> Self {
         let eval = (0..1 << nv)
             .map(|_| E::BaseField::random(&mut rng))
             .collect();
@@ -281,9 +281,8 @@ impl<E: ExtensionField> DenseMultilinearExtension<E> {
     pub fn random_mle_list(
         nv: usize,
         degree: usize,
-        mut rng: &mut impl RngCore,
+        mut rng: &mut impl Rng,
     ) -> (Vec<ArcDenseMultilinearExtension<E>>, E) {
-        let start = start_timer!(|| "sample random mle list");
         let mut multiplicands = Vec::with_capacity(degree);
         for _ in 0..degree {
             multiplicands.push(Vec::with_capacity(1 << nv))
@@ -306,7 +305,6 @@ impl<E: ExtensionField> DenseMultilinearExtension<E> {
             .map(|x| DenseMultilinearExtension::from_evaluations_vec(nv, x).into())
             .collect();
 
-        end_timer!(start);
         (list, sum)
     }
 
@@ -314,10 +312,8 @@ impl<E: ExtensionField> DenseMultilinearExtension<E> {
     pub fn random_zero_mle_list(
         nv: usize,
         degree: usize,
-        mut rng: impl RngCore,
+        mut rng: impl Rng,
     ) -> Vec<ArcDenseMultilinearExtension<E>> {
-        let start = start_timer!(|| "sample random zero mle list");
-
         let mut multiplicands = Vec::with_capacity(degree);
         for _ in 0..degree {
             multiplicands.push(Vec::with_capacity(1 << nv))
@@ -334,7 +330,6 @@ impl<E: ExtensionField> DenseMultilinearExtension<E> {
             .map(|x| DenseMultilinearExtension::from_evaluations_vec(nv, x).into())
             .collect();
 
-        end_timer!(start);
         list
     }
 }

--- a/multilinear_extensions/src/test.rs
+++ b/multilinear_extensions/src/test.rs
@@ -1,7 +1,7 @@
-use ark_std::test_rng;
 use ff_ext::{ExtensionField, FromUniformBytes};
 use p3_field::{PrimeCharacteristicRing, extension::BinomialExtensionField};
 use p3_goldilocks::Goldilocks;
+use rand::rng;
 
 type F = Goldilocks;
 type E = BinomialExtensionField<F, 2>;
@@ -14,7 +14,7 @@ use crate::{
 
 #[test]
 fn test_virtual_polynomial_additions() {
-    let mut rng = test_rng();
+    let mut rng = rng();
     for nv in 2..5 {
         for num_products in 2..5 {
             let base: Vec<E> = (0..nv).map(|_| E::random(&mut rng)).collect();
@@ -34,7 +34,7 @@ fn test_virtual_polynomial_additions() {
 
 #[test]
 fn test_eq_xr() {
-    let mut rng = test_rng();
+    let mut rng = rng();
     for nv in 4..10 {
         let r: Vec<_> = (0..nv).map(|_| E::random(&mut rng)).collect();
         let eq_x_r = build_eq_x_r(r.as_ref());

--- a/poseidon/Cargo.toml
+++ b/poseidon/Cargo.toml
@@ -22,8 +22,6 @@ serde.workspace = true
 unroll = "0.1"
 
 [dev-dependencies]
-ark-std.workspace = true
-plonky2.workspace = true
 rand.workspace = true
 
 [[bench]]

--- a/poseidon/benches/hashing.rs
+++ b/poseidon/benches/hashing.rs
@@ -1,53 +1,24 @@
-use ark_std::test_rng;
 use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
 use ff_ext::FromUniformBytes;
 use p3_field::PrimeCharacteristicRing;
 use p3_goldilocks::Goldilocks;
-use plonky2::{
-    field::{goldilocks_field::GoldilocksField, types::Sample},
-    hash::{
-        hash_types::HashOut,
-        hashing::PlonkyPermutation,
-        poseidon::{PoseidonHash as PlonkyPoseidonHash, PoseidonPermutation},
-    },
-    plonk::config::Hasher,
-};
 use poseidon::{challenger::DefaultChallenger, digest::Digest, poseidon_hash::PoseidonHash};
-
-fn random_plonky_2_goldy() -> GoldilocksField {
-    GoldilocksField::rand()
-}
+use rand::rng;
 
 fn random_ceno_goldy() -> Goldilocks {
-    Goldilocks::random(&mut test_rng())
+    Goldilocks::random(&mut rng())
 }
 
 fn random_ceno_hash() -> Digest<Goldilocks> {
-    Digest(
-        vec![Goldilocks::random(&mut test_rng()); 4]
-            .try_into()
-            .unwrap(),
-    )
-}
-
-fn plonky_hash_single(a: GoldilocksField) {
-    let _result = black_box(PlonkyPoseidonHash::hash_or_noop(&[a]));
+    Digest(vec![Goldilocks::random(&mut rng()); 4].try_into().unwrap())
 }
 
 fn ceno_hash_single(a: Goldilocks) {
     let _result = black_box(PoseidonHash::<Goldilocks>::hash_or_noop(&[a]));
 }
 
-fn plonky_hash_2_to_1(left: HashOut<GoldilocksField>, right: HashOut<GoldilocksField>) {
-    let _result = black_box(PlonkyPoseidonHash::two_to_one(left, right));
-}
-
 fn ceno_hash_2_to_1(left: &Digest<Goldilocks>, right: &Digest<Goldilocks>) {
     let _result = black_box(PoseidonHash::<Goldilocks>::two_to_one(left, right));
-}
-
-fn plonky_hash_many_to_1(values: &[GoldilocksField]) {
-    let _result = black_box(PlonkyPoseidonHash::hash_or_noop(values));
 }
 
 fn ceno_hash_many_to_1(values: &[Goldilocks]) {
@@ -55,35 +26,6 @@ fn ceno_hash_many_to_1(values: &[Goldilocks]) {
 }
 
 pub fn hashing_benchmark(c: &mut Criterion) {
-    c.bench_function("plonky hash single", |bencher| {
-        bencher.iter_batched(
-            random_plonky_2_goldy,
-            plonky_hash_single,
-            BatchSize::SmallInput,
-        )
-    });
-
-    c.bench_function("plonky hash 2 to 1", |bencher| {
-        bencher.iter_batched(
-            || {
-                (
-                    HashOut::<GoldilocksField>::rand(),
-                    HashOut::<GoldilocksField>::rand(),
-                )
-            },
-            |(left, right)| plonky_hash_2_to_1(left, right),
-            BatchSize::SmallInput,
-        )
-    });
-
-    c.bench_function("plonky hash 60 to 1", |bencher| {
-        bencher.iter_batched(
-            || GoldilocksField::rand_vec(60),
-            |sixty_elems| plonky_hash_many_to_1(sixty_elems.as_slice()),
-            BatchSize::SmallInput,
-        )
-    });
-
     c.bench_function("ceno hash single", |bencher| {
         bencher.iter_batched(random_ceno_goldy, ceno_hash_single, BatchSize::SmallInput)
     });
@@ -100,7 +42,7 @@ pub fn hashing_benchmark(c: &mut Criterion) {
         bencher.iter_batched(
             || {
                 (0..60)
-                    .map(|_| Goldilocks::random(&mut test_rng()))
+                    .map(|_| Goldilocks::random(&mut rng()))
                     .collect::<Vec<_>>()
             },
             |values| ceno_hash_many_to_1(values.as_slice()),

--- a/sumcheck/Cargo.toml
+++ b/sumcheck/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-ark-std.workspace = true
 ff_ext = { path = "../ff_ext" }
 itertools.workspace = true
 p3-field.workspace = true

--- a/sumcheck/benches/devirgo_sumcheck.rs
+++ b/sumcheck/benches/devirgo_sumcheck.rs
@@ -3,10 +3,10 @@
 
 use std::{array, time::Duration};
 
-use ark_std::test_rng;
 use criterion::*;
 use ff_ext::{ExtensionField, GoldilocksExt2};
 use itertools::Itertools;
+use rand::rng;
 use sumcheck::{structs::IOPProverState, util::ceil_log2};
 
 use multilinear_extensions::{
@@ -42,7 +42,7 @@ pub fn transpose<T>(v: Vec<Vec<T>>) -> Vec<Vec<T>> {
 fn prepare_input<'a, E: ExtensionField>(
     nv: usize,
 ) -> (E, VirtualPolynomial<'a, E>, Vec<VirtualPolynomial<'a, E>>) {
-    let mut rng = test_rng();
+    let mut rng = rng();
     let max_thread_id = max_usable_threads();
     let size_log2 = ceil_log2(max_thread_id);
     let fs: [ArcMultilinearExtension<'a, E>; NUM_DEGREE] = array::from_fn(|_| {

--- a/sumcheck/src/prover.rs
+++ b/sumcheck/src/prover.rs
@@ -1,6 +1,5 @@
 use std::{mem, sync::Arc};
 
-use ark_std::{end_timer, start_timer};
 use crossbeam_channel::bounded;
 use ff_ext::ExtensionField;
 use itertools::Itertools;
@@ -62,7 +61,6 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                 ..Default::default()
             });
         }
-        let start = start_timer!(|| "sum check prove");
 
         transcript.append_message(&(num_variables + log2_max_thread_id).to_le_bytes());
         transcript.append_message(&max_degree.to_le_bytes());
@@ -298,7 +296,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         };
         exit_span!(span);
 
-        end_timer!(start);
+
         (
             IOPProof {
                 point: [
@@ -321,12 +319,10 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         polynomial: VirtualPolynomial<'a, E>,
         extrapolation_aux: Vec<(Vec<E>, Vec<E>)>,
     ) -> Self {
-        let start = start_timer!(|| "sum check prover init");
         assert_ne!(
             polynomial.aux_info.max_num_variables, 0,
             "Attempt to prove a constant."
         );
-        end_timer!(start);
 
         let max_degree = polynomial.aux_info.max_degree;
         assert!(extrapolation_aux.len() == max_degree - 1);
@@ -347,15 +343,12 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         &mut self,
         challenge: &Option<Challenge<E>>,
     ) -> IOPProverMessage<E> {
-        let start =
-            start_timer!(|| format!("sum check prove {}-th round and update state", self.round));
-
         assert!(
             self.round < self.poly.aux_info.max_num_variables,
             "Prover is not active"
         );
 
-        // let fix_argument = start_timer!(|| "fix argument");
+
 
         // Step 1:
         // fix argument and evaluate f(x) over x_m = r; where r is the challenge
@@ -407,7 +400,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
             }
         }
         exit_span!(span);
-        // end_timer!(fix_argument);
+        //
 
         self.round += 1;
 
@@ -459,7 +452,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         );
         exit_span!(span);
 
-        end_timer!(start);
+
 
         IOPProverMessage {
             evaluations: products_sum,
@@ -505,7 +498,6 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                 ..Default::default()
             });
         }
-        let start = start_timer!(|| "sum check prove");
 
         transcript.append_message(&num_variables.to_le_bytes());
         transcript.append_message(&max_degree.to_le_bytes());
@@ -562,7 +554,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         };
         exit_span!(span);
 
-        end_timer!(start);
+
         (
             IOPProof {
                 // the point consists of the first elements in the challenge
@@ -580,7 +572,6 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
     /// Initialize the prover state to argue for the sum of the input polynomial
     /// over {0,1}^`num_vars`.
     pub(crate) fn prover_init_parallel(polynomial: VirtualPolynomial<'a, E>) -> Self {
-        let start = start_timer!(|| "sum check prover init");
         assert_ne!(
             polynomial.aux_info.max_num_variables, 0,
             "Attempt to prove a constant."
@@ -600,7 +591,6 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                 .collect(),
         };
 
-        end_timer!(start);
         prover_state
     }
 
@@ -613,15 +603,12 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         &mut self,
         challenge: &Option<Challenge<E>>,
     ) -> IOPProverMessage<E> {
-        let start =
-            start_timer!(|| format!("sum check prove {}-th round and update state", self.round));
-
         assert!(
             self.round < self.poly.aux_info.max_num_variables,
             "Prover is not active"
         );
 
-        // let fix_argument = start_timer!(|| "fix argument");
+
 
         // Step 1:
         // fix argument and evaluate f(x) over x_m = r; where r is the challenge
@@ -672,7 +659,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
             }
         }
         exit_span!(span);
-        // end_timer!(fix_argument);
+        //
 
         self.round += 1;
 
@@ -720,8 +707,6 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
             .reduce_with(|acc, item| acc + item)
             .unwrap();
         exit_span!(span);
-
-        end_timer!(start);
 
         IOPProverMessage {
             evaluations: products_sum,

--- a/sumcheck/src/test.rs
+++ b/sumcheck/src/test.rs
@@ -18,7 +18,7 @@ fn test_sumcheck<E: ExtensionField>(
     num_multiplicands_range: (usize, usize),
     num_products: usize,
 ) {
-    let mut rng = test_rng();
+    let mut rng = rng();
     let mut transcript = BasicTranscript::new(b"test");
 
     let (poly, asserted_sum) =
@@ -47,7 +47,7 @@ fn test_sumcheck_internal<E: ExtensionField>(
     num_multiplicands_range: (usize, usize),
     num_products: usize,
 ) {
-    let mut rng = test_rng();
+    let mut rng = rng();
     let (poly, asserted_sum) =
         VirtualPolynomial::<E>::random(nv, num_multiplicands_range, num_products, &mut rng);
     let (poly_info, num_variables) = (poly.aux_info.clone(), poly.aux_info.max_num_variables);
@@ -155,7 +155,7 @@ fn test_extract_sum() {
 }
 
 fn test_extract_sum_helper<E: ExtensionField>() {
-    let mut rng = test_rng();
+    let mut rng = rng();
     let mut transcript = BasicTranscript::new(b"test");
     let (poly, asserted_sum) = VirtualPolynomial::<E>::random(8, (2, 3), 3, &mut rng);
     #[allow(deprecated)]
@@ -187,7 +187,7 @@ impl DensePolynomial {
 
 #[test]
 fn test_interpolation() {
-    let mut prng = ark_std::test_rng();
+    let mut prng = ark_std::rng();
 
     // test a polynomial with 20 known points, i.e., with degree 19
     let poly = DensePolynomial::rand(20 - 1, &mut prng);

--- a/sumcheck/src/util.rs
+++ b/sumcheck/src/util.rs
@@ -6,7 +6,6 @@ use std::{
     sync::Arc,
 };
 
-use ark_std::{end_timer, start_timer};
 use ff_ext::ExtensionField;
 use multilinear_extensions::{
     mle::DenseMultilinearExtension, op_mle, virtual_poly::VirtualPolynomial,
@@ -146,8 +145,6 @@ fn inner_extrapolate<F: Field, const IS_PARALLEL: bool>(
 /// TODO: The quadratic term can be removed by precomputing the lagrange
 /// coefficients.
 pub(crate) fn interpolate_uni_poly<F: Field>(p_i: &[F], eval_at: F) -> F {
-    let start = start_timer!(|| "sum check interpolate uni poly opt");
-
     let len = p_i.len();
     let mut evals = vec![];
     let mut prod = eval_at;
@@ -190,7 +187,7 @@ pub(crate) fn interpolate_uni_poly<F: Field>(p_i: &[F], eval_at: F) -> F {
             denom_down *= F::from_u64(i as u64);
         }
     }
-    end_timer!(start);
+
     res
 }
 

--- a/sumcheck/src/verifier.rs
+++ b/sumcheck/src/verifier.rs
@@ -1,4 +1,3 @@
-use ark_std::{end_timer, start_timer};
 use ff_ext::ExtensionField;
 use multilinear_extensions::virtual_poly::VPAuxInfo;
 use transcript::{Challenge, Transcript};
@@ -21,7 +20,6 @@ impl<E: ExtensionField> IOPVerifierState<E> {
                 expected_evaluation: claimed_sum,
             };
         }
-        let start = start_timer!(|| "sum check verify");
 
         transcript.append_message(&aux_info.max_num_variables.to_le_bytes());
         transcript.append_message(&aux_info.max_degree.to_le_bytes());
@@ -38,13 +36,11 @@ impl<E: ExtensionField> IOPVerifierState<E> {
 
         let res = Self::check_and_generate_subclaim(&verifier_state, &claimed_sum);
 
-        end_timer!(start);
         res
     }
 
     /// Initialize the verifier's state.
     pub fn verifier_init(index_info: &VPAuxInfo<E>) -> Self {
-        let start = start_timer!(|| "sum check verifier init");
         let verifier_state = Self {
             round: 1,
             num_vars: index_info.max_num_variables,
@@ -53,7 +49,7 @@ impl<E: ExtensionField> IOPVerifierState<E> {
             polynomials_received: Vec::with_capacity(index_info.max_num_variables),
             challenges: Vec::with_capacity(index_info.max_num_variables),
         };
-        end_timer!(start);
+
         verifier_state
     }
 
@@ -68,9 +64,6 @@ impl<E: ExtensionField> IOPVerifierState<E> {
         prover_msg: &IOPProverMessage<E>,
         transcript: &mut impl Transcript<E>,
     ) -> Challenge<E> {
-        let start =
-            start_timer!(|| format!("sum check verify {}-th round and update state", self.round));
-
         assert!(
             !self.finished,
             "Incorrect verifier state: Verifier is already finished."
@@ -97,7 +90,6 @@ impl<E: ExtensionField> IOPVerifierState<E> {
             self.round += 1;
         }
 
-        end_timer!(start);
         challenge
     }
 
@@ -110,7 +102,6 @@ impl<E: ExtensionField> IOPVerifierState<E> {
     /// Otherwise, it is highly unlikely that those two will be equal.
     /// Larger field size guarantees smaller soundness error.
     pub(crate) fn check_and_generate_subclaim(&self, asserted_sum: &E) -> SumCheckSubClaim<E> {
-        let start = start_timer!(|| "sum check check and generate subclaim");
         if !self.finished {
             panic!("Incorrect verifier state: Verifier has not finished.",);
         }
@@ -158,7 +149,7 @@ impl<E: ExtensionField> IOPVerifierState<E> {
                 );
             }
         }
-        end_timer!(start);
+
         SumCheckSubClaim {
             point: self.challenges.clone(),
             // the last expected value (not checked within this function) will be included in the


### PR DESCRIPTION
This PR upgrade plonky3 to include two_adict improvement on https://github.com/Plonky3/Plonky3/pull/690 to support WHIR migration.

- [x] dependency upgrade/cleanup are due to conflict with plonky3
- [x] remove `plonky2` and `ark-std` entirely