### PR TITLE
control `num_instances` in one place to improve soundness check

### DIFF
--- a/ceno_zkvm/src/bin/e2e.rs
+++ b/ceno_zkvm/src/bin/e2e.rs
@@ -222,7 +222,7 @@ fn verify(proof_file: &str, vk_file: &str) {
     let transcript = TranscriptWithStat::new(&stat_recorder, b"riscv");
     assert!(
         verifier
-            .verify_proof_halt(zkvm_proof.clone(), transcript, zkvm_proof.has_halt())
+            .verify_proof_halt(zkvm_proof.clone(), transcript, zkvm_proof.has_halt(&vk))
             .is_ok()
     );
     println!("e2e proof stat: {}", zkvm_proof);

--- a/ceno_zkvm/src/scheme.rs
+++ b/ceno_zkvm/src/scheme.rs
@@ -30,9 +30,6 @@ mod tests;
     deserialize = "E::BaseField: DeserializeOwned"
 ))]
 pub struct ZKVMOpcodeProof<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> {
-    // TODO support >1 opcodes
-    pub num_instances: usize,
-
     // product constraints
     pub record_r_out_evals: Vec<E>,
     pub record_w_out_evals: Vec<E>,
@@ -144,6 +141,8 @@ pub struct ZKVMProof<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> {
     pub raw_pi: Vec<Vec<E::BaseField>>,
     // the evaluation of raw_pi.
     pub pi_evals: Vec<E>,
+    // circuit size -> instance mapping
+    pub num_instances: Vec<(usize, usize)>,
     opcode_proofs: BTreeMap<String, (usize, ZKVMOpcodeProof<E, PCS>)>,
     table_proofs: BTreeMap<String, (usize, ZKVMTableProof<E, PCS>)>,
 }

--- a/ceno_zkvm/src/scheme.rs
+++ b/ceno_zkvm/src/scheme.rs
@@ -12,7 +12,7 @@ use sumcheck::structs::IOPProverMessage;
 
 use crate::{
     instructions::{Instruction, riscv::ecall::HaltInstruction},
-    structs::TowerProofs,
+    structs::{TowerProofs, ZKVMVerifyingKey},
 };
 
 pub mod constants;
@@ -69,9 +69,6 @@ pub struct ZKVMTableProof<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>
     pub lk_in_evals: Vec<E>,
 
     pub tower_proof: TowerProofs<E>,
-
-    // num_vars hint for rw dynamic address to work
-    pub rw_hints_num_vars: Vec<usize>,
 
     pub fixed_in_evals: Vec<E>,
     pub fixed_opening_proof: Option<PCS::Proof>,
@@ -143,8 +140,8 @@ pub struct ZKVMProof<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> {
     pub pi_evals: Vec<E>,
     // circuit size -> instance mapping
     pub num_instances: Vec<(usize, usize)>,
-    opcode_proofs: BTreeMap<String, (usize, ZKVMOpcodeProof<E, PCS>)>,
-    table_proofs: BTreeMap<String, (usize, ZKVMTableProof<E, PCS>)>,
+    opcode_proofs: BTreeMap<usize, ZKVMOpcodeProof<E, PCS>>,
+    table_proofs: BTreeMap<usize, ZKVMTableProof<E, PCS>>,
 }
 
 impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProof<E, PCS> {
@@ -166,6 +163,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProof<E, PCS> {
         Self {
             raw_pi,
             pi_evals,
+            num_instances: vec![],
             opcode_proofs: BTreeMap::new(),
             table_proofs: BTreeMap::new(),
         }
@@ -179,11 +177,19 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProof<E, PCS> {
         self.opcode_proofs.len() + self.table_proofs.len()
     }
 
-    pub fn has_halt(&self) -> bool {
+    pub fn has_halt(&self, vk: &ZKVMVerifyingKey<E, PCS>) -> bool {
         let halt_instance_count = self
-            .opcode_proofs
-            .get(&HaltInstruction::<E>::name())
-            .map(|(_, p)| p.num_instances)
+            .num_instances
+            .iter()
+            .find_map(|(circuit_index, num_instances)| {
+                (*circuit_index
+                    == vk
+                        .circuit_vks
+                        .keys()
+                        .position(|circuit_name| *circuit_name == HaltInstruction::<E>::name())
+                        .expect("halt circuit not exist"))
+                .then_some(*num_instances)
+            })
             .unwrap_or(0);
         if halt_instance_count > 0 {
             assert_eq!(
@@ -207,10 +213,10 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + Serialize> fmt::Dis
         let mpcs_opcode_commitment = self
             .opcode_proofs
             .iter()
-            .map(|(circuit_name, (_, proof))| {
+            .map(|(circuit_index, proof)| {
                 let size = bincode::serialized_size(&proof.wits_commit);
                 size.inspect(|size| {
-                    *by_circuitname_stats.entry(circuit_name).or_insert(0) += size;
+                    *by_circuitname_stats.entry(circuit_index).or_insert(0) += size;
                 })
             })
             .collect::<Result<Vec<u64>, _>>()
@@ -220,10 +226,10 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + Serialize> fmt::Dis
         let mpcs_opcode_opening = self
             .opcode_proofs
             .iter()
-            .map(|(circuit_name, (_, proof))| {
+            .map(|(circuit_index, proof)| {
                 let size = bincode::serialized_size(&proof.wits_opening_proof);
                 size.inspect(|size| {
-                    *by_circuitname_stats.entry(circuit_name).or_insert(0) += size;
+                    *by_circuitname_stats.entry(circuit_index).or_insert(0) += size;
                 })
             })
             .collect::<Result<Vec<u64>, _>>()
@@ -234,10 +240,10 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + Serialize> fmt::Dis
         let tower_proof_opcode = self
             .opcode_proofs
             .iter()
-            .map(|(circuit_name, (_, proof))| {
+            .map(|(circuit_index, proof)| {
                 let size = bincode::serialized_size(&proof.tower_proof);
                 size.inspect(|size| {
-                    *by_circuitname_stats.entry(circuit_name).or_insert(0) += size;
+                    *by_circuitname_stats.entry(circuit_index).or_insert(0) += size;
                 })
             })
             .collect::<Result<Vec<u64>, _>>()
@@ -248,10 +254,10 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + Serialize> fmt::Dis
         let main_sumcheck_opcode = self
             .opcode_proofs
             .iter()
-            .map(|(circuit_name, (_, proof))| {
+            .map(|(circuit_index, proof)| {
                 let size = bincode::serialized_size(&proof.main_sel_sumcheck_proofs);
                 size.inspect(|size| {
-                    *by_circuitname_stats.entry(circuit_name).or_insert(0) += size;
+                    *by_circuitname_stats.entry(circuit_index).or_insert(0) += size;
                 })
             })
             .collect::<Result<Vec<u64>, _>>()
@@ -262,10 +268,10 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + Serialize> fmt::Dis
         let mpcs_table_commitment = self
             .table_proofs
             .iter()
-            .map(|(circuit_name, (_, proof))| {
+            .map(|(circuit_index, proof)| {
                 let size = bincode::serialized_size(&proof.wits_commit);
                 size.inspect(|size| {
-                    *by_circuitname_stats.entry(circuit_name).or_insert(0) += size;
+                    *by_circuitname_stats.entry(circuit_index).or_insert(0) += size;
                 })
             })
             .collect::<Result<Vec<u64>, _>>()
@@ -275,10 +281,10 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + Serialize> fmt::Dis
         let mpcs_table_opening = self
             .table_proofs
             .iter()
-            .map(|(circuit_name, (_, proof))| {
+            .map(|(circuit_index, proof)| {
                 let size = bincode::serialized_size(&proof.wits_opening_proof);
                 size.inspect(|size| {
-                    *by_circuitname_stats.entry(circuit_name).or_insert(0) += size;
+                    *by_circuitname_stats.entry(circuit_index).or_insert(0) += size;
                 })
             })
             .collect::<Result<Vec<u64>, _>>()
@@ -288,10 +294,10 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + Serialize> fmt::Dis
         let mpcs_table_fixed_opening = self
             .table_proofs
             .iter()
-            .map(|(circuit_name, (_, proof))| {
+            .map(|(circuit_index, proof)| {
                 let size = bincode::serialized_size(&proof.fixed_opening_proof);
                 size.inspect(|size| {
-                    *by_circuitname_stats.entry(circuit_name).or_insert(0) += size;
+                    *by_circuitname_stats.entry(circuit_index).or_insert(0) += size;
                 })
             })
             .collect::<Result<Vec<u64>, _>>()
@@ -302,10 +308,10 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + Serialize> fmt::Dis
         let tower_proof_table = self
             .table_proofs
             .iter()
-            .map(|(circuit_name, (_, proof))| {
+            .map(|(circuit_index, proof)| {
                 let size = bincode::serialized_size(&proof.tower_proof);
                 size.inspect(|size| {
-                    *by_circuitname_stats.entry(circuit_name).or_insert(0) += size;
+                    *by_circuitname_stats.entry(circuit_index).or_insert(0) += size;
                 })
             })
             .collect::<Result<Vec<u64>, _>>()
@@ -316,10 +322,10 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + Serialize> fmt::Dis
         let same_r_sumcheck_table = self
             .table_proofs
             .iter()
-            .map(|(circuit_name, (_, proof))| {
+            .map(|(circuit_index, proof)| {
                 let size = bincode::serialized_size(&proof.same_r_sumcheck_proofs);
                 size.inspect(|size| {
-                    *by_circuitname_stats.entry(circuit_name).or_insert(0) += size;
+                    *by_circuitname_stats.entry(circuit_index).or_insert(0) += size;
                 })
             })
             .collect::<Result<Vec<u64>, _>>()

--- a/ceno_zkvm/src/scheme/tests.rs
+++ b/ceno_zkvm/src/scheme/tests.rs
@@ -166,6 +166,7 @@ fn test_rw_lk_expression_combination() {
                 &vk.vp,
                 verifier.vk.circuit_vks.get(&name).unwrap(),
                 &proof,
+                num_instances,
                 &[],
                 &mut v_transcript,
                 NUM_FANIN,

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -11,6 +11,7 @@ use multilinear_extensions::{
     virtual_poly::{VPAuxInfo, build_eq_x_r_vec_sequential, eq_eval},
 };
 use p3::field::PrimeCharacteristicRing;
+use std::collections::HashSet;
 use sumcheck::structs::{IOPProof, IOPVerifierState};
 use transcript::{ForkableTranscript, Transcript};
 use witness::next_pow2_instance_padding;
@@ -57,7 +58,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         expect_halt: bool,
     ) -> Result<bool, ZKVMError> {
         // require ecall/halt proof to exist, depending whether we expect a halt.
-        let has_halt = vm_proof.has_halt();
+        let has_halt = vm_proof.has_halt(&self.vk);
         if has_halt != expect_halt {
             return Err(ZKVMError::VerifyError(format!(
                 "ecall/halt mismatch: expected {expect_halt} != {has_halt}",
@@ -78,6 +79,45 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         let mut logup_sum = E::ZERO;
 
         let pi_evals = &vm_proof.pi_evals;
+
+        // make sure circuit index are
+        // 1. unique
+        // 2. less than self.vk.circuit_vks.len()
+        assert!(
+            vm_proof
+                .num_instances
+                .iter()
+                .fold(None, |prev, &(circuit_index, _)| {
+                    (circuit_index < self.vk.circuit_vks.len()
+                        && prev.is_none_or(|p| p < circuit_index))
+                    .then_some(circuit_index)
+                })
+                .is_some(),
+            "num_instances validity check failed"
+        );
+
+        assert_eq!(
+            vm_proof
+                .num_instances
+                .iter()
+                .map(|(x, _)| x)
+                .collect::<HashSet<&usize>>(),
+            vm_proof
+                .opcode_proofs
+                .keys()
+                .chain(vm_proof.table_proofs.keys())
+                .collect::<HashSet<_>>(),
+            "num_instance circuit index exactly equal with provided proofs"
+        );
+
+        assert!(
+            vm_proof
+                .opcode_proofs
+                .keys()
+                .collect::<HashSet<_>>()
+                .is_disjoint(&vm_proof.table_proofs.keys().collect::<HashSet<_>>()),
+            "there is duplicated circuit index"
+        );
 
         // TODO fix soundness: construct raw public input by ourself and trustless from proof
         // including raw public input to transcript
@@ -108,17 +148,26 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
             }
         }
 
-        for (circuit_name, _) in self.vk.circuit_vks.iter() {
-            if let Some((_, opcode_proof)) = vm_proof.opcode_proofs.get(circuit_name) {
+        // write (circuit_size, num_var) to transcript
+        for (circuit_size, num_var) in &vm_proof.num_instances {
+            transcript.append_message(&circuit_size.to_le_bytes());
+            transcript.append_message(&num_var.to_le_bytes());
+        }
+
+        let circuit_vks: Vec<&VerifyingKey<E, PCS>> = self.vk.circuit_vks.values().collect_vec();
+        let circuit_names: Vec<&String> = self.vk.circuit_vks.keys().collect_vec();
+        for (index, _) in &vm_proof.num_instances {
+            let circuit_name = circuit_names[*index];
+            if let Some(opcode_proof) = vm_proof.opcode_proofs.get(index) {
                 tracing::debug!("read {}'s commit", circuit_name);
                 PCS::write_commitment(&opcode_proof.wits_commit, &mut transcript)
                     .map_err(ZKVMError::PCSError)?;
-            } else if let Some((_, table_proof)) = vm_proof.table_proofs.get(circuit_name) {
+            } else if let Some(table_proof) = vm_proof.table_proofs.get(index) {
                 tracing::debug!("read {}'s commit", circuit_name);
                 PCS::write_commitment(&table_proof.wits_commit, &mut transcript)
                     .map_err(ZKVMError::PCSError)?;
             } else {
-                // all proof are optional
+                unreachable!("respective proof of index {} should exist", index)
             }
         }
 
@@ -132,15 +181,17 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         let dummy_table_item = challenges[0];
         let mut dummy_table_item_multiplicity = 0;
         let point_eval = PointAndEval::default();
-        for (index, (circuit_name, circuit_vk)) in self.vk.circuit_vks.iter().enumerate() {
-            if let Some((_, opcode_proof)) = vm_proof.opcode_proofs.get(circuit_name) {
-                transcript.append_field_element(&E::BaseField::from_u64(index as u64));
-                let name = circuit_name;
+        for (index, num_instances) in &vm_proof.num_instances {
+            let circuit_vk = circuit_vks[*index];
+            let name = circuit_names[*index];
+            if let Some(opcode_proof) = vm_proof.opcode_proofs.get(index) {
+                transcript.append_field_element(&E::BaseField::from_u64(*index as u64));
                 let _rand_point = self.verify_opcode_proof(
                     name,
                     &self.vk.vp,
                     circuit_vk,
                     opcode_proof,
+                    *num_instances,
                     pi_evals,
                     &mut transcript,
                     NUM_FANIN,
@@ -152,10 +203,9 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
                 // getting the number of dummy padding item that we used in this opcode circuit
                 let num_lks = circuit_vk.get_cs().lk_expressions.len();
                 let num_padded_lks_per_instance = next_pow2_instance_padding(num_lks) - num_lks;
-                let num_padded_instance = next_pow2_instance_padding(opcode_proof.num_instances)
-                    - opcode_proof.num_instances;
-                dummy_table_item_multiplicity += num_padded_lks_per_instance
-                    * opcode_proof.num_instances
+                let num_padded_instance =
+                    next_pow2_instance_padding(*num_instances) - num_instances;
+                dummy_table_item_multiplicity += num_padded_lks_per_instance * num_instances
                     + num_lks.next_power_of_two() * num_padded_instance;
 
                 prod_r *= opcode_proof
@@ -171,14 +221,14 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
 
                 logup_sum += opcode_proof.lk_p1_out_eval * opcode_proof.lk_q1_out_eval.inverse();
                 logup_sum += opcode_proof.lk_p2_out_eval * opcode_proof.lk_q2_out_eval.inverse();
-            } else if let Some((_, table_proof)) = vm_proof.table_proofs.get(circuit_name) {
-                transcript.append_field_element(&E::BaseField::from_u64(index as u64));
-                let name = circuit_name;
+            } else if let Some(table_proof) = vm_proof.table_proofs.get(index) {
+                transcript.append_field_element(&E::BaseField::from_u64(*index as u64));
                 let _rand_point = self.verify_table_proof(
                     name,
                     &self.vk.vp,
                     circuit_vk,
                     table_proof,
+                    *num_instances,
                     &vm_proof.raw_pi,
                     &vm_proof.pi_evals,
                     &mut transcript,
@@ -208,7 +258,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
                     .copied()
                     .product::<E>();
             } else {
-                // all proof are optional
+                unreachable!("respective proof of index {} should exist", index)
             }
         }
         logup_sum -= E::from_u64(dummy_table_item_multiplicity as u64) * dummy_table_item.inverse();
@@ -255,6 +305,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         vp: &PCS::VerifierParam,
         circuit_vk: &VerifyingKey<E, PCS>,
         proof: &ZKVMOpcodeProof<E, PCS>,
+        num_instances: usize,
         pi: &[E],
         transcript: &mut impl Transcript<E>,
         num_product_fanin: usize,
@@ -274,7 +325,6 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         );
         let (chip_record_alpha, _) = (challenges[0], challenges[1]);
 
-        let num_instances = proof.num_instances;
         let next_pow2_instance = next_pow2_instance_padding(num_instances);
         let log2_num_instances = ceil_log2(next_pow2_instance);
 
@@ -501,6 +551,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         vp: &PCS::VerifierParam,
         circuit_vk: &VerifyingKey<E, PCS>,
         proof: &ZKVMTableProof<E, PCS>,
+        num_instances: usize,
         raw_pi: &[Vec<E::BaseField>],
         pi: &[E],
         transcript: &mut impl Transcript<E>,
@@ -515,6 +566,9 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
                 .zip_eq(cs.w_table_expressions.iter())
                 .all(|(r, w)| r.table_spec.len == w.table_spec.len)
         );
+
+        let log2_num_instances = ceil_log2(num_instances);
+
         // in table proof, we always skip same point sumcheck for now
         // as tower sumcheck batch product argument/logup in same length
         let is_skip_same_point_sumcheck = true;
@@ -522,6 +576,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         // verify and reduce product tower sumcheck
         let tower_proofs = &proof.tower_proof;
 
+        // NOTE: for all structural witness within same constrain system should got same hints num variable via `log2_num_instances`
         let expected_rounds = cs
             // only iterate r set, as read/write set round should match
             .r_table_expressions
@@ -532,14 +587,15 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
                     r.table_spec
                         .structural_witins
                         .iter()
-                        .map(|StructuralWitIn { id, max_len, .. }| {
-                            let hint_num_vars = proof.rw_hints_num_vars[*id as usize];
+                        .map(|StructuralWitIn { max_len, .. }| {
+                            let hint_num_vars = log2_num_instances;
                             assert!((1 << hint_num_vars) <= *max_len);
                             hint_num_vars
                         })
                         .max()
                         .unwrap()
                 });
+                assert_eq!(num_vars, log2_num_instances);
                 [num_vars, num_vars] // format: [read_round, write_round]
             })
             .chain(cs.lk_table_expressions.iter().map(|l| {
@@ -548,21 +604,18 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
                     l.table_spec
                         .structural_witins
                         .iter()
-                        .map(|StructuralWitIn { id, max_len, .. }| {
-                            let hint_num_vars = proof.rw_hints_num_vars[*id as usize];
+                        .map(|StructuralWitIn { max_len, .. }| {
+                            let hint_num_vars = log2_num_instances;
                             assert!((1 << hint_num_vars) <= *max_len);
                             hint_num_vars
                         })
                         .max()
                         .unwrap()
                 });
+                assert_eq!(num_vars, log2_num_instances);
                 num_vars
             }))
             .collect_vec();
-
-        for var in proof.rw_hints_num_vars.iter() {
-            transcript.append_message(&var.to_le_bytes());
-        }
 
         let expected_max_rounds = expected_rounds.iter().cloned().max().unwrap();
         let (rt_tower, prod_point_and_eval, logup_p_point_and_eval, logup_q_point_and_eval) =


### PR DESCRIPTION
This features is preliminary support to batched all opcode/table in one mpcs proof https://github.com/scroll-tech/ceno/pull/894

Previously we got few issues
1. `num_instance` are specify in each opcode proof
2. `rw_hint_var` are specify in each table proof

while both are describe the same thing in different place, which make thing hard to control and make room for malicious prover to crack based on inconsistency.

In this PR, we unify num_instance in one central place, and do a strictly check of it's consistency.
This also addressed feature in #648 

