### PR TITLE
optimise number of permutation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2968,6 +2968,7 @@ version = "0.1.0"
 dependencies = [
  "crossbeam-channel",
  "ff_ext",
+ "itertools 0.13.0",
  "p3-field",
  "p3-goldilocks",
  "p3-mds",

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -1215,9 +1215,7 @@ impl TowerProver {
             logup_specs.len() * 2,
             transcript,
         );
-        let initial_rt: Point<E> = (0..log_num_fanin)
-            .map(|_| transcript.get_and_append_challenge(b"product_sum").elements)
-            .collect_vec();
+        let initial_rt: Point<E> = transcript.sample_and_append_vec(b"product_sum", log_num_fanin);
 
         let (next_rt, _) =
             (1..=max_round_index).fold((initial_rt, alpha_pows), |(out_rt, alpha_pows), round| {
@@ -1293,9 +1291,7 @@ impl TowerProver {
                 proofs.push_sumcheck_proofs(sumcheck_proofs.proofs);
 
                 // rt' = r_merge || rt
-                let r_merge = (0..log_num_fanin)
-                    .map(|_| transcript.get_and_append_challenge(b"merge").elements)
-                    .collect_vec();
+                let r_merge =  transcript.sample_and_append_vec(b"merge", log_num_fanin);
                 let rt_prime = [sumcheck_proofs.point, r_merge].concat();
 
                 // generate next round challenge

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -869,9 +869,7 @@ impl TowerVerify {
             num_prod_spec + num_logup_spec * 2, /* logup occupy 2 sumcheck: numerator and denominator */
             transcript,
         );
-        let initial_rt: Point<E> = (0..log2_num_fanin)
-            .map(|_| transcript.get_and_append_challenge(b"product_sum").elements)
-            .collect_vec();
+        let initial_rt: Point<E> = transcript.sample_and_append_vec(b"product_sum", log2_num_fanin);
         // initial_claim = \sum_j alpha^j * out_j[rt]
         // out_j[rt] := (record_{j}[rt])
         // out_j[rt] := (logup_p{j}[rt])
@@ -974,9 +972,7 @@ impl TowerVerify {
                 // derive single eval
                 // rt' = r_merge || rt
                 // r_merge.len() == ceil_log2(num_product_fanin)
-                let r_merge = (0..log2_num_fanin)
-                    .map(|_| transcript.get_and_append_challenge(b"merge").elements)
-                    .collect_vec();
+                let r_merge =transcript.sample_and_append_vec(b"merge", log2_num_fanin);
                 let coeffs = build_eq_x_r_vec_sequential(&r_merge);
                 assert_eq!(coeffs.len(), num_fanin);
                 let rt_prime = [rt, r_merge].concat();

--- a/ceno_zkvm/src/utils.rs
+++ b/ceno_zkvm/src/utils.rs
@@ -64,7 +64,7 @@ pub fn get_challenge_pows<E: ExtensionField>(
 ) -> Vec<E> {
     // println!("alpha_pow");
     let alpha = transcript
-        .get_and_append_challenge(b"combine subset evals")
+        .sample_and_append_challenge(b"combine subset evals")
         .elements;
     (0..size)
         .scan(E::ONE, |state, _| {

--- a/mpcs/src/basefold/commit_phase.rs
+++ b/mpcs/src/basefold/commit_phase.rs
@@ -86,7 +86,7 @@ where
         transcript.append_field_element_exts(&last_sumcheck_message);
         sumcheck_messages.push(last_sumcheck_message);
 
-        let challenge = transcript.get_and_append_challenge(b"commit round");
+        let challenge = transcript.sample_and_append_challenge(b"commit round");
 
         // Fold the current oracle for FRI
         let new_running_oracle = basefold_one_round_by_interpolation_weights::<E, Spec>(
@@ -250,7 +250,7 @@ where
         transcript.append_field_element_exts(&last_sumcheck_message);
 
         let challenge = transcript
-            .get_and_append_challenge(b"commit round")
+            .sample_and_append_challenge(b"commit round")
             .elements;
 
         // Fold the current oracle for FRI
@@ -394,7 +394,7 @@ where
         sumcheck_messages.push(last_sumcheck_message);
 
         let challenge = transcript
-            .get_and_append_challenge(b"commit round")
+            .sample_and_append_challenge(b"commit round")
             .elements;
 
         // Fold the current oracle for FRI

--- a/mpcs/src/basefold/query_phase.rs
+++ b/mpcs/src/basefold/query_phase.rs
@@ -37,13 +37,7 @@ pub fn prover_query_phase<E: ExtensionField>(
 where
     E::BaseField: Serialize + DeserializeOwned,
 {
-    let queries: Vec<_> = (0..num_verifier_queries)
-        .map(|_| {
-            transcript
-                .get_and_append_challenge(b"query indices")
-                .elements
-        })
-        .collect();
+    let queries: Vec<_> = transcript.sample_and_append_vec(b"query indices", num_verifier_queries);
 
     // Transform the challenge queries from field elements into integers
     let queries_usize: Vec<usize> = queries
@@ -74,13 +68,7 @@ pub fn batch_prover_query_phase<E: ExtensionField>(
 where
     E::BaseField: Serialize + DeserializeOwned,
 {
-    let queries: Vec<_> = (0..num_verifier_queries)
-        .map(|_| {
-            transcript
-                .get_and_append_challenge(b"query indices")
-                .elements
-        })
-        .collect();
+    let queries: Vec<_> = transcript.sample_and_append_vec(b"query indices", num_verifier_queries);
 
     // Transform the challenge queries from field elements into integers
     let queries_usize: Vec<usize> = queries
@@ -110,13 +98,7 @@ pub fn simple_batch_prover_query_phase<E: ExtensionField>(
 where
     E::BaseField: Serialize + DeserializeOwned,
 {
-    let queries: Vec<_> = (0..num_verifier_queries)
-        .map(|_| {
-            transcript
-                .get_and_append_challenge(b"query indices")
-                .elements
-        })
-        .collect();
+    let queries: Vec<_> = transcript.sample_and_append_vec(b"query indices", num_verifier_queries);
 
     // Transform the challenge queries from field elements into integers
     let queries_usize: Vec<usize> = queries

--- a/mpcs/src/lib.rs
+++ b/mpcs/src/lib.rs
@@ -424,9 +424,7 @@ pub mod test_util {
         num_vars: usize,
         transcript: &mut impl Transcript<E>,
     ) -> Vec<E> {
-        (0..num_vars)
-            .map(|_| transcript.get_and_append_challenge(b"Point").elements)
-            .collect()
+        transcript.sample_and_append_vec(b"Point", num_vars)
     }
     pub fn get_points_from_challenge<E: ExtensionField>(
         num_vars: impl Fn(usize) -> usize,

--- a/mpcs/src/sum_check/classic.rs
+++ b/mpcs/src/sum_check/classic.rs
@@ -267,7 +267,7 @@ where
             }
 
             let challenge = transcript
-                .get_and_append_challenge(b"sumcheck round")
+                .sample_and_append_challenge(b"sumcheck round")
                 .elements;
             challenges.push(challenge);
 
@@ -300,7 +300,7 @@ where
                 msgs.push(proof.rounds[i].clone());
                 challenges.push(
                     transcript
-                        .get_and_append_challenge(b"sumcheck round")
+                        .sample_and_append_challenge(b"sumcheck round")
                         .elements,
                 );
             }

--- a/sumcheck/src/prover.rs
+++ b/sumcheck/src/prover.rs
@@ -105,7 +105,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                         thread_based_transcript.append_field_element_exts(&prover_msg.evaluations);
 
                         challenge = Some(
-                            thread_based_transcript.get_and_append_challenge(b"Internal round"),
+                            thread_based_transcript.sample_and_append_challenge(b"Internal round"),
                         );
                         thread_based_transcript.commit_rolling();
                     }
@@ -164,7 +164,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                 let get_challenge_span = entered_span!("main_thread_get_challenge");
                 transcript.append_field_element_exts(&evaluations.0);
 
-                let next_challenge = transcript.get_and_append_challenge(b"Internal round");
+                let next_challenge = transcript.sample_and_append_challenge(b"Internal round");
                 (0..num_worker_threads).for_each(|_| {
                     thread_based_transcript.send_challenge(next_challenge.elements);
                 });
@@ -271,7 +271,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                 .iter()
                 .for_each(|e| transcript.append_field_element_ext(e));
             prover_msgs.push(prover_msg);
-            challenge = Some(transcript.get_and_append_challenge(b"Internal round"));
+            challenge = Some(transcript.sample_and_append_challenge(b"Internal round"));
         }
         exit_span!(span);
 
@@ -527,7 +527,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
 
             prover_msgs.push(prover_msg);
             let span = entered_span!("get_challenge");
-            challenge = Some(transcript.get_and_append_challenge(b"Internal round"));
+            challenge = Some(transcript.sample_and_append_challenge(b"Internal round"));
             exit_span!(span);
         }
         exit_span!(span);

--- a/sumcheck/src/verifier.rs
+++ b/sumcheck/src/verifier.rs
@@ -84,7 +84,7 @@ impl<E: ExtensionField> IOPVerifierState<E> {
         // When we turn the protocol to a non-interactive one, it is sufficient to defer
         // such checks to `check_and_generate_subclaim` after the last round.
 
-        let challenge = transcript.get_and_append_challenge(b"Internal round");
+        let challenge = transcript.sample_and_append_challenge(b"Internal round");
         self.challenges.push(challenge);
         self.polynomials_received
             .push(prover_msg.evaluations.to_vec());

--- a/transcript/Cargo.toml
+++ b/transcript/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 [dependencies]
 crossbeam-channel.workspace = true
 ff_ext = { path = "../ff_ext" }
+itertools.workspace = true
 p3-field.workspace = true
 p3-goldilocks.workspace = true
 p3-mds.workspace = true

--- a/transcript/src/basic.rs
+++ b/transcript/src/basic.rs
@@ -1,5 +1,5 @@
 use ff_ext::{ExtensionField, PoseidonField};
-use poseidon::challenger::{CanObserve, DefaultChallenger, FieldChallenger};
+use poseidon::challenger::{CanObserve, DefaultChallenger, FieldChallenger, FieldChallengerExt};
 
 use crate::{Challenge, ForkableTranscript, Transcript};
 use ff_ext::SmallField;
@@ -48,6 +48,10 @@ impl<E: ExtensionField> Transcript<E> for BasicTranscript<E> {
 
     fn commit_rolling(&mut self) {
         // do nothing
+    }
+
+    fn sample_vec(&mut self, n: usize) -> Vec<E> {
+        self.challenger.sample_ext_vec(n)
     }
 }
 

--- a/transcript/src/statistics.rs
+++ b/transcript/src/statistics.rs
@@ -54,6 +54,10 @@ impl<E: ExtensionField> Transcript<E> for BasicTranscriptWithStat<'_, E> {
     fn commit_rolling(&mut self) {
         self.inner.commit_rolling()
     }
+
+    fn sample_vec(&mut self, n: usize) -> Vec<E> {
+        self.inner.sample_vec(n)
+    }
 }
 
 impl<E: ExtensionField> ForkableTranscript<E> for BasicTranscriptWithStat<'_, E> {}

--- a/transcript/src/syncronized.rs
+++ b/transcript/src/syncronized.rs
@@ -58,7 +58,7 @@ impl<E: ExtensionField> Transcript<E> for TranscriptSyncronized<E> {
         unimplemented!()
     }
 
-    fn get_and_append_challenge(&mut self, _label: &'static [u8]) -> Challenge<E> {
+    fn sample_and_append_challenge(&mut self, _label: &'static [u8]) -> Challenge<E> {
         Challenge {
             elements: self.challenge_rx[self.rolling_index].recv().unwrap(),
         }
@@ -84,5 +84,9 @@ impl<E: ExtensionField> Transcript<E> for TranscriptSyncronized<E> {
 
     fn commit_rolling(&mut self) {
         self.rolling_index = (self.rolling_index + 1) % 2
+    }
+
+    fn sample_vec(&mut self, _n: usize) -> Vec<E> {
+        unimplemented!()
     }
 }


### PR DESCRIPTION
This PR aim to reduce recursion cost by
- avoid repeating labels added during list of poseidon2 sampling => avoid many redundant costly permutation
- mpcs batching coeffs by single challenge + power: [1, alpha, alpha^2, ....] without #log(batch_size) permutation cost

### result
```
### before
append element api called = 41974
### after
append element api called = 37367
```
reduce around (41974 - 37367) / 37367 around 10% of append extension field element and respective permutation. 