### PR TITLE
generalize main sumcheck as one gkr layer

### DIFF
--- a/ceno_zkvm/src/chip_handler/general.rs
+++ b/ceno_zkvm/src/chip_handler/general.rs
@@ -469,4 +469,8 @@ impl<'a, E: ExtensionField> CircuitBuilder<'a, E> {
 
         Ok((is_eq, diff_inverse))
     }
+
+    pub(crate) fn finalize(&mut self) {
+        self.cs.finalize_backend_monomial_expression();
+    }
 }

--- a/ceno_zkvm/src/circuit_builder.rs
+++ b/ceno_zkvm/src/circuit_builder.rs
@@ -13,6 +13,7 @@ use crate::{
     error::ZKVMError,
     structs::{ProgramParams, ProvingKey, RAMType, VerifyingKey},
 };
+use multilinear_extensions::monomial::Term;
 use p3::field::PrimeCharacteristicRing;
 
 /// namespace used for annotation, preserve meta info during circuit construction
@@ -135,6 +136,13 @@ pub struct ConstraintSystem<E: ExtensionField> {
 
     pub debug_map: HashMap<usize, Vec<Expression<E>>>,
 
+    // this main expr will be finalized when constrian system finish
+    pub backend_expr_monomial_form: Vec<Term<Expression<E>, Expression<E>>>,
+    // this will be finalized when constriansystem finish
+    // represent all the alloc of witin: fixed, witin, structural_wit, ...
+    pub num_backend_witin: u16,
+    pub num_layer_challenges: u16,
+
     pub(crate) phantom: PhantomData<E>,
 }
 
@@ -171,6 +179,10 @@ impl<E: ExtensionField> ConstraintSystem<E> {
             max_non_lc_degree: 0,
             chip_record_alpha: Expression::Challenge(0, 1, E::ONE, E::ZERO),
             chip_record_beta: Expression::Challenge(1, 1, E::ONE, E::ZERO),
+
+            backend_expr_monomial_form: vec![],
+            num_backend_witin: 0,
+            num_layer_challenges: 0,
 
             debug_map: HashMap::new(),
 
@@ -454,6 +466,86 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         let t = cb(self);
         self.ns.pop_namespace();
         t
+    }
+
+    pub fn finalize_backend_monomial_expression(&mut self) {
+        let exprs =
+            self.r_table_expressions
+                .iter()
+                .map(|r| r.expr.clone())
+                .chain(
+                    // padding with 1
+                    self.r_expressions
+                        .iter()
+                        .map(|expr| expr - E::BaseField::ONE.expr()),
+                )
+                .chain(self.w_table_expressions.iter().map(|w| &w.expr).cloned())
+                .chain(
+                    // padding with 1
+                    self.w_expressions
+                        .iter()
+                        .map(|expr| expr - E::BaseField::ONE.expr()),
+                )
+                .chain(
+                    self.lk_table_expressions
+                        .iter()
+                        .map(|lk| &lk.multiplicity)
+                        .cloned(),
+                )
+                .chain(
+                    self.lk_table_expressions
+                        .iter()
+                        .map(|lk| &lk.values)
+                        .cloned(),
+                )
+                .chain(
+                    // padding with alpha
+                    self.lk_expressions
+                        .iter()
+                        .map(|expr| expr.clone() - Expression::Challenge(0, 1, E::ONE, E::ZERO)),
+                )
+                .chain(self.assert_zero_sumcheck_expressions.clone())
+                .chain(self.assert_zero_expressions.clone())
+                .zip(
+                    (2u16..) // challenge id start from 2 because 0, 1 is alpha, beta respectively
+                        .map(|challenge_id| {
+                            Expression::Challenge(challenge_id, 1, E::ONE, E::ZERO)
+                        }),
+                )
+                .map(|(expr, r)| expr * r)
+                .collect_vec();
+
+        let num_layer_challenges = exprs.len() as u16;
+        let main_sumcheck_expr = exprs.into_iter().sum::<Expression<E>>();
+
+        let witid_offset = 0 as WitnessId;
+        let structural_witin_offset = witid_offset + self.num_witin;
+        let fixed_offset = structural_witin_offset + self.num_structural_witin;
+
+        let monomial_terms_expr = main_sumcheck_expr.get_monomial_terms();
+        self.backend_expr_monomial_form = monomial_terms_expr
+            .into_iter()
+            .map(
+                |Term {
+                     scalar,
+                     mut product,
+                 }| {
+                    product.iter_mut().for_each(|t| match t {
+                        Expression::WitIn(_) => (),
+                        Expression::StructuralWitIn(structural_wit_id, _, _, _) => {
+                            *t = Expression::WitIn(structural_witin_offset + *structural_wit_id);
+                        }
+                        Expression::Fixed(Fixed(fixed_id)) => {
+                            *t = Expression::WitIn(fixed_offset + (*fixed_id as u16));
+                        }
+                        e => panic!("unknown monimial terms {:?}", e),
+                    });
+                    Term { scalar, product }
+                },
+            )
+            .collect_vec();
+        self.num_backend_witin = fixed_offset;
+        self.num_layer_challenges = num_layer_challenges;
     }
 }
 

--- a/ceno_zkvm/src/scheme/hal.rs
+++ b/ceno_zkvm/src/scheme/hal.rs
@@ -104,6 +104,11 @@ pub trait TowerProver<PB: ProverBackend> {
     ) -> (Point<PB::E>, TowerProofs<PB::E>);
 }
 
+pub struct MainSumcheckEvals<E: ExtensionField> {
+    pub wits_in_evals: Vec<E>,
+    pub fixed_in_evals: Vec<E>,
+}
+
 pub trait MainSumcheckProver<PB: ProverBackend> {
     // this prover aims to achieve two goals:
     // 1. the validity of last layer in the tower tree is reduced to
@@ -119,7 +124,14 @@ pub trait MainSumcheckProver<PB: ProverBackend> {
         cs: &ConstraintSystem<PB::E>,
         challenges: &[PB::E; 2],
         transcript: &mut impl Transcript<PB::E>,
-    ) -> Result<(Point<PB::E>, Option<Vec<IOPProverMessage<PB::E>>>), ZKVMError>;
+    ) -> Result<
+        (
+            Point<PB::E>,
+            MainSumcheckEvals<PB::E>,
+            Option<Vec<IOPProverMessage<PB::E>>>,
+        ),
+        ZKVMError,
+    >;
 }
 
 pub trait OpeningProver<PB: ProverBackend> {

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -230,6 +230,7 @@ impl<E: ExtensionField> ZKVMConstraintSystem<E> {
         let config =
             LargeEcallDummy::<E, KeccakSpec>::construct_circuit_with_gkr_iop(&mut circuit_builder)
                 .unwrap();
+        circuit_builder.finalize();
         assert!(
             self.circuit_css
                 .insert(KeccakSpec::NAME.to_owned(), cs)
@@ -244,6 +245,7 @@ impl<E: ExtensionField> ZKVMConstraintSystem<E> {
         let mut circuit_builder =
             CircuitBuilder::<E>::new_with_params(&mut cs, self.params.clone());
         let config = OC::construct_circuit(&mut circuit_builder).unwrap();
+        circuit_builder.finalize();
         assert!(self.circuit_css.insert(OC::name(), cs).is_none());
 
         config
@@ -254,6 +256,7 @@ impl<E: ExtensionField> ZKVMConstraintSystem<E> {
         let mut circuit_builder =
             CircuitBuilder::<E>::new_with_params(&mut cs, self.params.clone());
         let config = TC::construct_circuit(&mut circuit_builder).unwrap();
+        circuit_builder.finalize();
         assert!(self.circuit_css.insert(TC::name(), cs).is_none());
 
         config
@@ -267,6 +270,7 @@ impl<E: ExtensionField> ZKVMConstraintSystem<E> {
             SC::initial_global_state(&mut circuit_builder).expect("global_state_in failed");
         self.finalize_global_state_expr =
             SC::finalize_global_state(&mut circuit_builder).expect("global_state_out failed");
+        circuit_builder.finalize();
     }
 
     pub fn get_css(&self) -> &BTreeMap<String, ConstraintSystem<E>> {

--- a/ceno_zkvm/src/utils.rs
+++ b/ceno_zkvm/src/utils.rs
@@ -1,19 +1,12 @@
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::HashMap,
     fmt::Display,
     hash::Hash,
-    mem,
     panic::{self, PanicHookInfo},
 };
 
-use either::Either;
 use ff_ext::{ExtensionField, SmallField};
 use itertools::Itertools;
-use multilinear_extensions::{
-    Expression,
-    mle::{ArcMultilinearExtension, MultilinearExtension},
-    virtual_polys::VirtualPolynomialsBuilder,
-};
 use p3::field::Field;
 
 pub fn i64_to_base<F: SmallField>(x: i64) -> F {
@@ -192,90 +185,6 @@ where
     result
 }
 
-/// add mle terms into virtual poly by expression
-/// return distinct witin in set
-pub fn add_mle_list_by_expr<'a, E: ExtensionField>(
-    expr_builder: &mut VirtualPolynomialsBuilder<'a, E>,
-    exprs: &mut Vec<Expression<E>>,
-    selector: Option<&'a MultilinearExtension<'a, E>>,
-    wit_ins: Vec<&'a ArcMultilinearExtension<'a, E>>,
-    expr: &Expression<E>,
-    challenges: &[E],
-    // sumcheck batch challenge
-    alpha: E,
-) -> BTreeSet<u16> {
-    assert!(expr.is_monomial_form());
-    let monomial_terms = expr.evaluate(
-        &|_| unreachable!(),
-        &|witness_id| vec![(E::ONE, { vec![witness_id] })],
-        &|structural_witness_id, _, _, _| vec![(E::ONE, { vec![structural_witness_id] })],
-        &|scalar| {
-            vec![(scalar.map_either(E::from, |scalar| scalar).into_inner(), {
-                vec![]
-            })]
-        },
-        &|challenge_id, pow, scalar, offset| {
-            let challenge = challenges[challenge_id as usize];
-            vec![(challenge.exp_u64(pow as u64) * scalar + offset, vec![])]
-        },
-        &|mut a, b| {
-            a.extend(b);
-            a
-        },
-        &|mut a, mut b| {
-            assert!(a.len() <= 2);
-            assert!(b.len() <= 2);
-            // special logic to deal with scaledsum
-            // scaledsum second parameter must be 0
-            if a.len() == 2 {
-                assert!((a[1].0, a[1].1.is_empty()) == (E::ZERO, true));
-                a.truncate(1);
-            }
-            if b.len() == 2 {
-                assert!((b[1].0, b[1].1.is_empty()) == (E::ZERO, true));
-                b.truncate(1);
-            }
-
-            a[0].1.extend(mem::take(&mut b[0].1));
-            // return [ab]
-            vec![(a[0].0 * b[0].0, mem::take(&mut a[0].1))]
-        },
-        &|mut x, a, b| {
-            assert!(a.len() == 1 && a[0].1.is_empty()); // for challenge or constant, term should be empty
-            assert!(b.len() == 1 && b[0].1.is_empty()); // for challenge or constant, term should be empty
-            assert!(x.len() == 1 && (x[0].0, x[0].1.len()) == (E::ONE, 1)); // witin size only 1
-            if b[0].0 == E::ZERO {
-                // only include first term if b = 0
-                vec![(a[0].0, mem::take(&mut x[0].1))]
-            } else {
-                // return [ax, b]
-                vec![(a[0].0, mem::take(&mut x[0].1)), (b[0].0, vec![])]
-            }
-        },
-    );
-    for (constant, monomial_term) in monomial_terms.iter() {
-        if *constant != E::ZERO && monomial_term.is_empty() && selector.is_none() {
-            todo!("make virtual poly support pure constant")
-        }
-        let sel = selector.map(|sel| expr_builder.lift(Either::Left(sel)));
-        let terms_polys = monomial_term
-            .iter()
-            .map(|wit_id| expr_builder.lift(Either::Left(wit_ins[*wit_id as usize])))
-            .collect_vec();
-        exprs.push(
-            sel.into_iter()
-                .chain(terms_polys)
-                .product::<Expression<E>>()
-                * Expression::Constant(Either::Right(*constant * alpha)),
-        );
-    }
-
-    monomial_terms
-        .into_iter()
-        .flat_map(|(_, monomial_term)| monomial_term.into_iter().collect_vec())
-        .collect::<BTreeSet<u16>>()
-}
-
 #[cfg(all(feature = "jemalloc", unix, not(test)))]
 pub fn print_allocated_bytes() {
     use tikv_jemalloc_ctl::{epoch, stats};
@@ -287,80 +196,4 @@ pub fn print_allocated_bytes() {
     // Read allocated bytes
     let allocated = stats::allocated::read().unwrap();
     tracing::info!("jemalloc total allocated bytes: {}", allocated);
-}
-
-#[cfg(test)]
-mod tests {
-    use ff_ext::GoldilocksExt2;
-    use itertools::Itertools;
-    use multilinear_extensions::{
-        Expression, ToExpr,
-        mle::{ArcMultilinearExtension, IntoMLE},
-        virtual_polys::VirtualPolynomialsBuilder,
-    };
-    use p3::field::PrimeCharacteristicRing;
-
-    use crate::{
-        circuit_builder::{CircuitBuilder, ConstraintSystem},
-        utils::add_mle_list_by_expr,
-    };
-    use p3::goldilocks::Goldilocks;
-
-    #[test]
-    fn test_add_mle_list_by_expr() {
-        type E = GoldilocksExt2;
-        type F = Goldilocks;
-        let mut cs = ConstraintSystem::new(|| "test_root");
-        let mut cb = CircuitBuilder::<E>::new(&mut cs);
-        let x = cb.create_witin(|| "x");
-        let y = cb.create_witin(|| "y");
-
-        let wits_in: Vec<ArcMultilinearExtension<E>> = (0..cs.num_witin as usize)
-            .map(|_| vec![F::from_u64(1)].into_mle().into())
-            .collect();
-
-        let mut expr_builder = VirtualPolynomialsBuilder::new(1, 0);
-        let mut exprs = vec![];
-
-        // 3xy + 2y
-        let expr: Expression<E> = 3 * x.expr() * y.expr() + 2 * y.expr();
-
-        let distrinct_zerocheck_terms_set = add_mle_list_by_expr(
-            &mut expr_builder,
-            &mut exprs,
-            None,
-            wits_in.iter().collect_vec(),
-            &expr,
-            &[],
-            GoldilocksExt2::ONE,
-        );
-        assert!(distrinct_zerocheck_terms_set.len() == 2);
-        assert!(
-            expr_builder
-                .to_virtual_polys(&[exprs.into_iter().sum::<Expression<E>>()], &[])
-                .degree()
-                == 2
-        );
-
-        // 3x^3
-        let mut expr_builder = VirtualPolynomialsBuilder::new(1, 0);
-        let mut exprs = vec![];
-        let expr: Expression<E> = 3 * x.expr() * x.expr() * x.expr();
-        let distrinct_zerocheck_terms_set = add_mle_list_by_expr(
-            &mut expr_builder,
-            &mut exprs,
-            None,
-            wits_in.iter().collect_vec(),
-            &expr,
-            &[],
-            GoldilocksExt2::ONE,
-        );
-        assert!(distrinct_zerocheck_terms_set.len() == 1);
-        assert!(
-            expr_builder
-                .to_virtual_polys(&[exprs.into_iter().sum::<Expression<E>>()], &[])
-                .degree()
-                == 3
-        );
-    }
 }

--- a/multilinear_extensions/src/expression/monomial.rs
+++ b/multilinear_extensions/src/expression/monomial.rs
@@ -27,14 +27,15 @@ impl<E: ExtensionField> Expression<E> {
 
     fn distribute(&self) -> Vec<Term<Expression<E>, Expression<E>>> {
         match self {
-            Constant(_) => {
+            // only contribute to scalar terms
+            Constant(_) | Challenge(..) | Instance(_) => {
                 vec![Term {
                     scalar: self.clone(),
                     product: vec![],
                 }]
             }
 
-            Fixed(_) | WitIn(_) | StructuralWitIn(..) | Instance(_) | Challenge(..) => {
+            Fixed(_) | WitIn(_) | StructuralWitIn(..) => {
                 vec![Term {
                     scalar: Expression::ONE,
                     product: vec![self.clone()],

--- a/multilinear_extensions/src/virtual_polys.rs
+++ b/multilinear_extensions/src/virtual_polys.rs
@@ -96,6 +96,28 @@ impl<'a, E: ExtensionField> VirtualPolynomialsBuilder<'a, E> {
         .into_inner()
     }
 
+    pub fn to_virtual_polys_with_monimial_terms(
+        self,
+        monimial_terms: MonomialTermsExpr<'a, E>,
+    ) -> VirtualPolynomials<'a, E> {
+        let mles = self
+            .mle_ptr_registry
+            .into_values()
+            .collect::<Vec<_>>() // collect into Vec<&(usize, &ArcMultilinearExtension)>
+            .into_iter()
+            .sorted_by_key(|(witin_id, _)| *witin_id) // sort by witin_id
+            .map(|(_, mle)| mle) // extract &ArcMultilinearExtension
+            .collect::<Vec<_>>();
+
+        let mut virtual_polys =
+            VirtualPolynomials::<E>::new(self.num_threads, self.max_num_variables);
+        // register mles to assure index matching the arc_poly order
+        virtual_polys.register_mles(mles);
+
+        virtual_polys.add_monomial_terms(monimial_terms);
+        virtual_polys
+    }
+
     pub fn to_virtual_polys(
         self,
         expressions: &[Expression<E>],


### PR DESCRIPTION
This PR build on top of #799  with one extra https://github.com/scroll-tech/ceno/pull/964/commits/48ded1a7d6ab40f20336dd03bf65779a78007e51 to introduce backend expression and cached in constrain system. This align the design with pre-compile so its easier for next step refactor to introduce precompile chip in main flow.
Main sumcheck read/write lookup expression was simplified, as post `evaluate()` was also removed. 

### Expression

Expression will be simplified into 2 kind: frontend and backend expression
- frontend expression: expression with Witin/StructuralWitin/Fixed, in recursive/nested style
- backend expression: expression with Witin only, in monomial style.

After circuit setup, both expression content are all known and freezed. During runtime, we can take backend expression and evaluate its scalar with "challenge/instance" then the final expression can be put into sumcheck.


### benchmark

The nice thing is before/after change, there is no performance difference.

| Benchmark                        | Median Time (s) | Median Change (%)                     |
|----------------------------------|------------------|----------------------------------------|
| fibonacci_max_steps_1048576      | 2.0641           | -0.9869% (No change in performance detected) |
| fibonacci_max_steps_2097152      | 3.5514           | -1.0748% (Change within noise threshold)     |
| fibonacci_max_steps_1048576      | 2.0641           | -0.9869% (No change in performance detected) |