### PR TITLE
Chore: field access adjustment

### DIFF
--- a/ceno_zkvm/src/scheme.rs
+++ b/ceno_zkvm/src/scheme.rs
@@ -115,8 +115,8 @@ pub struct ZKVMProof<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> {
     pub raw_pi: Vec<Vec<E::BaseField>>,
     // the evaluation of raw_pi.
     pub pi_evals: Vec<E>,
-    chip_proofs: BTreeMap<usize, ZKVMChipProof<E>>,
-    witin_commit: <PCS as PolynomialCommitmentScheme<E>>::Commitment,
+    pub chip_proofs: BTreeMap<usize, ZKVMChipProof<E>>,
+    pub witin_commit: <PCS as PolynomialCommitmentScheme<E>>::Commitment,
     pub opening_proof: PCS::Proof,
 }
 

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -31,7 +31,7 @@ use multilinear_extensions::{Instance, StructuralWitIn, utils::eval_by_expr_with
 use super::{ZKVMChipProof, ZKVMProof};
 
 pub struct ZKVMVerifier<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> {
-    pub(crate) vk: ZKVMVerifyingKey<E, PCS>,
+    pub vk: ZKVMVerifyingKey<E, PCS>,
 }
 
 impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS> {

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -62,7 +62,7 @@ impl<E: ExtensionField> ProvingKey<E> {
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(bound = "E: ExtensionField + DeserializeOwned")]
 pub struct VerifyingKey<E: ExtensionField> {
-    pub(crate) cs: ComposedConstrainSystem<E>,
+    pub cs: ComposedConstrainSystem<E>,
 }
 
 impl<E: ExtensionField> VerifyingKey<E> {

--- a/mpcs/src/basefold/structure.rs
+++ b/mpcs/src/basefold/structure.rs
@@ -151,8 +151,8 @@ pub struct BasefoldCommitment<E: ExtensionField>
 where
     E::BaseField: Serialize + DeserializeOwned,
 {
-    pub(super) commit: Digest<E>,
-    pub(crate) log2_max_codeword_size: usize,
+    pub commit: Digest<E>,
+    pub log2_max_codeword_size: usize,
 }
 
 impl<E: ExtensionField> BasefoldCommitment<E>


### PR DESCRIPTION
## Summary

We aims to make fields in data type that used by verifier to be public. These data type are needed by the recursion verifier program.