### PR TITLE
[Build] Field Access Adjustment

### DIFF
--- a/ceno_zkvm/src/scheme.rs
+++ b/ceno_zkvm/src/scheme.rs
@@ -116,9 +116,9 @@ pub struct ZKVMProof<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> {
     pub pi_evals: Vec<E>,
     // circuit size -> instance mapping
     pub num_instances: Vec<(usize, usize)>,
-    opcode_proofs: BTreeMap<usize, ZKVMChipProof<E>>,
-    table_proofs: BTreeMap<usize, ZKVMChipProof<E>>,
-    witin_commit: <PCS as PolynomialCommitmentScheme<E>>::Commitment,
+    pub opcode_proofs: BTreeMap<usize, ZKVMChipProof<E>>,
+    pub table_proofs: BTreeMap<usize, ZKVMChipProof<E>>,
+    pub witin_commit: <PCS as PolynomialCommitmentScheme<E>>::Commitment,
     pub fixed_witin_opening_proof: PCS::Proof,
 }
 

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -33,7 +33,7 @@ use super::{ZKVMChipProof, ZKVMProof};
 
 #[derive(Clone)]
 pub struct ZKVMVerifier<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> {
-    pub(crate) vk: ZKVMVerifyingKey<E, PCS>,
+    pub vk: ZKVMVerifyingKey<E, PCS>,
 }
 
 impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS> {

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -85,7 +85,7 @@ impl<E: ExtensionField> ProvingKey<E> {
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(bound = "E: ExtensionField + DeserializeOwned")]
 pub struct VerifyingKey<E: ExtensionField> {
-    pub(crate) cs: ConstraintSystem<E>,
+    pub cs: ConstraintSystem<E>,
 }
 
 impl<E: ExtensionField> VerifyingKey<E> {

--- a/mpcs/src/basefold/structure.rs
+++ b/mpcs/src/basefold/structure.rs
@@ -168,9 +168,9 @@ pub struct BasefoldCommitment<E: ExtensionField>
 where
     E::BaseField: Serialize + DeserializeOwned,
 {
-    pub(super) commit: Digest<E>,
-    pub(crate) log2_max_codeword_size: usize,
-    pub(crate) trivial_commits: Vec<Digest<E>>,
+    pub commit: Digest<E>,
+    pub log2_max_codeword_size: usize,
+    pub trivial_commits: Vec<Digest<E>>,
 }
 
 impl<E: ExtensionField> BasefoldCommitment<E>

--- a/multilinear_extensions/src/lib.rs
+++ b/multilinear_extensions/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::cargo)]
 #![feature(decl_macro)]
 #![feature(strict_overflow_ops)]
-mod expression;
+pub mod expression;
 pub use expression::*;
 pub mod macros;
 pub mod mle;


### PR DESCRIPTION
- Due to `ceno-recursion-verifier` not being a subcrate of `Ceno`, certain private fields need to be exported for use.