### PR TITLE
Chore: bump up plonky3 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,7 +1895,7 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -1921,7 +1921,7 @@ dependencies = [
 [[package]]
 name = "p3-commit"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-challenger",
@@ -1935,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -1948,7 +1948,7 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -1965,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "p3-fri"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-challenger",
@@ -1984,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "p3-goldilocks"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "num-bigint",
  "p3-dft",
@@ -2001,7 +2001,7 @@ dependencies = [
 [[package]]
 name = "p3-interpolation"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -2012,7 +2012,7 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -2027,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "rayon",
 ]
@@ -2035,7 +2035,7 @@ dependencies = [
 [[package]]
 name = "p3-mds"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-dft",
@@ -2049,7 +2049,7 @@ dependencies = [
 [[package]]
 name = "p3-merkle-tree"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-commit",
@@ -2066,7 +2066,7 @@ dependencies = [
 [[package]]
 name = "p3-monty-31"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -2087,7 +2087,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -2098,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "gcd",
  "p3-field",
@@ -2110,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -2120,7 +2120,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
+source = "git+https://github.com/Plonky3/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,12 +1024,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "forward_ref"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,7 +1895,7 @@ dependencies = [
 [[package]]
 name = "p3-baby-bear"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=20c3cb9#20c3cb9119da0d5196d7a2e7b2e4f1a62dc8cae7"
+source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -1915,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "p3-challenger"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=20c3cb9#20c3cb9119da0d5196d7a2e7b2e4f1a62dc8cae7"
+source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -1927,7 +1921,7 @@ dependencies = [
 [[package]]
 name = "p3-commit"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=20c3cb9#20c3cb9119da0d5196d7a2e7b2e4f1a62dc8cae7"
+source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-challenger",
@@ -1941,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "p3-dft"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=20c3cb9#20c3cb9119da0d5196d7a2e7b2e4f1a62dc8cae7"
+source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -1954,9 +1948,8 @@ dependencies = [
 [[package]]
 name = "p3-field"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=20c3cb9#20c3cb9119da0d5196d7a2e7b2e4f1a62dc8cae7"
+source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
- "forward_ref",
  "itertools 0.14.0",
  "num-bigint",
  "num-integer",
@@ -1964,7 +1957,6 @@ dependencies = [
  "nums",
  "p3-maybe-rayon",
  "p3-util",
- "paste",
  "rand",
  "serde",
  "tracing",
@@ -1973,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "p3-fri"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=20c3cb9#20c3cb9119da0d5196d7a2e7b2e4f1a62dc8cae7"
+source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-challenger",
@@ -1992,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "p3-goldilocks"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=20c3cb9#20c3cb9119da0d5196d7a2e7b2e4f1a62dc8cae7"
+source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "num-bigint",
  "p3-dft",
@@ -2002,7 +1994,6 @@ dependencies = [
  "p3-poseidon2",
  "p3-symmetric",
  "p3-util",
- "paste",
  "rand",
  "serde",
 ]
@@ -2010,7 +2001,7 @@ dependencies = [
 [[package]]
 name = "p3-interpolation"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=20c3cb9#20c3cb9119da0d5196d7a2e7b2e4f1a62dc8cae7"
+source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -2021,7 +2012,7 @@ dependencies = [
 [[package]]
 name = "p3-matrix"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=20c3cb9#20c3cb9119da0d5196d7a2e7b2e4f1a62dc8cae7"
+source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -2036,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "p3-maybe-rayon"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=20c3cb9#20c3cb9119da0d5196d7a2e7b2e4f1a62dc8cae7"
+source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "rayon",
 ]
@@ -2044,7 +2035,7 @@ dependencies = [
 [[package]]
 name = "p3-mds"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=20c3cb9#20c3cb9119da0d5196d7a2e7b2e4f1a62dc8cae7"
+source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-dft",
@@ -2058,7 +2049,7 @@ dependencies = [
 [[package]]
 name = "p3-merkle-tree"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=20c3cb9#20c3cb9119da0d5196d7a2e7b2e4f1a62dc8cae7"
+source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-commit",
@@ -2075,7 +2066,7 @@ dependencies = [
 [[package]]
 name = "p3-monty-31"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=20c3cb9#20c3cb9119da0d5196d7a2e7b2e4f1a62dc8cae7"
+source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -2087,7 +2078,6 @@ dependencies = [
  "p3-poseidon2",
  "p3-symmetric",
  "p3-util",
- "paste",
  "rand",
  "serde",
  "tracing",
@@ -2097,7 +2087,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=20c3cb9#20c3cb9119da0d5196d7a2e7b2e4f1a62dc8cae7"
+source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -2108,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "p3-poseidon2"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=20c3cb9#20c3cb9119da0d5196d7a2e7b2e4f1a62dc8cae7"
+source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "gcd",
  "p3-field",
@@ -2120,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "p3-symmetric"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=20c3cb9#20c3cb9119da0d5196d7a2e7b2e4f1a62dc8cae7"
+source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -2130,7 +2120,7 @@ dependencies = [
 [[package]]
 name = "p3-util"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/plonky3?rev=20c3cb9#20c3cb9119da0d5196d7a2e7b2e4f1a62dc8cae7"
+source = "git+https://github.com/scroll-tech/plonky3?rev=1ba4e5c#1ba4e5c40417f4f7aae86bcca56b6484b4b2490b"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,21 +43,21 @@ num-bigint = { version = "0.4.6" }
 num-derive = "0.4"
 num-traits = "0.2"
 p3 = { path = "p3" }
-p3-baby-bear = { git = "https://github.com/scroll-tech/plonky3", rev = "20c3cb9" }
-p3-challenger = { git = "https://github.com/scroll-tech/plonky3", rev = "20c3cb9" }
-p3-commit = { git = "https://github.com/scroll-tech/plonky3", rev = "20c3cb9" }
-p3-dft = { git = "https://github.com/scroll-tech/plonky3", rev = "20c3cb9" }
-p3-field = { git = "https://github.com/scroll-tech/plonky3", rev = "20c3cb9" }
-p3-fri = { git = "https://github.com/scroll-tech/plonky3", rev = "20c3cb9" }
-p3-goldilocks = { git = "https://github.com/scroll-tech/plonky3", rev = "20c3cb9" }
-p3-matrix = { git = "https://github.com/scroll-tech/plonky3", rev = "20c3cb9" }
-p3-maybe-rayon = { git = "https://github.com/scroll-tech/plonky3", rev = "20c3cb9" }
-p3-mds = { git = "https://github.com/scroll-tech/plonky3", rev = "20c3cb9" }
-p3-merkle-tree = { git = "https://github.com/scroll-tech/plonky3", rev = "20c3cb9" }
-p3-poseidon = { git = "https://github.com/scroll-tech/plonky3", rev = "20c3cb9" }
-p3-poseidon2 = { git = "https://github.com/scroll-tech/plonky3", rev = "20c3cb9" }
-p3-symmetric = { git = "https://github.com/scroll-tech/plonky3", rev = "20c3cb9" }
-p3-util = { git = "https://github.com/scroll-tech/plonky3", rev = "20c3cb9" }
+p3-baby-bear = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
+p3-challenger = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
+p3-commit = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
+p3-dft = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
+p3-field = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
+p3-fri = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
+p3-goldilocks = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
+p3-matrix = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
+p3-maybe-rayon = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
+p3-mds = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
+p3-merkle-tree = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
+p3-poseidon = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
+p3-poseidon2 = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
+p3-symmetric = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
+p3-util = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
 paste = "1"
 poseidon = { path = "./poseidon" }
 pprof2 = { version = "0.13", features = ["flamegraph"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,21 +43,21 @@ num-bigint = { version = "0.4.6" }
 num-derive = "0.4"
 num-traits = "0.2"
 p3 = { path = "p3" }
-p3-baby-bear = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
-p3-challenger = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
-p3-commit = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
-p3-dft = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
-p3-field = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
-p3-fri = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
-p3-goldilocks = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
-p3-matrix = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
-p3-maybe-rayon = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
-p3-mds = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
-p3-merkle-tree = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
-p3-poseidon = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
-p3-poseidon2 = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
-p3-symmetric = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
-p3-util = { git = "https://github.com/scroll-tech/plonky3", rev = "1ba4e5c" }
+p3-baby-bear = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
+p3-challenger = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
+p3-commit = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
+p3-dft = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
+p3-field = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
+p3-fri = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
+p3-goldilocks = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
+p3-matrix = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
+p3-maybe-rayon = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
+p3-mds = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
+p3-merkle-tree = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
+p3-poseidon = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
+p3-poseidon2 = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
+p3-symmetric = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
+p3-util = { git = "https://github.com/Plonky3/plonky3", rev = "1ba4e5c" }
 paste = "1"
 poseidon = { path = "./poseidon" }
 pprof2 = { version = "0.13", features = ["flamegraph"] }

--- a/ceno_zkvm/src/bin/e2e.rs
+++ b/ceno_zkvm/src/bin/e2e.rs
@@ -18,7 +18,7 @@ use ff_ext::{BabyBearExt4, ExtensionField, GoldilocksExt2};
 use mpcs::{
     Basefold, BasefoldRSParams, PolynomialCommitmentScheme, SecurityLevel, Whir, WhirDefaultSpec,
 };
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 use serde::{Serialize, de::DeserializeOwned};
 use std::{fs, panic, panic::AssertUnwindSafe, path::PathBuf};
 use tracing::{error, level_filters::LevelFilter};

--- a/ceno_zkvm/src/chip_handler/global_state.rs
+++ b/ceno_zkvm/src/chip_handler/global_state.rs
@@ -3,12 +3,12 @@ use ff_ext::ExtensionField;
 use super::GlobalStateRegisterMachineChipOperations;
 use crate::{circuit_builder::CircuitBuilder, error::ZKVMError, structs::RAMType};
 use multilinear_extensions::{Expression, ToExpr};
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 
 impl<E: ExtensionField> GlobalStateRegisterMachineChipOperations<E> for CircuitBuilder<'_, E> {
     fn state_in(&mut self, pc: Expression<E>, ts: Expression<E>) -> Result<(), ZKVMError> {
         let record: Vec<Expression<E>> = vec![
-            E::BaseField::from_u64(RAMType::GlobalState as u64).expr(),
+            E::BaseField::from_canonical_u64(RAMType::GlobalState as u64).expr(),
             pc,
             ts,
         ];
@@ -18,7 +18,7 @@ impl<E: ExtensionField> GlobalStateRegisterMachineChipOperations<E> for CircuitB
 
     fn state_out(&mut self, pc: Expression<E>, ts: Expression<E>) -> Result<(), ZKVMError> {
         let record: Vec<Expression<E>> = vec![
-            E::BaseField::from_u64(RAMType::GlobalState as u64).expr(),
+            E::BaseField::from_canonical_u64(RAMType::GlobalState as u64).expr(),
             pc,
             ts,
         ];

--- a/ceno_zkvm/src/chip_handler/utils.rs
+++ b/ceno_zkvm/src/chip_handler/utils.rs
@@ -3,7 +3,7 @@ use std::iter::successors;
 use ff_ext::ExtensionField;
 use itertools::izip;
 use multilinear_extensions::{Expression, ToExpr};
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 
 pub fn rlc_chip_record<E: ExtensionField>(
     records: Vec<Expression<E>>,

--- a/ceno_zkvm/src/circuit_builder.rs
+++ b/ceno_zkvm/src/circuit_builder.rs
@@ -14,7 +14,7 @@ use crate::{
     structs::{ProgramParams, ProvingKey, RAMType, VerifyingKey},
 };
 use multilinear_extensions::monomial::Term;
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 
 /// namespace used for annotation, preserve meta info during circuit construction
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
@@ -270,7 +270,7 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         record: Vec<Expression<E>>,
     ) -> Result<(), ZKVMError> {
         let rlc_record = self.rlc_chip_record(
-            std::iter::once(E::BaseField::from_u64(rom_type as u64).expr())
+            std::iter::once(E::BaseField::from_canonical_u64(rom_type as u64).expr())
                 .chain(record.clone())
                 .collect(),
         );

--- a/ceno_zkvm/src/gadgets/is_lt.rs
+++ b/ceno_zkvm/src/gadgets/is_lt.rs
@@ -242,7 +242,13 @@ impl InnerLtConfig {
         lhs: u64,
         rhs: u64,
     ) -> Result<(), ZKVMError> {
-        self.assign_instance_field(instance, lkm, F::from_u64(lhs), F::from_u64(rhs), lhs < rhs)
+        self.assign_instance_field(
+            instance,
+            lkm,
+            F::from_canonical_u64(lhs),
+            F::from_canonical_u64(rhs),
+            lhs < rhs,
+        )
     }
 
     /// Assign instance values to this configuration where the ordering is

--- a/ceno_zkvm/src/gadgets/signed_ext.rs
+++ b/ceno_zkvm/src/gadgets/signed_ext.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use ff_ext::{ExtensionField, FieldInto};
 use multilinear_extensions::{Expression, ToExpr, WitIn};
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 use std::marker::PhantomData;
 
 /// Extract the most significant bit from an expression previously constrained
@@ -103,7 +103,7 @@ impl<E: ExtensionField> SignedExtendConfig<E> {
         };
 
         assert_ux(lk_multiplicity, 2 * val - (msb << self.n_bits));
-        set_val!(instance, self.msb, E::BaseField::from_u64(msb));
+        set_val!(instance, self.msb, E::BaseField::from_canonical_u64(msb));
 
         Ok(())
     }

--- a/ceno_zkvm/src/instructions/riscv/branch/branch_circuit.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch/branch_circuit.rs
@@ -19,7 +19,7 @@ use crate::{
     witness::LkMultiplicity,
 };
 use multilinear_extensions::Expression;
-pub use p3::field::PrimeCharacteristicRing;
+pub use p3::field::FieldAlgebra;
 
 pub struct BranchCircuit<E, I>(PhantomData<(E, I)>);
 
@@ -151,8 +151,8 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BranchCircuit<E, I
         if let Some(equal) = &config.is_equal {
             equal.assign_instance(
                 instance,
-                E::BaseField::from_u64(rs2.as_u64()),
-                E::BaseField::from_u64(rs1.as_u64()),
+                E::BaseField::from_canonical_u64(rs2.as_u64()),
+                E::BaseField::from_canonical_u64(rs1.as_u64()),
             )?;
         }
 

--- a/ceno_zkvm/src/instructions/riscv/ecall/halt.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/halt.rs
@@ -16,7 +16,7 @@ use crate::{
 use ceno_emul::{StepRecord, Tracer};
 use ff_ext::{ExtensionField, FieldInto};
 use multilinear_extensions::{ToExpr, WitIn};
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 use std::marker::PhantomData;
 
 pub struct HaltConfig {
@@ -51,7 +51,7 @@ impl<E: ExtensionField> Instruction<E> for HaltInstruction<E> {
         // read exit_code from arg0 (X10 register)
         let (_, lt_x10_cfg) = cb.register_read(
             || "read x10",
-            E::BaseField::from_u64(ceno_emul::Platform::reg_arg0() as u64),
+            E::BaseField::from_canonical_u64(ceno_emul::Platform::reg_arg0() as u64),
             prev_x10_ts.expr(),
             ecall_cfg.ts.expr() + Tracer::SUBCYCLE_RS2,
             exit_code,

--- a/ceno_zkvm/src/instructions/riscv/ecall_insn.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall_insn.rs
@@ -12,7 +12,7 @@ use crate::{
 use ceno_emul::{InsnKind::ECALL, PC_STEP_SIZE, Platform, StepRecord, Tracer};
 use ff_ext::{ExtensionField, FieldInto};
 use multilinear_extensions::{Expression, ToExpr, WitIn};
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 
 pub struct EcallInstructionConfig {
     pub pc: WitIn,
@@ -51,7 +51,7 @@ impl EcallInstructionConfig {
         // read syscall_id from x5 and write return value to x5
         let (_, lt_x5_cfg) = cb.register_write(
             || "write x5",
-            E::BaseField::from_u64(Platform::reg_ecall() as u64),
+            E::BaseField::from_canonical_u64(Platform::reg_ecall() as u64),
             prev_x5_ts.expr(),
             ts.expr() + Tracer::SUBCYCLE_RS1,
             syscall_id.clone(),

--- a/ceno_zkvm/src/instructions/riscv/insn_base.rs
+++ b/ceno_zkvm/src/instructions/riscv/insn_base.rs
@@ -1,7 +1,7 @@
 use ceno_emul::{Cycle, StepRecord, Word, WriteOp};
 use ff_ext::{ExtensionField, FieldInto, SmallField};
 use itertools::Itertools;
-use p3::field::{Field, PrimeCharacteristicRing};
+use p3::field::{Field, FieldAlgebra};
 
 use super::constants::{PC_STEP_SIZE, UINT_LIMBS, UInt};
 use crate::{
@@ -436,7 +436,7 @@ impl<E: ExtensionField> MemAddr<E> {
             .sum();
 
         // Range check the middle bits, that is the low limb excluding the low bits.
-        let shift_right = E::BaseField::from_u64(1 << Self::N_LOW_BITS)
+        let shift_right = E::BaseField::from_canonical_u64(1 << Self::N_LOW_BITS)
             .inverse()
             .expr();
         let mid_u14 = (&limbs[0] - low_sum) * shift_right;

--- a/ceno_zkvm/src/instructions/riscv/jump/jalr.rs
+++ b/ceno_zkvm/src/instructions/riscv/jump/jalr.rs
@@ -18,7 +18,7 @@ use crate::{
 use ceno_emul::{InsnKind, PC_STEP_SIZE};
 use ff_ext::FieldInto;
 use multilinear_extensions::{Expression, ToExpr, WitIn};
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 
 pub struct JalrConfig<E: ExtensionField> {
     pub i_insn: IInstructionConfig<E>,

--- a/ceno_zkvm/src/instructions/riscv/memory/gadget.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/gadget.rs
@@ -10,7 +10,7 @@ use ceno_emul::StepRecord;
 use ff_ext::{ExtensionField, FieldInto};
 use itertools::izip;
 use multilinear_extensions::{Expression, ToExpr, WitIn};
-use p3::field::{Field, PrimeCharacteristicRing};
+use p3::field::{Field, FieldAlgebra};
 
 pub struct MemWordChange<const N_ZEROS: usize> {
     prev_limb_bytes: Vec<WitIn>,
@@ -76,7 +76,7 @@ impl<const N_ZEROS: usize> MemWordChange<N_ZEROS> {
 
                 // extract the least significant byte from u16 limb
                 let rs2_limb_bytes = alloc_bytes(cb, "rs2_limb[0]", 1)?;
-                let u8_base_inv = E::BaseField::from_u64(1 << 8).inverse();
+                let u8_base_inv = E::BaseField::from_canonical_u64(1 << 8).inverse();
                 cb.assert_ux::<_, _, 8>(
                     || "rs2_limb[0].le_bytes[1]",
                     u8_base_inv.expr() * (&rs2_limbs[0] - rs2_limb_bytes[0].expr()),
@@ -162,40 +162,41 @@ impl<const N_ZEROS: usize> MemWordChange<N_ZEROS> {
         match N_ZEROS {
             0 => {
                 for (&col, byte) in izip!(&self.prev_limb_bytes, prev_limb.to_le_bytes()) {
-                    set_val!(instance, col, E::BaseField::from_u8(byte));
+                    set_val!(instance, col, E::BaseField::from_canonical_u8(byte));
                     lk_multiplicity.assert_ux::<8>(byte as u64);
                 }
 
                 set_val!(
                     instance,
                     self.rs2_limb_bytes[0],
-                    E::BaseField::from_u8(rs2_limb.to_le_bytes()[0])
+                    E::BaseField::from_canonical_u8(rs2_limb.to_le_bytes()[0])
                 );
 
                 rs2_limb.to_le_bytes().into_iter().for_each(|byte| {
                     lk_multiplicity.assert_ux::<8>(byte as u64);
                 });
                 let change = if low_bits[0] == 0 {
-                    E::BaseField::from_u8(rs2_limb.to_le_bytes()[0])
-                        - E::BaseField::from_u8(prev_limb.to_le_bytes()[0])
+                    E::BaseField::from_canonical_u8(rs2_limb.to_le_bytes()[0])
+                        - E::BaseField::from_canonical_u8(prev_limb.to_le_bytes()[0])
                 } else {
-                    E::BaseField::from_u64((rs2_limb.to_le_bytes()[0] as u64) << 8)
-                        - E::BaseField::from_u64((prev_limb.to_le_bytes()[1] as u64) << 8)
+                    E::BaseField::from_canonical_u64((rs2_limb.to_le_bytes()[0] as u64) << 8)
+                        - E::BaseField::from_canonical_u64((prev_limb.to_le_bytes()[1] as u64) << 8)
                 };
                 let final_change = if low_bits[1] == 0 {
                     change
                 } else {
-                    E::BaseField::from_u64(1u64 << 16) * change
+                    E::BaseField::from_canonical_u64(1u64 << 16) * change
                 };
                 set_val!(instance, self.expected_changes[0], change);
                 set_val!(instance, self.expected_changes[1], final_change);
             }
             1 => {
                 let final_change = if low_bits[1] == 0 {
-                    E::BaseField::from_u16(rs2_limb) - E::BaseField::from_u16(prev_limb)
+                    E::BaseField::from_canonical_u16(rs2_limb)
+                        - E::BaseField::from_canonical_u16(prev_limb)
                 } else {
-                    E::BaseField::from_u64((rs2_limb as u64) << 16)
-                        - E::BaseField::from_u64((prev_limb as u64) << 16)
+                    E::BaseField::from_canonical_u64((rs2_limb as u64) << 16)
+                        - E::BaseField::from_canonical_u64((prev_limb as u64) << 16)
                 };
                 set_val!(instance, self.expected_changes[0], final_change);
             }

--- a/ceno_zkvm/src/instructions/riscv/memory/load.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/load.rs
@@ -18,7 +18,7 @@ use ceno_emul::{ByteAddr, InsnKind, StepRecord};
 use ff_ext::{ExtensionField, FieldInto};
 use itertools::izip;
 use multilinear_extensions::{Expression, ToExpr, WitIn};
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 use std::marker::PhantomData;
 
 pub struct LoadConfig<E: ExtensionField> {
@@ -221,7 +221,11 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for LoadInstruction<E,
             .memory_addr
             .assign_instance(instance, lk_multiplicity, unaligned_addr.into())?;
         if let Some(&limb) = config.target_limb.as_ref() {
-            set_val!(instance, limb, E::BaseField::from_u16(target_limb));
+            set_val!(
+                instance,
+                limb,
+                E::BaseField::from_canonical_u16(target_limb)
+            );
         }
         if let Some(limb_bytes) = config.target_limb_bytes.as_ref() {
             if addr_low_bits[0] == 1 {
@@ -231,7 +235,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for LoadInstruction<E,
             }
             for (&col, byte) in izip!(limb_bytes.iter(), target_limb_bytes.into_iter()) {
                 lk_multiplicity.assert_ux::<8>(byte as u64);
-                set_val!(instance, col, E::BaseField::from_u8(byte));
+                set_val!(instance, col, E::BaseField::from_canonical_u8(byte));
             }
         }
         let val = match I::INST_KIND {

--- a/ceno_zkvm/src/instructions/riscv/mul.rs
+++ b/ceno_zkvm/src/instructions/riscv/mul.rs
@@ -82,7 +82,7 @@ use std::marker::PhantomData;
 
 use ceno_emul::{InsnKind, StepRecord};
 use ff_ext::{ExtensionField, SmallField};
-use p3::{field::PrimeCharacteristicRing, goldilocks::Goldilocks};
+use p3::{field::FieldAlgebra, goldilocks::Goldilocks};
 
 use crate::{
     circuit_builder::CircuitBuilder,
@@ -353,8 +353,8 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for MulhInstructionBas
             }
             MulhSignDependencies::UU { constrain_rd } => {
                 // assign nonzero value (u32::MAX - rd)
-                let rd_f = E::BaseField::from_u64(rd as u64);
-                let avoid_f = E::BaseField::from_u32(u32::MAX);
+                let rd_f = E::BaseField::from_canonical_u64(rd as u64);
+                let avoid_f = E::BaseField::from_canonical_u32(u32::MAX);
                 constrain_rd.assign_instance(instance, rd_f, avoid_f)?;
 
                 // only take the low part of the product
@@ -366,8 +366,12 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for MulhInstructionBas
                 assert_eq!(prod_lo, rd);
 
                 let prod_hi = prod >> BIT_WIDTH;
-                let avoid_f = E::BaseField::from_u32(u32::MAX);
-                constrain_rd.assign_instance(instance, E::BaseField::from_u64(prod_hi), avoid_f)?;
+                let avoid_f = E::BaseField::from_canonical_u32(u32::MAX);
+                constrain_rd.assign_instance(
+                    instance,
+                    E::BaseField::from_canonical_u64(prod_hi),
+                    avoid_f,
+                )?;
                 prod_hi as u32
             }
             MulhSignDependencies::SU {

--- a/ceno_zkvm/src/scheme.rs
+++ b/ceno_zkvm/src/scheme.rs
@@ -2,7 +2,7 @@ use ff_ext::ExtensionField;
 use gkr_iop::gkr::GKRProof;
 use itertools::Itertools;
 use mpcs::PolynomialCommitmentScheme;
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -84,15 +84,17 @@ impl PublicValues {
     }
     pub fn to_vec<E: ExtensionField>(&self) -> Vec<Vec<E::BaseField>> {
         vec![
-            vec![E::BaseField::from_u32(self.exit_code & 0xffff)],
-            vec![E::BaseField::from_u32((self.exit_code >> 16) & 0xffff)],
-            vec![E::BaseField::from_u32(self.init_pc)],
-            vec![E::BaseField::from_u64(self.init_cycle)],
-            vec![E::BaseField::from_u32(self.end_pc)],
-            vec![E::BaseField::from_u64(self.end_cycle)],
+            vec![E::BaseField::from_canonical_u32(self.exit_code & 0xffff)],
+            vec![E::BaseField::from_canonical_u32(
+                (self.exit_code >> 16) & 0xffff,
+            )],
+            vec![E::BaseField::from_canonical_u32(self.init_pc)],
+            vec![E::BaseField::from_canonical_u64(self.init_cycle)],
+            vec![E::BaseField::from_canonical_u32(self.end_pc)],
+            vec![E::BaseField::from_canonical_u64(self.end_cycle)],
             self.public_io
                 .iter()
-                .map(|e| E::BaseField::from_u32(*e))
+                .map(|e| E::BaseField::from_canonical_u32(*e))
                 .collect(),
         ]
     }

--- a/ceno_zkvm/src/scheme/cpu/mod.rs
+++ b/ceno_zkvm/src/scheme/cpu/mod.rs
@@ -28,7 +28,7 @@ use multilinear_extensions::{
     virtual_polys::VirtualPolynomialsBuilder,
 };
 use p3::{
-    field::{PrimeCharacteristicRing, TwoAdicField},
+    field::{FieldAlgebra, TwoAdicField},
     matrix::dense::RowMajorMatrix,
 };
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -1339,9 +1339,12 @@ mod tests {
         let _ = RangeCheckCircuit::construct_circuit(&mut builder).unwrap();
 
         let wits_in = vec![
-            vec![Goldilocks::from_u64(3u64), Goldilocks::from_u64(5u64)]
-                .into_mle()
-                .into(),
+            vec![
+                Goldilocks::from_canonical_u64(3u64),
+                Goldilocks::from_canonical_u64(5u64),
+            ]
+            .into_mle()
+            .into(),
         ];
 
         let challenge = [1.into_f(), 1000.into_f()];
@@ -1375,7 +1378,7 @@ mod tests {
                             GoldilocksExt2::ONE,
                             GoldilocksExt2::ZERO,
                         )),
-                        Box::new(Goldilocks::from_u64(U5 as u64).expr()),
+                        Box::new(Goldilocks::from_canonical_u64(U5 as u64).expr()),
                     )),
                     Box::new(Expression::Challenge(
                         0,

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -20,7 +20,7 @@ use multilinear_extensions::{
     mle::{ArcMultilinearExtension, IntoMLEs},
     utils::{eval_by_expr, eval_by_expr_with_fixed, eval_by_expr_with_instance},
 };
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 use rand::thread_rng;
 use std::{
     cmp::max,

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -12,7 +12,7 @@ use multilinear_extensions::{
     Instance,
     mle::{IntoMLE, MultilinearExtension},
 };
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 use std::iter::Iterator;
 use sumcheck::{
     macros::{entered_span, exit_span},
@@ -194,7 +194,7 @@ impl<
                     // do nothing without point and evaluation insertion
                     return Ok::<(Vec<_>, Vec<Vec<_>>), ZKVMError>((points, evaluations));
                 }
-                transcript.append_field_element(&E::BaseField::from_u64(index as u64));
+                transcript.append_field_element(&E::BaseField::from_canonical_u64(index as u64));
                 // TODO: add an enum for circuit type either in constraint_system or vk
                 let cs = pk.get_cs();
                 let witness_mle = witness_mles

--- a/ceno_zkvm/src/scheme/tests.rs
+++ b/ceno_zkvm/src/scheme/tests.rs
@@ -33,7 +33,7 @@ use ff_ext::{Instrumented, PoseidonField};
 use itertools::Itertools;
 use mpcs::{PolynomialCommitmentScheme, SecurityLevel, WhirDefault};
 use multilinear_extensions::{mle::IntoMLE, util::ceil_log2};
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 use rand::thread_rng;
 use transcript::{BasicTranscript, Transcript};
 

--- a/ceno_zkvm/src/scheme/utils.rs
+++ b/ceno_zkvm/src/scheme/utils.rs
@@ -290,7 +290,7 @@ mod tests {
         smart_slice::SmartSlice,
         util::ceil_log2,
     };
-    use p3::field::PrimeCharacteristicRing;
+    use p3::field::FieldAlgebra;
 
     use crate::scheme::utils::{
         infer_tower_logup_witness, infer_tower_product_witness, interleaving_mles_to_mles,
@@ -301,8 +301,8 @@ mod tests {
         type E = GoldilocksExt2;
         let num_product_fanin = 2;
         let last_layer: Vec<MultilinearExtension<E>> = vec![
-            vec![E::ONE, E::from_u64(2u64)].into_mle(),
-            vec![E::from_u64(3u64), E::from_u64(4u64)].into_mle(),
+            vec![E::ONE, E::from_canonical_u64(2u64)].into_mle(),
+            vec![E::from_canonical_u64(3u64), E::from_canonical_u64(4u64)].into_mle(),
         ];
         let num_vars = ceil_log2(last_layer[0].evaluations().len()) + 1;
         let res = infer_tower_product_witness(num_vars, last_layer.clone(), 2);
@@ -335,10 +335,16 @@ mod tests {
         let num_product_fanin = 2;
         // [[1, 2], [3, 4], [5, 6], [7, 8]]
         let input_mles: Vec<ArcMultilinearExtension<E>> = vec![
-            vec![E::ONE, E::from_u64(2u64)].into_mle().into(),
-            vec![E::from_u64(3u64), E::from_u64(4u64)].into_mle().into(),
-            vec![E::from_u64(5u64), E::from_u64(6u64)].into_mle().into(),
-            vec![E::from_u64(7u64), E::from_u64(8u64)].into_mle().into(),
+            vec![E::ONE, E::from_canonical_u64(2u64)].into_mle().into(),
+            vec![E::from_canonical_u64(3u64), E::from_canonical_u64(4u64)]
+                .into_mle()
+                .into(),
+            vec![E::from_canonical_u64(5u64), E::from_canonical_u64(6u64)]
+                .into_mle()
+                .into(),
+            vec![E::from_canonical_u64(7u64), E::from_canonical_u64(8u64)]
+                .into_mle()
+                .into(),
         ];
         let res = interleaving_mles_to_mles(&input_mles, 2, num_product_fanin, E::ONE);
         // [[1, 3, 5, 7], [2, 4, 6, 8]]
@@ -346,18 +352,18 @@ mod tests {
             res[0].get_ext_field_vec(),
             vec![
                 E::ONE,
-                E::from_u64(3u64),
-                E::from_u64(5u64),
-                E::from_u64(7u64)
+                E::from_canonical_u64(3u64),
+                E::from_canonical_u64(5u64),
+                E::from_canonical_u64(7u64)
             ],
         );
         assert_eq!(
             res[1].get_ext_field_vec(),
             vec![
-                E::from_u64(2u64),
-                E::from_u64(4u64),
-                E::from_u64(6u64),
-                E::from_u64(8u64)
+                E::from_canonical_u64(2u64),
+                E::from_canonical_u64(4u64),
+                E::from_canonical_u64(6u64),
+                E::from_canonical_u64(8u64)
             ],
         );
     }
@@ -370,9 +376,13 @@ mod tests {
         // case 1: test limb level padding
         // [[1,2],[3,4],[5,6]]]
         let input_mles: Vec<ArcMultilinearExtension<E>> = vec![
-            vec![E::ONE, E::from_u64(2u64)].into_mle().into(),
-            vec![E::from_u64(3u64), E::from_u64(4u64)].into_mle().into(),
-            vec![E::from_u64(5u64), E::from_u64(6u64)].into_mle().into(),
+            vec![E::ONE, E::from_canonical_u64(2u64)].into_mle().into(),
+            vec![E::from_canonical_u64(3u64), E::from_canonical_u64(4u64)]
+                .into_mle()
+                .into(),
+            vec![E::from_canonical_u64(5u64), E::from_canonical_u64(6u64)]
+                .into_mle()
+                .into(),
         ];
         let res = interleaving_mles_to_mles(&input_mles, 2, num_product_fanin, E::ZERO);
         // [[1, 3, 5, 0], [2, 4, 6, 0]]
@@ -380,33 +390,42 @@ mod tests {
             res[0].get_ext_field_vec(),
             vec![
                 E::ONE,
-                E::from_u64(3u64),
-                E::from_u64(5u64),
-                E::from_u64(0u64)
+                E::from_canonical_u64(3u64),
+                E::from_canonical_u64(5u64),
+                E::from_canonical_u64(0u64)
             ],
         );
         assert_eq!(
             res[1].get_ext_field_vec(),
             vec![
-                E::from_u64(2u64),
-                E::from_u64(4u64),
-                E::from_u64(6u64),
-                E::from_u64(0u64)
+                E::from_canonical_u64(2u64),
+                E::from_canonical_u64(4u64),
+                E::from_canonical_u64(6u64),
+                E::from_canonical_u64(0u64)
             ],
         );
 
         // case 2: test instance level padding
         // [[1,0],[3,0],[5,0]]]
         let input_mles: Vec<ArcMultilinearExtension<E>> = vec![
-            vec![E::ONE, E::from_u64(0u64)].into_mle().into(),
-            vec![E::from_u64(3u64), E::from_u64(0u64)].into_mle().into(),
-            vec![E::from_u64(5u64), E::from_u64(0u64)].into_mle().into(),
+            vec![E::ONE, E::from_canonical_u64(0u64)].into_mle().into(),
+            vec![E::from_canonical_u64(3u64), E::from_canonical_u64(0u64)]
+                .into_mle()
+                .into(),
+            vec![E::from_canonical_u64(5u64), E::from_canonical_u64(0u64)]
+                .into_mle()
+                .into(),
         ];
         let res = interleaving_mles_to_mles(&input_mles, 1, num_product_fanin, E::ONE);
         // [[1, 3, 5, 1], [1, 1, 1, 1]]
         assert_eq!(
             res[0].get_ext_field_vec(),
-            vec![E::ONE, E::from_u64(3u64), E::from_u64(5u64), E::ONE],
+            vec![
+                E::ONE,
+                E::from_canonical_u64(3u64),
+                E::from_canonical_u64(5u64),
+                E::ONE
+            ],
         );
         assert_eq!(res[1].get_ext_field_vec(), vec![E::ONE; 4],);
     }
@@ -417,14 +436,14 @@ mod tests {
         let num_product_fanin = 2;
         // one instance, 2 mles: [[2], [3]]
         let input_mles: Vec<ArcMultilinearExtension<E>> = vec![
-            vec![E::from_u64(2u64)].into_mle().into(),
-            vec![E::from_u64(3u64)].into_mle().into(),
+            vec![E::from_canonical_u64(2u64)].into_mle().into(),
+            vec![E::from_canonical_u64(3u64)].into_mle().into(),
         ];
         let res = interleaving_mles_to_mles(&input_mles, 1, num_product_fanin, E::ONE);
         // [[2, 3], [1, 1]]
         assert_eq!(
             res[0].get_ext_field_vec(),
-            vec![E::from_u64(2u64), E::from_u64(3u64)],
+            vec![E::from_canonical_u64(2u64), E::from_canonical_u64(3u64)],
         );
         assert_eq!(res[1].get_ext_field_vec(), vec![E::ONE, E::ONE],);
     }
@@ -436,12 +455,12 @@ mod tests {
         let q: Vec<MultilinearExtension<E>> = vec![
             vec![1, 2, 3, 4]
                 .into_iter()
-                .map(E::from_u64)
+                .map(E::from_canonical_u64)
                 .collect_vec()
                 .into_mle(),
             vec![5, 6, 7, 8]
                 .into_iter()
-                .map(E::from_u64)
+                .map(E::from_canonical_u64)
                 .collect_vec()
                 .into_mle(),
         ];
@@ -484,32 +503,53 @@ mod tests {
         assert_eq!(
             layer[0].evaluations().clone(),
             FieldType::<E>::Ext(SmartSlice::Owned(vec![
-                vec![1 + 5].into_iter().map(E::from_u64).sum::<E>(),
-                vec![2 + 6].into_iter().map(E::from_u64).sum::<E>()
+                vec![1 + 5]
+                    .into_iter()
+                    .map(E::from_canonical_u64)
+                    .sum::<E>(),
+                vec![2 + 6]
+                    .into_iter()
+                    .map(E::from_canonical_u64)
+                    .sum::<E>()
             ]))
         );
         // next layer p2
         assert_eq!(
             layer[1].evaluations().clone(),
             FieldType::<E>::Ext(SmartSlice::Owned(vec![
-                vec![3 + 7].into_iter().map(E::from_u64).sum::<E>(),
-                vec![4 + 8].into_iter().map(E::from_u64).sum::<E>()
+                vec![3 + 7]
+                    .into_iter()
+                    .map(E::from_canonical_u64)
+                    .sum::<E>(),
+                vec![4 + 8]
+                    .into_iter()
+                    .map(E::from_canonical_u64)
+                    .sum::<E>()
             ]))
         );
         // next layer q1
         assert_eq!(
             layer[2].evaluations().clone(),
             FieldType::<E>::Ext(SmartSlice::Owned(vec![
-                vec![5].into_iter().map(E::from_u64).sum::<E>(),
-                vec![2 * 6].into_iter().map(E::from_u64).sum::<E>()
+                vec![5].into_iter().map(E::from_canonical_u64).sum::<E>(),
+                vec![2 * 6]
+                    .into_iter()
+                    .map(E::from_canonical_u64)
+                    .sum::<E>()
             ]))
         );
         // next layer q2
         assert_eq!(
             layer[3].evaluations().clone(),
             FieldType::<E>::Ext(SmartSlice::Owned(vec![
-                vec![3 * 7].into_iter().map(E::from_u64).sum::<E>(),
-                vec![4 * 8].into_iter().map(E::from_u64).sum::<E>()
+                vec![3 * 7]
+                    .into_iter()
+                    .map(E::from_canonical_u64)
+                    .sum::<E>(),
+                vec![4 * 8]
+                    .into_iter()
+                    .map(E::from_canonical_u64)
+                    .sum::<E>()
             ]))
         );
 
@@ -522,7 +562,7 @@ mod tests {
             FieldType::<E>::Ext(SmartSlice::Owned(vec![
                 vec![(1 + 5) * (3 * 7) + (3 + 7) * 5]
                     .into_iter()
-                    .map(E::from_u64)
+                    .map(E::from_canonical_u64)
                     .sum::<E>(),
             ]))
         );
@@ -533,7 +573,7 @@ mod tests {
             FieldType::<E>::Ext(SmartSlice::Owned(vec![
                 vec![(2 + 6) * (4 * 8) + (4 + 8) * (2 * 6)]
                     .into_iter()
-                    .map(E::from_u64)
+                    .map(E::from_canonical_u64)
                     .sum::<E>(),
             ]))
         );
@@ -542,7 +582,10 @@ mod tests {
             layer[2].evaluations().clone(),
             // q12 * q11
             FieldType::<E>::Ext(SmartSlice::Owned(vec![
-                vec![(3 * 7) * 5].into_iter().map(E::from_u64).sum::<E>(),
+                vec![(3 * 7) * 5]
+                    .into_iter()
+                    .map(E::from_canonical_u64)
+                    .sum::<E>(),
             ]))
         );
         // q2
@@ -552,7 +595,7 @@ mod tests {
             FieldType::<E>::Ext(SmartSlice::Owned(vec![
                 vec![(4 * 8) * (2 * 6)]
                     .into_iter()
-                    .map(E::from_u64)
+                    .map(E::from_canonical_u64)
                     .sum::<E>(),
             ]))
         );

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -12,7 +12,7 @@ use multilinear_extensions::{
     util::ceil_log2,
     virtual_poly::{VPAuxInfo, build_eq_x_r_vec_sequential, eq_eval},
 };
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 use std::collections::HashSet;
 use sumcheck::{
     structs::{IOPProof, IOPVerifierState},
@@ -187,7 +187,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
             let circuit_vk = circuit_vks[*index];
             let name = circuit_names[*index];
             if let Some(opcode_proof) = vm_proof.opcode_proofs.get(index) {
-                transcript.append_field_element(&E::BaseField::from_u64(*index as u64));
+                transcript.append_field_element(&E::BaseField::from_canonical_u64(*index as u64));
                 let input_opening_point = self.verify_opcode_proof(
                     name,
                     circuit_vk,
@@ -230,7 +230,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
                     logup_sum += p2 * q2.inverse();
                 }
             } else if let Some(table_proof) = vm_proof.table_proofs.get(index) {
-                transcript.append_field_element(&E::BaseField::from_u64(*index as u64));
+                transcript.append_field_element(&E::BaseField::from_canonical_u64(*index as u64));
 
                 let input_opening_point = self.verify_table_proof(
                     name,
@@ -276,7 +276,8 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
                 unreachable!("respective proof of index {} should exist", index)
             }
         }
-        logup_sum -= E::from_u64(dummy_table_item_multiplicity as u64) * dummy_table_item.inverse();
+        logup_sum -= E::from_canonical_u64(dummy_table_item_multiplicity as u64)
+            * dummy_table_item.inverse();
 
         // check logup relation across all proofs
         if logup_sum != E::ZERO {

--- a/ceno_zkvm/src/state.rs
+++ b/ceno_zkvm/src/state.rs
@@ -2,7 +2,7 @@ use ff_ext::ExtensionField;
 
 use crate::{circuit_builder::CircuitBuilder, error::ZKVMError, structs::RAMType};
 use multilinear_extensions::{Expression, ToExpr};
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 
 pub trait StateCircuit<E: ExtensionField> {
     fn initial_global_state(
@@ -20,7 +20,7 @@ impl<E: ExtensionField> StateCircuit<E> for GlobalState {
         circuit_builder: &mut crate::circuit_builder::CircuitBuilder<E>,
     ) -> Result<Expression<E>, ZKVMError> {
         let states: Vec<Expression<E>> = vec![
-            E::BaseField::from_u64(RAMType::GlobalState as u64).expr(),
+            E::BaseField::from_canonical_u64(RAMType::GlobalState as u64).expr(),
             circuit_builder.query_init_pc()?.expr(),
             circuit_builder.query_init_cycle()?.expr(),
         ];
@@ -32,7 +32,7 @@ impl<E: ExtensionField> StateCircuit<E> for GlobalState {
         circuit_builder: &mut crate::circuit_builder::CircuitBuilder<E>,
     ) -> Result<Expression<E>, ZKVMError> {
         let states: Vec<Expression<E>> = vec![
-            E::BaseField::from_u64(RAMType::GlobalState as u64).expr(),
+            E::BaseField::from_canonical_u64(RAMType::GlobalState as u64).expr(),
             circuit_builder.query_end_pc()?.expr(),
             circuit_builder.query_end_cycle()?.expr(),
         ];

--- a/ceno_zkvm/src/tables/program.rs
+++ b/ceno_zkvm/src/tables/program.rs
@@ -15,7 +15,7 @@ use ceno_emul::{
 use ff_ext::{ExtensionField, FieldInto, SmallField};
 use itertools::Itertools;
 use multilinear_extensions::{Expression, Fixed, ToExpr, WitIn};
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 use rayon::iter::{IndexedParallelIterator, ParallelIterator};
 use witness::{InstancePaddingStrategy, RowMajorMatrix};
 /// This structure establishes the order of the fields in instruction records, common to the program table and circuit fetches.
@@ -182,7 +182,11 @@ impl<E: ExtensionField> TableCircuit<E> for ProgramTableCircuit<E> {
             InstancePaddingStrategy::Default,
         );
         witness.par_rows_mut().zip(prog_mlt).for_each(|(row, mlt)| {
-            set_val!(row, config.mlt, E::BaseField::from_u64(mlt as u64));
+            set_val!(
+                row,
+                config.mlt,
+                E::BaseField::from_canonical_u64(mlt as u64)
+            );
         });
 
         Ok([witness, RowMajorMatrix::empty()])

--- a/ceno_zkvm/src/tables/ram/ram_impl.rs
+++ b/ceno_zkvm/src/tables/ram/ram_impl.rs
@@ -451,7 +451,7 @@ mod tests {
     use ff_ext::GoldilocksExt2 as E;
     use itertools::Itertools;
     use multilinear_extensions::mle::MultilinearExtension;
-    use p3::{field::PrimeCharacteristicRing, goldilocks::Goldilocks as F};
+    use p3::{field::FieldAlgebra, goldilocks::Goldilocks as F};
     use witness::next_pow2_instance_padding;
 
     #[test]
@@ -493,7 +493,7 @@ mod tests {
             structural_witness.to_mles()[addr_column].clone();
         // Expect addresses to proceed consecutively inside the padding as well
         let expected = successors(Some(addr_padded_view.get_base_field_vec()[0]), |idx| {
-            Some(*idx + F::from_u64(WORD_SIZE as u64))
+            Some(*idx + F::from_canonical_u64(WORD_SIZE as u64))
         })
         .take(next_pow2_instance_padding(
             structural_witness.num_instances(),

--- a/ceno_zkvm/src/tables/range/range_impl.rs
+++ b/ceno_zkvm/src/tables/range/range_impl.rs
@@ -71,8 +71,8 @@ impl RangeTableConfig {
             .zip(mlts)
             .zip(content)
             .for_each(|(((row, structural_row), mlt), i)| {
-                set_val!(row, self.mlt, F::from_u64(mlt as u64));
-                set_val!(structural_row, self.range, F::from_u64(i));
+                set_val!(row, self.mlt, F::from_canonical_u64(mlt as u64));
+                set_val!(structural_row, self.range, F::from_canonical_u64(i));
             });
 
         Ok([witness, structural_witness])

--- a/ceno_zkvm/src/uint.rs
+++ b/ceno_zkvm/src/uint.rs
@@ -15,7 +15,7 @@ use crate::{
 use ff_ext::{ExtensionField, SmallField};
 use itertools::{Itertools, enumerate};
 use multilinear_extensions::{Expression, ToExpr, WitIn};
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 use std::{
     borrow::Cow,
     mem::{self},
@@ -156,7 +156,7 @@ impl<const M: usize, const C: usize, E: ExtensionField> UIntLimbs<M, C, E> {
                 limbs
                     .into_iter()
                     .take(Self::NUM_LIMBS)
-                    .map(|limb| E::BaseField::from_u64(limb.into()).expr())
+                    .map(|limb| E::BaseField::from_canonical_u64(limb.into()).expr())
                     .collect::<Vec<Expression<E>>>(),
             ),
             carries: None,
@@ -233,7 +233,7 @@ impl<const M: usize, const C: usize, E: ExtensionField> UIntLimbs<M, C, E> {
             for (wire, limb) in wires.iter().zip(
                 limbs_values
                     .iter()
-                    .map(|v| E::BaseField::from_u64(*v as u64))
+                    .map(|v| E::BaseField::from_canonical_u64(*v as u64))
                     .chain(std::iter::repeat(E::BaseField::ZERO)),
             ) {
                 instance[wire.id as usize] = limb;
@@ -259,7 +259,7 @@ impl<const M: usize, const C: usize, E: ExtensionField> UIntLimbs<M, C, E> {
             for (wire, carry) in carries.iter().zip(
                 carry_values
                     .iter()
-                    .map(|v| E::BaseField::from_u64(Into::<u64>::into(*v)))
+                    .map(|v| E::BaseField::from_canonical_u64(Into::<u64>::into(*v)))
                     .chain(std::iter::repeat(E::BaseField::ZERO)),
             ) {
                 instance[wire.id as usize] = carry;
@@ -444,7 +444,7 @@ impl<const M: usize, const C: usize, E: ExtensionField> UIntLimbs<M, C, E> {
     pub fn counter_vector<F: SmallField>(size: usize) -> Vec<Vec<F>> {
         let num_vars = ceil_log2(size);
         let number_of_limbs = num_vars.div_ceil(C);
-        let cell_modulo = F::from_u64(1 << C);
+        let cell_modulo = F::from_canonical_u64(1 << C);
 
         let mut res = vec![vec![F::ZERO; number_of_limbs]];
 
@@ -711,7 +711,7 @@ impl<'a, T: Into<u64> + From<u32> + Copy + Default> Value<'a, T> {
     pub fn u16_fields<F: SmallField>(&self) -> Vec<F> {
         self.limbs
             .iter()
-            .map(|v| F::from_u64(*v as u64))
+            .map(|v| F::from_canonical_u64(*v as u64))
             .collect_vec()
     }
 

--- a/ceno_zkvm/src/utils.rs
+++ b/ceno_zkvm/src/utils.rs
@@ -11,9 +11,9 @@ use p3::field::Field;
 
 pub fn i64_to_base<F: SmallField>(x: i64) -> F {
     if x >= 0 {
-        F::from_u64(x as u64)
+        F::from_canonical_u64(x as u64)
     } else {
-        -F::from_u64((-x) as u64)
+        -F::from_canonical_u64((-x) as u64)
     }
 }
 
@@ -92,7 +92,7 @@ pub(crate) fn eq_eval_less_or_equal_than<E: ExtensionField>(max_idx: usize, a: &
         let mut running_product = vec![E::ZERO; b.len() + 1];
         running_product[b.len()] = E::ONE;
         for i in (0..b.len()).rev() {
-            let bit = E::from_u64(((max_idx >> i) & 1) as u64);
+            let bit = E::from_canonical_u64(((max_idx >> i) & 1) as u64);
             running_product[i] = running_product[i + 1]
                 * (a[i] * b[i] * bit + (E::ONE - a[i]) * (E::ONE - b[i]) * (E::ONE - bit));
         }
@@ -130,12 +130,12 @@ pub fn eval_wellform_address_vec<E: ExtensionField>(
     r: &[E],
     descending: bool,
 ) -> E {
-    let (offset, scaled) = (E::from_u64(offset), E::from_u64(scaled));
+    let (offset, scaled) = (E::from_canonical_u64(offset), E::from_canonical_u64(scaled));
     let tmp = scaled
         * r.iter()
             .scan(E::ONE, |state, x| {
                 let result = *x * *state;
-                *state *= E::from_u64(2); // Update the state for the next power of 2
+                *state *= E::from_canonical_u64(2); // Update the state for the next power of 2
                 Some(result)
             })
             .sum::<E>();

--- a/ff_ext/Cargo.toml
+++ b/ff_ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 categories.workspace = true
-description = "Extra functionality for the ff ((finite fields) crate"
+description = "Extra functionality for the ff (finite fields) crate"
 edition.workspace = true
 keywords.workspace = true
 license.workspace = true

--- a/ff_ext/src/babybear.rs
+++ b/ff_ext/src/babybear.rs
@@ -177,9 +177,9 @@ pub mod impl_babybear {
                 .map(|chunk| {
                     let mut array = [0u8; 4];
                     array[..chunk.len()].copy_from_slice(chunk);
-                    unsafe { std::ptr::read_unaligned(array.as_ptr() as *const u64) }
+                    unsafe { std::ptr::read_unaligned(array.as_ptr() as *const u32) }
                 })
-                .map(Self::from_canonical_u64)
+                .map(Self::from_canonical_u32)
                 .collect::<Vec<_>>()
         }
 

--- a/ff_ext/src/babybear.rs
+++ b/ff_ext/src/babybear.rs
@@ -195,11 +195,6 @@ pub mod impl_babybear {
         const DEGREE: usize = 4;
         const MULTIPLICATIVE_GENERATOR: Self = <BabyBearExt4 as Field>::GENERATOR;
         const TWO_ADICITY: usize = BabyBear::TWO_ADICITY;
-        // Passing two-adacity itself to this function will get the root of unity
-        // with the largest order, i.e., order = 2^two-adacity.
-        const BASE_TWO_ADIC_ROOT_OF_UNITY: Self::BaseField = BabyBear::new(0x78000000);
-        const TWO_ADIC_ROOT_OF_UNITY: Self =
-            BinomialExtensionField::from_bases(&[BabyBear::new(0x78000000); 4]);
         // non-residue is the value w such that the extension field is
         // F[X]/(X^2 - w)
         const NONRESIDUE: Self::BaseField = <BabyBear as BinomiallyExtendable<4>>::W;

--- a/ff_ext/src/babybear.rs
+++ b/ff_ext/src/babybear.rs
@@ -173,9 +173,9 @@ pub mod impl_babybear {
         /// Convert a byte string into a list of field elements
         fn bytes_to_field_elements(bytes: &[u8]) -> Vec<Self> {
             bytes
-                .chunks(8)
+                .chunks(4)
                 .map(|chunk| {
-                    let mut array = [0u8; 8];
+                    let mut array = [0u8; 4];
                     array[..chunk.len()].copy_from_slice(chunk);
                     unsafe { std::ptr::read_unaligned(array.as_ptr() as *const u64) }
                 })

--- a/ff_ext/src/goldilock.rs
+++ b/ff_ext/src/goldilock.rs
@@ -142,13 +142,6 @@ pub mod impl_goldilocks {
         const DEGREE: usize = 2;
         const MULTIPLICATIVE_GENERATOR: Self = <GoldilocksExt2 as Field>::GENERATOR;
         const TWO_ADICITY: usize = Goldilocks::TWO_ADICITY;
-        // Passing two-adacity itself to this function will get the root of unity
-        // with the largest order, i.e., order = 2^two-adacity.
-        const BASE_TWO_ADIC_ROOT_OF_UNITY: Self::BaseField =
-            Goldilocks::two_adic_generator(Goldilocks::TWO_ADICITY);
-        const TWO_ADIC_ROOT_OF_UNITY: Self = BinomialExtensionField::new_unchecked(
-            Goldilocks::ext_two_adic_generator_const(<GoldilocksExt2 as TwoAdicField>::TWO_ADICITY),
-        );
         // non-residue is the value w such that the extension field is
         // F[X]/(X^2 - w)
         const NONRESIDUE: Self::BaseField = <Goldilocks as BinomiallyExtendable<2>>::W;

--- a/ff_ext/src/goldilock.rs
+++ b/ff_ext/src/goldilock.rs
@@ -7,8 +7,7 @@ pub mod impl_goldilocks {
     use p3::{
         challenger::DuplexChallenger,
         field::{
-            BasedVectorSpace, Field, PackedValue, PrimeCharacteristicRing, PrimeField64,
-            TwoAdicField,
+            Field, FieldAlgebra, FieldExtensionAlgebra, PackedValue, PrimeField64, TwoAdicField,
             extension::{BinomialExtensionField, BinomiallyExtendable},
         },
         goldilocks::{
@@ -29,13 +28,13 @@ pub mod impl_goldilocks {
 
     impl FieldFrom<u64> for Goldilocks {
         fn from_v(v: u64) -> Self {
-            Self::from_u64(v)
+            Self::from_canonical_u64(v)
         }
     }
 
     impl FieldFrom<u64> for GoldilocksExt2 {
         fn from_v(v: u64) -> Self {
-            Self::from_u64(v)
+            Self::from_canonical_u64(v)
         }
     }
 
@@ -113,7 +112,7 @@ pub mod impl_goldilocks {
         fn try_from_uniform_bytes(bytes: [u8; 8]) -> Option<Self> {
             let value = u64::from_le_bytes(bytes);
             let is_canonical = value < Self::ORDER_U64;
-            is_canonical.then(|| Self::from_u64(value))
+            is_canonical.then(|| Self::from_canonical_u64(value))
         }
     }
 
@@ -129,7 +128,7 @@ pub mod impl_goldilocks {
                     array[..chunk.len()].copy_from_slice(chunk);
                     unsafe { std::ptr::read_unaligned(array.as_ptr() as *const u64) }
                 })
-                .map(Self::from_u64)
+                .map(Self::from_canonical_u64)
                 .collect::<Vec<_>>()
         }
 
@@ -146,7 +145,7 @@ pub mod impl_goldilocks {
         // Passing two-adacity itself to this function will get the root of unity
         // with the largest order, i.e., order = 2^two-adacity.
         const BASE_TWO_ADIC_ROOT_OF_UNITY: Self::BaseField =
-            Goldilocks::two_adic_generator_const(Goldilocks::TWO_ADICITY);
+            Goldilocks::two_adic_generator(Goldilocks::TWO_ADICITY);
         const TWO_ADIC_ROOT_OF_UNITY: Self = BinomialExtensionField::new_unchecked(
             Goldilocks::ext_two_adic_generator_const(<GoldilocksExt2 as TwoAdicField>::TWO_ADICITY),
         );
@@ -157,7 +156,7 @@ pub mod impl_goldilocks {
         type BaseField = Goldilocks;
 
         fn to_canonical_u64_vec(&self) -> Vec<u64> {
-            self.as_basis_coefficients_slice()
+            self.as_base_slice()
                 .iter()
                 .map(|v: &Self::BaseField| v.as_canonical_u64())
                 .collect()

--- a/ff_ext/src/lib.rs
+++ b/ff_ext/src/lib.rs
@@ -114,8 +114,6 @@ pub trait ExtensionField:
     const DEGREE: usize;
     const MULTIPLICATIVE_GENERATOR: Self;
     const TWO_ADICITY: usize;
-    const BASE_TWO_ADIC_ROOT_OF_UNITY: Self::BaseField;
-    const TWO_ADIC_ROOT_OF_UNITY: Self;
     const NONRESIDUE: Self::BaseField;
 
     type BaseField: SmallField
@@ -126,7 +124,7 @@ pub trait ExtensionField:
         + PoseidonField
         + DeserializeOwned;
 
-    fn from_base(base: &Self::BaseField) -> Self {
+    fn from_ref_base(base: &Self::BaseField) -> Self {
         Self::from_base_iter(
             iter::once(*base).chain(iter::repeat_n(Self::BaseField::ZERO, Self::DEGREE - 1)),
         )

--- a/ff_ext/src/lib.rs
+++ b/ff_ext/src/lib.rs
@@ -1,8 +1,7 @@
 #![deny(clippy::cargo)]
 
 use p3::field::{
-    BasedVectorSpace, ExtensionField as P3ExtensionField, Field as P3Field,
-    PrimeCharacteristicRing, PrimeField, TwoAdicField,
+    ExtensionField as P3ExtensionField, Field as P3Field, FieldAlgebra, PrimeField, TwoAdicField,
 };
 use rand_core::RngCore;
 use serde::{Serialize, de::DeserializeOwned};
@@ -64,7 +63,7 @@ macro_rules! impl_from_uniform_bytes_for_binomial_extension {
             type Bytes = [u8; <$base as FromUniformBytes>::Bytes::WIDTH * $degree];
 
             fn try_from_uniform_bytes(bytes: Self::Bytes) -> Option<Self> {
-                Some(p3::field::BasedVectorSpace::from_basis_coefficients_slice(
+                Some(p3::field::FieldExtensionAlgebra::from_base_slice(
                     &array_try_from_uniform_bytes::<
                         $base,
                         { <$base as FromUniformBytes>::Bytes::WIDTH },
@@ -128,26 +127,23 @@ pub trait ExtensionField:
         + DeserializeOwned;
 
     fn from_base(base: &Self::BaseField) -> Self {
-        Self::from_basis_coefficients_iter(
+        Self::from_base_iter(
             iter::once(*base).chain(iter::repeat_n(Self::BaseField::ZERO, Self::DEGREE - 1)),
         )
     }
 
     fn from_bases(bases: &[Self::BaseField]) -> Self {
-        debug_assert_eq!(
-            bases.len(),
-            <Self as BasedVectorSpace<Self::BaseField>>::DIMENSION
-        );
-        Self::from_basis_coefficients_slice(bases)
+        debug_assert_eq!(bases.len(), Self::D,);
+        Self::from_base_slice(bases)
     }
 
     fn as_bases(&self) -> &[Self::BaseField] {
-        self.as_basis_coefficients_slice()
+        self.as_base_slice()
     }
 
     /// Convert limbs into self
     fn from_limbs(limbs: &[Self::BaseField]) -> Self {
-        Self::from_bases(&limbs[0..<Self as BasedVectorSpace<Self::BaseField>>::DIMENSION])
+        Self::from_bases(&limbs[0..Self::D])
     }
 
     /// Convert a field elements to a u64 vector

--- a/ff_ext/src/poseidon.rs
+++ b/ff_ext/src/poseidon.rs
@@ -13,7 +13,7 @@ pub trait FieldChallengerExt<F: PoseidonField>: FieldChallenger<F> {
     }
 
     fn sample_ext_vec<E: ExtensionField<BaseField = F>>(&mut self, n: usize) -> Vec<E> {
-        (0..n).map(|_| self.sample_algebra_element()).collect()
+        (0..n).map(|_| self.sample_ext_element()).collect()
     }
 }
 
@@ -37,7 +37,7 @@ pub(crate) fn new_array<const N: usize, F: PrimeField>(input: [u64; N]) -> [F; N
     let mut output = [F::ZERO; N];
     let mut i = 0;
     while i < N {
-        output[i] = F::from_u64(input[i]);
+        output[i] = F::from_canonical_u64(input[i]);
         i += 1;
     }
     output

--- a/ff_ext/src/poseidon.rs
+++ b/ff_ext/src/poseidon.rs
@@ -9,7 +9,7 @@ use crate::{ExtensionField, SmallField};
 pub trait FieldChallengerExt<F: PoseidonField>: FieldChallenger<F> {
     fn observe_ext_slice<E: ExtensionField<BaseField = F>>(&mut self, exts: &[E]) {
         exts.iter()
-            .for_each(|ext| self.observe_slice(ext.as_basis_coefficients_slice()));
+            .for_each(|ext| self.observe_slice(ext.as_base_slice()));
     }
 
     fn sample_ext_vec<E: ExtensionField<BaseField = F>>(&mut self, n: usize) -> Vec<E> {

--- a/gkr_iop/examples/multi_layer_logup_table.rs
+++ b/gkr_iop/examples/multi_layer_logup_table.rs
@@ -12,7 +12,7 @@ use gkr_iop::{
 };
 use itertools::Itertools;
 use multilinear_extensions::{Expression, ToExpr, mle::PointAndEval, util::max_usable_threads};
-use p3_field::PrimeCharacteristicRing;
+use p3_field::FieldAlgebra;
 use rand::{Rng, rngs::OsRng};
 use transcript::{BasicTranscript, Transcript};
 
@@ -142,7 +142,12 @@ where
         let wits = phase1
             .table_with_multiplicity
             .iter()
-            .flat_map(|(x, y)| vec![E::BaseField::from_u64(*x), E::BaseField::from_u64(*y)])
+            .flat_map(|(x, y)| {
+                vec![
+                    E::BaseField::from_canonical_u64(*x),
+                    E::BaseField::from_canonical_u64(*y),
+                ]
+            })
             .collect_vec();
         RowMajorMatrix::new_by_values(wits, 2, witness::InstancePaddingStrategy::Default)
     }

--- a/gkr_iop/src/precompiles/bitwise_keccakf.rs
+++ b/gkr_iop/src/precompiles/bitwise_keccakf.rs
@@ -16,7 +16,7 @@ use multilinear_extensions::{
     mle::{MultilinearExtension, Point, PointAndEval},
     util::ceil_log2,
 };
-use p3_field::PrimeCharacteristicRing;
+use p3_field::FieldAlgebra;
 use sumcheck::{
     macros::{entered_span, exit_span},
     util::optimal_sumcheck_threads,
@@ -64,7 +64,7 @@ fn not_expr<E: ExtensionField>(a: Expression<E>) -> Expression<E> {
 }
 
 fn xor_expr<E: ExtensionField>(a: Expression<E>, b: Expression<E>) -> Expression<E> {
-    a.clone() + b.clone() - E::BaseField::from_u32(2).expr() * a * b
+    a.clone() + b.clone() - E::BaseField::from_canonical_u32(2).expr() * a * b
 }
 
 fn zero_expr<E: ExtensionField>() -> Expression<E> {
@@ -152,7 +152,7 @@ fn iota_expr<E: ExtensionField>(
     if x > 0 || y > 0 {
         bits[index].clone()
     } else {
-        let round_bit = E::BaseField::from_u64((round_value >> index) & 1).expr();
+        let round_bit = E::BaseField::from_canonical_u64((round_value >> index) & 1).expr();
         xor_expr(bits[from_xyz(0, 0, z)].clone(), round_bit)
     }
 }

--- a/gkr_iop/src/precompiles/lookup_keccakf.rs
+++ b/gkr_iop/src/precompiles/lookup_keccakf.rs
@@ -5,7 +5,7 @@ use ff_ext::ExtensionField;
 use itertools::{Itertools, chain, iproduct, izip, zip_eq};
 use multilinear_extensions::{Expression, ToExpr, WitIn, mle::PointAndEval, util::ceil_log2};
 use ndarray::{ArrayView, Ix2, Ix3, s};
-use p3_field::PrimeCharacteristicRing;
+use p3_field::FieldAlgebra;
 use rayon::{
     iter::{
         IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelExtend,
@@ -73,7 +73,7 @@ fn expansion_expr<E: ExtensionField, const SIZE: usize>(
             .fold((0, E::BaseField::ZERO.expr()), |acc, (sz, felt)| {
                 (
                     acc.0 + sz,
-                    acc.1 * E::BaseField::from_i64(1 << sz).expr() + felt.expr(),
+                    acc.1 * E::BaseField::from_canonical_u64(1 << sz).expr() + felt.expr(),
                 )
             });
 
@@ -174,7 +174,7 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         self.range_lookups.push(CenoLookup::U16(value.clone()));
         if size < 16 {
             self.range_lookups.push(CenoLookup::U16(
-                value * E::BaseField::from_i64(1 << (16 - size)).expr(),
+                value * E::BaseField::from_canonical_u64(1 << (16 - size)).expr(),
             ))
         }
     }
@@ -685,7 +685,7 @@ impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
             system.lookup_xor8(
                 chi_output[[0, 0, k]].0.into(),
                 // TODO figure out how to deal with RC, since it's not a constant in rotation
-                E::BaseField::from_i64(((RC[0] >> (k * 8)) & 0xFF) as i64).expr(),
+                E::BaseField::from_canonical_u64((RC[0] >> (k * 8)) & 0xFF).expr(),
                 iota_output_arr[[0, 0, k]].0.into(),
             );
         }

--- a/gkr_iop/src/precompiles/lookup_keccakf.rs
+++ b/gkr_iop/src/precompiles/lookup_keccakf.rs
@@ -1100,7 +1100,7 @@ pub fn run_faster_keccakf<E: ExtensionField>(
             //             .to_vec()
             //             .iter()
             //             .flat_map(|e| vec![*e as u32, (e >> 32) as u32])
-            //             .map(|e| Goldilocks::from_u64(e as u64))
+            //             .map(|e| Goldilocks::from_canonical_u64(e as u64))
             //             .collect_vec(),
             //         instance_outputs[i]
             //     );

--- a/gkr_iop/src/precompiles/utils.rs
+++ b/gkr_iop/src/precompiles/utils.rs
@@ -1,10 +1,10 @@
 use ff_ext::ExtensionField;
 use itertools::Itertools;
 use multilinear_extensions::{Expression, ToExpr};
-use p3_field::PrimeCharacteristicRing;
+use p3_field::FieldAlgebra;
 
 pub fn not8_expr<E: ExtensionField>(expr: Expression<E>) -> Expression<E> {
-    E::BaseField::from_u8(0xFF).expr() - expr
+    E::BaseField::from_canonical_u8(0xFF).expr() - expr
 }
 
 pub fn set_slice_felts_from_u64<E, I>(dst: &mut [E::BaseField], start_index: &mut usize, iter: I)
@@ -13,7 +13,7 @@ where
     I: IntoIterator<Item = u64>,
 {
     for word in iter {
-        dst[*start_index] = E::BaseField::from_u64(word);
+        dst[*start_index] = E::BaseField::from_canonical_u64(word);
         *start_index += 1;
     }
 }

--- a/gkr_iop/src/utils.rs
+++ b/gkr_iop/src/utils.rs
@@ -5,7 +5,7 @@ use multilinear_extensions::{
     util::ceil_log2,
     wit_infer_by_expr,
 };
-use p3_field::PrimeCharacteristicRing;
+use p3_field::FieldAlgebra;
 use rayon::{
     iter::{
         IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelExtend,

--- a/gkr_iop/src/utils.rs
+++ b/gkr_iop/src/utils.rs
@@ -147,7 +147,7 @@ mod tests {
     #[test]
     fn test_rotation_next_non_cyclic() {
         type E = GoldilocksExt2;
-        let mle = make_mle::<E>((0..32u64).map(Goldilocks::from_u64).collect_vec());
+        let mle = make_mle::<E>((0..32u64).map(Goldilocks::from_canonical_u64).collect_vec());
         let full_rotated = rotation_next_base_mle(&mle, 31, 5);
         assert_eq!(
             full_rotated

--- a/mpcs/src/basefold.rs
+++ b/mpcs/src/basefold.rs
@@ -9,10 +9,7 @@ use crate::{
 };
 pub use encoding::{EncodingScheme, RSCode, RSCodeDefaultSpec};
 use ff_ext::ExtensionField;
-use p3::{
-    commit::Mmcs, field::PrimeCharacteristicRing, matrix::dense::DenseMatrix,
-    util::log2_strict_usize,
-};
+use p3::{commit::Mmcs, field::FieldAlgebra, matrix::dense::DenseMatrix, util::log2_strict_usize};
 use query_phase::{batch_query_phase, batch_verifier_query_phase};
 use structure::{BasefoldProof, CircuitIndexMeta};
 pub use structure::{BasefoldSpec, Digest};
@@ -235,8 +232,9 @@ where
         for trivial_commit in &comm.trivial_commits {
             write_digest_to_transcript(trivial_commit, transcript);
         }
-        transcript
-            .append_field_element(&E::BaseField::from_u64(comm.log2_max_codeword_size as u64));
+        transcript.append_field_element(&E::BaseField::from_canonical_u64(
+            comm.log2_max_codeword_size as u64,
+        ));
         Ok(())
     }
 

--- a/mpcs/src/basefold/commit_phase.rs
+++ b/mpcs/src/basefold/commit_phase.rs
@@ -20,7 +20,7 @@ use multilinear_extensions::{
 };
 use p3::{
     commit::{ExtensionMmcs, Mmcs},
-    field::{Field, PrimeCharacteristicRing, dot_product},
+    field::{Field, FieldAlgebra, dot_product},
     matrix::{
         Matrix,
         dense::{DenseMatrix, RowMajorMatrix},
@@ -391,7 +391,7 @@ pub(crate) fn basefold_fri_round<E: ExtensionField, Spec: BasefoldSpec<E>>(
     let level = log2_strict_usize(target_len) - 1;
     let folding_coeffs =
         <Spec::EncodingScheme as EncodingScheme<E>>::prover_folding_coeffs_level(pp, level);
-    let inv_2 = E::BaseField::from_u64(2).inverse();
+    let inv_2 = E::BaseField::from_canonical_u64(2).inverse();
     debug_assert_eq!(folding_coeffs.len(), 1 << level);
 
     // take codewords match with target length then fold

--- a/mpcs/src/basefold/encoding/rs.rs
+++ b/mpcs/src/basefold/encoding/rs.rs
@@ -6,7 +6,7 @@ use ff_ext::{ExtensionField, FieldFrom};
 use itertools::Itertools;
 use p3::{
     dft::{Radix2Dit, Radix2DitParallel, TwoAdicSubgroupDft},
-    field::{Field, PrimeCharacteristicRing, TwoAdicField, batch_multiplicative_inverse},
+    field::{Field, FieldAlgebra, TwoAdicField, batch_multiplicative_inverse},
     matrix::{Matrix, bitrev::BitReversableMatrix, dense::DenseMatrix},
     util::reverse_bits_len,
 };
@@ -341,7 +341,7 @@ mod tests {
 
         // test basefold.encode(raw_message.fold(1-r, r)) ?= codeword.fold(1-r, r)
         let mut prove_data = vec![];
-        let r = E::from_u64(97);
+        let r = E::from_canonical_u64(97);
         basefold_fri_round::<E, BasefoldRSParams>(
             &pp,
             &mut codeword_ext,

--- a/mpcs/src/basefold/query_phase.rs
+++ b/mpcs/src/basefold/query_phase.rs
@@ -10,7 +10,7 @@ use itertools::{Itertools, izip};
 use multilinear_extensions::virtual_poly::{build_eq_x_r_vec, eq_eval};
 use p3::{
     commit::{ExtensionMmcs, Mmcs},
-    field::{Field, PrimeCharacteristicRing, dot_product},
+    field::{Field, FieldAlgebra, dot_product},
     fri::{BatchOpening, CommitPhaseProofStep},
     matrix::{Dimensions, dense::RowMajorMatrix},
     util::log2_strict_usize,
@@ -140,7 +140,7 @@ pub fn batch_verifier_query_phase<E: ExtensionField, Spec: BasefoldSpec<E>>(
 ) where
     E::BaseField: Serialize + DeserializeOwned,
 {
-    let inv_2 = E::BaseField::from_u64(2).inverse();
+    let inv_2 = E::BaseField::from_canonical_u64(2).inverse();
     debug_assert_eq!(point_evals.len(), circuit_meta.len());
     let encode_span = entered_span!("encode_final_codeword");
     let final_codeword = <Spec::EncodingScheme as EncodingScheme<E>>::encode_small(
@@ -383,7 +383,7 @@ pub fn batch_verifier_query_phase<E: ExtensionField, Spec: BasefoldSpec<E>>(
             point_evals.iter().zip_eq(circuit_meta.iter()).flat_map(
                 |((_, evals), CircuitIndexMeta { witin_num_vars, .. })| {
                     evals.iter().copied().map(move |eval| {
-                        eval * E::from_u64(1 << (max_num_var - witin_num_vars) as u64)
+                        eval * E::from_canonical_u64(1 << (max_num_var - witin_num_vars) as u64)
                     })
                 }
             )

--- a/mpcs/src/util.rs
+++ b/mpcs/src/util.rs
@@ -4,14 +4,14 @@ use std::collections::VecDeque;
 
 use ff_ext::{ExtensionField, SmallField};
 pub mod merkle_tree;
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 
 pub fn base_to_usize<E: ExtensionField>(x: &E::BaseField) -> usize {
     x.to_canonical_u64() as usize
 }
 
 pub fn u32_to_field<E: ExtensionField>(x: u32) -> E::BaseField {
-    E::BaseField::from_u32(x)
+    E::BaseField::from_canonical_u32(x)
 }
 
 /// splits a vector into multiple slices, where each slice length
@@ -106,7 +106,7 @@ pub mod test {
     #[cfg(test)]
     use crate::util::{base_to_usize, u32_to_field};
     use ff_ext::FromUniformBytes;
-    use p3::field::PrimeCharacteristicRing;
+    use p3::field::FieldAlgebra;
     #[cfg(test)]
     type E = ff_ext::GoldilocksExt2;
     #[cfg(test)]
@@ -139,7 +139,10 @@ pub mod test {
 
     #[test]
     pub fn test_field_transform() {
-        assert_eq!(F::from_u64(2) * F::from_u64(3), F::from_u64(6));
+        assert_eq!(
+            F::from_canonical_u64(2) * F::from_canonical_u64(3),
+            F::from_canonical_u64(6)
+        );
         assert_eq!(base_to_usize::<E>(&u32_to_field::<E>(1u32)), 1);
         assert_eq!(base_to_usize::<E>(&u32_to_field::<E>(10u32)), 10);
     }

--- a/mpcs/src/util/arithmetic.rs
+++ b/mpcs/src/util/arithmetic.rs
@@ -8,7 +8,7 @@ mod hypercube;
 pub use hypercube::{
     interpolate_field_type_over_boolean_hypercube, interpolate_over_boolean_hypercube,
 };
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 
 use itertools::Itertools;
 
@@ -157,7 +157,7 @@ pub fn degree_2_eval<F: Field>(poly: &[F], point: F) -> F {
 pub fn base_from_raw_bytes<E: ExtensionField>(bytes: &[u8]) -> E::BaseField {
     let mut res = E::BaseField::ZERO;
     bytes.iter().for_each(|b| {
-        res += E::BaseField::from_u8(*b);
+        res += E::BaseField::from_canonical_u8(*b);
     });
     res
 }

--- a/multilinear_extensions/src/expression.rs
+++ b/multilinear_extensions/src/expression.rs
@@ -1412,9 +1412,9 @@ mod tests {
         let res = wit_infer_by_expr(
             &[],
             &[
-                vec![B::from_u64(1)].into_mle().into(),
-                vec![B::from_u64(2)].into_mle().into(),
-                vec![B::from_u64(3)].into_mle().into(),
+                vec![B::from_canonical_u64(1)].into_mle().into(),
+                vec![B::from_canonical_u64(2)].into_mle().into(),
+                vec![B::from_canonical_u64(3)].into_mle().into(),
             ],
             &[],
             &[],
@@ -1441,9 +1441,9 @@ mod tests {
         let res = wit_infer_by_expr(
             &[],
             &[
-                vec![B::from_u64(1)].into_mle().into(),
-                vec![B::from_u64(2)].into_mle().into(),
-                vec![B::from_u64(3)].into_mle().into(),
+                vec![B::from_canonical_u64(1)].into_mle().into(),
+                vec![B::from_canonical_u64(2)].into_mle().into(),
+                vec![B::from_canonical_u64(3)].into_mle().into(),
             ],
             &[],
             &[],

--- a/multilinear_extensions/src/expression.rs
+++ b/multilinear_extensions/src/expression.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use ff_ext::{ExtensionField, SmallField};
 use itertools::Either;
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use serde::de::DeserializeOwned;
 use std::{
@@ -1074,7 +1074,7 @@ macro_rules! impl_expr_from_unsigned {
         $(
             impl<F: ff_ext::SmallField, E: ExtensionField<BaseField = F>> From<$t> for Expression<E> {
                 fn from(value: $t) -> Self {
-                    Expression::Constant(Either::Left(F::from_u64(value as u64)))
+                    Expression::Constant(Either::Left(F::from_canonical_u64(value as u64)))
                 }
             }
         )*
@@ -1089,7 +1089,7 @@ macro_rules! impl_from_signed {
             impl<F: SmallField, E: ExtensionField<BaseField = F>> From<$t> for Expression<E> {
                 fn from(value: $t) -> Self {
                     let reduced = (value as i128).rem_euclid(F::MODULUS_U64 as i128) as u64;
-                    Expression::Constant(Either::Left(F::from_u64(reduced)))
+                    Expression::Constant(Either::Left(F::from_canonical_u64(reduced)))
                 }
             }
         )*
@@ -1251,7 +1251,7 @@ mod tests {
     use crate::{expression::WitIn, mle::IntoMLE, wit_infer_by_expr};
     use either::Either;
     use ff_ext::{FieldInto, GoldilocksExt2};
-    use p3::field::PrimeCharacteristicRing;
+    use p3::field::FieldAlgebra;
 
     #[test]
     fn test_expression_arithmetics() {

--- a/multilinear_extensions/src/expression/monomial.rs
+++ b/multilinear_extensions/src/expression/monomial.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::Expression;
 use Expression::*;
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 use std::{fmt::Display, iter::Sum};
 
 impl<E: ExtensionField> Expression<E> {
@@ -115,7 +115,7 @@ mod tests {
     use super::*;
     use either::Either;
     use ff_ext::{FieldInto, FromUniformBytes, GoldilocksExt2 as E};
-    use p3::{field::PrimeCharacteristicRing, goldilocks::Goldilocks as F};
+    use p3::{field::FieldAlgebra, goldilocks::Goldilocks as F};
     use rand::thread_rng;
 
     #[test]
@@ -137,7 +137,7 @@ mod tests {
 
         let n1 = || Constant(Either::Left(103u64.into_f()));
         let n2 = || Constant(Either::Left(101u64.into_f()));
-        let m = || Constant(Either::Left(-F::from_u64(599)));
+        let m = || Constant(Either::Left(-F::from_canonical_u64(599)));
         let r = || Challenge(0, 1, E::ONE, E::ZERO);
 
         let test_exprs: &[Expression<E>] = &[

--- a/multilinear_extensions/src/mle.rs
+++ b/multilinear_extensions/src/mle.rs
@@ -9,7 +9,7 @@ use crate::{
 use core::hash::Hash;
 use either::Either;
 use ff_ext::{ExtensionField, FromUniformBytes};
-use p3::field::{Field, PrimeCharacteristicRing};
+use p3::field::{Field, FieldAlgebra};
 use rand::Rng;
 use rayon::iter::{
     IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,

--- a/multilinear_extensions/src/virtual_poly.rs
+++ b/multilinear_extensions/src/virtual_poly.rs
@@ -1,6 +1,4 @@
-use std::{
-    cmp::max, collections::HashMap, marker::PhantomData, mem::MaybeUninit, ops::Mul, sync::Arc,
-};
+use std::{cmp::max, collections::HashMap, marker::PhantomData, mem::MaybeUninit, sync::Arc};
 
 use crate::{
     Expression, WitnessId,
@@ -448,13 +446,10 @@ pub fn build_eq_x_r_vec<E: ExtensionField>(r: &[E]) -> Vec<E> {
     skip_all,
     name = "multilinear_extensions::build_eq_x_r_vec_with_scalar"
 )]
-pub fn build_eq_x_r_vec_with_scalar<E: ExtensionField + Mul<F, Output = E> + From<F>, F>(
-    r: &[E],
-    scalar: F,
-) -> Vec<E> {
+pub fn build_eq_x_r_vec_with_scalar<E: ExtensionField>(r: &[E], scalar: E) -> Vec<E> {
     // avoid unnecessary allocation
     if r.is_empty() {
-        return vec![E::from(scalar)];
+        return vec![scalar];
     }
     // we build eq(x,r) from its evaluations
     // we want to evaluate eq(x,r) over x \in {0, 1}^num_vars
@@ -472,10 +467,9 @@ pub fn build_eq_x_r_vec_with_scalar<E: ExtensionField + Mul<F, Output = E> + Fro
 
     let mut evals = create_uninit_vec(1 << r.len());
     if r.len() < nbits {
-        build_eq_x_r_helper_sequential(r, &mut evals, E::from(scalar));
+        build_eq_x_r_helper_sequential(r, &mut evals, scalar);
     } else {
-        let eq_ts =
-            build_eq_x_r_vec_sequential_with_scalar(&r[(r.len() - nbits)..], E::from(scalar));
+        let eq_ts = build_eq_x_r_vec_sequential_with_scalar(&r[(r.len() - nbits)..], scalar);
 
         // eq(x, r) = eq(x_lo, r_lo) * eq(x_hi, r_hi)
         // where rlen = r.len(), x_lo = x[0..rlen-nbits], x_hi = x[rlen-nbits..]

--- a/multilinear_extensions/src/virtual_polys.rs
+++ b/multilinear_extensions/src/virtual_polys.rs
@@ -336,7 +336,7 @@ impl<'a, E: ExtensionField> VirtualPolynomials<'a, E> {
                 let scalar = E::random(&mut *rng);
                 monimial_term.push(Term { scalar, product });
                 // need to scale up for the smaller nv
-                sum += E::from_u64(1 << (max_num_variables - nv)) * product_sum * scalar;
+                sum += E::from_canonical_u64(1 << (max_num_variables - nv)) * product_sum * scalar;
             }
         }
         exit_span!(start);

--- a/sumcheck/benches/devirgo_sumcheck.rs
+++ b/sumcheck/benches/devirgo_sumcheck.rs
@@ -7,7 +7,7 @@ use criterion::*;
 use either::Either;
 use ff_ext::{ExtensionField, GoldilocksExt2};
 use itertools::Itertools;
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 use rand::thread_rng;
 use sumcheck::structs::IOPProverState;
 
@@ -154,7 +154,7 @@ fn devirgo_sumcheck_fn(c: &mut Criterion) {
                                     mle.num_vars(),
                                     mle.get_base_field_vec()
                                         .iter()
-                                        .map(E::from_base)
+                                        .map(E::from_ref_base)
                                         .collect_vec(),
                                 )
                             })
@@ -195,7 +195,7 @@ fn devirgo_sumcheck_fn(c: &mut Criterion) {
                                     mle.num_vars(),
                                     mle.get_base_field_vec()
                                         .iter()
-                                        .map(E::from_base)
+                                        .map(E::from_ref_base)
                                         .collect_vec(),
                                 )
                             })

--- a/sumcheck/src/extrapolate.rs
+++ b/sumcheck/src/extrapolate.rs
@@ -43,7 +43,7 @@ impl<E: ExtensionField> ExtrapolationTable<E> {
         for d in min_degree..=max_degree {
             let mut degree_weights = Vec::new();
 
-            let xs: Vec<E> = (0..=d as u64).map(E::from_u64).collect_vec();
+            let xs: Vec<E> = (0..=d as u64).map(E::from_canonical_u64).collect_vec();
             let mut bary_weights = Vec::new();
 
             // Compute barycentric weights w_j = 1 / prod_{i != j} (x_j - x_i)
@@ -58,7 +58,7 @@ impl<E: ExtensionField> ExtrapolationTable<E> {
             }
 
             for z_idx in d + 1..=max_degree {
-                let z = E::from_u64(z_idx as u64);
+                let z = E::from_canonical_u64(z_idx as u64);
                 let mut den = E::ZERO;
                 let mut tmp: Vec<E> = Vec::with_capacity(d + 1);
 

--- a/sumcheck/src/prover.rs
+++ b/sumcheck/src/prover.rs
@@ -27,7 +27,7 @@ use crate::{
         AdditiveArray, AdditiveVec, ceil_log2, merge_sumcheck_polys, merge_sumcheck_prover_state,
     },
 };
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 
 impl<'a, E: ExtensionField> IOPProverState<'a, E> {
     /// Given a virtual polynomial, generate an IOP proof.

--- a/sumcheck/src/test.rs
+++ b/sumcheck/src/test.rs
@@ -12,7 +12,7 @@ use multilinear_extensions::{
     virtual_poly::{VPAuxInfo, VirtualPolynomial},
     virtual_polys::VirtualPolynomials,
 };
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 use rand::{Rng, thread_rng};
 use transcript::{BasicTranscript, Transcript};
 

--- a/sumcheck/src/test.rs
+++ b/sumcheck/src/test.rs
@@ -233,7 +233,7 @@ fn test_extrapolation() {
         let mut prng = rand::thread_rng();
         let poly = DensePolynomial::rand_coeffs(degree, &mut prng);
         let evals = (0..=degree)
-            .map(|i| poly.evaluate(&GoldilocksExt2::from_u64(i as u64)))
+            .map(|i| poly.evaluate(&GoldilocksExt2::from_canonical_u64(i as u64)))
             .collect::<Vec<_>>();
         let query = GoldilocksExt2::random(&mut prng);
         assert_eq!(poly.evaluate(&query), extrapolate_uni_poly(&evals, query));

--- a/sumcheck/src/util.rs
+++ b/sumcheck/src/util.rs
@@ -73,16 +73,16 @@ fn extrapolate_uni_poly_deg_1<F: Field>(p_i: &[F; 2], eval_at: F) -> F {
 }
 
 fn extrapolate_uni_poly_deg_2<F: Field>(p_i: &[F; 3], eval_at: F) -> F {
-    let x0 = F::from_u64(0);
-    let x1 = F::from_u64(1);
-    let x2 = F::from_u64(2);
+    let x0 = F::from_canonical_u64(0);
+    let x1 = F::from_canonical_u64(1);
+    let x2 = F::from_canonical_u64(2);
 
     // w0 = 1 / ((0−1)(0−2)) =  1/2
     // w1 = 1 / ((1−0)(1−2)) = -1
     // w2 = 1 / ((2−0)(2−1)) =  1/2
-    let w0 = F::from_u64(1).div(F::from_u64(2));
+    let w0 = F::from_canonical_u64(1).div(F::from_canonical_u64(2));
     let w1 = -F::ONE;
-    let w2 = F::from_u64(1).div(F::from_u64(2));
+    let w2 = F::from_canonical_u64(1).div(F::from_canonical_u64(2));
 
     let d0 = eval_at - x0;
     let d1 = eval_at - x1;
@@ -102,19 +102,19 @@ fn extrapolate_uni_poly_deg_2<F: Field>(p_i: &[F; 3], eval_at: F) -> F {
 }
 
 fn extrapolate_uni_poly_deg_3<F: Field>(p_i: &[F; 4], eval_at: F) -> F {
-    let x0 = F::from_u64(0);
-    let x1 = F::from_u64(1);
-    let x2 = F::from_u64(2);
-    let x3 = F::from_u64(3);
+    let x0 = F::from_canonical_u64(0);
+    let x1 = F::from_canonical_u64(1);
+    let x2 = F::from_canonical_u64(2);
+    let x3 = F::from_canonical_u64(3);
 
     // w0 = 1 / ((0−1)(0−2)(0−3)) = -1/6
     // w1 = 1 / ((1−0)(1−2)(1−3)) =  1/2
     // w2 = 1 / ((2−0)(2−1)(2−3)) = -1/2
     // w3 = 1 / ((3−0)(3−1)(3−2)) =  1/6
-    let w0 = -F::from_u64(1).div(F::from_u64(6));
-    let w1 = F::from_u64(1).div(F::from_u64(2));
-    let w2 = -F::from_u64(1).div(F::from_u64(2));
-    let w3 = F::from_u64(1).div(F::from_u64(6));
+    let w0 = -F::from_canonical_u64(1).div(F::from_canonical_u64(6));
+    let w1 = F::from_canonical_u64(1).div(F::from_canonical_u64(2));
+    let w2 = -F::from_canonical_u64(1).div(F::from_canonical_u64(2));
+    let w3 = F::from_canonical_u64(1).div(F::from_canonical_u64(6));
 
     let d0 = eval_at - x0;
     let d1 = eval_at - x1;
@@ -137,22 +137,22 @@ fn extrapolate_uni_poly_deg_3<F: Field>(p_i: &[F; 4], eval_at: F) -> F {
 }
 
 fn extrapolate_uni_poly_deg_4<F: Field>(p_i: &[F; 5], eval_at: F) -> F {
-    let x0 = F::from_u64(0);
-    let x1 = F::from_u64(1);
-    let x2 = F::from_u64(2);
-    let x3 = F::from_u64(3);
-    let x4 = F::from_u64(4);
+    let x0 = F::from_canonical_u64(0);
+    let x1 = F::from_canonical_u64(1);
+    let x2 = F::from_canonical_u64(2);
+    let x3 = F::from_canonical_u64(3);
+    let x4 = F::from_canonical_u64(4);
 
     // w0 = 1 / ((0−1)(0−2)(0−3)(0−4)) =  1/24
     // w1 = 1 / ((1−0)(1−2)(1−3)(1−4)) = -1/6
     // w2 = 1 / ((2−0)(2−1)(2−3)(2−4)) =  1/4
     // w3 = 1 / ((3−0)(3−1)(3−2)(3−4)) = -1/6
     // w4 = 1 / ((4−0)(4−1)(4−2)(4−3)) =  1/24
-    let w0 = F::from_u64(1).div(F::from_u64(24));
-    let w1 = -F::from_u64(1).div(F::from_u64(6));
-    let w2 = F::from_u64(1).div(F::from_u64(4));
-    let w3 = -F::from_u64(1).div(F::from_u64(6));
-    let w4 = F::from_u64(1).div(F::from_u64(24));
+    let w0 = F::from_canonical_u64(1).div(F::from_canonical_u64(24));
+    let w1 = -F::from_canonical_u64(1).div(F::from_canonical_u64(6));
+    let w2 = F::from_canonical_u64(1).div(F::from_canonical_u64(4));
+    let w3 = -F::from_canonical_u64(1).div(F::from_canonical_u64(6));
+    let w4 = F::from_canonical_u64(1).div(F::from_canonical_u64(24));
 
     let d0 = eval_at - x0;
     let d1 = eval_at - x1;
@@ -445,13 +445,13 @@ impl<F: MulAssign + Copy> Mul<F> for AdditiveVec<F> {
 mod tests {
     use super::*;
     use ff_ext::GoldilocksExt2;
-    use p3::field::PrimeCharacteristicRing;
+    use p3::field::FieldAlgebra;
 
     #[test]
     fn test_extrapolate_from_table() {
         type E = GoldilocksExt2;
         fn f(x: u64) -> E {
-            E::from_u64(2u64) * E::from_u64(x) + E::from_u64(3u64)
+            E::from_canonical_u64(2u64) * E::from_canonical_u64(x) + E::from_canonical_u64(3u64)
         }
         // Test a known linear polynomial: f(x) = 2x + 3
 

--- a/sumcheck_macro/examples/expand.rs
+++ b/sumcheck_macro/examples/expand.rs
@@ -7,7 +7,7 @@ use multilinear_extensions::{
     mle::FieldType, util::largest_even_below, virtual_poly::VirtualPolynomial,
     virtual_polys::PolyMeta,
 };
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 use rand::rngs::OsRng;
 use sumcheck::util::{AdditiveArray, ceil_log2};
 

--- a/sumcheck_macro/src/lib.rs
+++ b/sumcheck_macro/src/lib.rs
@@ -291,7 +291,7 @@ pub fn sumcheck_code_gen(input: proc_macro::TokenStream) -> proc_macro::TokenStr
                             // the multiplicity
                             .saturating_sub(num_var);
                         if num_vars_multiplicity > 0 {
-                            sum *= E::BaseField::from_u64(1 << num_vars_multiplicity);
+                            sum *= E::BaseField::from_canonical_u64(1 << num_vars_multiplicity);
                         }
                         AdditiveArray::<_, #degree_plus_one>([sum; #degree_plus_one])
                     } else {
@@ -315,7 +315,7 @@ pub fn sumcheck_code_gen(input: proc_macro::TokenStream) -> proc_macro::TokenStr
                             .saturating_sub(1)
                             .saturating_sub(num_var);
                         if num_vars_multiplicity > 0 {
-                            sum *= E::BaseField::from_u64(1 << num_vars_multiplicity);
+                            sum *= E::BaseField::from_canonical_u64(1 << num_vars_multiplicity);
                         }
                         AdditiveArray::<_, #degree_plus_one>([sum; #degree_plus_one])
                     } else {

--- a/transcript/src/basic.rs
+++ b/transcript/src/basic.rs
@@ -26,12 +26,12 @@ impl<E: ExtensionField> Transcript<E> for BasicTranscript<E> {
     }
 
     fn append_field_element_ext(&mut self, element: &E) {
-        self.challenger.observe_algebra_element(*element);
+        self.challenger.observe_ext_element(*element);
     }
 
     fn read_challenge(&mut self) -> Challenge<E> {
         Challenge {
-            elements: self.challenger.sample_algebra_element(),
+            elements: self.challenger.sample_ext_element(),
         }
     }
 

--- a/transcript/src/lib.rs
+++ b/transcript/src/lib.rs
@@ -9,7 +9,7 @@ pub mod syncronized;
 pub use basic::BasicTranscript;
 use ff_ext::SmallField;
 use itertools::Itertools;
-use p3::{challenger::GrindingChallenger, field::PrimeCharacteristicRing};
+use p3::{challenger::GrindingChallenger, field::FieldAlgebra};
 pub use syncronized::TranscriptSyncronized;
 #[derive(Default, Copy, Clone, Eq, PartialEq, Debug)]
 pub struct Challenge<F> {
@@ -138,7 +138,7 @@ pub trait ForkableTranscript<E: ExtensionField>: Transcript<E> + Sized + Clone {
         (0..n)
             .map(|i| {
                 let mut fork = self.clone();
-                fork.append_field_element(&E::BaseField::from_u64(i as u64));
+                fork.append_field_element(&E::BaseField::from_canonical_u64(i as u64));
                 fork
             })
             .collect()

--- a/whir/src/bin/main.rs
+++ b/whir/src/bin/main.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use multilinear_extensions::mle::MultilinearExtension;
-use p3::field::PrimeCharacteristicRing;
+use p3::field::FieldAlgebra;
 use transcript::BasicTranscript;
 use whir::{
     cmdline_utils::{AvailableFields, AvailableMerkle, WhirType},
@@ -128,7 +128,7 @@ fn run_whir_as_ldt(args: Args, hash_params: Poseidon2MerkleMmcs<E>) {
 
     let polynomial = MultilinearExtension::from_evaluations_ext_vec(
         num_variables,
-        (0..num_coeffs).map(E::from_u64).collect(),
+        (0..num_coeffs).map(E::from_canonical_u64).collect(),
     );
 
     let whir_prover_time = Instant::now();
@@ -218,10 +218,10 @@ fn run_whir_pcs(args: Args, hash_params: Poseidon2MerkleMmcs<E>) {
 
     let polynomial = MultilinearExtension::from_evaluations_ext_vec(
         num_variables,
-        (0..num_coeffs).map(E::from_u64).collect(),
+        (0..num_coeffs).map(E::from_canonical_u64).collect(),
     );
     let points: Vec<_> = (0..num_evaluations)
-        .map(|i| vec![E::from_u64(i as u64); num_variables])
+        .map(|i| vec![E::from_canonical_u64(i as u64); num_variables])
         .collect();
     let evaluations = points
         .iter()

--- a/whir/src/crypto/mod.rs
+++ b/whir/src/crypto/mod.rs
@@ -92,7 +92,7 @@ impl<E: ExtensionField> MultiPath<E> {
                 .map(|(leaves, _)| {
                     leaves
                         .iter()
-                        .map(|leaf| leaf.iter().map(|x| E::from_base(x)).collect())
+                        .map(|leaf| leaf.iter().map(|x| E::from_ref_base(x)).collect())
                         .collect()
                 })
                 .collect(),

--- a/whir/src/domain.rs
+++ b/whir/src/domain.rs
@@ -1,7 +1,7 @@
 use ff_ext::ExtensionField;
 use p3::{
     commit::TwoAdicMultiplicativeCoset,
-    field::{Field, PrimeCharacteristicRing, TwoAdicField},
+    field::{Field, FieldAlgebra, TwoAdicField},
 };
 
 #[derive(Debug, Clone)]
@@ -22,7 +22,7 @@ where
         let size = degree * (1 << log_rho_inv);
         let base_domain = TwoAdicMultiplicativeCoset {
             log_n: p3::util::log2_strict_usize(size),
-            shift: E::BaseField::from_u64(1),
+            shift: E::BaseField::from_canonical_u64(1),
         };
         let backing_domain = Self::to_extension_domain(&base_domain);
 

--- a/whir/src/ntt/ntt_impl.rs
+++ b/whir/src/ntt/ntt_impl.rs
@@ -131,8 +131,8 @@ impl<F: TwoAdicField> NttEngine<F> {
             let omega_3_1 = res.root(3);
             let omega_3_2 = omega_3_1 * omega_3_1;
             // Note: char F cannot be 2 and so division by 2 works, because primitive roots of unity with even order exist.
-            res.half_omega_3_1_min_2 = (omega_3_1 - omega_3_2) / F::from_u64(2u64);
-            res.half_omega_3_1_plus_2 = (omega_3_1 + omega_3_2) / F::from_u64(2u64);
+            res.half_omega_3_1_min_2 = (omega_3_1 - omega_3_2) / F::from_canonical_u64(2u64);
+            res.half_omega_3_1_plus_2 = (omega_3_1 + omega_3_2) / F::from_canonical_u64(2u64);
         }
         if order % 4 == 0 {
             res.omega_4_1 = res.root(4);

--- a/whir/src/sumcheck/mod.rs
+++ b/whir/src/sumcheck/mod.rs
@@ -222,7 +222,7 @@ mod tests {
         {
             FieldType::Base(evals) => {
                 assert_eq!(evals.len(), 1);
-                F::from_base(&evals[0])
+                F::from_ref_base(&evals[0])
             }
             FieldType::Ext(evals) => {
                 assert_eq!(evals.len(), 1);
@@ -312,7 +312,7 @@ mod tests {
             .fix_variables(&folding_randomness_3.clone())
             .evaluations()
         {
-            FieldType::Base(evals) => F::from_base(&evals[0]),
+            FieldType::Base(evals) => F::from_ref_base(&evals[0]),
             FieldType::Ext(evals) => evals[0],
             _ => panic!("Invalid folded polynomial"),
         };

--- a/whir/src/sumcheck/mod.rs
+++ b/whir/src/sumcheck/mod.rs
@@ -13,7 +13,7 @@ mod tests {
         mle::{FieldType, MultilinearExtension},
         virtual_poly::eq_eval,
     };
-    use p3::field::PrimeCharacteristicRing;
+    use p3::field::FieldAlgebra;
 
     use crate::whir::fold::expand_from_univariate;
 
@@ -24,28 +24,28 @@ mod tests {
     #[test]
     fn test_sumcheck_folding_factor_1() {
         let folding_factor = 1;
-        let eval_point = vec![F::from_u64(10), F::from_u64(11)];
+        let eval_point = vec![F::from_canonical_u64(10), F::from_canonical_u64(11)];
         let polynomial = MultilinearExtension::from_evaluations_ext_vec(
             2,
             vec![
-                F::from_u64(1),
-                F::from_u64(5),
-                F::from_u64(10),
-                F::from_u64(14),
+                F::from_canonical_u64(1),
+                F::from_canonical_u64(5),
+                F::from_canonical_u64(10),
+                F::from_canonical_u64(14),
             ],
         );
 
         let claimed_value = polynomial.evaluate(&eval_point);
 
-        let mut prover = SumcheckCore::new(polynomial, &[eval_point], &[F::from_u64(1)]);
+        let mut prover = SumcheckCore::new(polynomial, &[eval_point], &[F::from_canonical_u64(1)]);
 
         let poly_1 = prover.compute_sumcheck_polynomial(folding_factor);
 
         // First, check that is sums to the right value over the hypercube
         assert_eq!(poly_1.sum_over_hypercube(), claimed_value);
 
-        let combination_randomness = F::from_u64(100101);
-        let folding_randomness = vec![F::from_u64(4999)];
+        let combination_randomness = F::from_canonical_u64(100101);
+        let folding_randomness = vec![F::from_canonical_u64(4999)];
 
         prover.compress(folding_factor, combination_randomness, &folding_randomness);
 
@@ -64,21 +64,21 @@ mod tests {
         let polynomial = MultilinearExtension::from_evaluations_ext_vec(
             2,
             vec![
-                F::from_u64(1),
-                F::from_u64(2),
-                F::from_u64(3),
-                F::from_u64(4),
+                F::from_canonical_u64(1),
+                F::from_canonical_u64(2),
+                F::from_canonical_u64(3),
+                F::from_canonical_u64(4),
             ],
         );
 
-        let ood_point = expand_from_univariate(F::from_u64(2), num_variables);
-        let statement_point = expand_from_univariate(F::from_u64(3), num_variables);
+        let ood_point = expand_from_univariate(F::from_canonical_u64(2), num_variables);
+        let statement_point = expand_from_univariate(F::from_canonical_u64(3), num_variables);
 
         let ood_answer = polynomial.evaluate(&ood_point);
         let statement_answer = polynomial.evaluate(&statement_point);
 
-        let epsilon_1 = F::from_u64(10);
-        let epsilon_2 = F::from_u64(100);
+        let epsilon_1 = F::from_canonical_u64(10);
+        let epsilon_2 = F::from_canonical_u64(100);
 
         let prover = SumcheckCore::new(
             polynomial.clone(),
@@ -93,7 +93,7 @@ mod tests {
             epsilon_1 * ood_answer + epsilon_2 * statement_answer
         );
 
-        let folding_randomness = vec![F::from_u64(400000), F::from_u64(800000)];
+        let folding_randomness = vec![F::from_canonical_u64(400000), F::from_canonical_u64(800000)];
 
         let poly_eval = polynomial.evaluate(&folding_randomness);
         let v_eval = epsilon_1 * eq_eval(&ood_point, &folding_randomness)
@@ -109,25 +109,29 @@ mod tests {
     fn test_sumcheck_folding_factor_2() {
         let num_variables = 6;
         let folding_factor = 2;
-        let eval_point = vec![F::from_u64(97); num_variables];
+        let eval_point = vec![F::from_canonical_u64(97); num_variables];
         let polynomial = MultilinearExtension::from_evaluations_ext_vec(
             num_variables,
-            (0..1 << num_variables).map(F::from_u64).collect(),
+            (0..1 << num_variables).map(F::from_canonical_u64).collect(),
         );
 
         let claimed_value = polynomial.evaluate(&eval_point);
 
-        let mut prover = SumcheckCore::new(polynomial.clone(), &[eval_point], &[F::from_u64(1)]);
+        let mut prover = SumcheckCore::new(
+            polynomial.clone(),
+            &[eval_point],
+            &[F::from_canonical_u64(1)],
+        );
 
         let poly_1 = prover.compute_sumcheck_polynomial(folding_factor);
 
         // First, check that is sums to the right value over the hypercube
         assert_eq!(poly_1.sum_over_hypercube(), claimed_value);
 
-        let combination_randomness = [F::from_u64(293), F::from_u64(42)];
-        let folding_randomness = vec![F::from_u64(335), F::from_u64(222)];
+        let combination_randomness = [F::from_canonical_u64(293), F::from_canonical_u64(42)];
+        let folding_randomness = vec![F::from_canonical_u64(335), F::from_canonical_u64(222)];
 
-        let new_eval_point = vec![F::from_u64(32); num_variables - folding_factor];
+        let new_eval_point = vec![F::from_canonical_u64(32); num_variables - folding_factor];
         let folded_polynomial = polynomial.fix_variables(&folding_randomness);
         let new_fold_eval = folded_polynomial.evaluate(&new_eval_point);
 
@@ -146,7 +150,7 @@ mod tests {
                 + combination_randomness[1] * new_fold_eval
         );
 
-        let combination_randomness = F::from_u64(23212);
+        let combination_randomness = F::from_canonical_u64(23212);
         prover.compress(folding_factor, combination_randomness, &folding_randomness);
 
         let poly_3 = prover.compute_sumcheck_polynomial(folding_factor);
@@ -163,19 +167,19 @@ mod tests {
         let folding_factor = 2;
         let polynomial = MultilinearExtension::from_evaluations_ext_vec(
             num_variables,
-            (0..1 << num_variables).map(F::from_u64).collect(),
+            (0..1 << num_variables).map(F::from_canonical_u64).collect(),
         );
 
         // Initial stuff
-        let ood_point = expand_from_univariate(F::from_u64(42), num_variables);
-        let statement_point = expand_from_univariate(F::from_u64(97), num_variables);
+        let ood_point = expand_from_univariate(F::from_canonical_u64(42), num_variables);
+        let statement_point = expand_from_univariate(F::from_canonical_u64(97), num_variables);
 
         // All the randomness
-        let [epsilon_1, epsilon_2] = [F::from_u64(15), F::from_u64(32)];
-        let folding_randomness_1 = vec![F::from_u64(11), F::from_u64(31)];
-        let fold_point = vec![F::from_u64(31), F::from_u64(15)];
-        let combination_randomness = [F::from_u64(31), F::from_u64(4999)];
-        let folding_randomness_2 = vec![F::from_u64(97), F::from_u64(36)];
+        let [epsilon_1, epsilon_2] = [F::from_canonical_u64(15), F::from_canonical_u64(32)];
+        let folding_randomness_1 = vec![F::from_canonical_u64(11), F::from_canonical_u64(31)];
+        let fold_point = vec![F::from_canonical_u64(31), F::from_canonical_u64(15)];
+        let combination_randomness = [F::from_canonical_u64(31), F::from_canonical_u64(4999)];
+        let folding_randomness_2 = vec![F::from_canonical_u64(97), F::from_canonical_u64(36)];
 
         let mut prover = SumcheckCore::new(
             polynomial.clone(),
@@ -242,33 +246,37 @@ mod tests {
         let folding_factor = 2;
         let polynomial = MultilinearExtension::from_evaluations_ext_vec(
             num_variables,
-            (0..1 << num_variables).map(F::from_u64).collect(),
+            (0..1 << num_variables).map(F::from_canonical_u64).collect(),
         );
 
         // Initial stuff
-        let ood_point = expand_from_univariate(F::from_u64(42), num_variables);
-        let statement_point = expand_from_univariate(F::from_u64(97), num_variables);
+        let ood_point = expand_from_univariate(F::from_canonical_u64(42), num_variables);
+        let statement_point = expand_from_univariate(F::from_canonical_u64(97), num_variables);
 
         // All the randomness
-        let [epsilon_1, epsilon_2] = [F::from_u64(15), F::from_u64(32)];
-        let folding_randomness_1 = vec![F::from_u64(11), F::from_u64(31)];
-        let folding_randomness_2 = vec![F::from_u64(97), F::from_u64(36)];
-        let folding_randomness_3 = vec![F::from_u64(11297), F::from_u64(42136)];
+        let [epsilon_1, epsilon_2] = [F::from_canonical_u64(15), F::from_canonical_u64(32)];
+        let folding_randomness_1 = vec![F::from_canonical_u64(11), F::from_canonical_u64(31)];
+        let folding_randomness_2 = vec![F::from_canonical_u64(97), F::from_canonical_u64(36)];
+        let folding_randomness_3 = vec![F::from_canonical_u64(11297), F::from_canonical_u64(42136)];
         let fold_point_11 = vec![
-            F::from_u64(31),
-            F::from_u64(15),
-            F::from_u64(31),
-            F::from_u64(15),
+            F::from_canonical_u64(31),
+            F::from_canonical_u64(15),
+            F::from_canonical_u64(31),
+            F::from_canonical_u64(15),
         ];
         let fold_point_12 = vec![
-            F::from_u64(1231),
-            F::from_u64(15),
-            F::from_u64(4231),
-            F::from_u64(15),
+            F::from_canonical_u64(1231),
+            F::from_canonical_u64(15),
+            F::from_canonical_u64(4231),
+            F::from_canonical_u64(15),
         ];
-        let fold_point_2 = vec![F::from_u64(311), F::from_u64(115)];
-        let combination_randomness_1 = [F::from_u64(1289), F::from_u64(3281), F::from_u64(10921)];
-        let combination_randomness_2 = [F::from_u64(3281), F::from_u64(3232)];
+        let fold_point_2 = vec![F::from_canonical_u64(311), F::from_canonical_u64(115)];
+        let combination_randomness_1 = [
+            F::from_canonical_u64(1289),
+            F::from_canonical_u64(3281),
+            F::from_canonical_u64(10921),
+        ];
+        let combination_randomness_2 = [F::from_canonical_u64(3281), F::from_canonical_u64(3232)];
 
         let mut prover = SumcheckCore::new(
             polynomial.clone(),

--- a/whir/src/sumcheck/proof.rs
+++ b/whir/src/sumcheck/proof.rs
@@ -76,7 +76,7 @@ where
 mod tests {
 
     use ff_ext::GoldilocksExt2;
-    use p3::field::PrimeCharacteristicRing;
+    use p3::field::FieldAlgebra;
 
     use crate::utils::base_decomposition;
 
@@ -89,13 +89,18 @@ mod tests {
         let num_variables = 2;
 
         let num_evaluation_points = 3_usize.pow(num_variables as u32);
-        let evaluations = (0..num_evaluation_points as u64).map(F::from_u64).collect();
+        let evaluations = (0..num_evaluation_points as u64)
+            .map(F::from_canonical_u64)
+            .collect();
 
         let poly = SumcheckPolynomial::new(evaluations, num_variables);
 
         for i in 0..num_evaluation_points {
             let decomp = base_decomposition(i, 3, num_variables);
-            let point = decomp.into_iter().map(F::from_u8).collect::<Vec<_>>();
+            let point = decomp
+                .into_iter()
+                .map(F::from_canonical_u8)
+                .collect::<Vec<_>>();
             assert_eq!(poly.evaluate_at_point(&point), poly.evaluations()[i]);
         }
     }

--- a/whir/src/sumcheck/prover_batched.rs
+++ b/whir/src/sumcheck/prover_batched.rs
@@ -50,7 +50,7 @@ where
             SumcheckSingle::eval_eq(
                 point,
                 &mut prover.evaluations_of_equality[i],
-                F::from_u64(1),
+                F::from_canonical_u64(1),
             );
             prover.sum += poly_comb_coeff[i] * evals[i];
         }
@@ -234,7 +234,7 @@ where
 mod tests {
     use ff_ext::GoldilocksExt2;
     use multilinear_extensions::mle::MultilinearExtension;
-    use p3::field::PrimeCharacteristicRing;
+    use p3::field::FieldAlgebra;
 
     use super::SumcheckBatched;
 
@@ -244,24 +244,24 @@ mod tests {
     fn test_sumcheck_folding_factor_1() {
         let num_rounds = 2;
         let eval_points = vec![
-            vec![F::from_u64(10), F::from_u64(11)],
-            vec![F::from_u64(7), F::from_u64(8)],
+            vec![F::from_canonical_u64(10), F::from_canonical_u64(11)],
+            vec![F::from_canonical_u64(7), F::from_canonical_u64(8)],
         ];
         let polynomials = vec![
             vec![
-                F::from_u64(1),
-                F::from_u64(5),
-                F::from_u64(10),
-                F::from_u64(14),
+                F::from_canonical_u64(1),
+                F::from_canonical_u64(5),
+                F::from_canonical_u64(10),
+                F::from_canonical_u64(14),
             ],
             vec![
-                F::from_u64(2),
-                F::from_u64(6),
-                F::from_u64(11),
-                F::from_u64(13),
+                F::from_canonical_u64(2),
+                F::from_canonical_u64(6),
+                F::from_canonical_u64(11),
+                F::from_canonical_u64(13),
             ],
         ];
-        let poly_comb_coeffs = vec![F::from_u64(2), F::from_u64(3)];
+        let poly_comb_coeffs = vec![F::from_canonical_u64(2), F::from_canonical_u64(3)];
 
         let evals: Vec<F> = polynomials
             .iter()
@@ -273,7 +273,7 @@ mod tests {
         let mut claimed_value: F = evals
             .iter()
             .zip(&poly_comb_coeffs)
-            .fold(F::from_u64(0), |sum, (eval, poly_rand)| {
+            .fold(F::from_canonical_u64(0), |sum, (eval, poly_rand)| {
                 *eval * *poly_rand + sum
             });
 
@@ -288,8 +288,8 @@ mod tests {
             // First, check that is sums to the right value over the hypercube
             assert_eq!(poly.sum_over_hypercube(), claimed_value);
 
-            let next_comb_randomness = F::from_u64(100101);
-            let next_fold_randomness = vec![F::from_u64(4999)];
+            let next_comb_randomness = F::from_canonical_u64(100101);
+            let next_fold_randomness = vec![F::from_canonical_u64(4999)];
 
             prover.compress(next_comb_randomness, &next_fold_randomness, &poly);
             claimed_value = next_comb_randomness * poly.evaluate_at_point(&next_fold_randomness);

--- a/whir/src/sumcheck/prover_core.rs
+++ b/whir/src/sumcheck/prover_core.rs
@@ -26,7 +26,10 @@ impl<F: ExtensionField> SumcheckCore<F> {
 
         let mut prover = SumcheckCore {
             evaluation_of_p: match coeffs.evaluations() {
-                FieldType::Base(evals) => evals.iter().map(|e| F::from_base(e)).collect::<Vec<_>>(),
+                FieldType::Base(evals) => evals
+                    .iter()
+                    .map(|e| F::from_ref_base(e))
+                    .collect::<Vec<_>>(),
                 FieldType::Ext(evals) => evals.to_vec(),
                 _ => panic!("Invalid field type"),
             }, // transform coefficient form -> evaluation form

--- a/whir/src/sumcheck/prover_not_skipping.rs
+++ b/whir/src/sumcheck/prover_not_skipping.rs
@@ -75,7 +75,7 @@ mod tests {
         mle::{FieldType, MultilinearExtension},
         virtual_poly::eq_eval,
     };
-    use p3::{field::PrimeCharacteristicRing, util::log2_strict_usize};
+    use p3::{field::FieldAlgebra, util::log2_strict_usize};
     use transcript::{BasicTranscript, Transcript};
 
     use crate::{
@@ -102,14 +102,16 @@ mod tests {
     fn test_e2e_short() -> Result<(), Error> {
         let num_variables = 2;
         let folding_factor = 2;
-        let polynomial = (0..1 << num_variables).map(F::from_u64).collect::<Vec<_>>();
+        let polynomial = (0..1 << num_variables)
+            .map(F::from_canonical_u64)
+            .collect::<Vec<_>>();
 
         // Initial stuff
-        let ood_point = expand_from_univariate(F::from_u64(42), num_variables);
-        let statement_point = expand_from_univariate(F::from_u64(97), num_variables);
+        let ood_point = expand_from_univariate(F::from_canonical_u64(42), num_variables);
+        let statement_point = expand_from_univariate(F::from_canonical_u64(97), num_variables);
 
         // All the randomness
-        let [epsilon_1, epsilon_2] = [F::from_u64(15), F::from_u64(32)];
+        let [epsilon_1, epsilon_2] = [F::from_canonical_u64(15), F::from_canonical_u64(32)];
 
         // Prover part
         let mut transcript = T::new(b"test");
@@ -188,16 +190,18 @@ mod tests {
     fn test_e2e() -> Result<(), Error> {
         let num_variables = 4;
         let folding_factor = 2;
-        let polynomial = (0..1 << num_variables).map(F::from_u64).collect::<Vec<_>>();
+        let polynomial = (0..1 << num_variables)
+            .map(F::from_canonical_u64)
+            .collect::<Vec<_>>();
 
         // Initial stuff
-        let ood_point = expand_from_univariate(F::from_u64(42), num_variables);
-        let statement_point = expand_from_univariate(F::from_u64(97), num_variables);
+        let ood_point = expand_from_univariate(F::from_canonical_u64(42), num_variables);
+        let statement_point = expand_from_univariate(F::from_canonical_u64(97), num_variables);
 
         // All the randomness
-        let [epsilon_1, epsilon_2] = [F::from_u64(15), F::from_u64(32)];
-        let fold_point = vec![F::from_u64(31), F::from_u64(15)];
-        let combination_randomness = vec![F::from_u64(1000)];
+        let [epsilon_1, epsilon_2] = [F::from_canonical_u64(15), F::from_canonical_u64(32)];
+        let fold_point = vec![F::from_canonical_u64(31), F::from_canonical_u64(15)];
+        let combination_randomness = vec![F::from_canonical_u64(1000)];
 
         // Prover part
         let mut transcript = T::new(b"test");

--- a/whir/src/sumcheck/prover_not_skipping_batched.rs
+++ b/whir/src/sumcheck/prover_not_skipping_batched.rs
@@ -64,7 +64,7 @@ mod tests {
         mle::{FieldType, MultilinearExtension},
         virtual_poly::eq_eval,
     };
-    use p3::{field::PrimeCharacteristicRing, util::log2_strict_usize};
+    use p3::{field::FieldAlgebra, util::log2_strict_usize};
     use transcript::{BasicTranscript, Transcript};
 
     use crate::{
@@ -96,18 +96,20 @@ mod tests {
         let num_variables = 2;
         let folding_factor = 2;
         let polynomials = vec![
-            (0..1 << num_variables).map(F::from_u64).collect(),
-            (1..(1 << num_variables) + 1).map(F::from_u64).collect(),
+            (0..1 << num_variables).map(F::from_canonical_u64).collect(),
+            (1..(1 << num_variables) + 1)
+                .map(F::from_canonical_u64)
+                .collect(),
         ];
 
         // Initial stuff
         let statement_points = vec![
-            expand_from_univariate(F::from_u64(97), num_variables),
-            expand_from_univariate(F::from_u64(75), num_variables),
+            expand_from_univariate(F::from_canonical_u64(97), num_variables),
+            expand_from_univariate(F::from_canonical_u64(75), num_variables),
         ];
 
         // Poly randomness
-        let [alpha_1, alpha_2] = [F::from_u64(15), F::from_u64(32)];
+        let [alpha_1, alpha_2] = [F::from_canonical_u64(15), F::from_canonical_u64(32)];
 
         // Prover part
         let mut transcript = T::new(b"test");

--- a/whir/src/sumcheck/prover_single.rs
+++ b/whir/src/sumcheck/prover_single.rs
@@ -240,7 +240,7 @@ where
 mod tests {
     use ff_ext::GoldilocksExt2;
     use multilinear_extensions::mle::MultilinearExtension;
-    use p3::field::PrimeCharacteristicRing;
+    use p3::field::FieldAlgebra;
 
     use super::SumcheckSingle;
 
@@ -248,12 +248,12 @@ mod tests {
 
     #[test]
     fn test_sumcheck_folding_factor_1() {
-        let eval_point = vec![E::from_u64(10), E::from_u64(11)];
+        let eval_point = vec![E::from_canonical_u64(10), E::from_canonical_u64(11)];
         let polynomial = vec![
-            E::from_u64(1),
-            E::from_u64(5),
-            E::from_u64(10),
-            E::from_u64(14),
+            E::from_canonical_u64(1),
+            E::from_canonical_u64(5),
+            E::from_canonical_u64(10),
+            E::from_canonical_u64(14),
         ];
 
         let claimed_value = MultilinearExtension::from_evaluations_ext_vec(2, polynomial.clone())
@@ -261,15 +261,20 @@ mod tests {
 
         let eval = MultilinearExtension::from_evaluations_ext_vec(2, polynomial.clone())
             .evaluate(&eval_point);
-        let mut prover = SumcheckSingle::new(polynomial, &[eval_point], &[E::from_u64(1)], &[eval]);
+        let mut prover = SumcheckSingle::new(
+            polynomial,
+            &[eval_point],
+            &[E::from_canonical_u64(1)],
+            &[eval],
+        );
 
         let poly_1 = prover.compute_sumcheck_polynomial();
 
         // First, check that is sums to the right value over the hypercube
         assert_eq!(poly_1.sum_over_hypercube(), claimed_value);
 
-        let combination_randomness = E::from_u64(100101);
-        let folding_randomness = vec![E::from_u64(4999)];
+        let combination_randomness = E::from_canonical_u64(100101);
+        let folding_randomness = vec![E::from_canonical_u64(4999)];
 
         prover.compress(combination_randomness, &folding_randomness, &poly_1);
 

--- a/whir/src/utils.rs
+++ b/whir/src/utils.rs
@@ -214,13 +214,14 @@ pub fn evaluate_over_hypercube<F: Field>(coeffs: &mut [F]) {
 pub fn evaluate_as_multilinear_evals<E: ExtensionField>(evals: &[E::BaseField], point: &[E]) -> E {
     if evals.len() == 1 {
         // It's a constant function, so just return the constant value.
-        return E::from_base(&evals[0]);
+        return E::from_ref_base(&evals[0]);
     }
     assert_eq!(evals.len(), 1 << point.len());
     let mut fold_result = evals
         .par_chunks_exact(2)
         .map(|chunk| {
-            (E::ONE - point[0]) * E::from_base(&chunk[0]) + E::from_base(&chunk[1]) * point[0]
+            (E::ONE - point[0]) * E::from_ref_base(&chunk[0])
+                + E::from_ref_base(&chunk[1]) * point[0]
         })
         .collect::<Vec<_>>();
     let mut index = 1;
@@ -278,7 +279,7 @@ pub fn evaluate_as_univariate<E: ExtensionField>(evals: &[E], points: &[E]) -> V
 #[cfg(test)]
 mod tests {
     use multilinear_extensions::mle::FieldType;
-    use p3::field::PrimeCharacteristicRing;
+    use p3::field::FieldAlgebra;
     use rand::thread_rng;
     use witness::RowMajorMatrix;
 
@@ -297,7 +298,7 @@ mod tests {
         let folding_factor = 3;
         let fold_size = 1 << folding_factor;
         assert_eq!(num % fold_size, 0);
-        let evals: Vec<F> = (0..num as u64).map(F::from_u64).collect();
+        let evals: Vec<F> = (0..num as u64).map(F::from_canonical_u64).collect();
 
         let stacked = stack_evaluations(evals, folding_factor);
         assert_eq!(stacked.len(), num);
@@ -305,7 +306,10 @@ mod tests {
         for (i, fold) in stacked.chunks_exact(fold_size).enumerate() {
             assert_eq!(fold.len(), fold_size);
             for (j, item) in fold.iter().copied().enumerate().take(fold_size) {
-                assert_eq!(item, F::from_u64((i + j * num / fold_size) as u64));
+                assert_eq!(
+                    item,
+                    F::from_canonical_u64((i + j * num / fold_size) as u64)
+                );
             }
         }
     }

--- a/whir/src/whir/batch/prover.rs
+++ b/whir/src/whir/batch/prover.rs
@@ -145,7 +145,7 @@ where
                     .polys
                     .iter()
                     .zip(&random_coeff)
-                    .map(|(eval, coeff)| E::from_base(&eval[i]) * *coeff)
+                    .map(|(eval, coeff)| E::from_ref_base(&eval[i]) * *coeff)
                     .sum()
             })
             .collect::<Vec<_>>();
@@ -387,7 +387,7 @@ where
                             &round_state.folding_randomness,
                             coset_offset_inv,
                             coset_generator_inv,
-                            E::from_u64(2).inverse(),
+                            E::from_canonical_u64(2).inverse(),
                             self.0.folding_factor.at_round(round_state.round),
                         )
                     },
@@ -516,7 +516,7 @@ where
             witness
                 .polys
                 .par_iter()
-                .map(|poly| poly.par_iter().map(|x| E::from_base(x)).collect())
+                .map(|poly| poly.par_iter().map(|x| E::from_ref_base(x)).collect())
                 .collect(),
             initial_eval_claims,
             &poly_comb_randomness,

--- a/whir/src/whir/committer.rs
+++ b/whir/src/whir/committer.rs
@@ -12,7 +12,7 @@ use crate::{
 use ff_ext::ExtensionField;
 use multilinear_extensions::mle::{FieldType, MultilinearExtension};
 use p3::{
-    field::{Field, PrimeCharacteristicRing},
+    field::{Field, FieldAlgebra},
     matrix::dense::RowMajorMatrix,
 };
 use sumcheck::macros::{entered_span, exit_span};
@@ -39,7 +39,7 @@ where
             #[cfg(feature = "parallel")]
             FieldType::Base(evals) => evals.to_vec(),
             #[cfg(not(feature = "parallel"))]
-            FieldType::Base(evals) => evals.iter().map(|x| E::from_base(x)).collect(),
+            FieldType::Base(evals) => evals.iter().map(|x| E::from_ref_base(x)).collect(),
             FieldType::Ext(_) => panic!("Not supporting committing to ext polys"),
             _ => panic!("Unsupported field type"),
         };

--- a/whir/src/whir/fold.rs
+++ b/whir/src/whir/fold.rs
@@ -67,7 +67,7 @@ pub fn restructure_evaluations<F: TwoAdicField>(
 
             // Apply coset and size correction.
             // Stacked evaluation at i is f(B_l) where B_l = w^i * <w^n/k>
-            let size_inv = F::from_u64(folding_size).inverse();
+            let size_inv = F::from_canonical_u64(folding_size).inverse();
             #[cfg(not(feature = "parallel"))]
             {
                 let mut coset_offset_inv = F::ONE;
@@ -121,7 +121,7 @@ pub fn restructure_evaluations_mut<F: TwoAdicField>(
 
             // Apply coset and size correction.
             // Stacked evaluation at i is f(B_l) where B_l = w^i * <w^n/k>
-            let size_inv = F::from_u64(folding_size).inverse();
+            let size_inv = F::from_canonical_u64(folding_size).inverse();
             #[cfg(not(feature = "parallel"))]
             {
                 let mut coset_offset_inv = F::ONE;
@@ -174,7 +174,7 @@ pub fn restructure_evaluations_mut_rmm<F: TwoAdicField + Ord>(
 
             // Apply coset and size correction.
             // Stacked evaluation at i is f(B_l) where B_l = w^i * <w^n/k>
-            let size_inv = F::from_u64(folding_size).inverse();
+            let size_inv = F::from_canonical_u64(folding_size).inverse();
             #[cfg(not(feature = "parallel"))]
             {
                 let mut coset_offset_inv = F::ONE;
@@ -361,7 +361,7 @@ where
 mod tests {
     use ff_ext::GoldilocksExt2;
     use multilinear_extensions::mle::MultilinearExtension;
-    use p3::field::{Field, PrimeCharacteristicRing, TwoAdicField};
+    use p3::field::{Field, FieldAlgebra, TwoAdicField};
 
     use crate::{
         utils::{evaluate_over_hypercube, stack_evaluations},
@@ -383,14 +383,17 @@ mod tests {
 
         let poly = MultilinearExtension::from_evaluations_ext_vec(
             num_variables,
-            (0..num_coeffs).map(F::from_u64).collect::<Vec<_>>(),
+            (0..num_coeffs)
+                .map(F::from_canonical_u64)
+                .collect::<Vec<_>>(),
         );
 
         let root_of_unity = F::two_adic_generator(p3::util::log2_strict_usize(domain_size));
 
         let index = 15;
-        let folding_randomness: Vec<_> =
-            (0..folding_factor).map(|i| F::from_u64(i as u64)).collect();
+        let folding_randomness: Vec<_> = (0..folding_factor)
+            .map(|i| F::from_canonical_u64(i as u64))
+            .collect();
 
         let coset_offset = root_of_unity.exp_u64(index);
         let coset_gen = root_of_unity.exp_u64((domain_size / folding_factor_exp) as u64);
@@ -410,7 +413,7 @@ mod tests {
             &folding_randomness,
             coset_offset.inverse(),
             coset_gen.inverse(),
-            F::from_u64(2).inverse(),
+            F::from_canonical_u64(2).inverse(),
             folding_factor,
         );
 
@@ -435,14 +438,17 @@ mod tests {
 
         let poly = MultilinearExtension::from_evaluations_ext_vec(
             num_variables,
-            (0..num_coeffs).map(F::from_u64).collect::<Vec<_>>(),
+            (0..num_coeffs)
+                .map(F::from_canonical_u64)
+                .collect::<Vec<_>>(),
         );
 
         let root_of_unity = F::two_adic_generator(p3::util::log2_strict_usize(domain_size));
         let root_of_unity_inv = root_of_unity.inverse();
 
-        let folding_randomness: Vec<_> =
-            (0..folding_factor).map(|i| F::from_u64(i as u64)).collect();
+        let folding_randomness: Vec<_> = (0..folding_factor)
+            .map(|i| F::from_canonical_u64(i as u64))
+            .collect();
 
         // Evaluate the polynomial on the domain
         let domain_evaluations: Vec<_> = (0..domain_size)
@@ -471,7 +477,7 @@ mod tests {
                 &folding_randomness,
                 offset_inv,
                 coset_gen_inv,
-                F::from_u64(2).inverse(),
+                F::from_canonical_u64(2).inverse(),
                 folding_factor,
             );
 

--- a/whir/src/whir/mod.rs
+++ b/whir/src/whir/mod.rs
@@ -39,7 +39,7 @@ where
 mod tests {
     use ff_ext::{ExtensionField, FromUniformBytes, GoldilocksExt2};
     use multilinear_extensions::mle::MultilinearExtension;
-    use p3::field::PrimeCharacteristicRing;
+    use p3::field::FieldAlgebra;
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
     use transcript::BasicTranscript;
@@ -91,7 +91,7 @@ mod tests {
 
         let polynomial = MultilinearExtension::from_evaluations_vec(
             num_variables,
-            vec![<E as ExtensionField>::BaseField::from_u64(1); num_coeffs],
+            vec![<E as ExtensionField>::BaseField::from_canonical_u64(1); num_coeffs],
         );
 
         let points: Vec<_> = (0..num_points)

--- a/whir/src/whir/prover.rs
+++ b/whir/src/whir/prover.rs
@@ -114,7 +114,7 @@ where
             sumcheck_prover = Some(SumcheckProverNotSkipping::new(
                 witness.polys[0]
                     .par_iter()
-                    .map(|x| E::from_base(x))
+                    .map(|x| E::from_ref_base(x))
                     .collect(),
                 &initial_claims,
                 &combination_randomness,
@@ -151,7 +151,7 @@ where
                 self.0.mv_parameters.num_variables,
                 witness.polys[0]
                     .par_iter()
-                    .map(|x| E::from_base(x))
+                    .map(|x| E::from_ref_base(x))
                     .collect(),
             ),
             prev_merkle: Some(&witness.merkle_tree),
@@ -365,7 +365,7 @@ where
                             &round_state.folding_randomness,
                             coset_offset_inv,
                             coset_generator_inv,
-                            E::from_u64(2).inverse(),
+                            E::from_canonical_u64(2).inverse(),
                             self.0.folding_factor.at_round(round_state.round),
                         )
                     },

--- a/whir/src/whir/verifier.rs
+++ b/whir/src/whir/verifier.rs
@@ -6,7 +6,7 @@ use ff_ext::{ExtensionField, PoseidonField};
 use multilinear_extensions::{mle::MultilinearExtension, virtual_poly::eq_eval};
 use p3::{
     commit::Mmcs,
-    field::{Field, PrimeCharacteristicRing},
+    field::{Field, FieldAlgebra},
 };
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
@@ -74,7 +74,7 @@ where
     pub fn new(params: WhirConfig<E>) -> Self {
         Verifier {
             params,
-            two_inv: E::BaseField::from_u64(2).inverse(), // The only inverse in the entire code :)
+            two_inv: E::BaseField::from_canonical_u64(2).inverse(), /* The only inverse in the entire code :) */
         }
     }
 
@@ -441,7 +441,7 @@ where
                         &round.folding_randomness,
                         coset_offset_inv,
                         coset_generator_inv,
-                        E::from_base(&self.two_inv),
+                        E::from_ref_base(&self.two_inv),
                         self.params.folding_factor.at_round(round_index),
                     )
                 })
@@ -469,7 +469,7 @@ where
                     &parsed.final_folding_randomness,
                     coset_offset_inv,
                     coset_generator_inv,
-                    E::from_base(&self.two_inv),
+                    E::from_ref_base(&self.two_inv),
                     self.params.folding_factor.at_round(parsed.rounds.len()),
                 )
             })

--- a/witness/src/lib.rs
+++ b/witness/src/lib.rs
@@ -1,6 +1,6 @@
 use multilinear_extensions::mle::{IntoMLE, MultilinearExtension};
 use p3::{
-    field::{Field, PrimeCharacteristicRing},
+    field::{Field, FieldAlgebra},
     matrix::Matrix,
 };
 use rand::{Rng, distributions::Standard, prelude::Distribution};
@@ -44,7 +44,7 @@ pub struct RowMajorMatrix<T: Sized + Sync + Clone + Send + Copy> {
     padding_strategy: InstancePaddingStrategy,
 }
 
-impl<T: Sized + Sync + Clone + Send + Copy + Default + PrimeCharacteristicRing> RowMajorMatrix<T> {
+impl<T: Sized + Sync + Clone + Send + Copy + Default + FieldAlgebra> RowMajorMatrix<T> {
     pub fn rand<R: Rng>(rng: &mut R, rows: usize, cols: usize) -> Self
     where
         Standard: Distribution<T>,
@@ -187,7 +187,7 @@ impl<T: Sized + Sync + Clone + Send + Copy + Default + PrimeCharacteristicRing> 
                     .enumerate()
                     .for_each(|(i, instance)| {
                         instance.iter_mut().enumerate().for_each(|(j, v)| {
-                            *v = T::from_u64(fun((start_index + i) as u64, j as u64));
+                            *v = T::from_canonical_u64(fun((start_index + i) as u64, j as u64));
                         })
                     });
             }
@@ -214,7 +214,7 @@ impl<T: Sized + Sync + Clone + Send + Copy + Default + PrimeCharacteristicRing> 
     }
 }
 
-impl<F: Field + PrimeCharacteristicRing> RowMajorMatrix<F> {
+impl<F: Field> RowMajorMatrix<F> {
     pub fn to_mles<'a, E: ff_ext::ExtensionField<BaseField = F>>(
         &self,
     ) -> Vec<MultilinearExtension<'a, E>> {
@@ -264,16 +264,14 @@ impl<F: Field + PrimeCharacteristicRing> RowMajorMatrix<F> {
                     .skip(i)
                     .step_by(n_column)
                     .copied()
-                    .map(|v| E::from_base(&v))
+                    .map(|v| E::from_ref_base(&v))
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>()
     }
 }
 
-impl<T: Sized + Sync + Clone + Send + Copy + Default + PrimeCharacteristicRing> Deref
-    for RowMajorMatrix<T>
-{
+impl<T: Sized + Sync + Clone + Send + Copy + Default> Deref for RowMajorMatrix<T> {
     type Target = p3::matrix::dense::DenseMatrix<T>;
 
     fn deref(&self) -> &Self::Target {
@@ -281,15 +279,13 @@ impl<T: Sized + Sync + Clone + Send + Copy + Default + PrimeCharacteristicRing> 
     }
 }
 
-impl<T: Sized + Sync + Clone + Send + Copy + Default + PrimeCharacteristicRing> DerefMut
-    for RowMajorMatrix<T>
-{
+impl<T: Sized + Sync + Clone + Send + Copy + Default> DerefMut for RowMajorMatrix<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
 
-impl<F: Sync + Send + Copy + PrimeCharacteristicRing> Index<usize> for RowMajorMatrix<F> {
+impl<F: Sync + Send + Copy + FieldAlgebra> Index<usize> for RowMajorMatrix<F> {
     type Output = [F];
 
     fn index(&self, idx: usize) -> &Self::Output {


### PR DESCRIPTION
## Rationale

We want to unify the `Plonky3` dependency among several repos.
- ceno: it depends on scroll's fork of Plonky3.
- [ceno-recursion-verifier](https://github.com/scroll-tech/ceno-recursion-verifier/):  it depends on OpenVM which use Plonky3 directly without any fork.

The PR will allow us to access the data structure of `ceno` inside `ceno-recursion-verifier` without having to seralize then deserialize it.

## Contents

- The old trait `PrimeCharacteristicRing` is replaced by `FieldAlgebra`;
- `from_u64` is replaced by `from_canonical_u64`;
- `from_u32` is replaced by `from_canonical_u32`;
- `from_u16` is replaced by `from_canonical_u16`;
- `from_u8` is replaced by `from_canonical_u8`.