### PR TITLE
bug fix: e2e missed proof validity check

### DIFF
--- a/ceno_zkvm/src/bin/e2e.rs
+++ b/ceno_zkvm/src/bin/e2e.rs
@@ -148,7 +148,11 @@ fn main() {
     // do statistics
     let stat_recorder = StatisticRecorder::default();
     let transcript = TranscriptWithStat::new(&stat_recorder, b"riscv");
-    verifier.verify_proof(zkvm_proof.clone(), transcript).ok();
+    assert!(
+        verifier
+            .verify_proof_halt(zkvm_proof.clone(), transcript, zkvm_proof.has_halt())
+            .is_ok()
+    );
     println!("e2e proof stat: {}", zkvm_proof);
     println!(
         "hashes count = {}",

--- a/ceno_zkvm/src/scheme.rs
+++ b/ceno_zkvm/src/scheme.rs
@@ -10,7 +10,10 @@ use std::{
 };
 use sumcheck::structs::IOPProverMessage;
 
-use crate::structs::TowerProofs;
+use crate::{
+    instructions::{Instruction, riscv::ecall::HaltInstruction},
+    structs::TowerProofs,
+};
 
 pub mod constants;
 pub mod prover;
@@ -167,6 +170,21 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProof<E, PCS> {
 
     pub fn num_circuits(&self) -> usize {
         self.opcode_proofs.len() + self.table_proofs.len()
+    }
+
+    pub fn has_halt(&self) -> bool {
+        let halt_instance_count = self
+            .opcode_proofs
+            .get(&HaltInstruction::<E>::name())
+            .map(|(_, p)| p.num_instances)
+            .unwrap_or(0);
+        if halt_instance_count > 0 {
+            assert_eq!(
+                halt_instance_count, 1,
+                "abnormal halt instance count {halt_instance_count} != 1"
+            );
+        }
+        halt_instance_count == 1
     }
 }
 

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -16,7 +16,6 @@ use transcript::{ForkableTranscript, Transcript};
 use crate::{
     error::ZKVMError,
     expression::{Instance, StructuralWitIn},
-    instructions::{Instruction, riscv::ecall::HaltInstruction},
     scheme::{
         constants::{NUM_FANIN, NUM_FANIN_LOGUP, SEL_DEGREE},
         utils::eval_by_expr_with_instance,
@@ -56,18 +55,13 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         &self,
         vm_proof: ZKVMProof<E, PCS>,
         transcript: impl ForkableTranscript<E>,
-        does_halt: bool,
+        expect_halt: bool,
     ) -> Result<bool, ZKVMError> {
         // require ecall/halt proof to exist, depending whether we expect a halt.
-        let num_instances = vm_proof
-            .opcode_proofs
-            .get(&HaltInstruction::<E>::name())
-            .map(|(_, p)| p.num_instances)
-            .unwrap_or(0);
-        if num_instances != (does_halt as usize) {
+        let has_halt = vm_proof.has_halt();
+        if has_halt != expect_halt {
             return Err(ZKVMError::VerifyError(format!(
-                "ecall/halt num_instances={}, expected={}",
-                num_instances, does_halt as usize
+                "ecall/halt mismatch: expected {expect_halt} != {has_halt}",
             )));
         }
 


### PR DESCRIPTION
previously end-to-end (e2e) tests were missing an assertion check for `verify_proof`, meaning that failed proofs due to the absence of a halt instruction were not properly detected.

Since the absence of a halt instruction can be a valid scenario (as execution can be controlled via max_step), this PR:
- Adds the missing verification check in e2e tests
- Makes the halt instruction optional

> Note: its doen't affect previous e2e testing result