### PR TITLE
fix dependency chain of var.rs error

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,11 +48,6 @@ jobs:
           key: integration-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: dtolnay/rust-toolchain@nightly
 
-      - name: Build ceno examples
-        env:
-          RUSTFLAGS: "-C opt-level=3"
-        run: cargo build -p ceno-examples --release
-
       - name: Run fibonacci
         env:
           RUST_LOG: debug

--- a/examples-builder/build.rs
+++ b/examples-builder/build.rs
@@ -1,6 +1,6 @@
 use glob::glob;
 use std::{
-    fs::{File, read_dir},
+    fs::{File, read_dir, remove_file},
     io::{self, Write},
     path::Path,
     process::Command,
@@ -20,7 +20,8 @@ fn rerun_all_but_target(dir: &Path) {
 fn build_elfs() {
     let out_dir = std::env::var_os("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("vars.rs");
-    let mut dest = File::create(dest_path).expect("failed to create vars.rs");
+    let _ = remove_file(&dest_path);
+    let mut dest = File::create(&dest_path).expect("failed to create vars.rs");
 
     // TODO(Matthias): skip building the elfs if we are in clippy or check mode.
     // See git history for an attempt to do this.


### PR DESCRIPTION
Addressed the root cause in #887, for previously I thought it's due to example not build thus add a new ci step for it.

Integration build still occasionally failed. Finally figure out the root cause - invalid generated file, which probably due to CI interrupt after PR update.

"build.rs" generate "var.rs", but if "var.rs" exist but invalid, "build.rs" will failed BEFORE compile example and generate "var.rs", which is a dead loop.

The fix is simple, via clean up "var.rs" before generate "var.rs".