### PR TITLE
output num instructions executed

### DIFF
--- a/ceno_emul/src/tracer.rs
+++ b/ceno_emul/src/tracer.rs
@@ -481,6 +481,11 @@ impl Tracer {
         self.record.cycle
     }
 
+    /// Return the number of instruction executed til this moment
+    pub fn insts(&self) -> Cycle {
+        self.record.cycle / Self::SUBCYCLES_PER_INSN
+    }
+
     /// giving a start address, return (min, max) accessed address within section
     pub fn probe_min_max_address_by_start_addr(
         &self,

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -132,7 +132,8 @@ fn emulate_program(
 
     let final_access = vm.tracer().final_accesses();
     let end_cycle: u32 = vm.tracer().cycle().try_into().unwrap();
-    tracing::debug!("program took {end_cycle} cycles");
+    let insts: u32 = vm.tracer().insts().try_into().unwrap();
+    tracing::debug!("program executed {insts} instructions in {end_cycle} cycles");
 
     let pi = PublicValues::new(
         exit_code.unwrap_or(0),


### PR DESCRIPTION
along with cycles consumption, as in ceno one instruction != one cycle
see comment in [tracer](https://github.com/scroll-tech/ceno/blob/master/ceno_emul/src/tracer.rs#L15-L25)