### PR TITLE
Fixed few issues found from repo examples other than `fibonacci`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,15 @@ A variety of [examples](https://github.com/scroll-tech/ceno/tree/master/examples
 To run an example in e2e, use the following command:
 
 ```sh
-cargo run --release --package ceno_zkvm --bin e2e -- \
-    --profiling=1 \
+# release mode
+RUST_LOG=info cargo run --release --package ceno_zkvm --bin e2e -- \
+    --platform=ceno \
+    --hints=<hint value> \
+    --public-io=<pub io> \
+    examples/target/riscv32im-ceno-zkvm-elf/release/examples/<example name>
+
+# run a guest program with debug output (e.g., `debug_print` / `debug_println` visible), works in non-release mode
+RUST_LOG=info cargo run --package ceno_zkvm --bin e2e -- \
     --platform=ceno \
     --hints=<hint value> \
     --public-io=<pub io> \
@@ -37,11 +44,12 @@ cargo run --release --package ceno_zkvm --bin e2e -- \
 The example will be automatically compiled before execution
 
 For instance, with [fibonacci](https://github.com/scroll-tech/ceno/blob/master/examples/examples/fibonacci.rs)
+Below example command runs **2^10 (1024) Fibonacci steps** via `--hints=10`.
+The expected result is `4191`, which will be used as the `--public-io=4191`.
 
 ```sh
-cargo run --release --package ceno_zkvm --bin e2e -- --profiling=1 --platform=ceno --hints=10 --public-io=4191 examples/target/riscv32im-ceno-zkvm-elf/release/examples/fibonacci
+RUST_LOG=info cargo run --release --package ceno_zkvm --bin e2e -- --platform=ceno --hints=10 --public-io=4191 examples/target/riscv32im-ceno-zkvm-elf/release/examples/fibonacci
 ```
-
 
 ## Building Ceno and running tests
 

--- a/ceno_emul/src/tracer.rs
+++ b/ceno_emul/src/tracer.rs
@@ -435,14 +435,19 @@ impl Tracer {
         if let Some((_, (_, end_addr, min_addr, max_addr))) = self
             .mmio_min_max_access
             .as_mut()
+            // find the MMIO region whose start address is less than or equal to the target address
             .and_then(|mmio_max_access| mmio_max_access.range_mut(..=addr).next_back())
         {
+            // skip if the target address is not within the range tracked by this MMIO region
+            // this condition ensures the address is within the MMIO region's end address
             if addr < *end_addr {
+                // expand the max bound if the address exceeds the current max
                 if addr >= *max_addr {
-                    *max_addr = addr + WordAddr::from(WORD_SIZE as u32); // end exclusive
+                    *max_addr = addr + WordAddr::from(WORD_SIZE as u32); // end is exclusive
                 }
+                // shrink the min bound if the address is below the current min
                 if addr < *min_addr {
-                    *min_addr = addr; // start inclusive
+                    *min_addr = addr; // start is inclusive
                 }
             }
         }

--- a/ceno_zkvm/src/bin/e2e.rs
+++ b/ceno_zkvm/src/bin/e2e.rs
@@ -209,13 +209,20 @@ fn main() {
         })
         .or_else(|| {
             args.hints.and_then(|hint| {
-                hint.iter()
-                    .try_fold(CenoStdin::default(), |mut std_in, hint| {
-                        std_in.write(hint)?;
-                        Ok::<CenoStdin, rkyv::rancor::Error>(std_in)
-                    })
-                    .ok()
-                    .map(|std_in| Into::<Vec<u32>>::into(&std_in))
+                // if the hint vector contains only one element, write it as a raw `u32`
+                // otherwise, write the entire vector
+                // in both cases, convert the resulting `CenoStdin` into a `Vec<u32>`
+                if hint.len() == 1 {
+                    CenoStdin::default()
+                        .write(&hint[0])
+                        .ok()
+                        .map(|stdin| Into::<Vec<u32>>::into(&*stdin))
+                } else {
+                    CenoStdin::default()
+                        .write(&hint)
+                        .ok()
+                        .map(|stdin| Into::<Vec<u32>>::into(&*stdin))
+                }
             })
         })
         .unwrap_or_default();

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -827,11 +827,11 @@ fn debug_memory_ranges<'a, I: Iterator<Item = &'a MemFinalRecord>>(vm: &VMState,
         .map(|rec| ByteAddr(rec.addr))
         .collect::<HashSet<_>>();
 
-    tracing::debug!(
+    tracing::trace!(
         "Memory range (accessed): {:?}",
         format_segments(vm.platform(), accessed_addrs.iter().copied())
     );
-    tracing::debug!(
+    tracing::trace!(
         "Memory range (handled):  {:?}",
         format_segments(vm.platform(), handled_addrs.iter().copied())
     );
@@ -876,7 +876,7 @@ pub fn verify<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + serde::Ser
     tracing::info!("e2e proof stat: {}", zkvm_proof);
     #[cfg(debug_assertions)]
     {
-        tracing::info!(
+        tracing::debug!(
             "instrumented metrics\n{}",
             Instrumented::<<<E as ExtensionField>::BaseField as PoseidonField>::P>::format_metrics(
             )

--- a/ceno_zkvm/src/instructions/riscv/rv32im.rs
+++ b/ceno_zkvm/src/instructions/riscv/rv32im.rs
@@ -347,7 +347,7 @@ impl<E: ExtensionField> Rv32imConfig<E> {
         for (insn_kind, (_, records)) in
             izip!(InsnKind::iter(), &all_records).sorted_by_key(|(_, (_, a))| Reverse(a.len()))
         {
-            tracing::info!("tracer generated {:?} {} records", insn_kind, records.len());
+            tracing::trace!("tracer generated {:?} {} records", insn_kind, records.len());
         }
 
         macro_rules! assign_opcode {

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -184,7 +184,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
             transcript.read_challenge().elements,
             transcript.read_challenge().elements,
         ];
-        tracing::debug!("challenges in prover: {:?}", challenges);
+        tracing::trace!("challenges in prover: {:?}", challenges);
 
         let main_proofs_span = entered_span!("main_proofs", profiling_1 = true);
         let (points, evaluations) = self.pk.circuit_pks.iter().enumerate().try_fold(
@@ -206,7 +206,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
                     && cs.w_table_expressions.is_empty();
 
                 if is_opcode_circuit {
-                    tracing::debug!(
+                    tracing::trace!(
                         "opcode circuit {} has {} witnesses, {} reads, {} writes, {} lookups",
                         circuit_name,
                         cs.num_witin,
@@ -225,7 +225,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
                         &mut transcript,
                         &challenges,
                     )?;
-                    tracing::info!(
+                    tracing::trace!(
                         "generated proof for opcode {} with num_instances={}",
                         circuit_name,
                         num_instances
@@ -709,12 +709,12 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
                     ));
                 }
             }
-            tracing::debug!("main sel sumcheck start");
+            tracing::trace!("main sel sumcheck start");
             let (main_sel_sumcheck_proofs, _) = IOPProverState::prove(
                 expr_builder.to_virtual_polys(&[exprs.into_iter().sum()], &[]),
                 transcript,
             );
-            tracing::debug!("main sel sumcheck end");
+            tracing::trace!("main sel sumcheck end");
             exit_span!(main_sel_span);
 
             (
@@ -750,7 +750,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProver<E, PCS> {
         }
         exit_span!(span);
 
-        tracing::debug!(
+        tracing::trace!(
             "[table {}] build opening proof for {} polys",
             name,
             witnesses.len(),

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -173,7 +173,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
             transcript.read_challenge().elements,
             transcript.read_challenge().elements,
         ];
-        tracing::debug!("challenges in verifier: {:?}", challenges);
+        tracing::trace!("challenges in verifier: {:?}", challenges);
 
         let dummy_table_item = challenges[0];
         let mut dummy_table_item_multiplicity = 0;
@@ -198,7 +198,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
                 )?;
                 rt_points.push(input_opening_point);
                 evaluations.push(opcode_proof.wits_in_evals.clone());
-                tracing::info!("verified proof for opcode {}", name);
+                tracing::trace!("verified proof for opcode {}", name);
 
                 // getting the number of dummy padding item that we used in this opcode circuit
                 let num_lks = circuit_vk.get_cs().lk_expressions.len();
@@ -246,7 +246,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
                 if circuit_vk.cs.num_fixed > 0 {
                     evaluations.push(table_proof.fixed_in_evals.clone());
                 }
-                tracing::info!("verified proof for table {}", name);
+                tracing::trace!("verified proof for table {}", name);
 
                 logup_sum = table_proof
                     .lk_out_evals
@@ -796,7 +796,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
                     "pub input on index {idx} mismatch  {expected_eval:?} != {eval:?}"
                 )));
             }
-            tracing::debug!(
+            tracing::trace!(
                 "[table {name}] verified public inputs on index {idx} with point {:?}",
                 input_opening_point
             );


### PR DESCRIPTION
### Change Scope
- example run failed in e2e https://github.com/scroll-tech/ceno/blob/ef93198c83e3b4fcd7f9949ebbc07bc9c93e4de9/examples/examples/hashing.rs#L16 In e2e we only support hints as u32 item and write one by one. But some example requires it as whole vector. Thus, guest program will always failed since unable to serve hint properly.
- move most of verbose message from `info` to `trace/debug` so the default e2e be more clean 
- more comments and polish readme