### PR TITLE
fix: find the correct target when using cargo workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "clap",
  "console",
  "ff_ext",
+ "get_dir",
  "mpcs",
  "parse-size",
  "serde",
@@ -1043,6 +1044,12 @@ checksum = "28ccff179d8070317671db09aee6d20affc26e88c5394714553b04f509b43a60"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "get_dir"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f4f860e1edc7cb887dc8c0089e2e437fadb6ab1b2756664e4e3d3983913b6e0"
 
 [[package]]
 name = "getrandom"

--- a/ceno_cli/Cargo.toml
+++ b/ceno_cli/Cargo.toml
@@ -15,6 +15,7 @@ bincode.workspace = true
 cargo_metadata = "0.19"
 clap.workspace = true
 console = "0.15"
+get_dir = "0.4"
 parse-size = "1.1"
 serde.workspace = true
 tempfile = "3.19"

--- a/ceno_cli/src/commands/run.rs
+++ b/ceno_cli/src/commands/run.rs
@@ -92,13 +92,17 @@ impl ProveCmd {
 
 impl CmdInner {
     fn run(self, toolchain: Option<String>, kind: RunKind) -> anyhow::Result<()> {
+        let workspace_root = search_workspace_root(current_dir()?)?;
         let manifest_path = match self.manifest_options.manifest_path.clone() {
             Some(path) => path,
-            None => search_cargo_manifest_path(current_dir()?)?,
+            None => search_cargo_manifest(current_dir()?)?,
         };
-        let target_selection = self
-            .target_selection
-            .canonicalize(manifest_path, &self.package_selection)?;
+        println!("Using manifest {}", manifest_path.display());
+        let target_selection = self.target_selection.canonicalize(
+            &workspace_root,
+            &manifest_path,
+            &self.package_selection,
+        )?;
 
         let build = BuildCmd {
             cargo_options: self.cargo_options.clone(),
@@ -110,7 +114,8 @@ impl CmdInner {
         };
         build.run(toolchain.clone())?;
 
-        let target_elf = target_selection.get_target_path(&self.compilation_options);
+        let target_elf =
+            target_selection.get_target_path(&workspace_root, &self.compilation_options);
         assert!(target_elf.exists(), "{}", target_elf.display());
 
         match kind {

--- a/ceno_cli/src/utils.rs
+++ b/ceno_cli/src/utils.rs
@@ -33,7 +33,7 @@ pub fn search_cargo_manifest<P: AsRef<Path>>(path: P) -> anyhow::Result<PathBuf>
                 path.display()
             );
         }
-        path @ _ => Ok(path?.join("Cargo.toml")),
+        path => Ok(path?.join("Cargo.toml")),
     }
 }
 
@@ -48,13 +48,12 @@ pub fn search_workspace_root<P: AsRef<Path>>(path: P) -> anyhow::Result<PathBuf>
         Err(e) if e.kind() == io::ErrorKind::NotFound => {
             // try to generate a lockfile if we are in a workspace
             eprintln!(
-                "{}{} {}",
+                "{}{} No Cargo.lock found, try to generating one.",
                 style("warning").yellow().bold(),
                 style(":").white().bold(),
-                "No Cargo.lock found, try to generating one."
             );
         }
-        path @ _ => return Ok(path?),
+        path => return Ok(path?),
     }
 
     let result = Command::new("cargo").arg("generate-lockfile").status()?;
@@ -71,7 +70,7 @@ pub fn search_workspace_root<P: AsRef<Path>>(path: P) -> anyhow::Result<PathBuf>
                 path.display()
             );
         }
-        path @ _ => Ok(path?),
+        path => Ok(path?),
     }
 }
 

--- a/ceno_cli/src/utils.rs
+++ b/ceno_cli/src/utils.rs
@@ -1,5 +1,6 @@
 use anyhow::bail;
 use console::style;
+use get_dir::{FileTarget, GetDir, Target};
 use std::{
     backtrace::BacktraceStatus,
     fmt,
@@ -18,23 +19,60 @@ pub static QUITE: OnceLock<bool> = OnceLock::new();
 /// The rustc target triple name for ceno.
 pub const RUSTC_TARGET: &str = "riscv32im-ceno-zkvm-elf";
 
-/// Search for a `Cargo.toml` file in the given path and its parent directories.
-pub fn search_cargo_manifest_path<P: AsRef<Path>>(path: P) -> anyhow::Result<PathBuf> {
-    let path = path.as_ref();
-    let mut path_buf = path.to_path_buf();
-    loop {
-        let cargo_manifest = path_buf.join("Cargo.toml");
-        if cargo_manifest.try_exists()? {
-            return Ok(cargo_manifest.canonicalize()?);
+/// Search for a `Cargo.toml` in the given path and its parent directories.
+pub fn search_cargo_manifest<P: AsRef<Path>>(path: P) -> anyhow::Result<PathBuf> {
+    let path = path.as_ref().canonicalize()?;
+    match GetDir::new()
+        .directory(&path)
+        .targets(vec![Target::File(FileTarget { name: "Cargo.toml" })])
+        .run_reverse()
+    {
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            bail!(
+                "Could not find a `Cargo.toml` in {} or its parent directories",
+                path.display()
+            );
         }
-        if !path_buf.pop() {
-            break;
-        }
+        path @ _ => Ok(path?.join("Cargo.toml")),
     }
-    bail!(
-        "could not find `Cargo.toml` in `{}` or any parent directory",
-        path.display()
-    )
+}
+
+/// Search for a workspace root in the given path and its parent directories.
+pub fn search_workspace_root<P: AsRef<Path>>(path: P) -> anyhow::Result<PathBuf> {
+    let path = path.as_ref().canonicalize()?;
+    match GetDir::new()
+        .directory(&path)
+        .targets(vec![Target::File(FileTarget { name: "Cargo.lock" })])
+        .run_reverse()
+    {
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            // try to generate a lockfile if we are in a workspace
+            eprintln!(
+                "{}{} {}",
+                style("warning").yellow().bold(),
+                style(":").white().bold(),
+                "No Cargo.lock found, try to generating one."
+            );
+        }
+        path @ _ => return Ok(path?),
+    }
+
+    let result = Command::new("cargo").arg("generate-lockfile").status()?;
+    if !result.success() {
+        bail!("failed to generate lockfile");
+    }
+    match GetDir::new()
+        .targets(vec![Target::File(FileTarget { name: "Cargo.lock" })])
+        .run_reverse()
+    {
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            bail!(
+                "Could not find a cargo workspace in {} or its parent directories",
+                path.display()
+            );
+        }
+        path @ _ => Ok(path?),
+    }
 }
 
 /// Get `RUSTFLAGS` env (if any) and append the base flags.


### PR DESCRIPTION
found bug when ceno cli is used in a cargo workspace, this pr fixes how ceno cli finds workspace root and correct manifest/target to run with.