### PR TITLE
Feat: simplify zkvm verifier

### DIFF
--- a/ceno_zkvm/src/error.rs
+++ b/ceno_zkvm/src/error.rs
@@ -13,6 +13,7 @@ pub enum ZKVMError {
     UtilError(UtilError),
     WitnessNotFound(String),
     InvalidWitness(String),
+    InvalidProof(String),
     VKNotFound(String),
     FixedTraceNotFound(String),
     VerifyError(String),

--- a/ceno_zkvm/src/scheme.rs
+++ b/ceno_zkvm/src/scheme.rs
@@ -133,7 +133,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProof<E, PCS> {
             pi_evals,
             chip_proofs,
             witin_commit,
-            opening_proof: opening_proof,
+            opening_proof,
         }
     }
 

--- a/ceno_zkvm/src/scheme.rs
+++ b/ceno_zkvm/src/scheme.rs
@@ -49,6 +49,7 @@ pub struct ZKVMChipProof<E: ExtensionField> {
 
     pub tower_proof: TowerProofs<E>,
 
+    pub num_instances: usize,
     pub fixed_in_evals: Vec<E>,
     pub wits_in_evals: Vec<E>,
 }
@@ -114,32 +115,25 @@ pub struct ZKVMProof<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> {
     pub raw_pi: Vec<Vec<E::BaseField>>,
     // the evaluation of raw_pi.
     pub pi_evals: Vec<E>,
-    // circuit size -> instance mapping
-    pub num_instances: Vec<(usize, usize)>,
-    opcode_proofs: BTreeMap<usize, ZKVMChipProof<E>>,
-    table_proofs: BTreeMap<usize, ZKVMChipProof<E>>,
+    chip_proofs: BTreeMap<usize, ZKVMChipProof<E>>,
     witin_commit: <PCS as PolynomialCommitmentScheme<E>>::Commitment,
-    pub fixed_witin_opening_proof: PCS::Proof,
+    pub opening_proof: PCS::Proof,
 }
 
 impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProof<E, PCS> {
     pub fn new(
         raw_pi: Vec<Vec<E::BaseField>>,
         pi_evals: Vec<E>,
-        opcode_proofs: BTreeMap<usize, ZKVMChipProof<E>>,
-        table_proofs: BTreeMap<usize, ZKVMChipProof<E>>,
+        chip_proofs: BTreeMap<usize, ZKVMChipProof<E>>,
         witin_commit: <PCS as PolynomialCommitmentScheme<E>>::Commitment,
-        fixed_witin_opening_proof: PCS::Proof,
-        num_instances: Vec<(usize, usize)>,
+        opening_proof: PCS::Proof,
     ) -> Self {
         Self {
             raw_pi,
             pi_evals,
-            opcode_proofs,
-            table_proofs,
+            chip_proofs,
             witin_commit,
-            fixed_witin_opening_proof,
-            num_instances,
+            opening_proof: opening_proof,
         }
     }
 
@@ -164,23 +158,19 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProof<E, PCS> {
     }
 
     pub fn num_circuits(&self) -> usize {
-        self.opcode_proofs.len() + self.table_proofs.len()
+        self.chip_proofs.len()
     }
 
     pub fn has_halt(&self, vk: &ZKVMVerifyingKey<E, PCS>) -> bool {
+        let halt_circuit_index = vk
+            .circuit_vks
+            .keys()
+            .position(|circuit_name| *circuit_name == HaltInstruction::<E>::name())
+            .expect("halt circuit not exist");
         let halt_instance_count = self
-            .num_instances
-            .iter()
-            .find_map(|(circuit_index, num_instances)| {
-                (*circuit_index
-                    == vk
-                        .circuit_vks
-                        .keys()
-                        .position(|circuit_name| *circuit_name == HaltInstruction::<E>::name())
-                        .expect("halt circuit not exist"))
-                .then_some(*num_instances)
-            })
-            .unwrap_or(0);
+            .chip_proofs
+            .get(&halt_circuit_index)
+            .map_or(0, |proof| proof.num_instances);
         if halt_instance_count > 0 {
             assert_eq!(
                 halt_instance_count, 1,
@@ -203,11 +193,11 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + Serialize> fmt::Dis
         let mpcs_opcode_commitment =
             bincode::serialized_size(&self.witin_commit).expect("serialization error");
         let mpcs_opcode_opening =
-            bincode::serialized_size(&self.fixed_witin_opening_proof).expect("serialization error");
+            bincode::serialized_size(&self.opening_proof).expect("serialization error");
 
-        // opcode circuit for tower proof size
-        let tower_proof_opcode = self
-            .opcode_proofs
+        // tower proof size
+        let tower_proof = self
+            .chip_proofs
             .iter()
             .map(|(circuit_index, proof)| {
                 let size = bincode::serialized_size(&proof.tower_proof);
@@ -219,37 +209,9 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + Serialize> fmt::Dis
             .expect("serialization error")
             .iter()
             .sum::<u64>();
-        // opcode circuit main sumcheck
-        let main_sumcheck_opcode = self
-            .opcode_proofs
-            .iter()
-            .map(|(circuit_index, proof)| {
-                let size = bincode::serialized_size(&proof.main_sumcheck_proofs);
-                size.inspect(|size| {
-                    *by_circuitname_stats.entry(circuit_index).or_insert(0) += size;
-                })
-            })
-            .collect::<Result<Vec<u64>, _>>()
-            .expect("serialization error")
-            .iter()
-            .sum::<u64>();
-        // table circuit for tower proof size
-        let tower_proof_table = self
-            .table_proofs
-            .iter()
-            .map(|(circuit_index, proof)| {
-                let size = bincode::serialized_size(&proof.tower_proof);
-                size.inspect(|size| {
-                    *by_circuitname_stats.entry(circuit_index).or_insert(0) += size;
-                })
-            })
-            .collect::<Result<Vec<u64>, _>>()
-            .expect("serialization error")
-            .iter()
-            .sum::<u64>();
-        // table circuit same r sumcheck
-        let same_r_sumcheck_table = self
-            .table_proofs
+        // main sumcheck
+        let main_sumcheck = self
+            .chip_proofs
             .iter()
             .map(|(circuit_index, proof)| {
                 let size = bincode::serialized_size(&proof.main_sumcheck_proofs);
@@ -286,20 +248,16 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + Serialize> fmt::Dis
             "overall_size {:.2}mb. \n\
             mpcs commitment {:?}% \n\
             mpcs opening {:?}% \n\
-            opcode tower proof {:?}% \n\
-            opcode main sumcheck proof {:?}% \n\
-            table tower proof {:?}% \n\
-            table same r sumcheck proof {:?}% \n\n\
+            tower proof {:?}% \n\
+            main sumcheck proof {:?}% \n\
             by circuit_name break down: \n\
             {}
             ",
             byte_to_mb(overall_size),
             (mpcs_opcode_commitment * 100).div(overall_size),
             (mpcs_opcode_opening * 100).div(overall_size),
-            (tower_proof_opcode * 100).div(overall_size),
-            (main_sumcheck_opcode * 100).div(overall_size),
-            (tower_proof_table * 100).div(overall_size),
-            (same_r_sumcheck_table * 100).div(overall_size),
+            (tower_proof * 100).div(overall_size),
+            (main_sumcheck * 100).div(overall_size),
             by_circuitname_stats,
         )
     }

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -236,13 +236,8 @@ impl<
                 } else {
                     // FIXME: PROGRAM table circuit is not guaranteed to have 2^n instances
                     input.num_instances = 1 << input.log2_num_instances();
-                    let (table_proof, pi_in_evals, input_opening_point) = self.create_chip_proof(
-                        circuit_name,
-                        pk,
-                        input,
-                        &mut transcript,
-                        &challenges,
-                    )?;
+                    let (mut table_proof, pi_in_evals, input_opening_point) = self
+                        .create_chip_proof(circuit_name, pk, input, &mut transcript, &challenges)?;
                     points.push(input_opening_point);
                     evaluations.push(
                         [
@@ -251,6 +246,8 @@ impl<
                         ]
                         .concat(),
                     );
+                    // FIXME: PROGRAM table circuit is not guaranteed to have 2^n instances
+                    table_proof.num_instances = num_instances;
                     chip_proofs.insert(index, table_proof);
                     for (idx, eval) in pi_in_evals {
                         pi_evals[idx] = eval;

--- a/ceno_zkvm/src/scheme/tests.rs
+++ b/ceno_zkvm/src/scheme/tests.rs
@@ -189,7 +189,6 @@ fn test_rw_lk_expression_combination() {
                 name.as_str(),
                 verifier.vk.circuit_vks.get(&name).unwrap(),
                 &proof,
-                num_instances,
                 &[],
                 &mut v_transcript,
                 NUM_FANIN,

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -180,6 +180,14 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
                     circuit_vk.get_cs().num_writes(),
                 )));
             }
+            if proof.lk_out_evals.len() != circuit_vk.get_cs().num_lks() {
+                return Err(ZKVMError::InvalidProof(format!(
+                    "lookup evaluations length mismatch: {} != {}",
+                    proof.lk_out_evals.len(),
+                    circuit_vk.get_cs().num_lks(),
+                )));
+            }
+
             let chip_logup_sum = proof
                 .lk_out_evals
                 .iter()

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -13,7 +13,6 @@ use multilinear_extensions::{
     virtual_poly::{VPAuxInfo, build_eq_x_r_vec_sequential, eq_eval},
 };
 use p3::field::FieldAlgebra;
-use std::collections::HashSet;
 use sumcheck::{
     structs::{IOPProof, IOPVerifierState},
     util::get_challenge_pows,
@@ -84,44 +83,16 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
 
         let pi_evals = &vm_proof.pi_evals;
 
-        // make sure circuit index are
-        // 1. unique
-        // 2. less than self.vk.circuit_vks.len()
-        assert!(
-            vm_proof
-                .num_instances
-                .iter()
-                .fold(None, |prev, &(circuit_index, _)| {
-                    (circuit_index < self.vk.circuit_vks.len()
-                        && prev.is_none_or(|p| p < circuit_index))
-                    .then_some(circuit_index)
-                })
-                .is_some(),
-            "num_instances validity check failed"
-        );
-
-        assert_eq!(
-            vm_proof
-                .num_instances
-                .iter()
-                .map(|(x, _)| x)
-                .collect::<HashSet<&usize>>(),
-            vm_proof
-                .opcode_proofs
-                .keys()
-                .chain(vm_proof.table_proofs.keys())
-                .collect::<HashSet<_>>(),
-            "num_instance circuit index exactly equal with provided proofs"
-        );
-
-        assert!(
-            vm_proof
-                .opcode_proofs
-                .keys()
-                .collect::<HashSet<_>>()
-                .is_disjoint(&vm_proof.table_proofs.keys().collect::<HashSet<_>>()),
-            "there is duplicated circuit index"
-        );
+        // make sure circuit index of chip proofs are
+        // subset of that of self.vk.circuit_vks
+        for chip_idx in vm_proof.chip_proofs.keys() {
+            if *chip_idx > self.vk.circuit_vks.len() {
+                return Err(ZKVMError::VKNotFound(format!(
+                    "chip index {chip_idx} not found in vk set [0..{})",
+                    self.vk.circuit_vks.len()
+                )));
+            }
+        }
 
         // TODO fix soundness: construct raw public input by ourself and trustless from proof
         // including raw public input to transcript
@@ -151,14 +122,11 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
             PCS::write_commitment(fixed_commit, &mut transcript).map_err(ZKVMError::PCSError)?;
         }
 
-        // write (circuit_size, num_var) to transcript
-        for (circuit_size, num_var) in &vm_proof.num_instances {
-            transcript.append_message(&circuit_size.to_le_bytes());
-            transcript.append_message(&num_var.to_le_bytes());
+        // write (circuit_idx, num_instance) to transcript
+        for (circuit_idx, proof) in &vm_proof.chip_proofs {
+            transcript.append_message(&circuit_idx.to_le_bytes());
+            transcript.append_message(&proof.num_instances.to_le_bytes());
         }
-
-        let circuit_vks: Vec<&VerifyingKey<E>> = self.vk.circuit_vks.values().collect_vec();
-        let circuit_names: Vec<&String> = self.vk.circuit_vks.keys().collect_vec();
 
         // write witin commitment to transcript
         PCS::write_commitment(&vm_proof.witin_commit, &mut transcript)
@@ -181,103 +149,77 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         let dummy_table_item = challenges[0];
         let mut dummy_table_item_multiplicity = 0;
         let point_eval = PointAndEval::default();
-        let mut rt_points = Vec::with_capacity(vm_proof.num_instances.len());
-        let mut evaluations = Vec::with_capacity(2 * vm_proof.num_instances.len()); // witin + fixed thus *2
-        for (index, num_instances) in &vm_proof.num_instances {
-            let circuit_vk = circuit_vks[*index];
-            let name = circuit_names[*index];
-            if let Some(opcode_proof) = vm_proof.opcode_proofs.get(index) {
-                transcript.append_field_element(&E::BaseField::from_canonical_u64(*index as u64));
-                let input_opening_point = self.verify_opcode_proof(
-                    name,
-                    circuit_vk,
-                    opcode_proof,
-                    *num_instances,
+        let mut rt_points = Vec::with_capacity(vm_proof.chip_proofs.len());
+        let mut evaluations = Vec::with_capacity(2 * vm_proof.chip_proofs.len()); // witin + fixed thus *2
+        for (index, proof) in &vm_proof.chip_proofs {
+            let circuit_name = self.vk.circuit_index_to_name[index];
+            let circuit_vk = self.vk.circuit_vks[&circuit_name];
+            let proof = vm_proof.chip_proofs[index];
+
+            // check the chip proof is well-formed
+            if proof.wits_in_evals.len() != circuit_vk.get_cs().num_witin()
+                || proof.fixed_in_evals.len() != circuit_vk.get_cs().num_fixed()
+            {
+                return Err(ZKVMError::InvalidProof(format!(
+                    "witness/fixed evaluations length mismatch: ({}, {}) != ({}, {})",
+                    proof.wits_in_evals.len(),
+                    proof.fixed_in_evals.len(),
+                    circuit_vk.get_cs().num_witin(),
+                    circuit_vk.get_cs().num_fixed(),
+                )));
+            }
+            if proof.r_out_evals.len() != circuit_vk.get_cs().num_reads()
+                || proof.w_out_evals.len() != circuit_vk.get_cs().num_writes()
+            {
+                return Err(ZKVMError::InvalidProof(format!(
+                    "read evaluations length mismatch: {} != {}",
+                    proof.r_out_evals.len(),
+                    circuit_vk.get_cs().num_r(),
+                )));
+            }
+
+            transcript.append_field_element(&E::BaseField::from_canonical_u64(*index as u64));
+            let input_opening_point = if circuit_vk.get_cs().is_opcode_circuit() {
+                // getting the number of dummy padding item that we used in this opcode circuit
+                let num_lks = circuit_vk.get_cs().num_lks();
+                let num_padded_instance =
+                    next_pow2_instance_padding(proof.num_instances) - proof.num_instances;
+                dummy_table_item_multiplicity += num_lks * num_padded_instance;
+
+                self.verify_opcode_proof(
+                    &circuit_name,
+                    &circuit_vk,
+                    &proof,
+                    proof.num_instances,
                     pi_evals,
                     &mut transcript,
                     NUM_FANIN,
                     &point_eval,
                     &challenges,
-                )?;
-                rt_points.push(input_opening_point);
-                evaluations.push(opcode_proof.wits_in_evals.clone());
-                tracing::debug!("verified proof for opcode {}", name);
-
-                // getting the number of dummy padding item that we used in this opcode circuit
-                let num_lks = circuit_vk.get_cs().num_lks();
-                let num_padded_instance =
-                    next_pow2_instance_padding(*num_instances) - num_instances;
-                dummy_table_item_multiplicity += num_lks * num_padded_instance;
-
-                prod_r *= opcode_proof
-                    .r_out_evals
-                    .iter()
-                    .flatten()
-                    .fold(E::ONE, |acc, e| acc * *e);
-                prod_w *= opcode_proof
-                    .w_out_evals
-                    .iter()
-                    .flatten()
-                    .fold(E::ONE, |acc, e| acc * *e);
-
-                for evals in opcode_proof.lk_out_evals.iter() {
-                    // TODO: return error instead of panic
-                    assert_eq!(evals.len(), 4);
-
-                    let (p1, p2, q1, q2) = (evals[0], evals[1], evals[2], evals[3]);
-
-                    logup_sum += p1 * q1.inverse();
-                    logup_sum += p2 * q2.inverse();
-                }
-            } else if let Some(table_proof) = vm_proof.table_proofs.get(index) {
-                transcript.append_field_element(&E::BaseField::from_canonical_u64(*index as u64));
-
-                let input_opening_point = self.verify_table_proof(
-                    name,
-                    circuit_vk,
-                    table_proof,
-                    *num_instances,
+                )?
+            } else {
+                self.verify_table_proof(
+                    &circuit_name,
+                    &circuit_vk,
+                    &proof,
+                    proof.num_instances,
                     &vm_proof.raw_pi,
                     &vm_proof.pi_evals,
                     &mut transcript,
                     NUM_FANIN_LOGUP,
                     &point_eval,
                     &challenges,
-                )?;
-                rt_points.push(input_opening_point);
-                evaluations.push(
-                    [
-                        table_proof.wits_in_evals.clone(),
-                        table_proof.fixed_in_evals.clone(),
-                    ]
-                    .concat(),
-                );
-                tracing::debug!("verified proof for table {}", name);
-
-                logup_sum = table_proof
-                    .lk_out_evals
-                    .iter()
-                    .fold(logup_sum, |acc, evals| {
-                        let (p1, p2, q1, q2) = (evals[0], evals[1], evals[2], evals[3]);
-
-                        acc - p1 * q1.inverse() - p2 * q2.inverse()
-                    });
-
-                prod_w *= table_proof
-                    .w_out_evals
-                    .iter()
-                    .flatten()
-                    .copied()
-                    .product::<E>();
-                prod_r *= table_proof
-                    .r_out_evals
-                    .iter()
-                    .flatten()
-                    .copied()
-                    .product::<E>();
-            } else {
-                unreachable!("respective proof of index {} should exist", index)
-            }
+                )?
+            };
+            rt_points.push(input_opening_point);
+            evaluations.push([proof.wits_in_evals.clone(), proof.fixed_in_evals.clone()].concat());
+            logup_sum = proof.lk_out_evals.iter().fold(logup_sum, |acc, evals| {
+                let (p1, p2, q1, q2) = (evals[0], evals[1], evals[2], evals[3]);
+                acc - p1 * q1.inverse() - p2 * q2.inverse()
+            });
+            prod_w *= proof.w_out_evals.iter().flatten().copied().product::<E>();
+            prod_r *= proof.r_out_evals.iter().flatten().copied().product::<E>();
+            tracing::debug!("verified proof for circuit {}", circuit_name);
         }
         logup_sum -= E::from_canonical_u64(dummy_table_item_multiplicity as u64)
             * dummy_table_item.inverse();
@@ -328,7 +270,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         PCS::batch_verify(
             &self.vk.vp,
             rounds,
-            &vm_proof.fixed_witin_opening_proof,
+            &vm_proof.opening_proof,
             &mut transcript,
         )
         .map_err(ZKVMError::PCSError)?;

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -133,7 +133,7 @@ impl<E: ExtensionField> ComposedConstrainSystem<E> {
 
     /// return number of lookup operation
     pub fn num_lks(&self) -> usize {
-        self.zkvm_v1_css.lk_expressions.len()
+        self.zkvm_v1_css.lk_expressions.len() + self.zkvm_v1_css.lk_table_expressions.len()
     }
 }
 

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -464,5 +464,5 @@ pub struct ZKVMVerifyingKey<E: ExtensionField, PCS: PolynomialCommitmentScheme<E
     pub finalize_global_state_expr: Expression<E>,
     // circuit index -> circuit name
     // mainly used for debugging
-    pub circuit_index: BTreeMap<usize, String>,
+    pub circuit_index_to_name: BTreeMap<usize, String>,
 }

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -113,6 +113,14 @@ impl<E: ExtensionField> ComposedConstrainSystem<E> {
         self.zkvm_v1_css.num_fixed
     }
 
+    pub fn num_reads(&self) -> usize {
+        self.zkvm_v1_css.r_expressions.len() + self.zkvm_v1_css.r_table_expressions.len()
+    }
+
+    pub fn num_writes(&self) -> usize {
+        self.zkvm_v1_css.w_expressions.len() + self.zkvm_v1_css.w_table_expressions.len()
+    }
+
     pub fn instance_name_map(&self) -> &HashMap<Instance, String> {
         &self.zkvm_v1_css.instance_name_map
     }
@@ -431,11 +439,12 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProvingKey<E, PC
             // expression for global state in/out
             initial_global_state_expr: self.initial_global_state_expr.clone(),
             finalize_global_state_expr: self.finalize_global_state_expr.clone(),
-            circuit_num_polys: self
+            circuit_index_to_name: self
                 .circuit_pks
-                .values()
-                .map(|pk| (pk.vk.get_cs().num_witin(), pk.vk.get_cs().num_fixed()))
-                .collect_vec(),
+                .keys()
+                .enumerate()
+                .map(|(index, name)| (index, name.clone()))
+                .collect(),
         }
     }
 }
@@ -453,6 +462,7 @@ pub struct ZKVMVerifyingKey<E: ExtensionField, PCS: PolynomialCommitmentScheme<E
     // expression for global state in/out
     pub initial_global_state_expr: Expression<E>,
     pub finalize_global_state_expr: Expression<E>,
-    // circuit index -> (witin num_polys, fixed_num_polys)
-    pub circuit_num_polys: Vec<(usize, usize)>,
+    // circuit index -> circuit name
+    // mainly used for debugging
+    pub circuit_index: BTreeMap<usize, String>,
 }


### PR DESCRIPTION
## Summary

In this pr, we have done 2 things to simplify the zkvm verifier's logic.

1. merge table proofs and opcode proofs in the `ZKVMProof struct`.
2. use the infos included in the circuit vk to check if each chip's proof is well-formed. This includes that check like  `proof.witin_evals.len() == vk.num_witin()`.
