### PR TITLE
Add binary exec to generate test vectors for verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,6 +1156,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hex-conservative"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,10 +1579,12 @@ dependencies = [
  "aes",
  "bincode",
  "bitvec",
+ "clap",
  "criterion",
  "ctr",
  "ff_ext",
  "generic-array",
+ "hex",
  "itertools 0.13.0",
  "multilinear_extensions",
  "num-bigint",

--- a/mpcs/Cargo.toml
+++ b/mpcs/Cargo.toml
@@ -13,9 +13,11 @@ version.workspace = true
 aes = "0.8"
 bincode = "1.3.3"
 bitvec = "1.0"
+clap = { version = "4.4.17", features = ["derive"] }
 ctr = "0.9"
 ff_ext = { path = "../ff_ext" }
 generic-array = { version = "0.14", features = ["serde"] }
+hex = "0.4"
 itertools.workspace = true
 multilinear_extensions = { path = "../multilinear_extensions" }
 num-bigint = "0.4"
@@ -43,6 +45,10 @@ default = ["parallel"] # Add "sanity-check" to debug
 parallel = ["dep:rayon"]
 print-trace = ["whir/print-trace"]
 sanity-check = []
+
+[[bin]]
+name = "generate_test_vector"
+path = "bin/generate_test_vector.rs"
 
 [[bench]]
 harness = false

--- a/mpcs/bin/generate_test_vector.rs
+++ b/mpcs/bin/generate_test_vector.rs
@@ -1,0 +1,95 @@
+use ff_ext::{BabyBearExt4, ExtensionField, GoldilocksExt2};
+use mpcs::{
+    PolynomialCommitmentScheme, Whir, WhirDefaultSpec,
+    test_util::{get_point_from_challenge, setup_pcs},
+};
+use multilinear_extensions::virtual_poly::ArcMultilinearExtension;
+use rand::{distributions::Standard, prelude::Distribution, thread_rng};
+use transcript::{BasicTranscript, Transcript};
+use witness::RowMajorMatrix;
+
+type PcsGoldilocks = Whir<GoldilocksExt2, WhirDefaultSpec>;
+type PcsBabyBear = Whir<BabyBearExt4, WhirDefaultSpec>;
+
+use clap::Parser;
+
+#[derive(Parser)]
+struct Args {
+    #[arg(short = 'f', long, default_value = "goldilocks")]
+    field: String,
+}
+
+fn main() {
+    // pass the parameters to determine which field to use, using the clap::Parser
+    let args = Args::parse();
+    match args.field.as_str() {
+        "goldilocks" => {
+            for num_var in 5..=10 {
+                let (vp, comm, eval, proof) =
+                    generate_test_vector::<GoldilocksExt2, PcsGoldilocks>(num_var);
+                println!("num_vars: {}", num_var);
+                println!("vp: {}", vp);
+                println!("comm: {}", comm);
+                println!("eval: {}", eval);
+                println!("proof: {}", proof);
+            }
+        }
+        "babybear" => {
+            for num_var in 5..=10 {
+                let (vp, comm, eval, proof) =
+                    generate_test_vector::<BabyBearExt4, PcsBabyBear>(num_var);
+                println!("num_vars: {}", num_var);
+                println!("vp: {}", vp);
+                println!("comm: {}", comm);
+                println!("eval: {}", eval);
+                println!("proof: {}", proof);
+            }
+        }
+        _ => {
+            eprintln!("Unsupported field");
+            std::process::exit(1);
+        }
+    }
+}
+
+pub fn generate_test_vector<E: ExtensionField, Pcs>(
+    num_vars: usize,
+) -> (String, String, String, String)
+where
+    Pcs: PolynomialCommitmentScheme<E>,
+    Standard: Distribution<E::BaseField>,
+{
+    let (pp, vp) = setup_pcs::<E, Pcs>(num_vars);
+    let mut test_rng = thread_rng();
+
+    // Commit and open
+    let (comm, eval, proof) = {
+        let mut transcript = BasicTranscript::new(b"BaseFold");
+        let rmm = RowMajorMatrix::<E::BaseField>::rand(&mut test_rng, 1 << num_vars, 1);
+        let poly: ArcMultilinearExtension<E> = rmm.to_mles().remove(0).into();
+        let comm = Pcs::commit_and_write(&pp, rmm, &mut transcript).unwrap();
+
+        let point = get_point_from_challenge(num_vars, &mut transcript);
+        let eval = poly.evaluate(point.as_slice());
+        transcript.append_field_element_ext(&eval);
+
+        (
+            Pcs::get_pure_commitment(&comm),
+            eval,
+            Pcs::open(&pp, &poly, &comm, &point, &eval, &mut transcript).unwrap(),
+        )
+    };
+    // Serialize vp, comm, eval, proof using bincode
+    let vp_bin = bincode::serialize(&vp).unwrap();
+    let comm_bin = bincode::serialize(&comm).unwrap();
+    let eval_bin = bincode::serialize(&eval).unwrap();
+    let proof_bin = bincode::serialize(&proof).unwrap();
+
+    // Encode them as hex strings
+    let vp_hex = hex::encode(vp_bin);
+    let comm_hex = hex::encode(comm_bin);
+    let eval_hex = hex::encode(eval_bin);
+    let proof_hex = hex::encode(proof_bin);
+
+    (vp_hex, comm_hex, eval_hex, proof_hex)
+}

--- a/mpcs/src/lib.rs
+++ b/mpcs/src/lib.rs
@@ -339,6 +339,7 @@ pub mod test_util {
     ) -> Vec<E> {
         transcript.sample_and_append_vec(b"Point", num_vars)
     }
+
     pub fn get_points_from_challenge<E: ExtensionField>(
         num_vars: impl Fn(usize) -> usize,
         num_points: usize,


### PR DESCRIPTION
Allow generating test data for both goldilocks (default) and babybear, for opening a single polynomial.
The output includes:
- vp (verifier parameter)
- comm (commitment)
- eval (evaluation)
- proof

The output is in hex format.