### PR TITLE
support debug mode in cargo cli run

### DIFF
--- a/ceno_cli/src/commands/common_args/cargo.rs
+++ b/ceno_cli/src/commands/common_args/cargo.rs
@@ -38,11 +38,11 @@ pub struct CargoOptions {
 }
 
 /// Package Selection:
-///   --package [<SPEC>]  Package with the target to run
+///   -p, --package [<SPEC>]  Package with the target to run
 #[derive(Clone, Args)]
 pub struct PackageSelection {
     /// Package with the target to run
-    #[arg(long)]
+    #[arg(short = 'p', long)]
     pub package: Option<String>,
 }
 

--- a/ceno_cli/src/commands/common_args/cargo.rs
+++ b/ceno_cli/src/commands/common_args/cargo.rs
@@ -38,11 +38,11 @@ pub struct CargoOptions {
 }
 
 /// Package Selection:
-///   -p, --package [<SPEC>]  Package with the target to run
+///   --package [<SPEC>]  Package with the target to run
 #[derive(Clone, Args)]
 pub struct PackageSelection {
     /// Package with the target to run
-    #[arg(short = 'p', long)]
+    #[arg(long)]
     pub package: Option<String>,
 }
 

--- a/ceno_cli/src/commands/common_args/ceno.rs
+++ b/ceno_cli/src/commands/common_args/ceno.rs
@@ -19,11 +19,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use super::CompilationOptions;
+
 /// Ceno options
 #[derive(Clone, Args)]
 pub struct CenoOptions {
     /// The preset configuration to use.
-    #[arg(short, long, value_enum, default_value_t = Preset::Ceno)]
+    #[arg(long, value_enum, default_value_t = Preset::Ceno)]
     pub platform: Preset,
 
     /// The polynomial commitment scheme to use.
@@ -75,10 +77,6 @@ pub struct CenoOptions {
     /// Setting any value restricts logs to profiling information
     #[arg(long)]
     profiling: Option<usize>,
-
-    #[clap(skip)]
-    /// run in release mode or not.
-    pub release: bool,
 }
 
 impl CenoOptions {
@@ -173,37 +171,56 @@ impl CenoOptions {
     }
 
     /// Run keygen the ceno elf file with given options
-    pub fn keygen<P: AsRef<Path>>(&self, elf_path: P) -> anyhow::Result<()> {
+    pub fn keygen<P: AsRef<Path>>(
+        &self,
+        compilation_options: &CompilationOptions,
+        elf_path: P,
+    ) -> anyhow::Result<()> {
         self.try_setup_logger();
         match (self.pcs, self.field) {
             (PcsKind::Basefold, FieldType::Goldilocks) => {
                 keygen_inner::<GoldilocksExt2, Basefold<GoldilocksExt2, BasefoldRSParams>, P>(
-                    self, elf_path,
+                    self,
+                    compilation_options,
+                    elf_path,
                 )
             }
             (PcsKind::Basefold, FieldType::BabyBear) => {
                 keygen_inner::<BabyBearExt4, Basefold<BabyBearExt4, BasefoldRSParams>, P>(
-                    self, elf_path,
+                    self,
+                    compilation_options,
+                    elf_path,
                 )
             }
             (PcsKind::Whir, FieldType::Goldilocks) => {
                 keygen_inner::<GoldilocksExt2, Whir<GoldilocksExt2, WhirDefaultSpec>, P>(
-                    self, elf_path,
+                    self,
+                    compilation_options,
+                    elf_path,
                 )
             }
             (PcsKind::Whir, FieldType::BabyBear) => {
-                keygen_inner::<BabyBearExt4, Whir<BabyBearExt4, WhirDefaultSpec>, P>(self, elf_path)
+                keygen_inner::<BabyBearExt4, Whir<BabyBearExt4, WhirDefaultSpec>, P>(
+                    self,
+                    compilation_options,
+                    elf_path,
+                )
             }
         }
     }
 
     /// Run the ceno elf file with given options
-    pub fn run<P: AsRef<Path>>(&self, elf_path: P) -> anyhow::Result<()> {
+    pub fn run<P: AsRef<Path>>(
+        &self,
+        compilation_options: &CompilationOptions,
+        elf_path: P,
+    ) -> anyhow::Result<()> {
         self.try_setup_logger();
         match (self.pcs, self.field) {
             (PcsKind::Basefold, FieldType::Goldilocks) => {
                 run_elf_inner::<GoldilocksExt2, Basefold<GoldilocksExt2, BasefoldRSParams>, P>(
                     self,
+                    compilation_options,
                     elf_path,
                     Checkpoint::PrepWitnessGen,
                 )?;
@@ -211,6 +228,7 @@ impl CenoOptions {
             (PcsKind::Basefold, FieldType::BabyBear) => {
                 run_elf_inner::<BabyBearExt4, Basefold<BabyBearExt4, BasefoldRSParams>, P>(
                     self,
+                    compilation_options,
                     elf_path,
                     Checkpoint::PrepWitnessGen,
                 )?;
@@ -218,6 +236,7 @@ impl CenoOptions {
             (PcsKind::Whir, FieldType::Goldilocks) => {
                 run_elf_inner::<GoldilocksExt2, Whir<GoldilocksExt2, WhirDefaultSpec>, P>(
                     self,
+                    compilation_options,
                     elf_path,
                     Checkpoint::PrepWitnessGen,
                 )?;
@@ -225,6 +244,7 @@ impl CenoOptions {
             (PcsKind::Whir, FieldType::BabyBear) => {
                 run_elf_inner::<BabyBearExt4, Whir<BabyBearExt4, WhirDefaultSpec>, P>(
                     self,
+                    compilation_options,
                     elf_path,
                     Checkpoint::PrepWitnessGen,
                 )?;
@@ -234,12 +254,17 @@ impl CenoOptions {
     }
 
     /// Run and prove the ceno elf file with given options
-    pub fn prove<P: AsRef<Path>>(&self, elf_path: P) -> anyhow::Result<()> {
+    pub fn prove<P: AsRef<Path>>(
+        &self,
+        compilation_options: &CompilationOptions,
+        elf_path: P,
+    ) -> anyhow::Result<()> {
         self.try_setup_logger();
         match (self.pcs, self.field) {
             (PcsKind::Basefold, FieldType::Goldilocks) => {
                 prove_inner::<GoldilocksExt2, Basefold<GoldilocksExt2, BasefoldRSParams>, P>(
                     self,
+                    compilation_options,
                     elf_path,
                     Checkpoint::Complete,
                 )
@@ -247,6 +272,7 @@ impl CenoOptions {
             (PcsKind::Basefold, FieldType::BabyBear) => {
                 prove_inner::<BabyBearExt4, Basefold<BabyBearExt4, BasefoldRSParams>, P>(
                     self,
+                    compilation_options,
                     elf_path,
                     Checkpoint::PrepVerify, // FIXME: when whir and babybear is ready
                 )
@@ -254,6 +280,7 @@ impl CenoOptions {
             (PcsKind::Whir, FieldType::Goldilocks) => {
                 prove_inner::<GoldilocksExt2, Whir<GoldilocksExt2, WhirDefaultSpec>, P>(
                     self,
+                    compilation_options,
                     elf_path,
                     Checkpoint::PrepVerify, // FIXME: when whir and babybear is ready
                 )
@@ -261,6 +288,7 @@ impl CenoOptions {
             (PcsKind::Whir, FieldType::BabyBear) => {
                 prove_inner::<BabyBearExt4, Whir<BabyBearExt4, WhirDefaultSpec>, P>(
                     self,
+                    compilation_options,
                     elf_path,
                     Checkpoint::PrepVerify, // FIXME: when whir and babybear is ready
                 )
@@ -275,6 +303,7 @@ fn run_elf_inner<
     P: AsRef<Path>,
 >(
     options: &CenoOptions,
+    compilation_options: &CompilationOptions,
     elf_path: P,
     checkpoint: Checkpoint,
 ) -> anyhow::Result<E2ECheckpointResult<E, PCS>> {
@@ -292,7 +321,7 @@ fn run_elf_inner<
         .next_power_of_two()
         .max(16);
 
-    let platform = if options.release {
+    let platform = if compilation_options.release {
         setup_platform(
             options.platform,
             &program,
@@ -341,9 +370,15 @@ fn keygen_inner<
     P: AsRef<Path>,
 >(
     args: &CenoOptions,
+    compilation_options: &CompilationOptions,
     elf_path: P,
 ) -> anyhow::Result<()> {
-    let result = run_elf_inner::<E, PCS, P>(args, elf_path, Checkpoint::PrepE2EProving)?;
+    let result = run_elf_inner::<E, PCS, P>(
+        args,
+        compilation_options,
+        elf_path,
+        Checkpoint::PrepE2EProving,
+    )?;
     let vk = result.vk.expect("Keygen should yield vk.");
     if let Some(out_vk) = args.out_vk.as_ref() {
         let path = canonicalize_allow_nx(out_vk)?;
@@ -361,10 +396,11 @@ fn prove_inner<
     P: AsRef<Path>,
 >(
     args: &CenoOptions,
+    compilation_options: &CompilationOptions,
     elf_path: P,
     checkpoint: Checkpoint,
 ) -> anyhow::Result<()> {
-    let result = run_elf_inner::<E, PCS, P>(args, elf_path, checkpoint)?;
+    let result = run_elf_inner::<E, PCS, P>(args, compilation_options, elf_path, checkpoint)?;
     let zkvm_proof = result.proof.expect("PrepSanityCheck should yield proof.");
     let vk = result.vk.expect("PrepSanityCheck should yield vk.");
 

--- a/ceno_cli/src/commands/common_args/ceno.rs
+++ b/ceno_cli/src/commands/common_args/ceno.rs
@@ -75,6 +75,10 @@ pub struct CenoOptions {
     /// Setting any value restricts logs to profiling information
     #[arg(long)]
     profiling: Option<usize>,
+
+    #[clap(skip)]
+    /// run in release mode or not.
+    pub release: bool,
 }
 
 impl CenoOptions {
@@ -288,13 +292,23 @@ fn run_elf_inner<
         .next_power_of_two()
         .max(16);
 
-    let platform = setup_platform(
-        options.platform,
-        &program,
-        options.stack_size(),
-        options.heap_size(),
-        pub_io_size,
-    );
+    let platform = if options.release {
+        setup_platform(
+            options.platform,
+            &program,
+            options.stack_size(),
+            options.heap_size(),
+            pub_io_size,
+        )
+    } else {
+        setup_platform_debug(
+            options.platform,
+            &program,
+            options.stack_size(),
+            options.heap_size(),
+            pub_io_size,
+        )
+    };
     tracing::info!("Running on platform {:?} {}", options.platform, platform);
     tracing::info!(
         "Stack: {} bytes. Heap: {} bytes.",

--- a/ceno_cli/src/commands/raw_run.rs
+++ b/ceno_cli/src/commands/raw_run.rs
@@ -9,12 +9,15 @@ pub struct RawKeygenCmd {
     elf: PathBuf,
     #[clap(flatten, next_help_heading = "Ceno Options")]
     ceno_options: CenoOptions,
+    #[clap(flatten, next_help_heading = "Compilation Options")]
+    compilation_options: CompilationOptions,
 }
 
 impl RawKeygenCmd {
     pub fn run(self) -> anyhow::Result<()> {
         self.ceno_options.try_setup_logger();
-        self.ceno_options.keygen(self.elf)
+        self.ceno_options
+            .keygen(&self.compilation_options, self.elf)
     }
 }
 
@@ -25,12 +28,14 @@ pub struct RawRunCmd {
     elf: PathBuf,
     #[clap(flatten, next_help_heading = "Ceno Options")]
     ceno_options: CenoOptions,
+    #[clap(flatten, next_help_heading = "Compilation Options")]
+    compilation_options: CompilationOptions,
 }
 
 impl RawRunCmd {
     pub fn run(self) -> anyhow::Result<()> {
         self.ceno_options.try_setup_logger();
-        self.ceno_options.run(self.elf)
+        self.ceno_options.run(&self.compilation_options, self.elf)
     }
 }
 
@@ -41,11 +46,13 @@ pub struct RawProveCmd {
     elf: PathBuf,
     #[clap(flatten, next_help_heading = "Ceno Options")]
     ceno_options: CenoOptions,
+    #[clap(flatten, next_help_heading = "Compilation Options")]
+    compilation_options: CompilationOptions,
 }
 
 impl RawProveCmd {
     pub fn run(self) -> anyhow::Result<()> {
         self.ceno_options.try_setup_logger();
-        self.ceno_options.prove(self.elf)
+        self.ceno_options.prove(&self.compilation_options, self.elf)
     }
 }

--- a/ceno_cli/src/commands/run.rs
+++ b/ceno_cli/src/commands/run.rs
@@ -91,7 +91,7 @@ impl ProveCmd {
 }
 
 impl CmdInner {
-    fn run(self, toolchain: Option<String>, kind: RunKind) -> anyhow::Result<()> {
+    fn run(mut self, toolchain: Option<String>, kind: RunKind) -> anyhow::Result<()> {
         let manifest_path = match self.manifest_options.manifest_path.clone() {
             Some(path) => path,
             None => search_cargo_manifest_path(current_dir()?)?,
@@ -99,6 +99,9 @@ impl CmdInner {
         let target_selection = self
             .target_selection
             .canonicalize(manifest_path, &self.package_selection)?;
+
+        // XXX: custom handling: set release mode from compilation_options
+        self.ceno_options.release = self.compilation_options.release;
 
         let build = BuildCmd {
             cargo_options: self.cargo_options.clone(),

--- a/ceno_cli/src/commands/run.rs
+++ b/ceno_cli/src/commands/run.rs
@@ -91,7 +91,7 @@ impl ProveCmd {
 }
 
 impl CmdInner {
-    fn run(mut self, toolchain: Option<String>, kind: RunKind) -> anyhow::Result<()> {
+    fn run(self, toolchain: Option<String>, kind: RunKind) -> anyhow::Result<()> {
         let manifest_path = match self.manifest_options.manifest_path.clone() {
             Some(path) => path,
             None => search_cargo_manifest_path(current_dir()?)?,
@@ -99,9 +99,6 @@ impl CmdInner {
         let target_selection = self
             .target_selection
             .canonicalize(manifest_path, &self.package_selection)?;
-
-        // XXX: custom handling: set release mode from compilation_options
-        self.ceno_options.release = self.compilation_options.release;
 
         let build = BuildCmd {
             cargo_options: self.cargo_options.clone(),
@@ -118,13 +115,16 @@ impl CmdInner {
 
         match kind {
             RunKind::Keygen => {
-                self.ceno_options.keygen(target_elf)?;
+                self.ceno_options
+                    .keygen(&self.compilation_options, target_elf)?;
             }
             RunKind::Run => {
-                self.ceno_options.run(target_elf)?;
+                self.ceno_options
+                    .run(&self.compilation_options, target_elf)?;
             }
             RunKind::Prove => {
-                self.ceno_options.prove(target_elf)?;
+                self.ceno_options
+                    .prove(&self.compilation_options, target_elf)?;
             }
         }
 

--- a/ceno_emul/src/platform.rs
+++ b/ceno_emul/src/platform.rs
@@ -20,6 +20,8 @@ pub struct Platform {
 
     /// If true, ecall instructions are no-op instead of trap. Testing only.
     pub unsafe_ecall_nop: bool,
+
+    pub is_debug: bool,
 }
 
 impl Display for Platform {
@@ -64,6 +66,7 @@ pub const CENO_PLATFORM: Platform = Platform {
     public_io: 0x3000_0000..0x3004_0000,
     hints: 0x4000_0000..0x5000_0000, // 256 MB
     unsafe_ecall_nop: false,
+    is_debug: false,
 };
 
 impl Platform {

--- a/ceno_zkvm/src/bin/e2e.rs
+++ b/ceno_zkvm/src/bin/e2e.rs
@@ -56,7 +56,7 @@ struct Args {
     profiling: Option<usize>,
 
     /// The preset configuration to use.
-    #[arg(short, long, value_enum, default_value_t = Preset::Ceno)]
+    #[arg(long, value_enum, default_value_t = Preset::Ceno)]
     platform: Preset,
 
     /// The polynomial commitment scheme to use.

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -119,14 +119,18 @@ fn emulate_program(
         .collect::<Result<Vec<StepRecord>, _>>()
         .expect("vm exec failed");
 
-    if cfg!(debug_assertions) {
+    if platform.is_debug {
         // show io message if have
         let all_messages = &read_all_messages(&vm)
             .iter()
             .map(|msg| String::from_utf8_lossy(msg).to_string())
             .collect::<Vec<String>>();
-        for msg in all_messages {
-            tracing::info!("{}", msg);
+        if !all_messages.is_empty() {
+            tracing::info!("========= BEGIN: I/O from guest =========");
+            for msg in all_messages {
+                tracing::info!("{}", msg);
+            }
+            tracing::info!("========= END: I/O from guest =========");
         }
     }
 
@@ -290,13 +294,37 @@ pub fn setup_platform(
     heap_size: u32,
     pub_io_size: u32,
 ) -> Platform {
+    setup_platform_inner(preset, program, stack_size, heap_size, pub_io_size, false)
+}
+
+pub fn setup_platform_debug(
+    preset: Preset,
+    program: &Program,
+    stack_size: u32,
+    heap_size: u32,
+    pub_io_size: u32,
+) -> Platform {
+    setup_platform_inner(preset, program, stack_size, heap_size, pub_io_size, true)
+}
+
+fn setup_platform_inner(
+    preset: Preset,
+    program: &Program,
+    stack_size: u32,
+    heap_size: u32,
+    pub_io_size: u32,
+    is_debug: bool,
+) -> Platform {
     let preset = match preset {
-        Preset::Ceno => CENO_PLATFORM,
+        Preset::Ceno => Platform {
+            is_debug,
+            ..CENO_PLATFORM
+        },
     };
 
     let prog_data = program.image.keys().copied().collect::<BTreeSet<_>>();
 
-    let stack = if cfg!(debug_assertions) {
+    let stack = if preset.is_debug {
         // reserve some extra space for io
         // thus memory consistent check could be satisfied
         preset.stack.end - stack_size..(preset.stack.end + 0x4000)


### PR DESCRIPTION
Previously cargo ceno cli only run on release mode, while there is some "debug_assertion" optional compilation in e2e which couldn't be switch on/off. 

This PR 
1. refactor debug flag into `Platform` so both cli/e2e can control it properly
2. print io message even vm execution failed

