### PR TITLE
Feat: commit to all matrices for BaseFold

### DIFF
--- a/ceno_zkvm/benches/riscv_add.rs
+++ b/ceno_zkvm/benches/riscv_add.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, time::Duration};
+use std::time::Duration;
 
 use ceno_zkvm::{
     self,
@@ -77,10 +77,7 @@ fn bench_add(c: &mut Criterion) {
                     for _ in 0..iters {
                         // generate mock witness
                         let num_instances = 1 << instance_num_vars;
-                        let rmms = BTreeMap::from([(
-                            0,
-                            RowMajorMatrix::rand(&mut OsRng, num_instances, num_witin),
-                        )]);
+                        let rmms = vec![RowMajorMatrix::rand(&mut OsRng, num_instances, num_witin)];
 
                         let instant = std::time::Instant::now();
                         let num_instances = 1 << instance_num_vars;

--- a/ceno_zkvm/src/scheme/cpu/mod.rs
+++ b/ceno_zkvm/src/scheme/cpu/mod.rs
@@ -269,7 +269,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> TraceCommitter<CpuBa
             self.pp = Some(prover_param);
             self.pp.as_ref().unwrap()
         };
-        let pcs_data = PCS::batch_commit(prover_param, traces).unwrap();
+        let pcs_data = PCS::batch_commit(prover_param, traces.into_values().collect_vec()).unwrap();
         let commit = PCS::get_pure_commitment(&pcs_data);
         let mles = PCS::get_arc_mle_witness_from_commitment(&pcs_data)
             .into_par_iter()

--- a/ceno_zkvm/src/scheme/tests.rs
+++ b/ceno_zkvm/src/scheme/tests.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, marker::PhantomData};
+use std::marker::PhantomData;
 
 use crate::{
     circuit_builder::CircuitBuilder,
@@ -138,12 +138,8 @@ fn test_rw_lk_expression_combination() {
         let rmm = zkvm_witness.into_iter_sorted().next().unwrap().1.remove(0);
         let wits_in = rmm.to_mles();
         // commit to main traces
-        let commit_with_witness = Pcs::batch_commit_and_write(
-            &prover.pk.pp,
-            vec![(0, rmm)].into_iter().collect::<BTreeMap<_, _>>(),
-            &mut transcript,
-        )
-        .unwrap();
+        let commit_with_witness =
+            Pcs::batch_commit_and_write(&prover.pk.pp, vec![rmm], &mut transcript).unwrap();
         let witin_commit = Pcs::get_pure_commitment(&commit_with_witness);
 
         let wits_in = wits_in.into_iter().map(|v| v.into()).collect_vec();

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -414,7 +414,8 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMProvingKey<E, PC
     ) -> Result<(), ZKVMError> {
         if !fixed_traces.is_empty() {
             let fixed_commit_wd =
-                PCS::batch_commit(&self.pp, fixed_traces).map_err(ZKVMError::PCSError)?;
+                PCS::batch_commit(&self.pp, fixed_traces.into_values().collect_vec())
+                    .map_err(ZKVMError::PCSError)?;
             let fixed_commit = PCS::get_pure_commitment(&fixed_commit_wd);
             self.fixed_commit_wd = Some(Arc::new(fixed_commit_wd));
             self.fixed_commit = Some(fixed_commit);

--- a/mpcs/benches/basefold.rs
+++ b/mpcs/benches/basefold.rs
@@ -8,7 +8,6 @@ use mpcs::{
     Basefold, BasefoldRSParams, PolynomialCommitmentScheme, SecurityLevel,
     test_util::{get_point_from_challenge, setup_pcs},
 };
-use std::collections::BTreeMap;
 
 use transcript::{BasicTranscript, Transcript};
 use witness::RowMajorMatrix;
@@ -45,7 +44,7 @@ fn bench_commit_open_verify_goldilocks<Pcs: PolynomialCommitmentScheme<E>>(
 
         let mut transcript = T::new(b"BaseFold");
         let mut rng = rand::thread_rng();
-        let rmms = BTreeMap::from([(0, RowMajorMatrix::rand(&mut rng, 1 << num_vars, 1))]);
+        let rmms = vec![RowMajorMatrix::rand(&mut rng, 1 << num_vars, 1)];
         let comm = Pcs::batch_commit_and_write(&pp, rmms.clone(), &mut transcript).unwrap();
         let poly = Pcs::get_arc_mle_witness_from_commitment(&comm).remove(0);
 
@@ -112,10 +111,9 @@ fn bench_batch_commit_open_verify_goldilocks<Pcs: PolynomialCommitmentScheme<E>>
             let (pp, vp) = setup_pcs::<E, Pcs>(num_vars);
             let mut transcript = T::new(b"BaseFold");
             let mut rng = rand::thread_rng();
-            let rmms =
-                BTreeMap::from([(0, RowMajorMatrix::rand(&mut rng, 1 << num_vars, batch_size))]);
+            let rmms = vec![RowMajorMatrix::rand(&mut rng, 1 << num_vars, batch_size)];
 
-            let polys = rmms[&0].to_mles();
+            let polys = rmms[0].to_mles();
             let comm = Pcs::batch_commit_and_write(&pp, rmms.clone(), &mut transcript).unwrap();
 
             group.bench_function(

--- a/mpcs/benches/whir.rs
+++ b/mpcs/benches/whir.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, time::Duration};
+use std::time::Duration;
 
 use criterion::*;
 use ff_ext::GoldilocksExt2;
@@ -107,8 +107,7 @@ fn bench_simple_batch_commit_open_verify_goldilocks<Pcs: PolynomialCommitmentSch
             let batch_size = 1 << batch_size_log;
             let (pp, vp) = setup_pcs::<E, Pcs>(num_vars);
 
-            let rmms =
-                BTreeMap::from([(0, RowMajorMatrix::rand(&mut rng, 1 << num_vars, batch_size))]);
+            let rmms = vec![RowMajorMatrix::rand(&mut rng, 1 << num_vars, batch_size)];
 
             group.bench_function(
                 BenchmarkId::new("batch_commit", format!("{}-{}", num_vars, batch_size)),
@@ -129,7 +128,7 @@ fn bench_simple_batch_commit_open_verify_goldilocks<Pcs: PolynomialCommitmentSch
             );
 
             let mut transcript = T::new(b"BaseFold");
-            let polys = rmms[&0].to_mles();
+            let polys = rmms[0].to_mles();
             let comm = Pcs::batch_commit_and_write(&pp, rmms, &mut transcript).unwrap();
             let point = get_point_from_challenge(num_vars, &mut transcript);
             let evals = polys.iter().map(|poly| poly.evaluate(&point)).collect_vec();

--- a/mpcs/src/basefold/commit_phase.rs
+++ b/mpcs/src/basefold/commit_phase.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashSet};
+use std::collections::HashSet;
 
 use super::{
     encoding::EncodingScheme,

--- a/mpcs/src/basefold/commit_phase.rs
+++ b/mpcs/src/basefold/commit_phase.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{HashSet};
 
 use super::{
     encoding::EncodingScheme,
@@ -92,16 +92,10 @@ where
     let mut initial_rlc_evals: Vec<MultilinearExtension<E>> = vec![];
     let mut eq: Vec<MultilinearExtension<E>> = vec![];
     for (pcs_data, point_and_evals) in rounds {
-        let codeword_idx_to_circuit_idx = pcs_data
-            .circuit_codeword_index
-            .iter()
-            .map(|(k, v)| (*v, *k))
-            .collect::<BTreeMap<_, _>>();
         let mats = mmcs.get_matrices(&pcs_data.codeword);
         for (i, mat) in mats.into_iter().enumerate() {
-            let circuit_idx = codeword_idx_to_circuit_idx[&i];
-            let (point, _) = &point_and_evals[circuit_idx];
-            let polys = &pcs_data.polys[&circuit_idx];
+            let (point, _) = &point_and_evals[i];
+            let polys = &pcs_data.polys[i];
             // the actual ith row and (i+n/2)th row are packed in same row
             let num_rows = mat.height() * 2;
             let num_polys = mat.width() / 2;

--- a/mpcs/src/basefold/encoding/rs.rs
+++ b/mpcs/src/basefold/encoding/rs.rs
@@ -43,7 +43,7 @@ impl RSCodeSpec for RSCodeDefaultSpec {
     }
 
     fn get_basecode_msg_size_log() -> usize {
-        7
+        1
     }
 }
 

--- a/mpcs/src/basefold/encoding/rs.rs
+++ b/mpcs/src/basefold/encoding/rs.rs
@@ -43,7 +43,7 @@ impl RSCodeSpec for RSCodeDefaultSpec {
     }
 
     fn get_basecode_msg_size_log() -> usize {
-        1
+        0
     }
 }
 

--- a/mpcs/src/basefold/query_phase.rs
+++ b/mpcs/src/basefold/query_phase.rs
@@ -161,7 +161,6 @@ pub fn batch_verifier_query_phase<E: ExtensionField, S: EncodingScheme<E>>(
                 {
                     let dimensions = batch_opening
                         .iter()
-                        .filter(|(num_var, _)| *num_var >= S::get_basecode_msg_size_log())
                         .map(|(num_var, (_, evals))| {
                             Dimensions {
                                 width: evals.len() * 2, // we pack two rows into one in the mmcs

--- a/mpcs/src/basefold/structure.rs
+++ b/mpcs/src/basefold/structure.rs
@@ -255,8 +255,6 @@ pub struct QueryOpeningProof<E: ExtensionField> {
 
 pub type QueryOpeningProofs<E> = Vec<QueryOpeningProof<E>>;
 
-pub type TrivialProof<E> = Vec<Vec<DenseMatrix<<E as ExtensionField>::BaseField>>>;
-
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(bound(
     serialize = "E::BaseField: Serialize",
@@ -270,8 +268,6 @@ where
     pub(crate) final_message: Vec<Vec<E>>,
     pub(crate) query_opening_proof: QueryOpeningProofs<E>,
     pub(crate) sumcheck_proof: Option<Vec<IOPProverMessage<E>>>,
-    // vec![witness, fixed], where fixed is optional
-    pub(crate) trivial_proof: TrivialProof<E>,
     pub(crate) pow_witness: E::BaseField,
 }
 

--- a/mpcs/src/basefold/structure.rs
+++ b/mpcs/src/basefold/structure.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use core::fmt::Debug;
 use ff_ext::{ExtensionField, PoseidonField};
-use itertools::{Itertools, izip};
+use itertools::izip;
 use p3::{
     commit::{ExtensionMmcs, Mmcs},
     fri::{BatchOpening, CommitPhaseProofStep},
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize, Serializer, de::DeserializeOwned};
 use sumcheck::structs::IOPProverMessage;
 
 use multilinear_extensions::mle::ArcMultilinearExtension;
-use std::{collections::BTreeMap, marker::PhantomData};
+use std::marker::PhantomData;
 
 pub type Digest<E> = <Poseidon2ExtMerkleMmcs<E> as Mmcs<E>>::Commitment;
 pub type MerkleTree<F> = <<F as PoseidonField>::MMCS as Mmcs<F>>::ProverData<DenseMatrix<F>>;
@@ -94,13 +94,7 @@ where
     pub(crate) codeword: MerkleTree<E::BaseField>,
 
     pub(crate) log2_max_codeword_size: usize,
-    // for small polynomials, the prover commits the entire polynomial as merkle leaves without encoding to codeword
-    // the verifier performs direct checks on these leaves without requiring a proximity test.
-    pub(crate) trivial_proofdata: BTreeMap<usize, (Digest<E>, MerkleTree<E::BaseField>)>,
-    // poly groups w.r.t circuit index
-    pub(crate) polys: BTreeMap<usize, Vec<ArcMultilinearExtension<'static, E>>>,
-    // keep codeword index w.r.t circuit index
-    pub circuit_codeword_index: BTreeMap<usize, usize>,
+    pub(crate) polys: Vec<Vec<ArcMultilinearExtension<'static, E>>>,
 }
 
 impl<E: ExtensionField> BasefoldCommitmentWithWitness<E>
@@ -110,9 +104,7 @@ where
     pub fn new(
         commit: Digest<E>,
         codeword: MerkleTree<E::BaseField>,
-        polys: BTreeMap<usize, Vec<ArcMultilinearExtension<'static, E>>>,
-        trivial_proofdata: BTreeMap<usize, (Digest<E>, MerkleTree<E::BaseField>)>,
-        circuit_codeword_index: BTreeMap<usize, usize>,
+        polys: Vec<Vec<ArcMultilinearExtension<'static, E>>>,
     ) -> Self {
         let mmcs = poseidon2_merkle_tree::<E>();
         // size = height * 2 because we split codeword leafs into left/right, concat and commit under same row index
@@ -127,21 +119,12 @@ where
             commit,
             codeword,
             polys,
-            trivial_proofdata,
-            circuit_codeword_index,
             log2_max_codeword_size,
         }
     }
 
     pub fn to_commitment(&self) -> BasefoldCommitment<E> {
-        BasefoldCommitment::new(
-            self.commit.clone(),
-            self.trivial_proofdata
-                .iter()
-                .map(|(i, (digest, _))| (*i, digest.clone()))
-                .collect_vec(),
-            self.log2_max_codeword_size,
-        )
+        BasefoldCommitment::new(self.commit.clone(), self.log2_max_codeword_size)
     }
 
     // pub fn poly_size(&self) -> usize {
@@ -170,21 +153,15 @@ where
 {
     pub(super) commit: Digest<E>,
     pub(crate) log2_max_codeword_size: usize,
-    pub(crate) trivial_commits: Vec<(usize, Digest<E>)>,
 }
 
 impl<E: ExtensionField> BasefoldCommitment<E>
 where
     E::BaseField: Serialize + DeserializeOwned,
 {
-    pub fn new(
-        commit: Digest<E>,
-        trivial_commits: Vec<(usize, Digest<E>)>,
-        log2_max_codeword_size: usize,
-    ) -> Self {
+    pub fn new(commit: Digest<E>, log2_max_codeword_size: usize) -> Self {
         Self {
             commit,
-            trivial_commits,
             log2_max_codeword_size,
         }
     }
@@ -201,10 +178,6 @@ where
     fn eq(&self, other: &Self) -> bool {
         izip!(self.get_codewords(), other.get_codewords())
             .all(|(codeword_a, codeword_b)| codeword_a.eq(codeword_b))
-            && izip!(self.polys.values(), other.polys.values()).all(|(evals_a, evals_b)| {
-                izip!(evals_a, evals_b)
-                    .all(|(evals_a, evals_b)| evals_a.evaluations() == evals_b.evaluations())
-            })
     }
 }
 

--- a/mpcs/src/lib.rs
+++ b/mpcs/src/lib.rs
@@ -389,8 +389,6 @@ pub mod test_util {
         Pcs: PolynomialCommitmentScheme<E>,
         Standard: Distribution<E::BaseField>,
     {
-        use std::collections::BTreeMap;
-
         use multilinear_extensions::mle::ArcMultilinearExtension;
 
         let mut rng = rand::thread_rng();
@@ -401,9 +399,7 @@ pub mod test_util {
                 let mut transcript = BasicTranscript::new(b"BaseFold");
                 let rmm = RowMajorMatrix::<E::BaseField>::rand(&mut rng, 1 << num_vars, batch_size);
                 let polys = rmm.to_mles();
-                let comm =
-                    Pcs::batch_commit_and_write(&pp, BTreeMap::from([(0, rmm)]), &mut transcript)
-                        .unwrap();
+                let comm = Pcs::batch_commit_and_write(&pp, vec![rmm], &mut transcript).unwrap();
                 let point = get_point_from_challenge(num_vars, &mut transcript);
                 let evals = polys.iter().map(|poly| poly.evaluate(&point)).collect_vec();
                 transcript.append_field_element_exts(&evals);
@@ -453,8 +449,6 @@ pub mod test_util {
         Pcs: PolynomialCommitmentScheme<E>,
         Standard: Distribution<E::BaseField>,
     {
-        use std::collections::BTreeMap;
-
         for num_vars in num_vars_start..num_vars_end {
             let (pp, vp) = setup_pcs::<E, Pcs>(num_vars);
 
@@ -465,9 +459,7 @@ pub mod test_util {
 
                 let polys = rmm.to_mles();
 
-                let comm =
-                    Pcs::batch_commit_and_write(&pp, BTreeMap::from([(0, rmm)]), &mut transcript)
-                        .unwrap();
+                let comm = Pcs::batch_commit_and_write(&pp, vec![rmm], &mut transcript).unwrap();
                 let point = get_point_from_challenge(num_vars, &mut transcript);
                 let evals = polys.iter().map(|poly| poly.evaluate(&point)).collect_vec();
                 transcript.append_field_element_exts(&evals);

--- a/mpcs/src/lib.rs
+++ b/mpcs/src/lib.rs
@@ -2,7 +2,7 @@
 use clap::ValueEnum;
 use ff_ext::ExtensionField;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use std::{collections::BTreeMap, fmt::Debug};
+use std::fmt::Debug;
 use transcript::Transcript;
 use witness::RowMajorMatrix;
 
@@ -42,7 +42,7 @@ pub fn pcs_commit<E: ExtensionField, Pcs: PolynomialCommitmentScheme<E>>(
 
 pub fn pcs_batch_commit<E: ExtensionField, Pcs: PolynomialCommitmentScheme<E>>(
     pp: &Pcs::ProverParam,
-    rmms: BTreeMap<usize, RowMajorMatrix<<E as ExtensionField>::BaseField>>,
+    rmms: Vec<RowMajorMatrix<E::BaseField>>,
 ) -> Result<Pcs::CommitmentWithWitness, Error> {
     Pcs::batch_commit(pp, rmms)
 }
@@ -113,12 +113,12 @@ pub trait PolynomialCommitmentScheme<E: ExtensionField>: Clone {
 
     fn batch_commit(
         pp: &Self::ProverParam,
-        rmms: BTreeMap<usize, RowMajorMatrix<<E as ExtensionField>::BaseField>>,
+        rmms: Vec<RowMajorMatrix<E::BaseField>>,
     ) -> Result<Self::CommitmentWithWitness, Error>;
 
     fn batch_commit_and_write(
         pp: &Self::ProverParam,
-        rmms: BTreeMap<usize, RowMajorMatrix<<E as ExtensionField>::BaseField>>,
+        rmms: Vec<RowMajorMatrix<E::BaseField>>,
         transcript: &mut impl Transcript<E>,
     ) -> Result<Self::CommitmentWithWitness, Error> {
         let comm = Self::batch_commit(pp, rmms)?;

--- a/mpcs/src/whir.rs
+++ b/mpcs/src/whir.rs
@@ -1,8 +1,6 @@
 mod spec;
 mod structure;
 
-use std::collections::BTreeMap;
-
 use super::PolynomialCommitmentScheme;
 use crate::{PCSFriParam, Point, SecurityLevel};
 use ff_ext::{ExtensionField, PoseidonField};
@@ -153,11 +151,11 @@ where
     ) -> Result<Self::CommitmentWithWitness, crate::Error> {
         let parameters = Spec::get_whir_parameters(true);
         let whir_config = WhirConfig::new(
-            MultivariateParameters::new(log2_strict_usize(rmms[&0].num_instances())),
+            MultivariateParameters::new(log2_strict_usize(rmms[0].num_instances())),
             parameters,
         );
         let (witness, _commitment) = Committer::new(whir_config)
-            .batch_commit(rmms.remove(&0).unwrap())
+            .batch_commit(rmms.remove(0))
             .map_err(crate::Error::WhirError)?;
 
         Ok(witness)

--- a/mpcs/src/whir.rs
+++ b/mpcs/src/whir.rs
@@ -149,7 +149,7 @@ where
 
     fn batch_commit(
         _pp: &Self::ProverParam,
-        mut rmms: BTreeMap<usize, witness::RowMajorMatrix<<E as ExtensionField>::BaseField>>,
+        mut rmms: Vec<witness::RowMajorMatrix<E::BaseField>>,
     ) -> Result<Self::CommitmentWithWitness, crate::Error> {
         let parameters = Spec::get_whir_parameters(true);
         let whir_config = WhirConfig::new(


### PR DESCRIPTION
## Summary

In this pr, we decide to encode all matrices using Reed Solomon code no matter their height. This decision will make it easier for us to write the **recursion** program for verifying BaseFold opening proof. 

In summary, it's **easier** for us to write recursion program (😊 ✅) but it **increases** the proof size(😭 ❌).

### Advantage
1. If we don't encode matrix with small height, then we need to put the full matrix itself in the opening proof (which is called `trivial_proof` in the code). And then we need to verify the correctness of that matrix by computing the merkle root  from matrix then compare the root with `trivial_commits[i]`. It's quite cumbersome for us to compute merkle root in our current DSL.

### Disadvantage
This comes at some price. Even for a matrix with 8 rows, we need to encode it using RS code. And the query phase requires us to sample at least 100 queries (each query includes 1 row). Therefore the proof itself will instead include around 100 rows which is larger than the original matrix.

## Performance (proof size)

|     field             | before          | after          |
|---------------|-------------|-----------|
| final message |       46k        |    1.13k      |
| opening proof.input opening |      432k       |    1024k (137% ⬆️)  |
| opening proof.commit phase |        307k     |     411k   (33% ⬆️)   |
| sumcheck proof |         0.5k    |       0.88k  |
| total                  |      1.06M      |      1.65M    (55% ⬆️) |

## Future work

It's easy to find that the input opening proofs increase a lot, we can reduce this increase by half. Here is the idea.

Currently we pack two rows (`i`th and `i+n/2`th row) in a matrix A into one row in matrix B. Therefore the matrix's width is increased by twice with its height is decreased by half. We then use these two rows to derive the `i`th value of the 1st matrix in the commit phase. 

In fact, we can commit to the original matrix A. And then computes the random linear combination of rows of A as the 1st matrix C1 in the commit phase. This will be the first codeword. In order to derive the 2nd codeword, we just need to  open the `i+n/2`th value in the matrix C1 (aka. sibling value). That is, we add one more merkle tree in the commit phase. 

This will allow us to reduce the number of values opened for the input matrix. Since we have almost 600 columns to open, this should save us about 470k.

This is tracked in https://github.com/scroll-tech/ceno/issues/983.