### PR TITLE
Fix an example code in doc comments (cargo test tries to run it)

### DIFF
--- a/mpcs/src/util.rs
+++ b/mpcs/src/util.rs
@@ -286,9 +286,11 @@ pub fn ext_try_into_base<E: ExtensionField>(x: &E) -> Result<E::BaseField, Error
 /// # example
 ///
 /// ```
+/// use mpcs::util::split_by_sizes;
+///
 /// let input = vec![10, 20, 30, 40, 50, 60];
 /// let sizes = vec![2, 3, 1];
-/// let result = split_by_sizes(input, &sizes);
+/// let result = split_by_sizes(&input, &sizes);
 ///
 /// assert_eq!(result.len(), 3);
 /// assert_eq!(result[0], &[10, 20]);


### PR DESCRIPTION
Cargo test fails on my laptop in master because it tries to run an example snippet in the documentation comment of the function `split_by_sizes`. Fixed that snippet.