### PR TITLE
Add rotation verifier

### DIFF
--- a/gkr_iop/examples/multi_layer_logup_table.rs
+++ b/gkr_iop/examples/multi_layer_logup_table.rs
@@ -132,7 +132,7 @@ pub struct TowerChipTrace {
     pub table_with_multiplicity: Vec<(u64, u64)>,
 }
 
-impl<'a, E> ProtocolWitnessGenerator<'a, E> for TowerChipLayout<E>
+impl<E> ProtocolWitnessGenerator<'_, E> for TowerChipLayout<E>
 where
     E: ExtensionField,
 {
@@ -188,7 +188,7 @@ fn main() {
         {
             use multilinear_extensions::{mle::FieldType, smart_slice::SmartSlice};
 
-            let last = gkr_witness.layers[0].bases.clone();
+            let last = gkr_witness.layers[0].wits.clone();
             MockProver::check(
                 gkr_circuit.clone(),
                 &gkr_witness,
@@ -207,7 +207,7 @@ fn main() {
         }
 
         let out_evals = {
-            let last = gkr_witness.layers[0].bases.clone();
+            let last = gkr_witness.layers[0].wits.clone();
             let point = vec![];
             assert_eq!(last[0].evaluations().len(), 1);
             vec![

--- a/gkr_iop/src/bin/lookup_keccak.rs
+++ b/gkr_iop/src/bin/lookup_keccak.rs
@@ -69,7 +69,6 @@ fn main() {
         .map(|_| std::array::from_fn(|_| rng.gen()))
         .collect_vec();
     let circuit_setup = setup_keccak_lookup_circuit();
-    let proof =
-        run_faster_keccakf::<E>(circuit_setup, states, false, false).expect("generate proof");
+    let proof = run_faster_keccakf::<E>(circuit_setup, states, true, true).expect("generate proof");
     tracing::info!("lookup keccak proof stat: {}", proof);
 }

--- a/gkr_iop/src/gkr.rs
+++ b/gkr_iop/src/gkr.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 use ff_ext::ExtensionField;
 use itertools::{Itertools, izip};
-use layer::{Layer, LayerWitness, sumcheck_layer::SumcheckLayerProof};
+use layer::{Layer, LayerWitness, sumcheck_layer::LayerProof};
 use multilinear_extensions::mle::{Point, PointAndEval};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use sumcheck::macros::{entered_span, exit_span};
@@ -47,7 +47,7 @@ pub struct GKRProverOutput<E: ExtensionField, Evaluation> {
     serialize = "E::BaseField: Serialize",
     deserialize = "E::BaseField: DeserializeOwned"
 ))]
-pub struct GKRProof<E: ExtensionField>(pub Vec<SumcheckLayerProof<E>>);
+pub struct GKRProof<E: ExtensionField>(pub Vec<LayerProof<E>>);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound(

--- a/gkr_iop/src/gkr/booleanhypercube.rs
+++ b/gkr_iop/src/gkr/booleanhypercube.rs
@@ -83,9 +83,9 @@ impl BooleanHypercube {
         point: &Point<E>,
     ) -> E {
         match self.num_vars {
-            // rotated_eval = (1-r4) * left_eval - r4 * right_eval
-            // right_eval = ((1-r4) * left_eval - rotated_eval) / r4
-            5 => ((E::ONE - point[4]) * left_eval - rotated_eval) / point[4],
+            // rotated_eval = (1-r4) * left_eval + r4 * right_eval
+            // right_eval = (rotated_eval - (1-r4) * left_eval) / r4
+            5 => (rotated_eval - (E::ONE - point[4]) * left_eval) / point[4],
             num_vars => unimplemented!("not support {num_vars}"),
         }
     }

--- a/gkr_iop/src/gkr/layer.rs
+++ b/gkr_iop/src/gkr/layer.rs
@@ -7,7 +7,7 @@ use multilinear_extensions::{
     mle::{ArcMultilinearExtension, Point, PointAndEval},
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use sumcheck_layer::SumcheckLayerProof;
+use sumcheck_layer::LayerProof;
 use transcript::Transcript;
 use zerocheck_layer::ZerocheckLayer;
 
@@ -74,7 +74,7 @@ pub struct Layer<E: ExtensionField> {
 
 #[derive(Clone, Debug, Default)]
 pub struct LayerWitness<'a, E: ExtensionField> {
-    pub bases: Vec<ArcMultilinearExtension<'a, E>>,
+    pub wits: Vec<ArcMultilinearExtension<'a, E>>,
     pub num_vars: usize,
 }
 
@@ -100,7 +100,7 @@ impl<E: ExtensionField> Layer<E> {
             expr_names.len() == exprs.len(),
             "there are expr without name"
         );
-        let max_expr_degree = exprs.iter().map(|expr| expr.degree()).max().unwrap();
+        let max_expr_degree = exprs.iter().map(|expr| expr.degree()).max().unwrap_or(1);
 
         Self {
             name,
@@ -126,7 +126,7 @@ impl<E: ExtensionField> Layer<E> {
         claims: &mut [PointAndEval<E>],
         challenges: &mut Vec<E>,
         transcript: &mut T,
-    ) -> SumcheckLayerProof<E> {
+    ) -> LayerProof<E> {
         self.update_challenges(challenges, transcript);
         let mut eval_and_dedup_points = self.extract_claim_and_point(claims, challenges);
 
@@ -157,7 +157,7 @@ impl<E: ExtensionField> Layer<E> {
             }
         };
 
-        self.update_claims(claims, &sumcheck_layer_proof.evals, &point);
+        self.update_claims(claims, &sumcheck_layer_proof.main.evals, &point);
 
         sumcheck_layer_proof
     }
@@ -165,7 +165,7 @@ impl<E: ExtensionField> Layer<E> {
     pub fn verify<Trans: Transcript<E>>(
         &self,
         max_num_variables: usize,
-        proof: SumcheckLayerProof<E>,
+        proof: LayerProof<E>,
         claims: &mut [PointAndEval<E>],
         challenges: &mut Vec<E>,
         transcript: &mut Trans,
@@ -261,6 +261,9 @@ impl<'a, E: ExtensionField> LayerWitness<'a, E> {
         assert!(!bases.is_empty() || !bases.is_empty());
         let num_vars = log2(bases[0].evaluations().len()) as usize;
         assert!(bases.iter().all(|b| b.evaluations().len() == 1 << num_vars));
-        Self { bases, num_vars }
+        Self {
+            wits: bases,
+            num_vars,
+        }
     }
 }

--- a/gkr_iop/src/gkr/layer.rs
+++ b/gkr_iop/src/gkr/layer.rs
@@ -257,13 +257,10 @@ impl<E: ExtensionField> Layer<E> {
 }
 
 impl<'a, E: ExtensionField> LayerWitness<'a, E> {
-    pub fn new(bases: Vec<ArcMultilinearExtension<'a, E>>) -> Self {
-        assert!(!bases.is_empty() || !bases.is_empty());
-        let num_vars = log2(bases[0].evaluations().len()) as usize;
-        assert!(bases.iter().all(|b| b.evaluations().len() == 1 << num_vars));
-        Self {
-            wits: bases,
-            num_vars,
-        }
+    pub fn new(wits: Vec<ArcMultilinearExtension<'a, E>>) -> Self {
+        assert!(!wits.is_empty() || !wits.is_empty());
+        let num_vars = log2(wits[0].evaluations().len()) as usize;
+        assert!(wits.iter().all(|b| b.evaluations().len() == 1 << num_vars));
+        Self { wits, num_vars }
     }
 }

--- a/gkr_iop/src/gkr/layer/zerocheck_layer.rs
+++ b/gkr_iop/src/gkr/layer/zerocheck_layer.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use multilinear_extensions::{
     Expression, WitnessId,
     mle::{MultilinearExtension, Point},
-    utils::eval_by_expr_with_instance,
+    utils::eval_by_expr,
     virtual_poly::{VPAuxInfo, build_eq_x_r_vec, eq_eval},
     virtual_polys::VirtualPolynomialsBuilder,
 };
@@ -15,7 +15,6 @@ use rayon::{
     iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator},
     slice::ParallelSlice,
 };
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use sumcheck::{
     macros::{entered_span, exit_span},
     structs::{IOPProof, IOPProverState, IOPVerifierState, SumCheckSubClaim, VerifierError},
@@ -25,20 +24,29 @@ use transcript::Transcript;
 
 use crate::{
     error::BackendError,
-    gkr::{booleanhypercube::BooleanHypercube, layer::ROTATION_OPENING_COUNT},
-    utils::{rotation_next_base_mle, rotation_selector},
+    gkr::{
+        booleanhypercube::BooleanHypercube,
+        layer::{ROTATION_OPENING_COUNT, sumcheck_layer::SumcheckLayerProof},
+    },
+    utils::{
+        extend_exprs_with_rotation, rotation_next_base_mle, rotation_selector,
+        rotation_selector_eval,
+    },
 };
 
-use super::{Layer, LayerWitness, linear_layer::LayerClaims, sumcheck_layer::SumcheckLayerProof};
+use super::{Layer, LayerWitness, linear_layer::LayerClaims, sumcheck_layer::LayerProof};
 
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(bound(
-    serialize = "E::BaseField: Serialize",
-    deserialize = "E::BaseField: DeserializeOwned"
-))]
-pub struct RotationProof<E: ExtensionField> {
-    proof: IOPProof<E>,
-    evals: Vec<E>,
+struct RotationPoints<E: ExtensionField> {
+    left: Point<E>,
+    right: Point<E>,
+    origin: Point<E>,
+}
+
+struct RotationClaims<E: ExtensionField> {
+    left_evals: Vec<E>,
+    right_evals: Vec<E>,
+    target_evals: Vec<E>,
+    rotation_points: RotationPoints<E>,
 }
 
 pub trait ZerocheckLayer<E: ExtensionField> {
@@ -51,12 +59,12 @@ pub trait ZerocheckLayer<E: ExtensionField> {
         out_points: &[Point<E>],
         challenges: &[E],
         transcript: &mut impl Transcript<E>,
-    ) -> (SumcheckLayerProof<E>, Point<E>);
+    ) -> (LayerProof<E>, Point<E>);
 
     fn verify(
         &self,
         max_num_variables: usize,
-        proof: SumcheckLayerProof<E>,
+        proof: LayerProof<E>,
         eval_and_dedup_points: Vec<(Vec<E>, Option<Point<E>>)>,
         challenges: &[E],
         transcript: &mut impl Transcript<E>,
@@ -72,7 +80,7 @@ impl<E: ExtensionField> ZerocheckLayer<E> for Layer<E> {
         out_points: &[Point<E>],
         challenges: &[E],
         transcript: &mut impl Transcript<E>,
-    ) -> (SumcheckLayerProof<E>, Point<E>) {
+    ) -> (LayerProof<E>, Point<E>) {
         assert_eq!(
             self.expr_evals.len(),
             out_points.len(),
@@ -81,30 +89,34 @@ impl<E: ExtensionField> ZerocheckLayer<E> for Layer<E> {
             out_points.len(),
         );
 
-        let (rotation_eq, rotation_exprs) = &self.rotation_exprs;
-        let (rotation_proof, rotation_point) = if !rotation_exprs.is_empty() {
-            // 1st sumcheck: process rotation_exprs
-            let rt = out_points.first().unwrap();
-            let (proof, point) = prove_rotation(
-                num_threads,
-                max_num_variables,
-                self,
-                &wit,
-                rotation_exprs,
-                self.rotation_cyclic_group_log2,
-                rt,
-                challenges,
-                transcript,
-            );
-            (Some(proof), Some(point))
-        } else {
-            (None, None)
-        };
+        let (_, rotation_exprs) = &self.rotation_exprs;
+        let (rotation_proof, rotation_left, rotation_right, rotation_point) =
+            if !rotation_exprs.is_empty() {
+                // 1st sumcheck: process rotation_exprs
+                let rt = out_points.first().unwrap();
+                let (
+                    proof,
+                    RotationPoints {
+                        left,
+                        right,
+                        origin,
+                    },
+                ) = prove_rotation(
+                    num_threads,
+                    max_num_variables,
+                    self.rotation_cyclic_subgroup_size,
+                    self.rotation_cyclic_group_log2,
+                    &wit,
+                    rotation_exprs,
+                    rt,
+                    transcript,
+                );
+                (Some(proof), Some(left), Some(right), Some(origin))
+            } else {
+                (None, None, None, None)
+            };
 
         // 2th sumcheck: batch rotation with other constrains
-        let mut expr_iter = self.exprs.iter();
-        let mut zero_check_exprs = Vec::with_capacity(self.expr_evals.len());
-
         let alpha_pows = get_challenge_pows(
             self.exprs.len() + rotation_exprs.len() * ROTATION_OPENING_COUNT,
             transcript,
@@ -112,67 +124,10 @@ impl<E: ExtensionField> ZerocheckLayer<E> for Layer<E> {
         .into_iter()
         .map(|r| Expression::Constant(Either::Right(r)))
         .collect_vec();
-        let mut alpha_pows_iter = alpha_pows.iter();
 
         let span = entered_span!("gen_expr", profiling_4 = true);
-        for (eq_expr, out_evals) in self.expr_evals.iter() {
-            let group_length = out_evals.len();
-            let zero_check_expr = expr_iter
-                .by_ref()
-                .take(group_length)
-                .cloned()
-                .zip_eq(alpha_pows_iter.by_ref().take(group_length))
-                .map(|(expr, alpha)| alpha * expr)
-                .sum::<Expression<E>>();
-            zero_check_exprs.push(eq_expr.clone().unwrap() * zero_check_expr);
-        }
-
-        // prepare rotation expr
-        let (mut left_rotation_expr, mut right_rotation_expr, mut rotation_expr) = (
-            Vec::with_capacity(rotation_exprs.len()),
-            Vec::with_capacity(rotation_exprs.len()),
-            Vec::with_capacity(rotation_exprs.len()),
-        );
-        for ((rotate_expr, expr), (alpha1, alpha2, alpha3)) in rotation_exprs.iter().zip_eq(
-            alpha_pows_iter
-                .by_ref()
-                .take(rotation_exprs.len() * ROTATION_OPENING_COUNT)
-                .tuples(),
-        ) {
-            assert!(
-                matches!(rotate_expr, Expression::WitIn(_)) && matches!(expr, Expression::WitIn(_))
-            );
-            left_rotation_expr.push(alpha1 * rotate_expr.clone());
-            right_rotation_expr.push(alpha2 * rotate_expr.clone());
-            rotation_expr.push(alpha3 * expr.clone());
-        }
-
-        // push rotation expr to zerocheck expr
-        if let Some(
-            [
-                rotation_left_eq_expr,
-                rotation_right_eq_expr,
-                rotation_eq_expr,
-            ],
-        ) = rotation_eq.as_ref()
-        {
-            // add rotation left expr
-            zero_check_exprs.push(
-                rotation_left_eq_expr.clone()
-                    * left_rotation_expr.into_iter().sum::<Expression<E>>(),
-            );
-            // add rotation right expr
-            zero_check_exprs.push(
-                rotation_right_eq_expr.clone()
-                    * right_rotation_expr.into_iter().sum::<Expression<E>>(),
-            );
-            // add target expr
-            zero_check_exprs
-                .push(rotation_eq_expr.clone() * rotation_expr.into_iter().sum::<Expression<E>>());
-        }
-
+        let zero_check_exprs = extend_exprs_with_rotation(self, &alpha_pows);
         exit_span!(span);
-        assert!(expr_iter.next().is_none() && alpha_pows_iter.next().is_none());
 
         let span = entered_span!("build_out_points_eq", profiling_4 = true);
         // zero check eq || rotation eq
@@ -182,21 +137,17 @@ impl<E: ExtensionField> ZerocheckLayer<E> for Layer<E> {
                 MultilinearExtension::from_evaluations_ext_vec(point.len(), build_eq_x_r_vec(point))
             })
             // for rotation left point
-            .chain(rotation_point.par_iter().map(|rotation_point| {
-                let (rotation_left, _) = BooleanHypercube::new(self.rotation_cyclic_group_log2)
-                    .get_rotation_points(rotation_point);
+            .chain(rotation_left.par_iter().map(|rotation_left| {
                 MultilinearExtension::from_evaluations_ext_vec(
                     rotation_left.len(),
-                    build_eq_x_r_vec(&rotation_left),
+                    build_eq_x_r_vec(rotation_left),
                 )
             }))
             // for rotation right point
-            .chain(rotation_point.par_iter().map(|rotation_point| {
-                let (_, rotation_right) = BooleanHypercube::new(self.rotation_cyclic_group_log2)
-                    .get_rotation_points(rotation_point);
+            .chain(rotation_right.par_iter().map(|rotation_right| {
                 MultilinearExtension::from_evaluations_ext_vec(
                     rotation_right.len(),
-                    build_eq_x_r_vec(&rotation_right),
+                    build_eq_x_r_vec(rotation_right),
                 )
             }))
             // for rotation point
@@ -212,24 +163,27 @@ impl<E: ExtensionField> ZerocheckLayer<E> for Layer<E> {
         let builder = VirtualPolynomialsBuilder::new_with_mles(
             num_threads,
             max_num_variables,
-            wit.bases
+            wit.wits
                 .iter()
                 .map(|mle| Either::Left(mle.as_ref()))
                 // extend eqs to the end of wit
                 .chain(eqs.iter_mut().map(Either::Right))
                 .collect_vec(),
         );
+
         let span = entered_span!("IOPProverState::prove", profiling_4 = true);
+        let zero_check_expr: Expression<E> = zero_check_exprs.into_iter().sum();
         let (proof, prover_state) = IOPProverState::prove(
-            builder.to_virtual_polys(&[zero_check_exprs.into_iter().sum()], challenges),
+            builder.to_virtual_polys(&[zero_check_expr], challenges),
             transcript,
         );
+
+        let evals = prover_state.get_mle_flatten_final_evaluations();
         exit_span!(span);
         (
-            SumcheckLayerProof {
-                proof,
-                rotation_proof,
-                evals: prover_state.get_mle_flatten_final_evaluations(),
+            LayerProof {
+                main: SumcheckLayerProof { proof, evals },
+                rotation: rotation_proof,
             },
             prover_state.collect_raw_challenges(),
         )
@@ -238,8 +192,8 @@ impl<E: ExtensionField> ZerocheckLayer<E> for Layer<E> {
     fn verify(
         &self,
         max_num_variables: usize,
-        proof: SumcheckLayerProof<E>,
-        eval_and_dedup_points: Vec<(Vec<E>, Option<Point<E>>)>,
+        proof: LayerProof<E>,
+        mut eval_and_dedup_points: Vec<(Vec<E>, Option<Point<E>>)>,
         challenges: &[E],
         transcript: &mut impl Transcript<E>,
     ) -> Result<LayerClaims<E>, BackendError<E>> {
@@ -250,16 +204,51 @@ impl<E: ExtensionField> ZerocheckLayer<E> for Layer<E> {
             self.expr_evals.len(),
             eval_and_dedup_points.len(),
         );
-        let SumcheckLayerProof {
-            proof: IOPProof { proofs, .. },
-            mut evals,
-            // TODO process rotation proof
-            ..
+        let LayerProof {
+            main:
+                SumcheckLayerProof {
+                    proof: IOPProof { proofs },
+                    evals: mut main_evals,
+                },
+            rotation: rotation_proof,
         } = proof;
 
-        let alpha_pows = get_challenge_pows(self.exprs.len(), transcript);
+        if let Some(rotation_proof) = rotation_proof {
+            // verify rotation proof
+            let rt = eval_and_dedup_points
+                .first()
+                .and_then(|(_, rt)| rt.as_ref())
+                .expect("rotation proof should have at least one point");
+            let RotationClaims {
+                left_evals,
+                right_evals,
+                target_evals,
+                rotation_points:
+                    RotationPoints {
+                        left: left_point,
+                        right: right_point,
+                        origin: origin_point,
+                    },
+            } = verify_rotation(
+                max_num_variables,
+                rotation_proof,
+                self.rotation_cyclic_subgroup_size,
+                self.rotation_cyclic_group_log2,
+                rt,
+                transcript,
+            )?;
+            eval_and_dedup_points.push((left_evals, Some(left_point)));
+            eval_and_dedup_points.push((right_evals, Some(right_point)));
+            eval_and_dedup_points.push((target_evals, Some(origin_point)));
+        }
 
-        let sigma: E = dot_product(
+        let rotation_exprs_len = self.rotation_exprs.1.len();
+        let alpha_pows = get_challenge_pows(
+            self.exprs.len() + rotation_exprs_len * ROTATION_OPENING_COUNT,
+            transcript,
+        );
+
+        let sigma = dot_product(
             alpha_pows.iter().copied(),
             eval_and_dedup_points
                 .iter()
@@ -288,80 +277,80 @@ impl<E: ExtensionField> ZerocheckLayer<E> for Layer<E> {
             .map(|(_, out_point)| eq_eval(out_point.as_ref().unwrap(), &in_point))
             .zip(&self.expr_evals)
             .for_each(|(eval, (eq_expr, _))| match eq_expr {
-                Some(Expression::WitIn(witin_id)) => evals[*witin_id as usize] = eval,
+                Some(Expression::WitIn(id)) => {
+                    #[cfg(debug_assertions)]
+                    assert_eq!(main_evals[*id as usize], eval, "eq compute wrong");
+                    main_evals[*id as usize] = eval;
+                }
                 _ => unreachable!(),
             });
 
-        // check the final evaluations.
-        let got_claim = self
-            .exprs
-            .iter()
-            .zip_eq(self.expr_evals.iter().flat_map(|(eq_expr, evals)| {
-                std::iter::repeat_n(eq_expr.clone().unwrap(), evals.len())
-            }))
-            .zip_eq(alpha_pows)
-            .map(|((expr, eq_expr), alpha)| {
-                alpha
-                    * eval_by_expr_with_instance(
-                        &[],
-                        &evals,
-                        &[],
-                        &[],
-                        challenges,
-                        &(expr * eq_expr),
-                    )
-                    .right()
-                    .unwrap()
-            })
-            .sum::<E>();
+        let zero_check_exprs = extend_exprs_with_rotation(
+            self,
+            &alpha_pows
+                .iter()
+                .cloned()
+                .map(|r| Expression::Constant(Either::Right(r)))
+                .collect_vec(),
+        );
+
+        let zero_check_expr = zero_check_exprs.into_iter().sum::<Expression<E>>();
+        let got_claim = eval_by_expr(&main_evals, &[], challenges, &zero_check_expr);
 
         if got_claim != expected_evaluation {
             return Err(BackendError::LayerVerificationFailed(
-                "sumcheck verify failed".to_string(),
-                VerifierError::ClaimNotMatch(
-                    self.exprs[0].clone(),
-                    expected_evaluation,
-                    got_claim,
-                    self.expr_names[0].clone(),
-                ),
+                self.name.clone(),
+                VerifierError::ClaimNotMatch(expected_evaluation, got_claim),
             ));
         }
 
-        Ok(LayerClaims { in_point, evals })
+        Ok(LayerClaims {
+            in_point,
+            evals: main_evals,
+        })
     }
 }
 
+/// This is to prove the following n rotation arguments:
+/// For the i-th argument, we check rotated(rotation_expr[i].0) == rotation_expr[i].1
+/// This is proved through the following arguments:
+///     0 = \sum_{b = 0}^{N - 1} sel(b) * \sum_i alpha^i * (rotated_rotation_expr[i].0(b) - rotation_expr[i].1(b))
+/// With the randomness rx, we check: (currently we only support cycle with length 32)
+///     rotated_rotation_expr[i].0(rx) == (1 - rx_4) * rotation_expr[i].1(0, rx_0, rx_1, ..., rx_3, rx_5, ...)
+///                                     + rx_4 * rotation_expr[i].1(1, rx_0, 1 - rx_1, ..., rx_3, rx_5, ...)
 #[allow(clippy::too_many_arguments)]
-pub fn prove_rotation<E: ExtensionField>(
+fn prove_rotation<E: ExtensionField>(
     num_threads: usize,
     max_num_variables: usize,
-    layer: &Layer<E>,
+    rotation_cyclic_subgroup_size: usize,
+    rotation_cyclic_group_log2: usize,
     wit: &LayerWitness<E>,
     rotation_exprs: &[(Expression<E>, Expression<E>)],
-    rotation_cyclic_group_log2: usize,
     rt: &Point<E>,
-    challenges: &[E],
     transcript: &mut impl Transcript<E>,
-) -> (RotationProof<E>, Point<E>) {
+) -> (SumcheckLayerProof<E>, RotationPoints<E>) {
     let span = entered_span!("rotate_witin_selector", profiling_4 = true);
-    let mut eq = MultilinearExtension::from_evaluations_ext_vec(rt.len(), build_eq_x_r_vec(rt));
+    let bh = BooleanHypercube::new(rotation_cyclic_group_log2);
     // rotated_mles is non-deterministic input, rotated from existing witness polynomial
     // we will reduce it to zero check, and finally reduce to commmitted polynomial opening
     let (mut selector, mut rotated_mles) = {
+        let eq = build_eq_x_r_vec(rt);
         let mut mles = rotation_exprs
             .par_iter()
             .map(|rotation_expr| match rotation_expr {
                 (Expression::WitIn(source_wit_id), _) => rotation_next_base_mle(
-                    &wit.bases[*source_wit_id as usize],
-                    layer.rotation_cyclic_subgroup_size,
-                    layer.rotation_cyclic_group_log2,
+                    &bh,
+                    &wit.wits[*source_wit_id as usize],
+                    rotation_cyclic_group_log2,
                 ),
                 _ => unimplemented!("unimplemented rotation"),
             })
             .chain(rayon::iter::once(rotation_selector(
-                layer.rotation_cyclic_subgroup_size,
-                layer.rotation_cyclic_group_log2,
-                wit.bases[0].evaluations().len(), // Take first mle just to retrieve total length
+                &bh,
+                &eq,
+                rotation_cyclic_subgroup_size,
+                rotation_cyclic_group_log2,
+                wit.wits[0].evaluations().len(), // Take first mle just to retrieve total length
             )))
             .collect::<Vec<_>>();
         let selector = mles.pop().unwrap();
@@ -384,13 +373,12 @@ pub fn prove_rotation<E: ExtensionField>(
                 Expression::WitIn(wit_id) => {
                     vec![
                         Either::Right(mle),
-                        Either::Left(wit.bases[*wit_id as usize].as_ref()),
+                        Either::Left(wit.wits[*wit_id as usize].as_ref()),
                     ]
                 }
                 _ => panic!(""),
             })
             .chain(std::iter::once(Either::Right(&mut selector)))
-            .chain(std::iter::once(Either::Right(&mut eq)))
             .collect_vec(),
     );
     // generate rotation expression
@@ -403,18 +391,15 @@ pub fn prove_rotation<E: ExtensionField>(
         })
         .sum::<Expression<E>>();
     // last 2 is [selector, eq]
-    let (selector_expr, eq_expr) = (
-        Expression::<E>::WitIn((rotation_exprs.len() * 2) as WitnessId),
-        Expression::<E>::WitIn((rotation_exprs.len() * 2 + 1) as WitnessId),
-    );
+    let selector_expr = Expression::<E>::WitIn((rotation_exprs.len() * 2) as WitnessId);
     let span = entered_span!("rotation IOPProverState::prove", profiling_4 = true);
     let (rotation_proof, prover_state) = IOPProverState::prove(
-        builder.to_virtual_polys(&[eq_expr * selector_expr * rotation_expr], challenges),
+        builder.to_virtual_polys(&[selector_expr * rotation_expr], &[]),
         transcript,
     );
     exit_span!(span);
     let mut evals = prover_state.get_mle_flatten_final_evaluations();
-    let point = prover_state.collect_raw_challenges();
+    let origin_point = prover_state.collect_raw_challenges();
     // skip selector/eq as verifier can derived itself
     evals.truncate(rotation_exprs.len() * 2);
 
@@ -429,6 +414,8 @@ pub fn prove_rotation<E: ExtensionField>(
     //    target_eval_1st,
     //    ...
     // ]
+    let bh = BooleanHypercube::new(rotation_cyclic_group_log2);
+    let (left_point, right_point) = bh.get_rotation_points(&origin_point);
     let evals = evals
         .par_chunks_exact(2)
         .zip_eq(rotation_exprs.par_iter())
@@ -436,25 +423,125 @@ pub fn prove_rotation<E: ExtensionField>(
             let [rotated_eval, target_eval] = evals else {
                 unreachable!()
             };
-            let bh = BooleanHypercube::new(rotation_cyclic_group_log2);
-            let (rotation_left, _) = bh.get_rotation_points(&point);
             let left_eval = match rotated_expr {
                 Expression::WitIn(source_wit_id) => {
-                    wit.bases[*source_wit_id as usize].evaluate(&rotation_left)
+                    wit.wits[*source_wit_id as usize].evaluate(&left_point)
                 }
                 _ => unreachable!(),
             };
-            let right_eval = bh.get_rotation_right_eval_from_left(*rotated_eval, left_eval, &point);
+            let right_eval =
+                bh.get_rotation_right_eval_from_left(*rotated_eval, left_eval, &origin_point);
+            #[cfg(debug_assertions)]
+            {
+                let expected_right_eval = match rotated_expr {
+                    Expression::WitIn(source_wit_id) => {
+                        wit.wits[*source_wit_id as usize].evaluate(&right_point)
+                    }
+                    _ => unreachable!(),
+                };
+                assert_eq!(
+                    expected_right_eval, right_eval,
+                    "rotation right eval mismatch: expected {expected_right_eval}, got {right_eval}"
+                );
+            }
             [left_eval, right_eval, *target_eval]
         })
         .collect::<Vec<E>>();
     exit_span!(span);
-    // add evaluation of state in left
     (
-        RotationProof {
+        SumcheckLayerProof {
             proof: rotation_proof,
             evals,
         },
-        point,
+        RotationPoints {
+            left: left_point,
+            right: right_point,
+            origin: origin_point,
+        },
     )
+}
+
+fn verify_rotation<E: ExtensionField>(
+    max_num_variables: usize,
+    rotation_proof: SumcheckLayerProof<E>,
+    rotation_cyclic_subgroup_size: usize,
+    rotation_cyclic_group_log2: usize,
+    rt: &Point<E>,
+    transcript: &mut impl Transcript<E>,
+) -> Result<RotationClaims<E>, BackendError<E>> {
+    let SumcheckLayerProof { proof, evals } = rotation_proof;
+    let rotation_expr_len = evals.len() / 3;
+    let rotation_alpha_pows = get_challenge_pows(rotation_expr_len, transcript)
+        .into_iter()
+        .collect_vec();
+
+    let sigma = E::ZERO;
+
+    let SumCheckSubClaim {
+        point: in_point,
+        expected_evaluation,
+    } = IOPVerifierState::verify(
+        sigma,
+        &proof,
+        &VPAuxInfo {
+            max_degree: 2, // selector * (rotated - target)
+            max_num_variables,
+            phantom: PhantomData,
+        },
+        transcript,
+    );
+    let origin_point = in_point.into_iter().map(|c| c.elements).collect_vec();
+
+    // compute the selector evaluation
+    let bh = BooleanHypercube::new(rotation_cyclic_group_log2);
+    let selector_eval = rotation_selector_eval(
+        &bh,
+        rt,
+        &origin_point,
+        rotation_cyclic_subgroup_size,
+        rotation_cyclic_group_log2,
+    );
+
+    // check the final evaluations.
+    let mut left_evals = Vec::with_capacity(evals.len() / 3);
+    let mut right_evals = Vec::with_capacity(evals.len() / 3);
+    let mut target_evals = Vec::with_capacity(evals.len() / 3);
+    let got_claim = selector_eval
+        * evals
+            .chunks_exact(3)
+            .zip_eq(rotation_alpha_pows.iter())
+            .map(|(evals, alpha)| {
+                let [left_eval, right_eval, target_eval] = evals else {
+                    unreachable!()
+                };
+                left_evals.push(*left_eval);
+                right_evals.push(*right_eval);
+                target_evals.push(*target_eval);
+                *alpha
+                    * ((E::ONE - origin_point[rotation_cyclic_group_log2 - 1]) * *left_eval
+                        + origin_point[rotation_cyclic_group_log2 - 1] * *right_eval
+                        - *target_eval)
+            })
+            .sum::<E>();
+
+    if got_claim != expected_evaluation {
+        return Err(BackendError::LayerVerificationFailed(
+            "rotation verify failed".to_string(),
+            VerifierError::ClaimNotMatch(expected_evaluation, got_claim),
+        ));
+    }
+
+    let (left_point, right_point) =
+        BooleanHypercube::new(rotation_cyclic_group_log2).get_rotation_points(&origin_point);
+
+    Ok(RotationClaims {
+        left_evals,
+        right_evals,
+        target_evals,
+        rotation_points: RotationPoints {
+            left: left_point,
+            right: right_point,
+            origin: origin_point,
+        },
+    })
 }

--- a/gkr_iop/src/gkr/mock.rs
+++ b/gkr_iop/src/gkr/mock.rs
@@ -58,6 +58,7 @@ impl<E: ExtensionField> MockProver<E> {
         mut evaluations: Vec<FieldType<'a, E>>,
         mut challenges: Vec<E>,
     ) -> Result<(), MockProverError<'a, E>> {
+        // TODO: check the rotation argument.
         let mut rng = thread_rng();
         evaluations.resize(
             circuit.n_evaluations,
@@ -80,7 +81,7 @@ impl<E: ExtensionField> MockProver<E> {
                     Arc::into_inner(wit_infer_by_expr(
                         &[],
                         &layer_wit
-                            .bases
+                            .wits
                             .iter()
                             .map(|mle| mle.as_view().into())
                             .chain(eqs.clone())
@@ -135,7 +136,7 @@ impl<E: ExtensionField> MockProver<E> {
                     }
                 }
             }
-            for (in_pos, base) in izip!(&layer.in_eval_expr, &layer_wit.bases) {
+            for (in_pos, base) in izip!(&layer.in_eval_expr, &layer_wit.wits) {
                 *(in_pos.entry_mut(&mut evaluations)) = base.evaluations().as_borrowed_view();
             }
         }

--- a/gkr_iop/src/precompiles/bitwise_keccakf.rs
+++ b/gkr_iop/src/precompiles/bitwise_keccakf.rs
@@ -10,7 +10,7 @@ use crate::{
     },
 };
 use ff_ext::ExtensionField;
-use itertools::{Itertools, chain, iproduct};
+use itertools::{Itertools, chain, iproduct, izip};
 use multilinear_extensions::{
     Expression, ToExpr,
     mle::{MultilinearExtension, Point, PointAndEval},
@@ -28,14 +28,25 @@ use witness::{InstancePaddingStrategy, RowMajorMatrix};
 #[derive(Clone, Debug, Default)]
 pub struct KeccakParams {}
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct KeccakLayout<E: ExtensionField> {
     _params: KeccakParams,
 
-    committed_bits_id: usize,
+    committed_bits_id: [usize; STATE_SIZE],
 
     _result: Vec<EvalExpression<E>>,
     _marker: PhantomData<E>,
+}
+
+impl<E: ExtensionField> Default for KeccakLayout<E> {
+    fn default() -> Self {
+        Self {
+            _params: KeccakParams {},
+            committed_bits_id: [0; STATE_SIZE],
+            _result: vec![],
+            _marker: PhantomData,
+        }
+    }
 }
 
 const X: usize = 5;
@@ -179,13 +190,13 @@ impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
     }
 
     fn build_commit_phase(&mut self, chip: &mut Chip<E>) {
-        [self.committed_bits_id] = chip.allocate_committed();
+        self.committed_bits_id = chip.allocate_committed();
     }
 
     fn build_gkr_phase(&mut self, chip: &mut Chip<E>) {
         let final_output = chip.allocate_output_evals::<STATE_SIZE>();
 
-        (0..ROUNDS).rev().fold(final_output, |round_output, round| {
+        let input_eval_exprs = (0..ROUNDS).rev().fold(final_output, |round_output, round| {
             let (chi_output, [eq]) = chip.allocate_wits_in_zero_layer::<STATE_SIZE, 1>();
 
             let exprs = (0..STATE_SIZE)
@@ -323,7 +334,9 @@ impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
             state.iter().map(|e| e.1.clone()).collect_vec()
         });
 
-        // Skip base opening allocation
+        izip!(&self.committed_bits_id, input_eval_exprs).for_each(|(id, expr)| {
+            chip.allocate_opening(*id, expr);
+        });
     }
 }
 
@@ -331,7 +344,7 @@ pub struct KeccakTrace<E: ExtensionField> {
     pub bits: RowMajorMatrix<E::BaseField>,
 }
 
-impl<'a, E> ProtocolWitnessGenerator<'a, E> for KeccakLayout<E>
+impl<E> ProtocolWitnessGenerator<'_, E> for KeccakLayout<E>
 where
     E: ExtensionField,
 {
@@ -406,7 +419,7 @@ pub fn run_keccakf<E: ExtensionField>(
 
     // Omit the commit phase1 and phase2.
     let span = entered_span!("gkr_witness", profiling_1 = true);
-    let (gkr_witness, _gkr_output) = layout.gkr_witness(&gkr_circuit, &phase1_witness, &[]);
+    let (gkr_witness, gkr_output) = layout.gkr_witness(&gkr_circuit, &phase1_witness, &[]);
     exit_span!(span);
 
     let out_evals = {
@@ -417,7 +430,7 @@ pub fn run_keccakf<E: ExtensionField>(
             // sanity check on first instance only
             // TODO test all instances
             let result_from_witness = gkr_witness.layers[0]
-                .bases
+                .wits
                 .iter()
                 .map(|bit| {
                     if <E as ExtensionField>::BaseField::ZERO == bit.get_base_field_vec()[0] {
@@ -441,8 +454,9 @@ pub fn run_keccakf<E: ExtensionField>(
             );
         }
 
-        gkr_witness.layers[0]
-            .bases
+        gkr_output
+            .0
+            .wits
             .iter()
             .map(|bit| PointAndEval {
                 point: point.clone(),
@@ -470,10 +484,16 @@ pub fn run_keccakf<E: ExtensionField>(
 
             // TODO verify output
             let mut point = Point::new();
-            point.extend(verifier_transcript.sample_vec(1).to_vec());
+            point.extend(verifier_transcript.sample_vec(log2_num_instances).to_vec());
 
             gkr_circuit
-                .verify(1, gkr_proof, &out_evals, &[], &mut verifier_transcript)
+                .verify(
+                    log2_num_instances,
+                    gkr_proof,
+                    &out_evals,
+                    &[],
+                    &mut verifier_transcript,
+                )
                 .expect("GKR verify failed");
 
             // Omit the PCS opening phase.
@@ -502,6 +522,6 @@ mod tests {
         let states: Vec<[u64; 25]> = (0..num_instance)
             .map(|_| std::array::from_fn(|_| rng.gen()))
             .collect_vec();
-        run_keccakf::<E>(setup_gkr_circuit(), states, false, false);
+        run_keccakf::<E>(setup_gkr_circuit(), states, false, false); // TODO: fix this, currently the output is wrong.
     }
 }

--- a/gkr_iop/src/precompiles/lookup_keccakf.rs
+++ b/gkr_iop/src/precompiles/lookup_keccakf.rs
@@ -1,4 +1,4 @@
-use std::{array, cmp::Ordering, marker::PhantomData};
+use std::{cmp::Ordering, marker::PhantomData};
 
 use crate::gkr::booleanhypercube::BooleanHypercube;
 use ff_ext::ExtensionField;
@@ -43,7 +43,8 @@ use super::utils::CenoLookup;
 pub struct KeccakParams {}
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct KeccakLayerLayout {
+pub struct KeccakLayout<E> {
+    input8: Vec<usize>,
     c_aux: Vec<usize>,
     c_temp: Vec<usize>,
     c_rot: Vec<usize>,
@@ -54,12 +55,6 @@ pub struct KeccakLayerLayout {
     nonlinear: Vec<usize>,
     chi_output: Vec<usize>,
     iota_output: Vec<usize>,
-}
-
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct KeccakLayout<E> {
-    keccak_input8: Vec<usize>,
-    keccak_layers: [KeccakLayerLayout; 1],
     _marker: PhantomData<E>,
 }
 
@@ -375,7 +370,7 @@ macro_rules! allocate_and_split {
 }
 
 macro_rules! split_from_offset {
-    ($witnesses:expr, $offset:ident, $total:expr, $( $size:expr ),* ) => {{
+    ($witnesses:expr, $offset:expr, $total:expr, $( $size:expr ),* ) => {{
         let mut iter = $witnesses[$offset..].iter().cloned();
         (
             $(
@@ -396,50 +391,35 @@ impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
 
     fn build_commit_phase(&mut self, chip: &mut Chip<E>) {
         let bases = chip.allocate_committed::<KECCAK_WIT_SIZE>();
-        self.keccak_input8 = bases[..KECCAK_LAYER_BYTE_SIZE].to_vec();
 
-        let mut offset = KECCAK_LAYER_BYTE_SIZE;
-        self.keccak_layers = array::from_fn(|_| {
-            let (
-                c_aux,
-                c_temp,
-                c_rot,
-                d,
-                theta_output,
-                rotation_witness,
-                rhopi_output,
-                nonlinear,
-                chi_output,
-                iota_output,
-            ) = split_from_offset!(
-                bases,
-                offset,
-                KECCAK_WIT_SIZE_PER_ROUND,
-                200,
-                30,
-                40,
-                40,
-                200,
-                146,
-                200,
-                200,
-                8,
-                200
-            );
-            offset += KECCAK_WIT_SIZE_PER_ROUND;
-            KeccakLayerLayout {
-                c_aux,
-                c_temp,
-                c_rot,
-                d,
-                theta_output,
-                rotation_witness,
-                rhopi_output,
-                nonlinear,
-                chi_output,
-                iota_output,
-            }
-        });
+        (
+            self.input8,
+            self.c_aux,
+            self.c_temp,
+            self.c_rot,
+            self.d,
+            self.theta_output,
+            self.rotation_witness,
+            self.rhopi_output,
+            self.nonlinear,
+            self.chi_output,
+            self.iota_output,
+        ) = split_from_offset!(
+            bases,
+            0,
+            KECCAK_WIT_SIZE,
+            KECCAK_LAYER_BYTE_SIZE,
+            200,
+            30,
+            40,
+            40,
+            200,
+            146,
+            200,
+            200,
+            8,
+            200
+        );
     }
 
     fn build_gkr_phase(&mut self, chip: &mut Chip<E>) {
@@ -467,14 +447,14 @@ impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
         // TODO   - group1: lookup one group (due to same tower prover length)
         // TODO   - group2: read/write another group
         // NOTE: eq order must follow gkr prover/verifier backend concat eq order
-        let (bases, [eq_zero, eq_rotation_left, eq_rotation_right, eq_rotation]) =
+        let (wits, [eq_zero, eq_rotation_left, eq_rotation_right, eq_rotation]) =
             chip.allocate_wits_in_zero_layer::<KECCAK_WIT_SIZE, 4>();
-        for (openings, wit) in bases.iter().enumerate() {
+        for (openings, wit) in wits.iter().enumerate() {
             chip.allocate_opening(openings, wit.1.clone());
         }
 
-        let keccak_input8 = &bases[..KECCAK_LAYER_BYTE_SIZE];
-        let keccak_output8 = &bases[KECCAK_WIT_SIZE - KECCAK_LAYER_BYTE_SIZE..];
+        let keccak_input8 = &wits[..KECCAK_LAYER_BYTE_SIZE];
+        let keccak_output8 = &wits[KECCAK_WIT_SIZE - KECCAK_LAYER_BYTE_SIZE..];
 
         let mut system = ConstraintSystem::new();
 
@@ -491,9 +471,9 @@ impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
             chi_output,
             iota_output,
         ) = split_from_offset!(
-            bases,
+            wits,
             KECCAK_LAYER_BYTE_SIZE,
-            KECCAK_WIT_SIZE_PER_ROUND,
+            KECCAK_WIT_SIZE,
             200,
             30,
             40,
@@ -507,8 +487,9 @@ impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
         );
 
         {
-            let n_wits = 200 + 30 + 40 + 40 + 200 + 146 + 200 + 200 + 8 + 200;
-            assert_eq!(KECCAK_WIT_SIZE_PER_ROUND, n_wits);
+            let n_wits =
+                KECCAK_LAYER_BYTE_SIZE + 200 + 30 + 40 + 40 + 200 + 146 + 200 + 200 + 8 + 200;
+            assert_eq!(KECCAK_WIT_SIZE, n_wits);
         }
 
         // TODO: ndarrays can be replaced with normal arrays
@@ -677,7 +658,6 @@ impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
             }
         }
 
-        // TODO: 24/25 elements stay the same after Iota; eliminate duplication?
         let iota_output_arr: ArrayView<(WitIn, EvalExpression<E>), Ix3> =
             ArrayView::from_shape((5, 5, 8), &iota_output).unwrap();
 
@@ -791,7 +771,7 @@ impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
             LayerType::Zerocheck,
             expressions,
             vec![],
-            bases.into_iter().map(|e| e.1).collect_vec(),
+            wits.into_iter().map(|e| e.1).collect_vec(),
             vec![(Some(eq_zero.0.expr()), evals)],
             (
                 (
@@ -815,7 +795,7 @@ pub struct KeccakTrace {
     pub instances: Vec<[u32; KECCAK_INPUT_SIZE]>,
 }
 
-impl<'a, E> ProtocolWitnessGenerator<'a, E> for KeccakLayout<E>
+impl<E> ProtocolWitnessGenerator<'_, E> for KeccakLayout<E>
 where
     E: ExtensionField,
 {
@@ -1055,8 +1035,7 @@ pub fn run_faster_keccakf<E: ExtensionField>(
     let mut prover_transcript = BasicTranscript::<E>::new(b"protocol");
 
     let span = entered_span!("gkr_witness", profiling_2 = true);
-    // Omit the commit phase1 and phase2.
-    let (gkr_witness, _gkr_output) = layout.gkr_witness(&gkr_circuit, &phase1_witness, &[]);
+    let (gkr_witness, gkr_output) = layout.gkr_witness(&gkr_circuit, &phase1_witness, &[]);
     exit_span!(span);
 
     let span = entered_span!("out_eval", profiling_2 = true);
@@ -1075,7 +1054,7 @@ pub fn run_faster_keccakf<E: ExtensionField>(
                 .layers
                 .last()
                 .unwrap()
-                .bases
+                .wits
                 .iter()
                 .take(KECCAK_OUTPUT_SIZE)
             {
@@ -1107,16 +1086,16 @@ pub fn run_faster_keccakf<E: ExtensionField>(
             // }
         }
 
-        let out_evals = _gkr_output
+        let out_evals = gkr_output
             .0
-            .bases
+            .wits
             .par_iter()
-            .map(|base| PointAndEval {
+            .map(|wit| PointAndEval {
                 point: point.clone(),
-                eval: if base.num_vars() == 0 {
-                    base.get_base_field_vec()[0].into()
+                eval: if wit.num_vars() == 0 {
+                    wit.get_base_field_vec()[0].into()
                 } else {
-                    base.evaluate(&point)
+                    wit.evaluate(&point)
                 },
             })
             .collect::<Vec<_>>();
@@ -1145,8 +1124,8 @@ pub fn run_faster_keccakf<E: ExtensionField>(
             let mut verifier_transcript = BasicTranscript::<E>::new(b"protocol");
 
             // This is to make prover/verifier match
-            let mut _point = Vec::with_capacity(log2_num_instance_rounds);
-            _point.extend(
+            let mut point = Vec::with_capacity(log2_num_instance_rounds);
+            point.extend(
                 verifier_transcript
                     .sample_vec(log2_num_instance_rounds)
                     .to_vec(),
@@ -1185,7 +1164,7 @@ mod tests {
             states.push(std::array::from_fn(|_| rng.gen()));
         }
         // TODO enable check
-        let _ = run_faster_keccakf(setup_gkr_circuit::<E>(), states, false, false);
+        let _ = run_faster_keccakf(setup_gkr_circuit::<E>(), states, true, true);
     }
 
     #[ignore]
@@ -1202,6 +1181,6 @@ mod tests {
         }
 
         // TODO enable check
-        let _ = run_faster_keccakf(setup_gkr_circuit::<E>(), states, false, false);
+        let _ = run_faster_keccakf(setup_gkr_circuit::<E>(), states, true, true);
     }
 }

--- a/multilinear_extensions/src/expression.rs
+++ b/multilinear_extensions/src/expression.rs
@@ -975,20 +975,21 @@ pub fn wit_infer_by_expr<'a, E: ExtensionField>(
         &|witness_id, _, _, _| structual_witnesses[witness_id as usize].clone(),
         &|i| instance[i.0].clone(),
         &|scalar| {
-            let scalar: ArcMultilinearExtension<E> =
-                MultilinearExtension::from_evaluations_vec(0, vec![
-                    scalar.left().expect("do not support extension field"),
-                ])
-                .into();
+            let scalar: ArcMultilinearExtension<E> = MultilinearExtension::from_evaluations_vec(
+                0,
+                vec![scalar.left().expect("do not support extension field")],
+            )
+            .into();
             scalar
         },
         &|challenge_id, pow, scalar, offset| {
             // TODO cache challenge power to be acquired once for each power
             let challenge = challenges[challenge_id as usize];
             let challenge: ArcMultilinearExtension<E> =
-                MultilinearExtension::from_evaluations_ext_vec(0, vec![
-                    challenge.exp_u64(pow as u64) * scalar + offset,
-                ])
+                MultilinearExtension::from_evaluations_ext_vec(
+                    0,
+                    vec![challenge.exp_u64(pow as u64) * scalar + offset],
+                )
                 .into();
             challenge
         },

--- a/multilinear_extensions/src/expression.rs
+++ b/multilinear_extensions/src/expression.rs
@@ -14,7 +14,7 @@ use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIter
 use serde::de::DeserializeOwned;
 use std::{
     cmp::max,
-    fmt::Display,
+    fmt::{Debug, Display},
     iter::{Product, Sum},
     ops::{Add, AddAssign, Deref, Mul, MulAssign, Neg, Shl, ShlAssign, Sub, SubAssign},
 };
@@ -23,9 +23,7 @@ pub type WitnessId = u16;
 pub type ChallengeId = u16;
 pub const MIN_PAR_SIZE: usize = 64;
 
-#[derive(
-    Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
-)]
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
 #[serde(bound = "E: ExtensionField + DeserializeOwned")]
 pub enum Expression<E: ExtensionField> {
     /// WitIn(Id)
@@ -49,6 +47,33 @@ pub enum Expression<E: ExtensionField> {
     ScaledSum(Box<Expression<E>>, Box<Expression<E>>, Box<Expression<E>>),
     /// Challenge(challenge_id, power, scalar, offset)
     Challenge(ChallengeId, usize, E, E),
+}
+
+impl<E: ExtensionField> Debug for Expression<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Expression::WitIn(id) => write!(f, "W[{}]", id),
+            Expression::StructuralWitIn(id, _max_len, _offset, _multi_factor) => {
+                write!(f, "S[{}]", id)
+            }
+            Expression::Fixed(fixed) => write!(f, "F[{}]", fixed.0),
+            Expression::Instance(instance) => write!(f, "I[{}]", instance.0),
+            Expression::Constant(c) => write!(f, "C[{}]", c),
+            Expression::Sum(a, b) => write!(f, "({} + {})", a, b),
+            Expression::Product(a, b) => write!(f, "({} * {})", a, b),
+            Expression::ScaledSum(x, a, b) => write!(f, "{} * {} + {}", x, a, b),
+            Expression::Challenge(challenge_id, pow, scalar, offset) => {
+                write!(
+                    f,
+                    "C({})^{} * {:?} + {:?}",
+                    challenge_id,
+                    pow,
+                    scalar.to_canonical_u64_vec(),
+                    offset.to_canonical_u64_vec(),
+                )
+            }
+        }
+    }
 }
 
 /// this is used as finite state machine state
@@ -111,6 +136,20 @@ impl<E: ExtensionField> Expression<E> {
             product,
             scaled,
         )
+    }
+
+    pub fn evaluate_constant<T>(
+        &self,
+        constant: &impl Fn(Either<E::BaseField, E>) -> T,
+        challenge: &impl Fn(ChallengeId, usize, E, E) -> T,
+    ) -> T {
+        match self {
+            Expression::Constant(either) => constant(*either),
+            Expression::Challenge(challenge_id, pow, scalar, offset) => {
+                challenge(*challenge_id, *pow, *scalar, *offset)
+            }
+            _ => unimplemented!("unsupported"),
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -936,21 +975,20 @@ pub fn wit_infer_by_expr<'a, E: ExtensionField>(
         &|witness_id, _, _, _| structual_witnesses[witness_id as usize].clone(),
         &|i| instance[i.0].clone(),
         &|scalar| {
-            let scalar: ArcMultilinearExtension<E> = MultilinearExtension::from_evaluations_vec(
-                0,
-                vec![scalar.left().expect("do not support extension field")],
-            )
-            .into();
+            let scalar: ArcMultilinearExtension<E> =
+                MultilinearExtension::from_evaluations_vec(0, vec![
+                    scalar.left().expect("do not support extension field"),
+                ])
+                .into();
             scalar
         },
         &|challenge_id, pow, scalar, offset| {
             // TODO cache challenge power to be acquired once for each power
             let challenge = challenges[challenge_id as usize];
             let challenge: ArcMultilinearExtension<E> =
-                MultilinearExtension::from_evaluations_ext_vec(
-                    0,
-                    vec![challenge.exp_u64(pow as u64) * scalar + offset],
-                )
+                MultilinearExtension::from_evaluations_ext_vec(0, vec![
+                    challenge.exp_u64(pow as u64) * scalar + offset,
+                ])
                 .into();
             challenge
         },

--- a/multilinear_extensions/src/expression/utils.rs
+++ b/multilinear_extensions/src/expression/utils.rs
@@ -17,6 +17,10 @@ impl StructuralWitIn {
     }
 }
 
+pub fn eval_by_expr_constant<E: ExtensionField>(challenges: &[E], expr: &Expression<E>) -> E {
+    eval_by_expr_with_fixed(&[], &[], &[], challenges, expr)
+}
+
 pub fn eval_by_expr<E: ExtensionField>(
     witnesses: &[E],
     structural_witnesses: &[E],

--- a/multilinear_extensions/src/mle.rs
+++ b/multilinear_extensions/src/mle.rs
@@ -934,6 +934,7 @@ macro_rules! op_mle {
             }
             $crate::mle::FieldType::Ext(a) => {
                 let $tmp_a = &a[..];
+                #[allow(clippy::useless_conversion)]
                 $op
             }
             _ => unreachable!(),

--- a/sumcheck/benches/devirgo_sumcheck.rs
+++ b/sumcheck/benches/devirgo_sumcheck.rs
@@ -119,11 +119,14 @@ fn devirgo_sumcheck_fn(c: &mut Criterion) {
                         let mut prover_transcript = Transcript::new(b"test");
                         let (_, fs) = { prepare_input(nv) };
 
-                        let virtual_poly_v2 =
-                            VirtualPolynomials::new_from_monimials(threads, nv, vec![Term {
+                        let virtual_poly_v2 = VirtualPolynomials::new_from_monimials(
+                            threads,
+                            nv,
+                            vec![Term {
                                 scalar: Either::Right(E::ONE),
                                 product: fs.iter().map(Either::Left).collect_vec(),
-                            }]);
+                            }],
+                        );
                         let instant = std::time::Instant::now();
                         let (_sumcheck_proof_v2, _) =
                             IOPProverState::<E>::prove(virtual_poly_v2, &mut prover_transcript);
@@ -157,11 +160,14 @@ fn devirgo_sumcheck_fn(c: &mut Criterion) {
                             })
                             .collect_vec();
 
-                        let virtual_poly_v2 =
-                            VirtualPolynomials::new_from_monimials(threads, nv, vec![Term {
+                        let virtual_poly_v2 = VirtualPolynomials::new_from_monimials(
+                            threads,
+                            nv,
+                            vec![Term {
                                 scalar: Either::Right(E::ONE),
                                 product: fs.iter().map(Either::Left).collect_vec(),
-                            }]);
+                            }],
+                        );
                         let instant = std::time::Instant::now();
                         let (_sumcheck_proof_v2, _) =
                             IOPProverState::<E>::prove(virtual_poly_v2, &mut prover_transcript);
@@ -195,11 +201,14 @@ fn devirgo_sumcheck_fn(c: &mut Criterion) {
                             })
                             .collect_vec();
 
-                        let virtual_poly_v2 =
-                            VirtualPolynomials::new_from_monimials(threads, nv, vec![Term {
+                        let virtual_poly_v2 = VirtualPolynomials::new_from_monimials(
+                            threads,
+                            nv,
+                            vec![Term {
                                 scalar: Either::Right(E::ONE),
                                 product: fs.iter_mut().map(Either::Right).collect_vec(),
-                            }]);
+                            }],
+                        );
                         let instant = std::time::Instant::now();
                         let (_sumcheck_proof_v2, _) =
                             IOPProverState::<E>::prove(virtual_poly_v2, &mut prover_transcript);

--- a/sumcheck/benches/devirgo_sumcheck.rs
+++ b/sumcheck/benches/devirgo_sumcheck.rs
@@ -119,14 +119,11 @@ fn devirgo_sumcheck_fn(c: &mut Criterion) {
                         let mut prover_transcript = Transcript::new(b"test");
                         let (_, fs) = { prepare_input(nv) };
 
-                        let virtual_poly_v2 = VirtualPolynomials::new_from_monimials(
-                            threads,
-                            nv,
-                            vec![Term {
+                        let virtual_poly_v2 =
+                            VirtualPolynomials::new_from_monimials(threads, nv, vec![Term {
                                 scalar: Either::Right(E::ONE),
                                 product: fs.iter().map(Either::Left).collect_vec(),
-                            }],
-                        );
+                            }]);
                         let instant = std::time::Instant::now();
                         let (_sumcheck_proof_v2, _) =
                             IOPProverState::<E>::prove(virtual_poly_v2, &mut prover_transcript);
@@ -160,14 +157,11 @@ fn devirgo_sumcheck_fn(c: &mut Criterion) {
                             })
                             .collect_vec();
 
-                        let virtual_poly_v2 = VirtualPolynomials::new_from_monimials(
-                            threads,
-                            nv,
-                            vec![Term {
+                        let virtual_poly_v2 =
+                            VirtualPolynomials::new_from_monimials(threads, nv, vec![Term {
                                 scalar: Either::Right(E::ONE),
                                 product: fs.iter().map(Either::Left).collect_vec(),
-                            }],
-                        );
+                            }]);
                         let instant = std::time::Instant::now();
                         let (_sumcheck_proof_v2, _) =
                             IOPProverState::<E>::prove(virtual_poly_v2, &mut prover_transcript);
@@ -201,14 +195,11 @@ fn devirgo_sumcheck_fn(c: &mut Criterion) {
                             })
                             .collect_vec();
 
-                        let virtual_poly_v2 = VirtualPolynomials::new_from_monimials(
-                            threads,
-                            nv,
-                            vec![Term {
+                        let virtual_poly_v2 =
+                            VirtualPolynomials::new_from_monimials(threads, nv, vec![Term {
                                 scalar: Either::Right(E::ONE),
                                 product: fs.iter_mut().map(Either::Right).collect_vec(),
-                            }],
-                        );
+                            }]);
                         let instant = std::time::Instant::now();
                         let (_sumcheck_proof_v2, _) =
                             IOPProverState::<E>::prove(virtual_poly_v2, &mut prover_transcript);

--- a/sumcheck/src/prover.rs
+++ b/sumcheck/src/prover.rs
@@ -510,13 +510,10 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
 
         // return empty proof when target polymonial is constant
         if num_variables == 0 {
-            return (
-                IOPProof::default(),
-                IOPProverState {
-                    poly,
-                    ..Default::default()
-                },
-            );
+            return (IOPProof::default(), IOPProverState {
+                poly,
+                ..Default::default()
+            });
         }
         let start = entered_span!("sum check prove");
 
@@ -711,7 +708,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
     }
 }
 
-impl<'a, E: ExtensionField> IOPProverState<'a, E> {
+impl<E: ExtensionField> IOPProverState<'_, E> {
     pub fn push_challenges(&mut self, challenge: Vec<Challenge<E>>) {
         self.challenges.extend(challenge)
     }

--- a/sumcheck/src/prover.rs
+++ b/sumcheck/src/prover.rs
@@ -510,10 +510,13 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
 
         // return empty proof when target polymonial is constant
         if num_variables == 0 {
-            return (IOPProof::default(), IOPProverState {
-                poly,
-                ..Default::default()
-            });
+            return (
+                IOPProof::default(),
+                IOPProverState {
+                    poly,
+                    ..Default::default()
+                },
+            );
         }
         let start = entered_span!("sum check prove");
 

--- a/sumcheck/src/structs.rs
+++ b/sumcheck/src/structs.rs
@@ -1,7 +1,5 @@
 use ff_ext::ExtensionField;
-use multilinear_extensions::{
-    Expression, virtual_poly::VirtualPolynomial, virtual_polys::PolyMeta,
-};
+use multilinear_extensions::{virtual_poly::VirtualPolynomial, virtual_polys::PolyMeta};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use thiserror::Error;
 use transcript::Challenge;
@@ -77,6 +75,6 @@ pub struct SumCheckSubClaim<E: ExtensionField> {
 
 #[derive(Clone, Debug, Error)]
 pub enum VerifierError<E: ExtensionField> {
-    #[error("Claim not match: expr: {0:?}\n (expr name: {3:?})\n expect: {1:?}, got: {2:?}")]
-    ClaimNotMatch(Expression<E>, E, E, String),
+    #[error("Claim not match: expect: {0:?}, got: {1:?}")]
+    ClaimNotMatch(E, E),
 }


### PR DESCRIPTION
Here is a summary of the updates in this PR:
1. Correct the previous typo in the rotation prover, and add a rotation verifier.
2. Change the selector formular:
	0(rt) = \sum_{b \in \{0, 1\}^n} sel(rt, b) * (\sum_i alpha^i * rotated[i](b) - target[i](b)))
   where sel(rt, b) = eq(rt[5..], b[5..]) * sel'(rt[..5], b[..5])
   where sel'(rt', b') = b' in rotated[0..24] ? eq(rt', b') : 0.
3. Refine the default method `gkr_witness`. Previously, it assumes the `phase1_witnesses` are connected to the input layer in the same order. In a more general case, the `phase1` witnesses can be connected to the wires in any layer, which is set by `allocate_opening` method. I modify `gkr_witness` in consider of this case.

| Benchmark                  | My PC Running Time | Median Change (%) |
|----------------------------|--------------------|-------------------|
| prove_keccak_lookup_f_4096 | 4.7770 s           | -10.773%          |
| prove_keccak_lookup_f_8192 | 11.178 s           | -1.9963%          |