### PR TITLE
inst count and cleanup sp1 platform

### DIFF
--- a/ceno_emul/src/tracer.rs
+++ b/ceno_emul/src/tracer.rs
@@ -482,8 +482,12 @@ impl Tracer {
     }
 
     /// Return the number of instruction executed til this moment
-    pub fn insts(&self) -> Cycle {
-        self.record.cycle / Self::SUBCYCLES_PER_INSN
+    /// minus 1 since cycle start from Self::SUBCYCLES_PER_INSN
+    pub fn executed_insts(&self) -> usize {
+        (self.record.cycle / Self::SUBCYCLES_PER_INSN)
+            .saturating_sub(1)
+            .try_into()
+            .unwrap()
     }
 
     /// giving a start address, return (min, max) accessed address within section

--- a/ceno_zkvm/benches/fibonacci_witness.rs
+++ b/ceno_zkvm/benches/fibonacci_witness.rs
@@ -32,7 +32,7 @@ fn setup() -> (Program, Platform) {
     let pub_io_size = 16;
     let elf_bytes = fs::read(&file_path).expect("read elf file");
     let program = Program::load_elf(&elf_bytes, u32::MAX).unwrap();
-    let platform = setup_platform(Preset::Sp1, &program, stack_size, heap_size, pub_io_size);
+    let platform = setup_platform(Preset::Ceno, &program, stack_size, heap_size, pub_io_size);
     (program, platform)
 }
 

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -132,7 +132,7 @@ fn emulate_program(
 
     let final_access = vm.tracer().final_accesses();
     let end_cycle: u32 = vm.tracer().cycle().try_into().unwrap();
-    let insts: u32 = vm.tracer().insts().try_into().unwrap();
+    let insts = vm.tracer().executed_insts();
     tracing::debug!("program executed {insts} instructions in {end_cycle} cycles");
 
     let pi = PublicValues::new(
@@ -268,7 +268,6 @@ fn emulate_program(
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum Preset {
     Ceno,
-    Sp1,
 }
 
 pub fn setup_platform(
@@ -280,12 +279,6 @@ pub fn setup_platform(
 ) -> Platform {
     let preset = match preset {
         Preset::Ceno => CENO_PLATFORM,
-        Preset::Sp1 => Platform {
-            // The stack section is not mentioned in ELF headers, so we repeat the constant STACK_TOP here.
-            stack: 0x0020_0400..0x0020_0400,
-            unsafe_ecall_nop: true,
-            ..CENO_PLATFORM
-        },
     };
 
     let prog_data = program.image.keys().copied().collect::<BTreeSet<_>>();


### PR DESCRIPTION
- fix instruction count since initial cycle start from `4`
- clean up sp1 platform for no-longer binary compatible with sp1 after https://github.com/scroll-tech/ceno/pull/889