### PR TITLE
refactor gkr circuit build logic with selector

### DIFF
--- a/ceno_zkvm/src/precompiles/bitwise_keccakf.rs
+++ b/ceno_zkvm/src/precompiles/bitwise_keccakf.rs
@@ -26,6 +26,7 @@ use gkr_iop::{
     evaluation::EvalExpression,
     gkr::{
         GKRCircuit, GKRProverOutput,
+        booleanhypercube::CYCLIC_POW2_5,
         layer::Layer,
         layer_constraint_system::{LayerConstraintSystem, expansion_expr},
     },
@@ -367,7 +368,10 @@ fn output32_layer<E: ExtensionField>(
     let mut keccak_output32_iter = out_evals.iter().map(|x| EvalExpression::Single(*x));
 
     // process keccak output
-    let sel_type = SelectorType::KeccakRound(23, layer.sel.expr());
+    let sel_type = SelectorType::OrderedSparse32 {
+        indices: vec![CYCLIC_POW2_5[ROUNDS - 1] as usize],
+        expression: layer.sel.expr(),
+    };
     for x in 0..X {
         for y in 0..Y {
             for k in 0..2 {
@@ -619,7 +623,10 @@ fn keccak_first_layer<E: ExtensionField>(
 
     // process keccak output
     let mut out_eval_iter = input32_out_evals.iter().map(|x| EvalExpression::Single(*x));
-    let sel_type = SelectorType::KeccakRound(0, layer.sel_keccak_out.expr());
+    let sel_type = SelectorType::OrderedSparse32 {
+        indices: vec![CYCLIC_POW2_5[0] as usize],
+        expression: layer.sel_keccak_out.expr(),
+    };
     for x in 0..X {
         for y in 0..Y {
             for k in 0..2 {

--- a/ceno_zkvm/src/precompiles/bitwise_keccakf.rs
+++ b/ceno_zkvm/src/precompiles/bitwise_keccakf.rs
@@ -18,7 +18,7 @@ use transcript::{BasicTranscript, Transcript};
 use witness::{InstancePaddingStrategy, RowMajorMatrix};
 
 use gkr_iop::{
-    ProtocolBuilder, ProtocolWitnessGenerator,
+    OutEvalGroups, ProtocolBuilder, ProtocolWitnessGenerator,
     chip::Chip,
     circuit_builder::{CircuitBuilder, ConstraintSystem},
     cpu::{CpuBackend, CpuProver},
@@ -367,7 +367,7 @@ fn output32_layer<E: ExtensionField>(
     let mut keccak_output32_iter = out_evals.iter().map(|x| EvalExpression::Single(*x));
 
     // process keccak output
-    let sel_type = SelectorType::KeccakRound(23, E::BaseField::ONE, layer.sel.expr());
+    let sel_type = SelectorType::KeccakRound(23, layer.sel.expr());
     for x in 0..X {
         for y in 0..Y {
             for k in 0..2 {
@@ -619,7 +619,7 @@ fn keccak_first_layer<E: ExtensionField>(
 
     // process keccak output
     let mut out_eval_iter = input32_out_evals.iter().map(|x| EvalExpression::Single(*x));
-    let sel_type = SelectorType::KeccakRound(0, E::BaseField::ONE, layer.sel_keccak_out.expr());
+    let sel_type = SelectorType::KeccakRound(0, layer.sel_keccak_out.expr());
     for x in 0..X {
         for y in 0..Y {
             for k in 0..2 {
@@ -774,7 +774,7 @@ impl<E: ExtensionField> KeccakLayout<E> {
 impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
     type Params = KeccakParams;
 
-    fn finalize(&mut self, _cb: &CircuitBuilder<E>) -> (Vec<(SelectorType<E>, usize)>, Chip<E>) {
+    fn finalize(&mut self, _cb: &CircuitBuilder<E>) -> (OutEvalGroups<E>, Chip<E>) {
         unimplemented!()
     }
 

--- a/ceno_zkvm/src/precompiles/bitwise_keccakf.rs
+++ b/ceno_zkvm/src/precompiles/bitwise_keccakf.rs
@@ -1,12 +1,12 @@
 use std::{array::from_fn, mem::transmute};
 
 use ff_ext::ExtensionField;
-use itertools::{Itertools, iproduct, izip};
+use itertools::{iproduct, izip, Itertools};
 use mpcs::PolynomialCommitmentScheme;
 use multilinear_extensions::{
-    ChallengeId, Expression, ToExpr, WitIn,
-    mle::{MultilinearExtension, Point, PointAndEval},
-    util::ceil_log2,
+    mle::{MultilinearExtension, Point, PointAndEval}, util::ceil_log2, ChallengeId, Expression,
+    ToExpr,
+    WitIn,
 };
 use p3::{field::FieldAlgebra, util::indices_arr};
 use sumcheck::{
@@ -18,19 +18,19 @@ use transcript::{BasicTranscript, Transcript};
 use witness::{InstancePaddingStrategy, RowMajorMatrix};
 
 use gkr_iop::{
-    ProtocolBuilder, ProtocolWitnessGenerator,
-    chip::Chip,
-    circuit_builder::{CircuitBuilder, ConstraintSystem},
+    chip::Chip, circuit_builder::{CircuitBuilder, ConstraintSystem},
     cpu::{CpuBackend, CpuProver},
     error::CircuitBuilderError,
     evaluation::EvalExpression,
     gkr::{
-        GKRCircuit, GKRProverOutput,
-        layer::Layer,
-        layer_constraint_system::{LayerConstraintSystem, expansion_expr},
+        layer::Layer, layer_constraint_system::{expansion_expr, LayerConstraintSystem},
+        GKRCircuit,
+        GKRProverOutput,
     },
     selector::SelectorType,
     utils::{indices_arr_with_offset, lk_multiplicity::LkMultiplicity, wits_fixed_and_eqs},
+    ProtocolBuilder,
+    ProtocolWitnessGenerator,
 };
 
 fn to_xyz(i: usize) -> (usize, usize, usize) {
@@ -646,12 +646,10 @@ fn keccak_first_layer<E: ExtensionField>(
     )
 }
 
-impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
-    type Params = KeccakParams;
-
-    fn build_gkr_chip(
+impl<E: ExtensionField> KeccakLayout<E> {
+    pub fn build_gkr_chip_old(
         _cb: &mut CircuitBuilder<E>,
-        _params: Self::Params,
+        _params: KeccakParams,
     ) -> Result<(Self, Chip<E>), CircuitBuilderError> {
         let layout = Self::default();
         let mut chip = Chip {
@@ -665,7 +663,7 @@ impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
                     layout.final_out_evals.clone(),
                 )
             }
-            .to_vec(),
+                .to_vec(),
         };
         chip.add_layer(output32_layer(
             &layout.layers.output32,
@@ -721,11 +719,11 @@ impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
             &layout.layers.inner_rounds,
             &layout.layer_in_evals.inner_rounds
         )
-        .rev()
-        .fold(
-            &layout.layer_in_evals.output32,
-            |round_output, (round_id, round_layers, round_in_evals)| {
-                add_common_layers!(
+            .rev()
+            .fold(
+                &layout.layer_in_evals.output32,
+                |round_output, (round_id, round_layers, round_in_evals)| {
+                    add_common_layers!(
                     round_layers,
                     round_output,
                     round_in_evals,
@@ -733,18 +731,18 @@ impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
                     layout.alpha.clone(),
                     layout.beta.clone()
                 );
-                chip.add_layer(theta_first_layer(
-                    &round_layers.theta_first,
-                    &round_in_evals.theta_second,
-                    &round_in_evals.theta_third[D_SIZE..],
-                    &round_in_evals.theta_first,
-                    round_id,
-                    layout.alpha.clone(),
-                    layout.beta.clone(),
-                ));
-                &round_in_evals.theta_first
-            },
-        );
+                    chip.add_layer(theta_first_layer(
+                        &round_layers.theta_first,
+                        &round_in_evals.theta_second,
+                        &round_in_evals.theta_third[D_SIZE..],
+                        &round_in_evals.theta_first,
+                        round_id,
+                        layout.alpha.clone(),
+                        layout.beta.clone(),
+                    ));
+                    &round_in_evals.theta_first
+                },
+            );
 
         // add Round 0
         let (round_layers, round_in_evals) = (
@@ -772,7 +770,23 @@ impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
         ));
         Ok((layout, chip))
     }
+}
+impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
+    type Params = KeccakParams;
 
+    fn finalize(
+        &mut self,
+        cb: &CircuitBuilder<E>,
+    ) -> (Vec<(SelectorType<E>, usize)>, Chip<E>) {
+        unimplemented!()
+    }
+
+    fn build_layer_logic(
+        cb: &mut CircuitBuilder<E>,
+        params: Self::Params,
+    ) -> Result<Self, CircuitBuilderError> {
+        unimplemented!()
+    }
     fn n_committed(&self) -> usize {
         STATE_SIZE
     }
@@ -862,11 +876,11 @@ fn rho_and_pi_permutation() -> Vec<usize> {
 }
 
 pub fn setup_gkr_circuit<E: ExtensionField>()
--> Result<(KeccakLayout<E>, GKRCircuit<E>), CircuitBuilderError> {
+    -> Result<(KeccakLayout<E>, GKRCircuit<E>), CircuitBuilderError> {
     let params = KeccakParams {};
     let mut cs = ConstraintSystem::new(|| "bitwise_keccak");
     let mut circuit_builder = CircuitBuilder::<E>::new(&mut cs);
-    let (layout, chip) = KeccakLayout::build_gkr_chip(&mut circuit_builder, params)?;
+    let (layout, chip) = KeccakLayout::build_gkr_chip_old(&mut circuit_builder, params)?;
     Ok((layout, chip.gkr_circuit()))
 }
 

--- a/ceno_zkvm/src/precompiles/lookup_keccakf.rs
+++ b/ceno_zkvm/src/precompiles/lookup_keccakf.rs
@@ -147,9 +147,9 @@ pub struct KeccakWitCols<T> {
 pub struct KeccakLayer<WitT, EqT> {
     pub wits: KeccakWitCols<WitT>,
     //  pub fixed: KeccakFixedCols<FixedT>,
-    pub eq_rotation_left: EqT,
-    pub eq_rotation_right: EqT,
-    pub eq_rotation: EqT,
+    pub(crate) eq_rotation_left: EqT,
+    pub(crate) eq_rotation_right: EqT,
+    pub(crate) eq_rotation: EqT,
 }
 
 #[derive(Clone, Debug)]
@@ -217,6 +217,8 @@ impl<E: ExtensionField> KeccakLayout<E> {
                     E::BaseField::ONE,
                     sel_mem_write.expr(),
                 ),
+                // sel_mem_read: SelectorType::Whole(sel_mem_read.expr()),
+                // sel_mem_write: SelectorType::Whole(sel_mem_write.expr()),
                 sel_lookup: SelectorType::Whole(eq_zero.expr()),
                 sel_zero: SelectorType::Whole(eq_zero.expr()),
             },

--- a/gkr_iop/src/chip.rs
+++ b/gkr_iop/src/chip.rs
@@ -36,7 +36,7 @@ impl<E: ExtensionField> Chip<E> {
         Self {
             n_fixed: cb.cs.num_fixed,
             n_committed: cb.cs.num_witin as usize,
-            n_challenges: n_challenges,
+            n_challenges,
             n_evaluations: cb.cs.w_expressions.len()
                 + cb.cs.r_expressions.len()
                 + cb.cs.lk_expressions.len()

--- a/gkr_iop/src/chip.rs
+++ b/gkr_iop/src/chip.rs
@@ -1,7 +1,7 @@
+use crate::{circuit_builder::CircuitBuilder, gkr::layer::Layer};
 use ff_ext::ExtensionField;
+use itertools::Itertools;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-
-use crate::gkr::layer::Layer;
 
 pub mod builder;
 pub mod protocol;
@@ -29,4 +29,24 @@ pub struct Chip<E: ExtensionField> {
     pub layers: Vec<Layer<E>>,
     /// The output of the circuit.
     pub final_out_evals: Vec<usize>,
+}
+
+impl<E: ExtensionField> Chip<E> {
+    pub fn new_from_cb(cb: &CircuitBuilder<E>, n_challenges: usize) -> Chip<E> {
+        Self {
+            n_fixed: cb.cs.num_fixed,
+            n_committed: cb.cs.num_witin as usize,
+            n_challenges: n_challenges,
+            n_evaluations: cb.cs.w_expressions.len()
+                + cb.cs.r_expressions.len()
+                + cb.cs.lk_expressions.len()
+                + cb.cs.num_fixed
+                + cb.cs.num_witin as usize,
+            final_out_evals: (0..cb.cs.w_expressions.len()
+                + cb.cs.r_expressions.len()
+                + cb.cs.lk_expressions.len())
+                .collect_vec(),
+            layers: vec![],
+        }
+    }
 }

--- a/gkr_iop/src/cpu/mod.rs
+++ b/gkr_iop/src/cpu/mod.rs
@@ -168,7 +168,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>
             // infer current layer output
             let current_layer_output: Vec<
                 Arc<multilinear_extensions::mle::MultilinearExtension<'_, E>>,
-            > = layer_witness(&layer, &current_layer_wits, challenges, num_instances);
+            > = layer_witness(layer, &current_layer_wits, challenges, num_instances);
             layer_wits.push(LayerWitness::new(current_layer_wits, vec![]));
 
             // process out to prepare output witness
@@ -215,7 +215,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>
     }
 }
 
-pub fn layer_witness<'a, E: ExtensionField>(
+pub fn layer_witness<'a, E>(
     layer: &Layer<E>,
     layer_wits: &[ArcMultilinearExtension<'a, E>],
     challenges: &[E],

--- a/gkr_iop/src/gkr/booleanhypercube.rs
+++ b/gkr_iop/src/gkr/booleanhypercube.rs
@@ -1,7 +1,6 @@
 use ff_ext::ExtensionField;
 use itertools::Itertools;
 use multilinear_extensions::mle::Point;
-use p3_field::FieldAlgebra;
 
 const BH_MAX_NUM_VAR: usize = 5;
 
@@ -102,12 +101,6 @@ impl IntoIterator for &BooleanHypercube {
             _ => unimplemented!(),
         }
     }
-}
-
-pub fn u5_to_binary_vec<F: FieldAlgebra>(x: u64) -> Vec<F> {
-    (0..5)
-        .map(|i| F::from_canonical_u64((x >> i) & 1))
-        .collect()
 }
 
 #[cfg(test)]

--- a/gkr_iop/src/gkr/layer.rs
+++ b/gkr_iop/src/gkr/layer.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, iter, ops::Neg, sync::Arc, vec::IntoIter};
+use std::{iter, ops::Neg, sync::Arc, vec::IntoIter};
 
 use ff_ext::ExtensionField;
 use itertools::{Itertools, chain, izip};
@@ -18,6 +18,7 @@ use transcript::Transcript;
 use zerocheck_layer::ZerocheckLayer;
 
 use crate::{
+    OutEvalGroups,
     circuit_builder::{CircuitBuilder, ConstraintSystem, RotationParams},
     error::BackendError,
     evaluation::EvalExpression,
@@ -329,7 +330,7 @@ impl<E: ExtensionField> Layer<E> {
         cb: &CircuitBuilder<E>,
         layer_name: String,
         n_challenges: usize,
-        out_evals: Vec<(SelectorType<E>, usize)>,
+        out_evals: OutEvalGroups<E>,
     ) -> Layer<E> {
         let w_len = cb.cs.w_expressions.len();
         let r_len = cb.cs.r_expressions.len();
@@ -337,79 +338,93 @@ impl<E: ExtensionField> Layer<E> {
         let zero_len =
             cb.cs.assert_zero_expressions.len() + cb.cs.assert_zero_sumcheck_expressions.len();
 
-        let w_record_evals = out_evals[r_len..][..w_len].iter().cloned();
-        let r_record_evals = out_evals[..r_len].iter().cloned();
-        let lookup_evals = out_evals[r_len + w_len..][..lk_len].iter().cloned();
-        let zero_evals = out_evals[r_len + w_len + lk_len..][..zero_len]
-            .iter()
-            .cloned();
+        let [r_record_evals, w_record_evals, lookup_evals, zero_evals] = out_evals;
+        assert_eq!(r_record_evals.1.len(), r_len);
+        assert_eq!(w_record_evals.1.len(), w_len);
+        assert_eq!(lookup_evals.1.len(), lk_len);
+        assert_eq!(zero_evals.1.len(), zero_len);
 
         let non_zero_expr_len = cb.cs.w_expressions_namespace_map.len()
             + cb.cs.r_expressions_namespace_map.len()
             + cb.cs.lk_expressions.len();
         let zero_expr_len =
             cb.cs.assert_zero_expressions.len() + cb.cs.assert_zero_sumcheck_expressions.len();
-        let mut gkr_expressions = Vec::with_capacity(non_zero_expr_len + zero_expr_len);
-        let mut gkr_expressions_eval = Vec::with_capacity(non_zero_expr_len + zero_expr_len);
-        let mut gkr_expressions_name = Vec::with_capacity(non_zero_expr_len + zero_expr_len);
 
-        assert_eq!(
-            w_record_evals.len() + r_record_evals.len(),
-            cb.cs.w_expressions.len() + cb.cs.r_expressions.len()
-        );
-        for (idx, (ram_expr, name), ram_eval) in izip!(
-            0..,
-            chain!(
-                cb.cs
-                    .w_expressions
-                    .iter()
-                    .zip_eq(&cb.cs.w_expressions_namespace_map),
-                cb.cs
-                    .r_expressions
-                    .iter()
-                    .zip_eq(&cb.cs.r_expressions_namespace_map),
-            ),
-            w_record_evals.chain(r_record_evals)
-        ) {
-            gkr_expressions.push(ram_expr - E::BaseField::ONE.expr()); // ONE is for padding;
-            gkr_expressions_eval.push((
-                ram_eval.0,
-                EvalExpression::<E>::Linear(
-                    // evaluation = claim * one - one (padding)
-                    ram_eval.1,
-                    E::BaseField::ONE.expr().into(),
-                    E::BaseField::ONE.neg().expr().into(),
-                ),
+        let mut expr_evals = Vec::with_capacity(4);
+        let mut expr_names = Vec::with_capacity(non_zero_expr_len + zero_expr_len);
+        let mut expressions = Vec::with_capacity(non_zero_expr_len + zero_expr_len);
+
+        // process r_record
+        let mut evals = vec![];
+        for (idx, ((ram_expr, name), ram_eval)) in cb
+            .cs
+            .r_expressions
+            .iter()
+            .zip_eq(&cb.cs.r_expressions_namespace_map)
+            .zip_eq(&r_record_evals.1)
+            .enumerate()
+        {
+            expressions.push(ram_expr - E::BaseField::ONE.expr());
+            evals.push(EvalExpression::<E>::Linear(
+                // evaluation = claim * one - one (padding)
+                *ram_eval,
+                E::BaseField::ONE.expr().into(),
+                E::BaseField::ONE.neg().expr().into(),
             ));
-            gkr_expressions_name.push(format!("{}/{idx}", name));
+            expr_names.push(format!("{}/{idx}", name));
         }
+        expr_evals.push((r_record_evals.0.clone(), evals));
+
+        // process w_record
+        let mut evals = vec![];
+        for (idx, ((ram_expr, name), ram_eval)) in cb
+            .cs
+            .w_expressions
+            .iter()
+            .zip_eq(&cb.cs.w_expressions_namespace_map)
+            .zip_eq(&w_record_evals.1)
+            .enumerate()
+        {
+            expressions.push(ram_expr - E::BaseField::ONE.expr());
+            evals.push(EvalExpression::<E>::Linear(
+                // evaluation = claim * one - one (padding)
+                *ram_eval,
+                E::BaseField::ONE.expr().into(),
+                E::BaseField::ONE.neg().expr().into(),
+            ));
+            expr_names.push(format!("{}/{idx}", name));
+        }
+        expr_evals.push((w_record_evals.0.clone(), evals));
 
         // process lookup records
-        assert_eq!(lookup_evals.len(), cb.cs.lk_expressions.len());
-        for (idx, (lookup, name), lookup_eval) in izip!(
-            0..,
-            cb.cs
-                .lk_expressions
-                .iter()
-                .zip_eq(&cb.cs.lk_expressions_namespace_map),
-            lookup_evals
-        ) {
-            gkr_expressions.push(lookup - cb.cs.chip_record_alpha.clone()); // alpha is for padding;
-            gkr_expressions_eval.push((
-                lookup_eval.0,
-                EvalExpression::<E>::Linear(
-                    // evaluation = claim * one - alpha (padding)
-                    lookup_eval.1,
-                    E::BaseField::ONE.expr().into(),
-                    cb.cs.chip_record_alpha.clone().neg().into(),
-                ),
+        let mut evals = vec![];
+        for (idx, ((lookup, name), lookup_eval)) in cb
+            .cs
+            .lk_expressions
+            .iter()
+            .zip_eq(&cb.cs.lk_expressions_namespace_map)
+            .zip_eq(&lookup_evals.1)
+            .enumerate()
+        {
+            expressions.push(lookup - cb.cs.chip_record_alpha.clone());
+            evals.push(EvalExpression::<E>::Linear(
+                // evaluation = claim * one - alpha (padding)
+                *lookup_eval,
+                E::BaseField::ONE.expr().into(),
+                cb.cs.chip_record_alpha.clone().neg().into(),
             ));
-            gkr_expressions_name.push(format!("{}/{idx}", name));
+            expr_names.push(format!("{}/{idx}", name));
         }
+        expr_evals.push((lookup_evals.0.clone(), evals));
 
-        // process zero record
-        assert_eq!(zero_evals.len(), zero_expr_len);
-        for (idx, (zero_expr, name), (zero_eq, _)) in izip!(
+        // sanity check
+        assert_eq!(
+            lookup_evals.0, zero_evals.0,
+            "require lookup selector be the same as zero selector"
+        );
+        // process zero_record
+        let (_, ref mut evals) = expr_evals.last_mut().unwrap();
+        for (idx, (zero_expr, name)) in izip!(
             0..,
             chain!(
                 cb.cs
@@ -420,12 +435,11 @@ impl<E: ExtensionField> Layer<E> {
                     .assert_zero_sumcheck_expressions
                     .iter()
                     .zip_eq(&cb.cs.assert_zero_sumcheck_expressions_namespace_map)
-            ),
-            zero_evals
+            )
         ) {
-            gkr_expressions.push(zero_expr.clone());
-            gkr_expressions_eval.push((zero_eq, EvalExpression::Zero));
-            gkr_expressions_name.push(format!("{}/{idx}", name));
+            expressions.push(zero_expr.clone());
+            evals.push(EvalExpression::Zero);
+            expr_names.push(format!("{}/{idx}", name));
         }
 
         let witin_offset = 0 as WitnessId;
@@ -440,7 +454,7 @@ impl<E: ExtensionField> Layer<E> {
         } = &cb.cs;
 
         let mut is_layer_linear =
-            gkr_expressions
+            expressions
                 .iter_mut()
                 .fold(rotations.is_empty(), |is_linear_so_far, t| {
                     // replace `Fixed` and `StructuralWitIn` with `WitIn`, keep other unchanged
@@ -458,29 +472,6 @@ impl<E: ExtensionField> Layer<E> {
                     );
                     is_linear_so_far && t.is_linear()
                 });
-
-        // process evaluation group by eq expression
-        let mut eq_map = BTreeMap::new();
-        izip!(
-            gkr_expressions_eval.into_iter(),
-            gkr_expressions_name.into_iter(),
-            gkr_expressions.into_iter()
-        )
-        .for_each(|((eq, eval), name, expr)| {
-            let (eval_group, names, exprs) =
-                eq_map.entry(eq.clone()).or_insert((vec![], vec![], vec![]));
-            eval_group.push(eval);
-            names.push(name.clone());
-            exprs.push(expr);
-        });
-        let mut expr_evals = vec![];
-        let mut expr_names = vec![];
-        let mut expressions = vec![];
-        eq_map.into_iter().for_each(|(eq, (evals, names, exprs))| {
-            expr_evals.push((eq, evals));
-            expr_names.extend(names);
-            expressions.extend(exprs);
-        });
 
         is_layer_linear = is_layer_linear && expr_evals.len() == 1;
 

--- a/gkr_iop/src/gkr/layer/cpu/mod.rs
+++ b/gkr_iop/src/gkr/layer/cpu/mod.rs
@@ -159,6 +159,8 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZerocheckLayerProver
         .map(|r| Expression::Constant(Either::Right(r)))
         .collect_vec();
 
+        dbg!(alpha_pows[1].clone());
+
         let span = entered_span!("gen_expr", profiling_4 = true);
         let zero_check_exprs =
             extend_exprs_with_rotation(layer, &alpha_pows, layer.n_witin as WitnessId);

--- a/gkr_iop/src/gkr/layer/cpu/mod.rs
+++ b/gkr_iop/src/gkr/layer/cpu/mod.rs
@@ -159,8 +159,6 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZerocheckLayerProver
         .map(|r| Expression::Constant(Either::Right(r)))
         .collect_vec();
 
-        dbg!(alpha_pows[1].clone());
-
         let span = entered_span!("gen_expr", profiling_4 = true);
         let zero_check_exprs =
             extend_exprs_with_rotation(layer, &alpha_pows, layer.n_witin as WitnessId);

--- a/gkr_iop/src/lib.rs
+++ b/gkr_iop/src/lib.rs
@@ -31,6 +31,9 @@ pub mod utils;
 
 pub type Phase1WitnessGroup<'a, E> = Vec<ArcMultilinearExtension<'a, E>>;
 
+// format: [r_records, w_records, lk_records, zero_records]
+pub type OutEvalGroups<E> = [(SelectorType<E>, Vec<usize>); 4];
+
 pub trait ProtocolBuilder<E: ExtensionField>: Sized {
     type Params;
 
@@ -42,7 +45,7 @@ pub trait ProtocolBuilder<E: ExtensionField>: Sized {
         params: Self::Params,
     ) -> Result<Self, CircuitBuilderError>;
 
-    fn finalize(&mut self, cb: &CircuitBuilder<E>) -> (Vec<(SelectorType<E>, usize)>, Chip<E>);
+    fn finalize(&mut self, cb: &CircuitBuilder<E>) -> (OutEvalGroups<E>, Chip<E>);
 
     fn n_committed(&self) -> usize;
     fn n_fixed(&self) -> usize;

--- a/gkr_iop/src/selector.rs
+++ b/gkr_iop/src/selector.rs
@@ -11,10 +11,7 @@ use p3_field::FieldAlgebra;
 use rayon::{iter::ParallelIterator, slice::ParallelSliceMut};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
-use crate::{
-    gkr::booleanhypercube::{CYCLIC_POW2_5, u5_to_binary_vec},
-    utils::eq_eval_less_or_equal_than,
-};
+use crate::{gkr::booleanhypercube::CYCLIC_POW2_5, utils::eq_eval_less_or_equal_than};
 
 /// Selector selects part of the witnesses in the sumcheck protocol.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
@@ -27,8 +24,13 @@ pub enum SelectorType<E: ExtensionField> {
     Whole(Expression<E>),
     /// Select a prefix as the instances, padded with a field element.
     Prefix(E::BaseField, Expression<E>),
-    /// Select a prefix as the instances, for each instance select the 1st or the last round.
-    KeccakRound(usize, Expression<E>),
+    /// selector activates on the specified `indices`, which are assumed to be in ascending order.
+    /// each index corresponds to a position within a fixed-size chunk (e.g., size 32),
+    /// and the same `expression` is applied at those positions across all chunks.
+    OrderedSparse32 {
+        indices: Vec<usize>,
+        expression: Expression<E>,
+    },
 }
 
 impl<E: ExtensionField> SelectorType<E> {
@@ -51,17 +53,28 @@ impl<E: ExtensionField> SelectorType<E> {
                 }
                 Some(sel.into_mle())
             }
-            SelectorType::KeccakRound(round, _expr) => {
+            SelectorType::OrderedSparse32 { indices, .. } => {
                 let mut sel = build_eq_x_r_vec(out_point);
-                let selected_id = CYCLIC_POW2_5[*round] as usize;
                 sel.par_chunks_exact_mut(CYCLIC_POW2_5.len())
                     .enumerate()
                     .for_each(|(chunk_index, chunk)| {
-                        chunk.iter_mut().enumerate().for_each(|(i, e)| {
-                            if i != selected_id || chunk_index >= num_instances {
-                                *e = E::ZERO
+                        if chunk_index >= num_instances {
+                            // Zero out the entire chunk if out of instance range
+                            chunk.iter_mut().for_each(|e| *e = E::ZERO);
+                            return;
+                        }
+
+                        let mut indices_iter = indices.iter().copied();
+                        let mut next_keep = indices_iter.next();
+
+                        for (i, e) in chunk.iter_mut().enumerate() {
+                            match next_keep {
+                                Some(idx) if i == idx => {
+                                    next_keep = indices_iter.next(); // Keep this one
+                                }
+                                _ => *e = E::ZERO, // Not in indices
                             }
-                        });
+                        }
                     });
                 Some(sel.into_mle())
             }
@@ -90,18 +103,19 @@ impl<E: ExtensionField> SelectorType<E> {
                     eq_eval_less_or_equal_than(num_instances - 1, out_point, in_point),
                 )
             }
-            SelectorType::KeccakRound(round, expr) => {
-                let eq_low_in = eq_eval(
-                    &u5_to_binary_vec::<E>(CYCLIC_POW2_5[*round]),
-                    &in_point[..5],
-                );
-                let eq_low_out = eq_eval(
-                    &u5_to_binary_vec::<E>(CYCLIC_POW2_5[*round]),
-                    &out_point[..5],
-                );
+            SelectorType::OrderedSparse32 {
+                indices,
+                expression,
+            } => {
+                let out_subgroup_eq = build_eq_x_r_vec(&out_point[..5]);
+                let in_subgroup_eq = build_eq_x_r_vec(&in_point[..5]);
+                let mut eval = E::ZERO;
+                for index in indices {
+                    eval += out_subgroup_eq[*index] * in_subgroup_eq[*index];
+                }
                 let sel =
                     eq_eval_less_or_equal_than(num_instances - 1, &out_point[5..], &in_point[5..]);
-                (expr, eq_low_in * eq_low_out * sel)
+                (expression, eval * sel)
             }
         };
         let Expression::StructuralWitIn(wit_id, _, _, _) = expr else {
@@ -130,13 +144,13 @@ pub(crate) fn select_from_expression_result<'a, E: ExtensionField>(
                 .into_mle()
                 .into()
         }
-        SelectorType::KeccakRound(round, _) => {
+        SelectorType::OrderedSparse32 { indices, .. } => {
             let evals = Arc::try_unwrap(out_mle).unwrap().evaluations_to_owned();
             evals
                 .pick_index_within_chunk(
                     CYCLIC_POW2_5.len(),
                     num_instances,
-                    CYCLIC_POW2_5[*round] as usize,
+                    indices,
                     &E::BaseField::ZERO,
                 )
                 .into_mle()

--- a/gkr_iop/src/selector.rs
+++ b/gkr_iop/src/selector.rs
@@ -93,7 +93,7 @@ impl<E: ExtensionField> SelectorType<E> {
                 )
             }
             SelectorType::KeccakRound(round, _, expr) => {
-                assert!(out_point.len() + 5 == in_point.len());
+                assert_eq!(out_point.len() + 5, in_point.len());
                 let eq_low = eq_eval(
                     &u5_to_binary_vec::<E>(CYCLIC_POW2_5[*round]),
                     &in_point[..5],

--- a/gkr_iop/src/utils.rs
+++ b/gkr_iop/src/utils.rs
@@ -3,7 +3,7 @@ pub mod lk_multiplicity;
 use ff_ext::{ExtensionField, SmallField};
 use itertools::{Itertools, izip};
 use multilinear_extensions::{
-    Expression, Fixed, ToExpr, WitIn, WitnessId,
+    Expression, Fixed, WitIn, WitnessId,
     mle::{ArcMultilinearExtension, MultilinearExtension},
     util::ceil_log2,
     virtual_poly::{build_eq_x_r_vec, eq_eval},
@@ -46,7 +46,7 @@ pub fn extend_exprs_with_rotation<E: ExtensionField>(
             SelectorType::None => zero_check_expr,
             SelectorType::Whole(sel)
             | SelectorType::Prefix(_, sel)
-            | SelectorType::KeccakRound(_, _, sel) => match_expr(sel) * zero_check_expr,
+            | SelectorType::KeccakRound(_, sel) => match_expr(sel) * zero_check_expr,
         };
         zero_check_exprs.push(expr);
     }

--- a/gkr_iop/src/utils.rs
+++ b/gkr_iop/src/utils.rs
@@ -44,10 +44,9 @@ pub fn extend_exprs_with_rotation<E: ExtensionField>(
             .sum::<Expression<E>>();
         let expr = match sel_type {
             SelectorType::None => zero_check_expr,
-            SelectorType::Whole(sel) => match_expr(sel) * zero_check_expr,
-            SelectorType::Prefix(pad, sel) | SelectorType::KeccakRound(_, pad, sel) => {
-                match_expr(sel) * (zero_check_expr - pad.expr())
-            }
+            SelectorType::Whole(sel)
+            | SelectorType::Prefix(_, sel)
+            | SelectorType::KeccakRound(_, _, sel) => match_expr(sel) * zero_check_expr,
         };
         zero_check_exprs.push(expr);
     }

--- a/gkr_iop/src/utils.rs
+++ b/gkr_iop/src/utils.rs
@@ -46,7 +46,9 @@ pub fn extend_exprs_with_rotation<E: ExtensionField>(
             SelectorType::None => zero_check_expr,
             SelectorType::Whole(sel)
             | SelectorType::Prefix(_, sel)
-            | SelectorType::KeccakRound(_, sel) => match_expr(sel) * zero_check_expr,
+            | SelectorType::OrderedSparse32 {
+                expression: sel, ..
+            } => match_expr(sel) * zero_check_expr,
         };
         zero_check_exprs.push(expr);
     }

--- a/gkr_iop/src/utils.rs
+++ b/gkr_iop/src/utils.rs
@@ -267,9 +267,6 @@ pub const fn wits_fixed_and_eqs<const N: usize, const M: usize, const Q: usize>(
     (wits, fixed, eqs)
 }
 
-/// TODO this is copy from gkr crate
-/// including gkr crate after gkr clippy fix
-///
 /// This is to compute a variant of eq(\mathbf{x}, \mathbf{y}) for indices in
 /// [0..=max_idx]. Specifically, it is an MLE of the following vector:
 ///     partial_eq_{\mathbf{x}}(\mathbf{y})

--- a/multilinear_extensions/src/mle.rs
+++ b/multilinear_extensions/src/mle.rs
@@ -230,7 +230,7 @@ impl<'a, E: ExtensionField> PartialEq for FieldType<'a, E> {
             (FieldType::Ext(a), FieldType::Ext(b)) => a == b,
             (FieldType::Base(a), FieldType::Ext(b)) | (FieldType::Ext(b), FieldType::Base(a)) => a
                 .par_iter()
-                .zip(b.par_iter())
+                .zip_eq(b.par_iter())
                 .all(|(a, b)| E::from_base(*a) == *b),
             _ => self.is_zero() && other.is_zero(),
         }

--- a/multilinear_extensions/src/mle.rs
+++ b/multilinear_extensions/src/mle.rs
@@ -210,11 +210,11 @@ impl<'a, E: ExtensionField> FieldType<'a, E> {
     pub fn pick_stride_offset(self, stride: usize, offset: usize) -> Self {
         match self {
             FieldType::Base(slice) => {
-                let res = slice.iter().cloned().skip(offset).step_by(stride).collect();
+                let res = slice.iter().copied().skip(offset).step_by(stride).collect();
                 FieldType::Base(SmartSlice::Owned(res))
             }
             FieldType::Ext(slice) => {
-                let res = slice.iter().cloned().skip(offset).step_by(stride).collect();
+                let res = slice.iter().copied().skip(offset).step_by(stride).collect();
                 FieldType::Ext(SmartSlice::Owned(res))
             }
             FieldType::Unreachable => panic!("unreachable"),


### PR DESCRIPTION
### reason for e2e not pass yet
- [ ] precompile lookup multiplicity on number of #padding not count yet. => affect lookup product evaluation final check 
```
1 / (alpha + (lk record rlc)) = multiplicity(x) / (alpha + (table rlc)) 
```

- [ ] fetch of precompile -> constrain opcode happend on correct program table pc

