### PR TITLE
optimize extrapolation with zero field inverse during runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2782,6 +2782,7 @@ dependencies = [
  "itertools 0.13.0",
  "multilinear_extensions",
  "p3",
+ "p3-goldilocks",
  "poseidon",
  "rand",
  "rayon",

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -16,7 +16,7 @@ use std::iter::Iterator;
 use sumcheck::{
     macros::{entered_span, exit_span},
     structs::{IOPProverMessage, IOPProverState},
-    util::optimal_sumcheck_threads,
+    util::{get_challenge_pows, optimal_sumcheck_threads},
 };
 use transcript::Transcript;
 use witness::{RowMajorMatrix, next_pow2_instance_padding};
@@ -33,7 +33,7 @@ use crate::{
     structs::{
         ProvingKey, TowerProofs, TowerProver, TowerProverSpec, ZKVMProvingKey, ZKVMWitnesses,
     },
-    utils::{add_mle_list_by_expr, get_challenge_pows},
+    utils::add_mle_list_by_expr,
 };
 use multilinear_extensions::{Instance, mle::FieldType};
 

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -14,7 +14,10 @@ use multilinear_extensions::{
 };
 use p3::field::PrimeCharacteristicRing;
 use std::collections::HashSet;
-use sumcheck::structs::{IOPProof, IOPVerifierState};
+use sumcheck::{
+    structs::{IOPProof, IOPVerifierState},
+    util::get_challenge_pows,
+};
 use transcript::{ForkableTranscript, Transcript};
 use witness::next_pow2_instance_padding;
 
@@ -22,7 +25,7 @@ use crate::{
     error::ZKVMError,
     scheme::constants::{NUM_FANIN, NUM_FANIN_LOGUP, SEL_DEGREE},
     structs::{PointAndEval, TowerProofs, VerifyingKey, ZKVMVerifyingKey},
-    utils::{eq_eval_less_or_equal_than, eval_wellform_address_vec, get_challenge_pows},
+    utils::{eq_eval_less_or_equal_than, eval_wellform_address_vec},
 };
 use multilinear_extensions::{Instance, StructuralWitIn, utils::eval_by_expr_with_instance};
 

--- a/ceno_zkvm/src/utils.rs
+++ b/ceno_zkvm/src/utils.rs
@@ -15,7 +15,6 @@ use multilinear_extensions::{
     virtual_polys::VirtualPolynomialsBuilder,
 };
 use p3::field::Field;
-use transcript::Transcript;
 
 pub fn i64_to_base<F: SmallField>(x: i64) -> F {
     if x >= 0 {
@@ -61,24 +60,6 @@ pub(crate) fn add_one_to_big_num<F: Field>(limb_modulo: F, limbs: &[F]) -> Vec<F
     }
 
     result
-}
-
-/// derive challenge from transcript and return all pows result
-pub fn get_challenge_pows<E: ExtensionField>(
-    size: usize,
-    transcript: &mut impl Transcript<E>,
-) -> Vec<E> {
-    // println!("alpha_pow");
-    let alpha = transcript
-        .sample_and_append_challenge(b"combine subset evals")
-        .elements;
-    (0..size)
-        .scan(E::ONE, |state, _| {
-            let res = *state;
-            *state *= alpha;
-            Some(res)
-        })
-        .collect_vec()
 }
 
 // split single u64 value into W slices, each slice got C bits.

--- a/mpcs/src/basefold/commit_phase.rs
+++ b/mpcs/src/basefold/commit_phase.rs
@@ -242,7 +242,6 @@ where
             IOPProverState::prover_init_with_extrapolation_aux(
                 thread_id == 0, // set thread_id 0 to be main worker
                 poly,
-                vec![(vec![], vec![])],
                 Some(log2_num_threads),
                 Some(poly_meta.clone()),
             )
@@ -282,11 +281,7 @@ where
     let merge_sumcheck_prover_state_span = entered_span!("merge_sumcheck_prover_state");
     let poly = merge_sumcheck_prover_state(&prover_states);
     let mut prover_states = vec![IOPProverState::prover_init_with_extrapolation_aux(
-        true,
-        poly,
-        vec![(vec![], vec![])],
-        None,
-        None,
+        true, poly, None, None,
     )];
     exit_span!(merge_sumcheck_prover_state_span);
 

--- a/sumcheck/Cargo.toml
+++ b/sumcheck/Cargo.toml
@@ -10,21 +10,21 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
+crossbeam-channel.workspace = true
 either.workspace = true
 ff_ext = { path = "../ff_ext" }
 itertools.workspace = true
+multilinear_extensions = { path = "../multilinear_extensions", features = ["parallel"] }
 p3.workspace = true
 rayon.workspace = true
 serde.workspace = true
-tracing.workspace = true
-
-crossbeam-channel.workspace = true
-multilinear_extensions = { path = "../multilinear_extensions", features = ["parallel"] }
 sumcheck_macro = { path = "../sumcheck_macro" }
+tracing.workspace = true
 transcript = { path = "../transcript" }
 
 [dev-dependencies]
 criterion.workspace = true
+p3-goldilocks.workspace = true
 poseidon.workspace = true
 rand.workspace = true
 

--- a/sumcheck/src/extrapolate.rs
+++ b/sumcheck/src/extrapolate.rs
@@ -1,0 +1,139 @@
+use ff_ext::ExtensionField;
+use itertools::Itertools;
+use std::{
+    any::{Any, TypeId},
+    collections::BTreeMap,
+    marker::PhantomData,
+    sync::{Arc, Mutex, OnceLock},
+};
+
+/// Precomputed extrapolation weights using the second form of barycentric interpolation.
+///
+/// This table supports extrapolation of univariate polynomials where:
+/// - The known values are at integer points `x = 0, 1, ..., d`
+/// - The degree `d` is in a fixed range [`min_degree`, `max_degree`]
+/// - A univariate polynomial of degree `d` has exactly `d + 1` evaluation points
+/// - The extrapolated values are computed at integer points `z > d`, up to `max_degree`
+/// - No field inversions are required at runtime
+///
+/// The second form of the barycentric interpolation formula is:
+///
+/// ```text
+/// L(z) = ∑_{j=0}^d (w_j / (z - x_j)) / ∑_{j=0}^d (w_j / (z - x_j)) * f(x_j)
+///      = ∑_{j=0}^d v_j * f(x_j)
+/// ```
+///
+/// Where:
+/// - `x_j = j` (fixed integer evaluation points)
+/// - `w_j = 1 / ∏_{i ≠ j} (x_j - x_i)` are barycentric weights (precomputed)
+/// - `v_j = (w_j / (z - x_j)) / denom` are normalized interpolation coefficients (precomputed)
+///
+/// This structure stores all `v_j` coefficients for each `(degree, target_z)` pair.
+/// At runtime, extrapolation is done by a simple dot product of `v_j` with the known values `f(x_j)`,
+/// without needing any inverses.
+pub struct ExtrapolationTable<E: ExtensionField> {
+    /// weights[degree][z - degree - 1][j] = coefficient for f(x_j) when extrapolating to z
+    pub weights: Vec<Vec<Vec<E>>>,
+}
+
+impl<E: ExtensionField> ExtrapolationTable<E> {
+    pub fn new(min_degree: usize, max_degree: usize) -> Self {
+        let mut weights = Vec::new();
+
+        for d in min_degree..=max_degree {
+            let mut degree_weights = Vec::new();
+
+            let xs: Vec<E> = (0..=d as u64).map(E::from_u64).collect_vec();
+            let mut bary_weights = Vec::new();
+
+            // Compute barycentric weights w_j = 1 / prod_{i != j} (x_j - x_i)
+            for j in 0..=d {
+                let mut w = E::ONE;
+                for i in 0..=d {
+                    if i != j {
+                        w *= xs[j] - xs[i];
+                    }
+                }
+                bary_weights.push(w.inverse()); // safe because all x_i are distinct
+            }
+
+            for z_idx in d + 1..=max_degree {
+                let z = E::from_u64(z_idx as u64);
+                let mut den = E::ZERO;
+                let mut tmp: Vec<E> = Vec::with_capacity(d + 1);
+
+                for j in 0..=d {
+                    let t = bary_weights[j] / (z - xs[j]);
+                    tmp.push(t);
+                    den += t;
+                }
+
+                // Normalize
+                for t in tmp.iter_mut() {
+                    *t = *t / den;
+                }
+
+                degree_weights.push(tmp);
+            }
+
+            weights.push(degree_weights);
+        }
+
+        Self { weights }
+    }
+}
+
+pub struct ExtrapolationCache<E> {
+    _marker: PhantomData<E>,
+}
+
+impl<E: ExtensionField> ExtrapolationCache<E> {
+    fn global_cache() -> &'static Mutex<BTreeMap<TypeId, Box<dyn Any + Send + Sync>>> {
+        static GLOBAL_CACHE: OnceLock<Mutex<BTreeMap<TypeId, Box<dyn Any + Send + Sync>>>> =
+            OnceLock::new();
+        GLOBAL_CACHE.get_or_init(|| Mutex::new(BTreeMap::new()))
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn cache_map() -> Arc<Mutex<BTreeMap<(usize, usize), Arc<ExtrapolationTable<E>>>>> {
+        let global = Self::global_cache();
+        let mut map = global.lock().unwrap();
+
+        map.entry(TypeId::of::<E>())
+            .or_insert_with(|| {
+                Box::new(Arc::new(Mutex::new(BTreeMap::<
+                    (usize, usize),
+                    Arc<ExtrapolationTable<E>>,
+                >::new()))) as Box<dyn Any + Send + Sync>
+            })
+            .downcast_ref::<Arc<Mutex<BTreeMap<(usize, usize), Arc<ExtrapolationTable<E>>>>>>()
+            .expect("TypeId mapped to wrong type")
+            .clone()
+    }
+
+    /// precompute and cache `ExtrapolationTable`s for all `(min_degree, max_degree)`
+    /// pairs where `2 ≤ max_degree` and `1 ≤ min_degree < max_degree`.
+    pub fn warm_up(max_degree: usize) {
+        assert!(max_degree >= 2, "max_degree must be at least 2");
+
+        for max in 2..=max_degree {
+            for min in 1..max {
+                let _ = Self::get(min, max);
+            }
+        }
+    }
+
+    /// get or create a cached `ExtrapolationTable` for the range `(min_degree, max_degree)`.
+    pub fn get(min_degree: usize, max_degree: usize) -> Arc<ExtrapolationTable<E>> {
+        let cache = Self::cache_map();
+        let mut map = cache.lock().unwrap();
+
+        if let Some(existing) = map.get(&(min_degree, max_degree)) {
+            return existing.clone();
+        }
+
+        let table = Arc::new(ExtrapolationTable::new(min_degree, max_degree));
+        map.insert((min_degree, max_degree), table.clone());
+        table
+    }
+}

--- a/sumcheck/src/lib.rs
+++ b/sumcheck/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::cargo)]
 pub use multilinear_extensions::macros;
+pub mod extrapolate;
 mod prover;
 pub mod structs;
 pub mod util;

--- a/sumcheck/src/prover.rs
+++ b/sumcheck/src/prover.rs
@@ -1,5 +1,6 @@
 use std::{mem, sync::Arc};
 
+use crate::{extrapolate::ExtrapolationCache, util::extrapolate_from_table};
 use crossbeam_channel::bounded;
 use ff_ext::ExtensionField;
 use itertools::Itertools;
@@ -23,8 +24,7 @@ use crate::{
     macros::{entered_span, exit_span},
     structs::{IOPProof, IOPProverMessage, IOPProverState},
     util::{
-        AdditiveArray, AdditiveVec, barycentric_weights, ceil_log2, extrapolate,
-        merge_sumcheck_polys, merge_sumcheck_prover_state, serial_extrapolate,
+        AdditiveArray, AdditiveVec, ceil_log2, merge_sumcheck_polys, merge_sumcheck_prover_state,
     },
 };
 use p3::field::PrimeCharacteristicRing;
@@ -34,7 +34,12 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
     /// multi-threads model follow https://arxiv.org/pdf/2210.00264#page=8 "distributed sumcheck"
     /// This is experiment features. It's preferable that we move parallel level up more to
     /// "bould_poly" so it can be more isolation
-    #[tracing::instrument(skip_all, name = "sumcheck::prove", level = "trace")]
+    #[tracing::instrument(
+        skip_all,
+        name = "sumcheck::prove",
+        level = "trace",
+        fields(profiling_5)
+    )]
     pub fn prove(
         virtual_poly: VirtualPolynomials<'a, E>,
         transcript: &mut impl Transcript<E>,
@@ -58,27 +63,35 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
             polys[0].aux_info.max_degree,
         );
 
-        // extrapolation_aux only need to init once
-        let extrapolation_aux: Vec<(Vec<E>, Vec<E>)> = (1..max_degree)
-            .map(|degree| {
-                let points = (0..1 + degree as u64).map(E::from_u64).collect::<Vec<_>>();
-                let weights = barycentric_weights(&points);
-                (points, weights)
+        let min_degree = polys[0]
+            .products
+            .iter()
+            .flat_map(|monomial_terms| {
+                monomial_terms
+                    .terms
+                    .iter()
+                    .map(|Term { product, .. }| product.len())
             })
-            .collect::<Vec<_>>();
+            .min()
+            .unwrap();
+        if min_degree < max_degree {
+            // warm up cache giving min/max_degree
+            let _ = ExtrapolationCache::<E>::get(min_degree, max_degree);
+        }
 
         transcript.append_message(&(num_variables + log2_max_thread_id).to_le_bytes());
         transcript.append_message(&max_degree.to_le_bytes());
         let (phase1_point, mut prover_state, mut prover_msgs) = if num_variables > 0 {
+            let span = entered_span!("phase1_sumcheck", profiling_6 = true);
             let (mut prover_states, prover_msgs) = Self::phase1_sumcheck(
                 max_thread_id,
                 num_variables,
-                extrapolation_aux.clone(),
                 poly_meta,
                 polys,
                 max_degree,
                 transcript,
             );
+            exit_span!(span);
             if log2_max_thread_id == 0 {
                 let prover_state = mem::take(&mut prover_states[0]);
                 return (
@@ -93,22 +106,17 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                     prover_state,
                 );
             }
+            let span = entered_span!("merged_poly", profiling_6 = true);
             let point = prover_states[0]
                 .challenges
                 .iter()
                 .map(|c| c.elements)
                 .collect_vec();
             let poly = merge_sumcheck_prover_state(&prover_states);
-
+            exit_span!(span);
             (
                 point,
-                Self::prover_init_with_extrapolation_aux(
-                    true,
-                    poly,
-                    extrapolation_aux.clone(),
-                    None,
-                    None,
-                ),
+                Self::prover_init_with_extrapolation_aux(true, poly, None, None),
                 prover_msgs,
             )
         } else {
@@ -117,7 +125,6 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                 Self::prover_init_with_extrapolation_aux(
                     true,
                     merge_sumcheck_polys(polys.iter().collect_vec(), Some(poly_meta)),
-                    extrapolation_aux.clone(),
                     None,
                     None,
                 ),
@@ -126,7 +133,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         };
 
         let mut challenge = None;
-        let span = entered_span!("prove_rounds_stage2");
+        let span = entered_span!("prove_rounds_stage2", profiling_6 = true);
         for _ in 0..log2_max_thread_id {
             let prover_msg =
                 IOPProverState::prove_round_and_update_state(&mut prover_state, &challenge);
@@ -163,7 +170,6 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
     fn phase1_sumcheck(
         max_thread_id: usize,
         num_variables: usize,
-        extrapolation_aux: Vec<(Vec<E>, Vec<E>)>,
         poly_meta: Vec<PolyMeta>,
         mut polys: Vec<VirtualPolynomial<'a, E>>,
         max_degree: usize,
@@ -183,7 +189,6 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                 let mut prover_state = Self::prover_init_with_extrapolation_aux(
                     false,
                     mem::take(poly),
-                    extrapolation_aux.clone(),
                     Some(log2_max_thread_id),
                     Some(poly_meta.clone()),
                 );
@@ -194,7 +199,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                     // Note: This span is not nested into the "spawn loop" span, although lexically it looks so.
                     // Nesting is possible, but then `tracing-forest` does the wrong thing when measuring duration.
                     // TODO: investigate possibility of nesting with correct duration of parent span
-                    let span = entered_span!("prove_rounds", profiling_5 = true);
+                    let span = entered_span!("prove_rounds");
                     for _ in 0..num_variables {
                         let prover_msg = IOPProverState::prove_round_and_update_state(
                             &mut prover_state,
@@ -228,7 +233,6 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
             let mut prover_state = Self::prover_init_with_extrapolation_aux(
                 true,
                 mem::take(&mut polys[main_thread_id]),
-                extrapolation_aux.clone(),
                 Some(log2_max_thread_id),
                 Some(poly_meta.clone()),
             );
@@ -316,7 +320,6 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
     pub fn prover_init_with_extrapolation_aux(
         is_main_worker: bool,
         polynomial: VirtualPolynomial<'a, E>,
-        extrapolation_aux: Vec<(Vec<E>, Vec<E>)>,
         phase2_numvar: Option<usize>,
         poly_meta: Option<Vec<PolyMeta>>,
     ) -> Self {
@@ -334,8 +337,6 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
         }
         exit_span!(start);
 
-        let max_degree = polynomial.aux_info.max_degree;
-        assert!(extrapolation_aux.len() == max_degree - 1);
         let num_polys = polynomial.flattened_ml_extensions.len();
 
         Self {
@@ -344,7 +345,6 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
             challenges: Vec::with_capacity(polynomial.aux_info.max_num_variables),
             round: 0,
             poly: polynomial,
-            extrapolation_aux,
             poly_meta: poly_meta.unwrap_or_else(|| vec![PolyMeta::Normal; num_polys]),
             phase2_numvar,
         }
@@ -412,7 +412,8 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                     let f = &self.poly.flattened_ml_extensions;
                     let f_type = &self.poly_meta;
                     let get_poly_meta = || f_type[prod[0]];
-                    let mut uni_variate: Vec<E> = match prod.len() {
+                    let mut uni_variate: Vec<E> = vec![E::ZERO; self.poly.aux_info.max_degree + 1];
+                    let uni_variate_monomial: Vec<E> = match prod.len() {
                         1 => sumcheck_code_gen!(1, false, |i| &f[prod[i]], || get_poly_meta())
                             .to_vec(),
                         2 => sumcheck_code_gen!(2, false, |i| &f[prod[i]], || get_poly_meta())
@@ -428,16 +429,19 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
 
                     uni_variate
                         .iter_mut()
-                        .for_each(|sum| either::for_both!(scalar, scalar => *sum *= *scalar));
+                        .zip(uni_variate_monomial)
+                        .take(prod.len() + 1)
+                        .for_each(|(eval, monimial_eval,)| either::for_both!(scalar, scalar => *eval = monimial_eval**scalar));
 
-                    let extrapolation = (0..self.poly.aux_info.max_degree - prod.len())
-                        .map(|i| {
-                            let (points, weights) = &self.extrapolation_aux[prod.len() - 1];
-                            let at = E::from_u64((prod.len() + 1 + i) as u64);
-                            serial_extrapolate(points, weights, &uni_variate, &at)
-                        })
-                        .collect::<Vec<_>>();
-                    uni_variate.extend(extrapolation);
+
+                    if prod.len() < self.poly.aux_info.max_degree {
+                        // Perform extrapolation using the precomputed extrapolation table
+                        extrapolate_from_table(
+                            &mut uni_variate,
+                            prod.len() + 1,
+                        );
+                    }
+
                     uni_polys += AdditiveVec(uni_variate);
                 }
                 uni_polys
@@ -587,7 +591,6 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
             "Attempt to prove a constant."
         );
 
-        let max_degree = polynomial.aux_info.max_degree;
         let num_polys = polynomial.flattened_ml_extensions.len();
         let poly_meta = vec![PolyMeta::Normal; num_polys];
         let prover_state = Self {
@@ -596,13 +599,6 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
             challenges: Vec::with_capacity(polynomial.aux_info.max_num_variables),
             round: 0,
             poly: polynomial,
-            extrapolation_aux: (1..max_degree)
-                .map(|degree| {
-                    let points = (0..1 + degree as u64).map(E::from_u64).collect::<Vec<_>>();
-                    let weights = barycentric_weights(&points);
-                    (points, weights)
-                })
-                .collect(),
             poly_meta,
             phase2_numvar: None,
         };
@@ -673,7 +669,9 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                         let f = &self.poly.flattened_ml_extensions;
                         let f_type = &self.poly_meta;
                         let get_poly_meta = || f_type[prod[0]];
-                        let mut sum: Vec<E> = match prod.len() {
+                        let mut uni_variate: Vec<E> =
+                            vec![E::ZERO; self.poly.aux_info.max_degree + 1];
+                        let uni_variate_monomial: Vec<E> = match prod.len() {
                             1 => sumcheck_code_gen!(1, true, |i| &f[prod[i]], || get_poly_meta())
                                 .to_vec(),
                             2 => sumcheck_code_gen!(2, true, |i| &f[prod[i]], || get_poly_meta())
@@ -686,19 +684,18 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                                 .to_vec(),
                             _ => unimplemented!("do not support degree {} > 5", prod.len()),
                         };
-                        sum.iter_mut()
-                            .for_each(|sum| either::for_both!(*scalar, scalar => *sum *= scalar));
+                        uni_variate
+                            .iter_mut()
+                            .zip(uni_variate_monomial)
+                            .take(prod.len() + 1)
+                            .for_each(|(eval, monimial_eval,)| either::for_both!(scalar, scalar => *eval = monimial_eval**scalar));
 
-                        let extrapolation = (0..self.poly.aux_info.max_degree - prod.len())
-                            .into_par_iter()
-                            .map(|i| {
-                                let (points, weights) = &self.extrapolation_aux[prod.len() - 1];
-                                let at = E::from_u64((prod.len() + 1 + i) as u64);
-                                extrapolate(points, weights, &sum, &at)
-                            })
-                            .collect::<Vec<_>>();
-                        sum.extend(extrapolation);
-                        uni_polys += AdditiveVec(sum);
+
+                        if prod.len() < self.poly.aux_info.max_degree {
+                            // Perform extrapolation using the precomputed extrapolation table
+                            extrapolate_from_table(&mut uni_variate, prod.len() + 1);
+                        }
+                        uni_polys += AdditiveVec(uni_variate);
                     }
                     uni_polys
                 },

--- a/sumcheck/src/structs.rs
+++ b/sumcheck/src/structs.rs
@@ -1,5 +1,7 @@
 use ff_ext::ExtensionField;
-use multilinear_extensions::{virtual_poly::VirtualPolynomial, virtual_polys::PolyMeta};
+use multilinear_extensions::{
+    mle::Point, virtual_poly::VirtualPolynomial, virtual_polys::PolyMeta,
+};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use transcript::Challenge;
 
@@ -12,7 +14,7 @@ use transcript::Challenge;
     deserialize = "E::BaseField: DeserializeOwned"
 ))]
 pub struct IOPProof<E: ExtensionField> {
-    pub point: Vec<E>,
+    pub point: Point<E>,
     pub proofs: Vec<IOPProverMessage<E>>,
 }
 impl<E: ExtensionField> IOPProof<E> {
@@ -42,9 +44,6 @@ pub struct IOPProverState<'a, E: ExtensionField> {
     pub(crate) round: usize,
     /// pointer to the virtual polynomial
     pub(crate) poly: VirtualPolynomial<'a, E>,
-    /// points with precomputed barycentric weights for extrapolating smaller
-    /// degree uni-polys to `max_degree + 1` evaluations.
-    pub(crate) extrapolation_aux: Vec<(Vec<E>, Vec<E>)>,
     pub(crate) max_num_variables: usize,
     pub(crate) poly_meta: Vec<PolyMeta>,
     /// phase 1 and phase 2 sumcheck we share similar implementation

--- a/sumcheck/src/util.rs
+++ b/sumcheck/src/util.rs
@@ -1,6 +1,5 @@
 use std::{
     array,
-    cmp::max,
     iter::Sum,
     ops::{Add, AddAssign, Deref, DerefMut, Mul, MulAssign},
     sync::Arc,
@@ -17,127 +16,42 @@ use multilinear_extensions::{
     virtual_polys::PolyMeta,
 };
 use p3::field::Field;
-use rayon::{prelude::ParallelIterator, slice::ParallelSliceMut};
+use transcript::Transcript;
 
-use crate::structs::IOPProverState;
+use crate::{extrapolate::ExtrapolationCache, structs::IOPProverState};
 
-pub fn barycentric_weights<F: Field>(points: &[F]) -> Vec<F> {
-    let mut weights = points
-        .iter()
-        .enumerate()
-        .map(|(j, point_j)| {
-            points
-                .iter()
-                .enumerate()
-                .filter(|&(i, _)| (i != j))
-                .map(|(_, point_i)| *point_j - *point_i)
-                .reduce(|acc, value| acc * value)
-                .unwrap_or(F::ONE)
-        })
-        .collect::<Vec<_>>();
-    batch_inversion(&mut weights);
-    weights
-}
+/// extrapolates values of a univariate polynomial in-place using precomputed barycentric weights.
+///
+/// this function fills in the remaining entries of `uni_variate[start..]` assuming the first `start`
+/// values are evaluations of a univariate polynomial at `0, 1, ..., start - 1`.
+/// it uses a precomputed [`ExtrapolationTable`] from [`ExtrapolationCache`] to perform
+/// efficient barycentric extrapolation without requiring any inverse operations at runtime.
+///
+/// Note: this function is highly optimized without field inverse. see [`ExtrapolationTable`] for how to achieve it
+pub fn extrapolate_from_table<E: ExtensionField>(uni_variate: &mut [E], start: usize) {
+    let cur_degree = start - 1;
+    let table = ExtrapolationCache::<E>::get(cur_degree, uni_variate.len() - 1);
+    let target_len = uni_variate.len();
+    assert!(start > 0, "start must be > 0 to define a degree");
+    assert!(
+        target_len > start,
+        "no extrapolation needed if target_len <= start"
+    );
 
-// Computes the inverse of each field element in a vector {v_i} using a parallelized batch inversion.
-pub fn batch_inversion<F: Field>(v: &mut [F]) {
-    batch_inversion_and_mul(v, &F::ONE);
-}
+    let (known, to_extrapolate) = uni_variate.split_at_mut(start);
+    let weight_sets = &table.weights[0]; // since min_degree == cur_degree
 
-// Computes the inverse of each field element in a vector {v_i} sequentially (serial version).
-pub fn serial_batch_inversion<F: Field>(v: &mut [F]) {
-    serial_batch_inversion_and_mul(v, &F::ONE)
-}
+    for (offset, target) in to_extrapolate.iter_mut().enumerate() {
+        let weights = &weight_sets[offset];
+        assert_eq!(weights.len(), known.len());
 
-// Given a vector of field elements {v_i}, compute the vector {coeff * v_i^(-1)}
-pub fn batch_inversion_and_mul<F: Field>(v: &mut [F], coeff: &F) {
-    // Divide the vector v evenly between all available cores
-    let min_elements_per_thread = 1;
-    let num_cpus_available = rayon::current_num_threads();
-    let num_elems = v.len();
-    let num_elem_per_thread = max(num_elems / num_cpus_available, min_elements_per_thread);
+        let acc = weights
+            .iter()
+            .zip(known.iter())
+            .fold(E::ZERO, |acc, (w, x)| acc + (*w * *x));
 
-    // Batch invert in parallel, without copying the vector
-    v.par_chunks_mut(num_elem_per_thread).for_each(|chunk| {
-        serial_batch_inversion_and_mul(chunk, coeff);
-    });
-}
-
-/// Given a vector of field elements {v_i}, compute the vector {coeff * v_i^(-1)}.
-/// This method is explicitly single-threaded.
-fn serial_batch_inversion_and_mul<F: Field>(v: &mut [F], coeff: &F) {
-    // Montgomery’s Trick and Fast Implementation of Masked AES
-    // Genelle, Prouff and Quisquater
-    // Section 3.2
-    // but with an optimization to multiply every element in the returned vector by
-    // coeff
-
-    // First pass: compute [a, ab, abc, ...]
-    let mut prod = Vec::with_capacity(v.len());
-    let mut tmp = F::ONE;
-    for f in v.iter().filter(|f| !f.is_zero()) {
-        tmp.mul_assign(*f);
-        prod.push(tmp);
+        *target = acc;
     }
-
-    // Invert `tmp`.
-    tmp = tmp.try_inverse().unwrap(); // Guaranteed to be nonzero.
-
-    // Multiply product by coeff, so all inverses will be scaled by coeff
-    tmp *= *coeff;
-
-    // Second pass: iterate backwards to compute inverses
-    for (f, s) in v
-        .iter_mut()
-        // Backwards
-        .rev()
-        // Ignore normalized elements
-        .filter(|f| !f.is_zero())
-        // Backwards, skip last element, fill in one for last term.
-        .zip(prod.into_iter().rev().skip(1).chain(Some(F::ONE)))
-    {
-        // tmp := tmp * f; f := tmp * s = 1/f
-        let new_tmp = tmp * *f;
-        *f = tmp * s;
-        tmp = new_tmp;
-    }
-}
-
-pub(crate) fn extrapolate<F: Field>(points: &[F], weights: &[F], evals: &[F], at: &F) -> F {
-    inner_extrapolate::<F, true>(points, weights, evals, at)
-}
-
-pub(crate) fn serial_extrapolate<F: Field>(points: &[F], weights: &[F], evals: &[F], at: &F) -> F {
-    inner_extrapolate::<F, false>(points, weights, evals, at)
-}
-
-fn inner_extrapolate<F: Field, const IS_PARALLEL: bool>(
-    points: &[F],
-    weights: &[F],
-    evals: &[F],
-    at: &F,
-) -> F {
-    let (coeffs, sum_inv) = {
-        let mut coeffs = points.iter().map(|point| *at - *point).collect::<Vec<_>>();
-        if IS_PARALLEL {
-            batch_inversion(&mut coeffs);
-        } else {
-            serial_batch_inversion(&mut coeffs);
-        }
-        let mut sum = F::ZERO;
-        coeffs.iter_mut().zip(weights).for_each(|(coeff, weight)| {
-            *coeff *= *weight;
-            sum += *coeff
-        });
-        let sum_inv = sum.try_inverse().unwrap_or(F::ZERO);
-        (coeffs, sum_inv)
-    };
-    coeffs
-        .iter()
-        .zip(evals)
-        .map(|(coeff, eval)| *coeff * *eval)
-        .sum::<F>()
-        * sum_inv
 }
 
 /// Interpolate a uni-variate degree-`p_i.len()-1` polynomial and evaluate this
@@ -326,6 +240,20 @@ pub fn optimal_sumcheck_threads(num_vars: usize) -> usize {
     }
 }
 
+/// Derive challenge from transcript and return all power results of the challenge.
+pub fn get_challenge_pows<E: ExtensionField>(
+    size: usize,
+    transcript: &mut impl Transcript<E>,
+) -> Vec<E> {
+    let alpha = transcript
+        .sample_and_append_challenge(b"combine subset evals")
+        .elements;
+
+    std::iter::successors(Some(E::ONE), move |prev| Some(*prev * alpha))
+        .take(size)
+        .collect()
+}
+
 #[derive(Clone, Copy, Debug)]
 /// util collection to support fundamental operation
 pub struct AdditiveArray<F, const N: usize>(pub [F; N]);
@@ -427,5 +355,38 @@ impl<F: MulAssign + Copy> Mul<F> for AdditiveVec<F> {
     fn mul(mut self, rhs: F) -> Self::Output {
         self *= rhs;
         self
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ff_ext::GoldilocksExt2;
+    use p3::field::PrimeCharacteristicRing;
+
+    #[test]
+    fn test_extrapolate_from_table() {
+        type E = GoldilocksExt2;
+        fn f(x: u64) -> E {
+            E::from_u64(2u64) * E::from_u64(x) + E::from_u64(3u64)
+        }
+        // Test a known linear polynomial: f(x) = 2x + 3
+
+        let degree = 1;
+        let target_len = 5; // Extrapolate up to x=4
+
+        // Known values at x=0 and x=1
+        let mut values: Vec<E> = (0..=degree as u64).map(f).collect();
+
+        // Allocate extra space for extrapolated values
+        values.resize(target_len, E::ZERO);
+
+        // Run extrapolation
+        extrapolate_from_table(&mut values, degree + 1);
+
+        // Verify values against f(x)
+        for (x, val) in values.iter().enumerate() {
+            let expected = f(x as u64);
+            assert_eq!(*val, expected, "Mismatch at x={}", x);
+        }
     }
 }


### PR DESCRIPTION
Extracted from #952.

Observe a bottleneck on previous interpolation which contribute to most of time due to `vector.extend` operation and bunch of allocations.
This PR rewrite univariate extrapolation
1. as the point to be interpolate are fixed set, we can pre-compute all stuff require field inverse
2. in-place change to avoid allocation 

### benchmark
In Ceno opcode main sumcheck part we batch different degree > 1 into one batch so this function will be used.
It shows a slightly improvement (~3%) on Fibonacci 2^24 e2e

| Benchmark                        | Median Time (s) | Median Change (%) |
|----------------------------------|------------------|--------------------|
| fibonacci_max_steps_1048576      | 2.3978           | +0.9805%   (No significant change    )        |
| fibonacci_max_steps_2097152      | 4.2579           | +1.7587%   (Change within noise)        |
| fibonacci_max_steps_4194304      | 7.7561           | -3.5338%           |