### PR TITLE
gkr-iop refactor selector witness generation

### DIFF
--- a/ceno_zkvm/src/instructions.rs
+++ b/ceno_zkvm/src/instructions.rs
@@ -94,6 +94,10 @@ pub trait Instruction<E: ExtensionField> {
         num_structural_witin: usize,
         steps: Vec<StepRecord>,
     ) -> Result<(RMMCollections<E::BaseField>, LkMultiplicity), ZKVMError> {
+        // selector is the only structural witness
+        assert!(num_structural_witin == 0 || num_structural_witin == 1);
+        let num_structural_witin = num_structural_witin.max(1);
+        
         let nthreads = max_usable_threads();
         let num_instance_per_batch = if steps.len() > 256 {
             steps.len().div_ceil(nthreads)
@@ -120,7 +124,7 @@ pub trait Instruction<E: ExtensionField> {
                 let mut lk_multiplicity = lk_multiplicity.clone();
                 instances
                     .chunks_mut(num_witin)
-                    .zip(structural_instance.chunks_mut(num_witin))
+                    .zip_eq(structural_instance.chunks_mut(num_structural_witin))
                     .zip(steps)
                     .map(|((instance, structural_instance), step)| {
                         set_val!(structural_instance, WitIn { id: 0 }, E::BaseField::ONE);

--- a/ceno_zkvm/src/precompiles/bitwise_keccakf.rs
+++ b/ceno_zkvm/src/precompiles/bitwise_keccakf.rs
@@ -915,8 +915,8 @@ pub fn run_keccakf<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'stat
     #[allow(clippy::type_complexity)]
     let (gkr_witness, gkr_output) = layout.gkr_witness::<CpuBackend<E, PCS>, CpuProver<_>>(
         &gkr_circuit,
-        phase1_witness.num_instances(),
         &phase1_witness_group,
+        &[],
         &[],
         &[],
         &[],

--- a/ceno_zkvm/src/scheme/cpu/mod.rs
+++ b/ceno_zkvm/src/scheme/cpu/mod.rs
@@ -534,10 +534,8 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> MainSumcheckProver<C
             zkvm_v1_css: cs,
             gkr_circuit,
         } = composed_cs;
-        let num_instances = input.num_instances;
         let log2_num_instances = input.log2_num_instances();
         let num_var_with_rotation = log2_num_instances + composed_cs.rotation_vars().unwrap_or(0);
-        let num_instances_with_rotation = num_instances << composed_cs.rotation_vars().unwrap_or(0);
 
         // sanity check
         assert_eq!(input.witness.len(), cs.num_witin as usize);
@@ -568,8 +566,8 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> MainSumcheckProver<C
 
             let (_, gkr_circuit_out) = Self::gkr_witness(
                 gkr_circuit,
-                num_instances_with_rotation,
                 &input.witness,
+                &input.structural_witness,
                 &input.fixed,
                 &input.public_input,
                 challenges,

--- a/ceno_zkvm/src/scheme/tests.rs
+++ b/ceno_zkvm/src/scheme/tests.rs
@@ -143,14 +143,20 @@ fn test_rw_lk_expression_combination() {
         // get proof
         let prover = ZkVMCpuProver::new(pk, device);
         let mut transcript = BasicTranscript::new(b"test");
-        let rmm = zkvm_witness.into_iter_sorted().next().unwrap().1.remove(0);
+        let mut rmm = zkvm_witness.into_iter_sorted().next().unwrap().1;
+        let (rmm, structural_rmm) = (rmm.remove(0), rmm.remove(0));
         let wits_in = rmm.to_mles();
+        let structural_wits_in = structural_rmm.to_mles();
         // commit to main traces
         let commit_with_witness =
             Pcs::batch_commit_and_write(&prover.pk.pp, vec![rmm], &mut transcript).unwrap();
         let witin_commit = Pcs::get_pure_commitment(&commit_with_witness);
 
         let wits_in = wits_in.into_iter().map(|v| v.into()).collect_vec();
+        let structural_in = structural_wits_in
+            .into_iter()
+            .map(|v| v.into())
+            .collect_vec();
         let prover_challenges = [
             transcript.read_challenge().elements,
             transcript.read_challenge().elements,
@@ -159,7 +165,7 @@ fn test_rw_lk_expression_combination() {
         let input = ProofInput {
             fixed: vec![],
             witness: wits_in,
-            structural_witness: vec![],
+            structural_witness: structural_in,
             public_input: vec![],
             num_instances,
         };

--- a/gkr_iop/src/cpu/mod.rs
+++ b/gkr_iop/src/cpu/mod.rs
@@ -258,6 +258,7 @@ where
                 sel_type,
                 wit_infer_by_expr(&[], layer_wits, &[], pub_io_evals, challenges, expr),
                 num_instances,
+                out_eval,
             );
             if let EvalExpression::Zero = out_eval {
                 // sanity check: zero mle

--- a/gkr_iop/src/cpu/mod.rs
+++ b/gkr_iop/src/cpu/mod.rs
@@ -258,7 +258,6 @@ where
                 sel_type,
                 wit_infer_by_expr(&[], layer_wits, &[], pub_io_evals, challenges, expr),
                 num_instances,
-                out_eval,
             );
             if let EvalExpression::Zero = out_eval {
                 // sanity check: zero mle

--- a/gkr_iop/src/gkr/layer.rs
+++ b/gkr_iop/src/gkr/layer.rs
@@ -69,6 +69,10 @@ pub struct Layer<E: ExtensionField> {
     /// TODO we should convert into monimial format Vec<Vec<Term<Expression<E>, Expression<E>>>
     /// TODO once we make eq, zero_check rlc challenge alpha all encoded into static expression
     pub exprs: Vec<Expression<E>>,
+    /// same as `exprs` but times with selector + out eval expression
+    pub exprs_with_selector_out_eval: Vec<Expression<E>>,
+    /// same as `exprs_with_selector_out_eval`, just in monomial form
+    pub exprs_with_selector_out_eval_monomial_form: Vec<Vec<Term<Expression<E>, Expression<E>>>>,
 
     /// Positions to place the evaluations of the base inputs of this layer.
     pub in_eval_expr: Vec<usize>,
@@ -150,6 +154,8 @@ impl<E: ExtensionField> Layer<E> {
                     max_expr_degree,
                     n_challenges,
                     exprs,
+                    exprs_with_selector_out_eval: vec![],
+                    exprs_with_selector_out_eval_monomial_form: vec![],
                     in_eval_expr,
                     out_sel_and_eval_exprs,
                     rotation_exprs: (rotation_eq, rotation_exprs),

--- a/gkr_iop/src/gkr/layer.rs
+++ b/gkr_iop/src/gkr/layer.rs
@@ -69,9 +69,7 @@ pub struct Layer<E: ExtensionField> {
     /// TODO we should convert into monimial format Vec<Vec<Term<Expression<E>, Expression<E>>>
     /// TODO once we make eq, zero_check rlc challenge alpha all encoded into static expression
     pub exprs: Vec<Expression<E>>,
-    /// same as `exprs` but times with selector + out eval expression
-    pub exprs_with_selector_out_eval: Vec<Expression<E>>,
-    /// same as `exprs_with_selector_out_eval`, just in monomial form
+    /// `exprs` in monomial form
     pub exprs_with_selector_out_eval_monomial_form: Vec<Vec<Term<Expression<E>, Expression<E>>>>,
 
     /// Positions to place the evaluations of the base inputs of this layer.
@@ -154,7 +152,6 @@ impl<E: ExtensionField> Layer<E> {
                     max_expr_degree,
                     n_challenges,
                     exprs,
-                    exprs_with_selector_out_eval: vec![],
                     exprs_with_selector_out_eval_monomial_form: vec![],
                     in_eval_expr,
                     out_sel_and_eval_exprs,

--- a/gkr_iop/src/gkr/layer/zerocheck_layer.rs
+++ b/gkr_iop/src/gkr/layer/zerocheck_layer.rs
@@ -104,13 +104,13 @@ impl<E: ExtensionField> ZerocheckLayer<E> for Layer<E> {
             .iter()
             .flat_map(|(sel_type, out_eval)| izip!(std::iter::repeat(sel_type), out_eval.iter()))
             .collect();
-        self.exprs_with_selector_out_eval = self
+        self.exprs_with_selector_out_eval_monomial_form = self
             .exprs
             .iter()
             .zip_eq(out_evals.iter())
             .map(|(expr, (sel_type, out_eval))| {
                 let sel_expr = sel_type.selector_expr();
-                match out_eval {
+                let expr = match out_eval {
                     EvalExpression::Linear(_, a, b) => {
                         assert_eq!(
                             a.as_ref().clone(),
@@ -123,21 +123,14 @@ impl<E: ExtensionField> ZerocheckLayer<E> for Layer<E> {
                     EvalExpression::Single(_) => sel_expr.clone() * expr,
                     EvalExpression::Zero => Expression::ZERO,
                     EvalExpression::Partition(_, _) => unimplemented!(),
-                }
-            })
-            .collect::<Vec<_>>();
-
-        self.exprs_with_selector_out_eval_monomial_form = self
-            .exprs_with_selector_out_eval
-            .iter()
-            .map(|expr| {
+                };
                 monomialize_expr_to_wit_terms(
-                    expr,
+                    &expr,
                     self.n_witin as WitnessId,
                     self.n_structural_witin as WitnessId,
                 )
             })
-            .collect_vec();
+            .collect::<Vec<_>>();
 
         // build main sumcheck expression
         let alpha_pows_expr = (2..)

--- a/gkr_iop/src/gkr/layer/zerocheck_layer.rs
+++ b/gkr_iop/src/gkr/layer/zerocheck_layer.rs
@@ -4,6 +4,7 @@ use multilinear_extensions::{
     ChallengeId, Expression, WitnessId,
     macros::{entered_span, exit_span},
     mle::Point,
+    monomialize_expr_to_wit_terms,
     utils::{eval_by_expr, eval_by_expr_with_instance},
     virtual_poly::VPAuxInfo,
 };
@@ -107,16 +108,24 @@ impl<E: ExtensionField> ZerocheckLayer<E> for Layer<E> {
                 .sum::<Expression<E>>();
 
         self.rotation_sumcheck_expression = rotation_expr.clone();
-        self.rotation_sumcheck_expression_monomial_terms = self
-            .rotation_sumcheck_expression
-            .as_ref()
-            .map(|expr| expr.get_monomial_terms());
+        self.rotation_sumcheck_expression_monomial_terms =
+            self.rotation_sumcheck_expression.as_ref().map(|expr| {
+                monomialize_expr_to_wit_terms(
+                    expr,
+                    self.n_witin as WitnessId,
+                    self.n_structural_witin as WitnessId,
+                )
+            });
 
         self.main_sumcheck_expression = Some(zero_expr);
-        self.main_sumcheck_expression_monomial_terms = self
-            .main_sumcheck_expression
-            .as_ref()
-            .map(|expr| expr.get_monomial_terms());
+        self.main_sumcheck_expression_monomial_terms =
+            self.main_sumcheck_expression.as_ref().map(|expr| {
+                monomialize_expr_to_wit_terms(
+                    expr,
+                    self.n_witin as WitnessId,
+                    self.n_structural_witin as WitnessId,
+                )
+            });
         exit_span!(span);
     }
 

--- a/gkr_iop/src/gkr/mock.rs
+++ b/gkr_iop/src/gkr/mock.rs
@@ -13,11 +13,7 @@ use multilinear_extensions::{
 use rand::thread_rng;
 use thiserror::Error;
 
-use crate::{
-    cpu::CpuBackend,
-    evaluation::EvalExpression,
-    selector::{SelectorType, select_from_expression_result},
-};
+use crate::{cpu::CpuBackend, evaluation::EvalExpression, selector::SelectorType};
 
 use super::{GKRCircuit, GKRCircuitWitness, layer::LayerType};
 
@@ -48,7 +44,6 @@ impl<E: ExtensionField> MockProver<E> {
         circuit_wit: &'a GKRCircuitWitness<'b, CpuBackend<E, PCS>>,
         mut evaluations: Vec<ArcMultilinearExtension<'b, E>>,
         mut challenges: Vec<E>,
-        num_instances: usize,
     ) -> Result<(), MockProverError<'a, E>>
     where
         'b: 'a,
@@ -60,14 +55,30 @@ impl<E: ExtensionField> MockProver<E> {
         // check the input layer
         for (layer, layer_wit) in izip!(&circuit.layers, &circuit_wit.layers) {
             let num_vars = layer_wit.num_vars();
-            let wits = layer_wit
+            let mut wits = layer_wit
                 .iter()
                 .map(|mle| mle.as_view().into())
                 .collect::<Vec<_>>();
+            let structural_wits = wits.split_off(layer.n_witin);
             let gots = layer
                 .exprs
                 .iter()
-                .map(|expr| wit_infer_by_expr(&[], &wits, &[], &[], &challenges, expr))
+                .zip_eq(
+                    layer
+                        .out_sel_and_eval_exprs
+                        .iter()
+                        .flat_map(|(sel_type, out)| izip!(iter::repeat(sel_type), out)),
+                )
+                .map(|(expr, (sel, _))| {
+                    wit_infer_by_expr(
+                        &[],
+                        &wits,
+                        &structural_wits,
+                        &[],
+                        &challenges,
+                        &(sel.selector_expr() * expr),
+                    )
+                })
                 .collect_vec();
 
             let expects = layer
@@ -80,7 +91,7 @@ impl<E: ExtensionField> MockProver<E> {
                 .collect::<Result<Vec<_>, _>>()?;
             match layer.ty {
                 LayerType::Zerocheck => {
-                    for (got, expect, expr, expr_name, (sel_type, out_eval)) in izip!(
+                    for (got, expect, expr, expr_name, (_, out_eval)) in izip!(
                         gots,
                         expects,
                         &layer.exprs,
@@ -90,7 +101,7 @@ impl<E: ExtensionField> MockProver<E> {
                             .iter()
                             .flat_map(|(sel_type, out)| izip!(iter::repeat(sel_type), out))
                     ) {
-                        let got = select_from_expression_result(sel_type, got, num_instances);
+                        // let got = select_from_expression_result(sel_type, got, num_instances);
                         if expect != got {
                             return Err(MockProverError::ZerocheckExpressionNotMatch(
                                 Box::new(out_eval.clone()),

--- a/gkr_iop/src/gkr/mock.rs
+++ b/gkr_iop/src/gkr/mock.rs
@@ -101,7 +101,6 @@ impl<E: ExtensionField> MockProver<E> {
                             .iter()
                             .flat_map(|(sel_type, out)| izip!(iter::repeat(sel_type), out))
                     ) {
-                        // let got = select_from_expression_result(sel_type, got, num_instances);
                         if expect != got {
                             return Err(MockProverError::ZerocheckExpressionNotMatch(
                                 Box::new(out_eval.clone()),

--- a/gkr_iop/src/hal.rs
+++ b/gkr_iop/src/hal.rs
@@ -43,8 +43,8 @@ where
 pub trait ProtocolWitnessGeneratorProver<PB: ProverBackend> {
     fn gkr_witness<'a, 'b>(
         circuit: &GKRCircuit<PB::E>,
-        num_instance_with_rotation: usize,
         phase1_witness_group: &[Arc<PB::MultilinearPoly<'b>>],
+        structural_witness: &[Arc<PB::MultilinearPoly<'b>>],
         fixed: &[Arc<PB::MultilinearPoly<'b>>],
         pub_io: &[Arc<PB::MultilinearPoly<'b>>],
         challenges: &[PB::E],

--- a/gkr_iop/src/lib.rs
+++ b/gkr_iop/src/lib.rs
@@ -75,16 +75,16 @@ pub trait ProtocolWitnessGenerator<E: ExtensionField> {
     fn gkr_witness<'a, PB: ProverBackend<E = E>, PD: ProverDevice<PB>>(
         &self,
         circuit: &GKRCircuit<PB::E>,
-        num_instance_with_rotation: usize,
         phase1_witness_group: &[Arc<PB::MultilinearPoly<'a>>],
+        structural_witness: &[Arc<PB::MultilinearPoly<'a>>],
         fixed: &[Arc<PB::MultilinearPoly<'a>>],
         pub_io: &[Arc<PB::MultilinearPoly<'a>>],
         challenges: &[PB::E],
     ) -> (GKRCircuitWitness<'a, PB>, GKRCircuitOutput<'a, PB>) {
         <PD as ProtocolWitnessGeneratorProver<PB>>::gkr_witness(
             circuit,
-            num_instance_with_rotation,
             phase1_witness_group,
+            structural_witness,
             fixed,
             pub_io,
             challenges,

--- a/gkr_iop/src/selector.rs
+++ b/gkr_iop/src/selector.rs
@@ -10,7 +10,10 @@ use multilinear_extensions::{
 use rayon::{iter::ParallelIterator, slice::ParallelSliceMut};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
-use crate::{gkr::booleanhypercube::CYCLIC_POW2_5, utils::eq_eval_less_or_equal_than};
+use crate::{
+    evaluation::EvalExpression, gkr::booleanhypercube::CYCLIC_POW2_5,
+    utils::eq_eval_less_or_equal_than,
+};
 
 /// Selector selects part of the witnesses in the sumcheck protocol.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
@@ -132,6 +135,7 @@ pub fn select_from_expression_result<'a, E: ExtensionField>(
     sel_type: &SelectorType<E>,
     out_mle: ArcMultilinearExtension<'a, E>,
     num_instances: usize,
+    eval_expression: EvalExpression<E>,
 ) -> ArcMultilinearExtension<'a, E> {
     match sel_type {
         SelectorType::None => out_mle.evaluations.sum().into_mle().into(),
@@ -145,7 +149,7 @@ pub fn select_from_expression_result<'a, E: ExtensionField>(
         SelectorType::OrderedSparse32 { indices, .. } => Arc::try_unwrap(out_mle)
             .unwrap()
             .evaluations_to_owned()
-            .pick_indices_within_chunk(CYCLIC_POW2_5.len(), num_instances, indices)
+            .pick_indices_within_chunk(CYCLIC_POW2_5.len(), num_instances, indices, eval_expression)
             .into_mle()
             .into(),
     }

--- a/gkr_iop/src/selector.rs
+++ b/gkr_iop/src/selector.rs
@@ -126,6 +126,45 @@ impl<E: ExtensionField> SelectorType<E> {
         }
         evals[wit_id] = eval;
     }
+
+    pub fn iter_sparse32(&self) -> OrderedSparse32Iter {
+        match self {
+            Self::OrderedSparse32 { indices, .. } => OrderedSparse32Iter {
+                indices,
+                current: 0,
+                index_ptr: 0,
+            },
+            _ => panic!("calling iter_sparse32 on non sparse type"),
+        }
+    }
+}
+
+pub struct OrderedSparse32Iter<'a> {
+    indices: &'a [usize],
+    current: usize,
+    index_ptr: usize,
+}
+
+impl<'a> Iterator for OrderedSparse32Iter<'a> {
+    type Item = u8;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current >= 32 {
+            return None;
+        }
+
+        let output = if self.index_ptr < self.indices.len()
+            && self.indices[self.index_ptr] == self.current
+        {
+            self.index_ptr += 1;
+            1
+        } else {
+            0
+        };
+
+        self.current += 1;
+        Some(output)
+    }
 }
 
 pub fn select_from_expression_result<'a, E: ExtensionField>(

--- a/gkr_iop/src/selector.rs
+++ b/gkr_iop/src/selector.rs
@@ -138,7 +138,7 @@ impl<E: ExtensionField> SelectorType<E> {
             Self::OrderedSparse32 { expression, .. }
             | Self::Whole(expression)
             | Self::Prefix(_, expression) => expression,
-            _ => panic!("calling sparse32_structural_witin_id on non sparse type"),
+            e => unimplemented!("no selector expression in {:?}", e),
         }
     }
 }

--- a/gkr_iop/src/selector.rs
+++ b/gkr_iop/src/selector.rs
@@ -10,10 +10,7 @@ use multilinear_extensions::{
 use rayon::{iter::ParallelIterator, slice::ParallelSliceMut};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
-use crate::{
-    evaluation::EvalExpression, gkr::booleanhypercube::CYCLIC_POW2_5,
-    utils::eq_eval_less_or_equal_than,
-};
+use crate::{gkr::booleanhypercube::CYCLIC_POW2_5, utils::eq_eval_less_or_equal_than};
 
 /// Selector selects part of the witnesses in the sumcheck protocol.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
@@ -135,7 +132,6 @@ pub fn select_from_expression_result<'a, E: ExtensionField>(
     sel_type: &SelectorType<E>,
     out_mle: ArcMultilinearExtension<'a, E>,
     num_instances: usize,
-    eval_expression: EvalExpression<E>,
 ) -> ArcMultilinearExtension<'a, E> {
     match sel_type {
         SelectorType::None => out_mle.evaluations.sum().into_mle().into(),
@@ -149,7 +145,7 @@ pub fn select_from_expression_result<'a, E: ExtensionField>(
         SelectorType::OrderedSparse32 { indices, .. } => Arc::try_unwrap(out_mle)
             .unwrap()
             .evaluations_to_owned()
-            .pick_indices_within_chunk(CYCLIC_POW2_5.len(), num_instances, indices, eval_expression)
+            .pick_indices_within_chunk(CYCLIC_POW2_5.len(), num_instances, indices)
             .into_mle()
             .into(),
     }

--- a/gkr_iop/src/selector.rs
+++ b/gkr_iop/src/selector.rs
@@ -1,10 +1,9 @@
 use rayon::iter::IndexedParallelIterator;
-use std::sync::Arc;
 
 use ff_ext::ExtensionField;
 use multilinear_extensions::{
     Expression,
-    mle::{ArcMultilinearExtension, IntoMLE, MultilinearExtension, Point},
+    mle::{IntoMLE, MultilinearExtension, Point},
     virtual_poly::{build_eq_x_r_vec, eq_eval},
 };
 use rayon::{iter::ParallelIterator, slice::ParallelSliceMut};
@@ -25,7 +24,6 @@ pub enum SelectorType<E: ExtensionField> {
     Prefix(E::BaseField, Expression<E>),
     /// selector activates on the specified `indices`, which are assumed to be in ascending order.
     /// each index corresponds to a position within a fixed-size chunk (e.g., size 32),
-    /// and the same `expression` is applied at those positions across all chunks.
     OrderedSparse32 {
         indices: Vec<usize>,
         expression: Expression<E>,
@@ -127,65 +125,20 @@ impl<E: ExtensionField> SelectorType<E> {
         evals[wit_id] = eval;
     }
 
-    pub fn iter_sparse32(&self) -> OrderedSparse32Iter {
+    /// return ordered indices of OrderedSparse32
+    pub fn sparse32_indices(&self) -> &[usize] {
         match self {
-            Self::OrderedSparse32 { indices, .. } => OrderedSparse32Iter {
-                indices,
-                current: 0,
-                index_ptr: 0,
-            },
-            _ => panic!("calling iter_sparse32 on non sparse type"),
+            Self::OrderedSparse32 { indices, .. } => indices,
+            _ => panic!("invalid calling on non sparse type"),
         }
     }
-}
 
-pub struct OrderedSparse32Iter<'a> {
-    indices: &'a [usize],
-    current: usize,
-    index_ptr: usize,
-}
-
-impl<'a> Iterator for OrderedSparse32Iter<'a> {
-    type Item = u8;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.current >= 32 {
-            return None;
+    pub fn selector_expr(&self) -> &Expression<E> {
+        match self {
+            Self::OrderedSparse32 { expression, .. }
+            | Self::Whole(expression)
+            | Self::Prefix(_, expression) => expression,
+            _ => panic!("calling sparse32_structural_witin_id on non sparse type"),
         }
-
-        let output = if self.index_ptr < self.indices.len()
-            && self.indices[self.index_ptr] == self.current
-        {
-            self.index_ptr += 1;
-            1
-        } else {
-            0
-        };
-
-        self.current += 1;
-        Some(output)
-    }
-}
-
-pub fn select_from_expression_result<'a, E: ExtensionField>(
-    sel_type: &SelectorType<E>,
-    out_mle: ArcMultilinearExtension<'a, E>,
-    num_instances: usize,
-) -> ArcMultilinearExtension<'a, E> {
-    match sel_type {
-        SelectorType::None => out_mle.evaluations.sum().into_mle().into(),
-        SelectorType::Whole(_) => out_mle,
-        SelectorType::Prefix(_pad, _) => Arc::try_unwrap(out_mle)
-            .unwrap()
-            .evaluations_to_owned()
-            .select_prefix(num_instances)
-            .into_mle()
-            .into(),
-        SelectorType::OrderedSparse32 { indices, .. } => Arc::try_unwrap(out_mle)
-            .unwrap()
-            .evaluations_to_owned()
-            .pick_indices_within_chunk(CYCLIC_POW2_5.len(), num_instances, indices)
-            .into_mle()
-            .into(),
     }
 }

--- a/multilinear_extensions/src/lib.rs
+++ b/multilinear_extensions/src/lib.rs
@@ -2,7 +2,7 @@
 #![feature(decl_macro)]
 #![feature(strict_overflow_ops)]
 mod expression;
-pub use expression::*;
+pub use expression::{utils::monomialize_expr_to_wit_terms, *};
 pub mod macros;
 pub mod mle;
 pub mod smart_slice;

--- a/multilinear_extensions/src/mle.rs
+++ b/multilinear_extensions/src/mle.rs
@@ -224,6 +224,15 @@ impl<'a, E: ExtensionField> FieldType<'a, E> {
             slice
         })
     }
+
+    #[inline(always)]
+    pub fn index(&self, index: usize) -> Either<E::BaseField, E> {
+        match self {
+            FieldType::Base(slice) => Either::Left(slice[index]),
+            FieldType::Ext(slice) => Either::Right(slice[index]),
+            FieldType::Unreachable => unreachable!(),
+        }
+    }
 }
 
 impl<'a, E: ExtensionField> PartialEq for FieldType<'a, E> {
@@ -943,6 +952,11 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
             evaluations: owned_eval,
             num_vars: self.num_vars,
         }
+    }
+
+    #[inline(always)]
+    pub fn index(&self, index: usize) -> Either<E::BaseField, E> {
+        self.evaluations.index(index)
     }
 }
 

--- a/multilinear_extensions/src/mle.rs
+++ b/multilinear_extensions/src/mle.rs
@@ -1,7 +1,7 @@
 use std::{any::TypeId, borrow::Cow, mem, sync::Arc};
 
 use crate::{
-    field_type_mut_map,
+    Expression, field_type_mut_map,
     macros::{entered_span, exit_span},
     op_mle,
     smart_slice::SmartSlice,
@@ -197,6 +197,7 @@ impl<'a, E: ExtensionField> FieldType<'a, E> {
         chunk_size: usize,
         valid_chunk_index: usize,
         indices: &[usize],
+        eval_expression: Expression<E>,
     ) -> Self {
         field_type_mut_map!(self, |slice| {
             slice

--- a/multilinear_extensions/src/mle.rs
+++ b/multilinear_extensions/src/mle.rs
@@ -1,7 +1,7 @@
 use std::{any::TypeId, borrow::Cow, mem, sync::Arc};
 
 use crate::{
-    Expression, field_type_mut_map,
+    field_type_mut_map,
     macros::{entered_span, exit_span},
     op_mle,
     smart_slice::SmartSlice,
@@ -197,7 +197,6 @@ impl<'a, E: ExtensionField> FieldType<'a, E> {
         chunk_size: usize,
         valid_chunk_index: usize,
         indices: &[usize],
-        eval_expression: Expression<E>,
     ) -> Self {
         field_type_mut_map!(self, |slice| {
             slice


### PR DESCRIPTION
This PR make gkr_witness expression as a static and finalized during circuit setup. 
There is another change to move selector witness construction to structural witness, which greatly boost performance for both CPU/GPU. In particular, GPU prefer [fused computation](https://dl.acm.org/doi/10.1109/SC41406.2024.00094) to combine multiple computation step into one to achieve better performance. Selector logic is a typical example: if we move selector witness construction to structural witness, then GPU can just take monomial term with selector in either 0 or 1, without any branching logic.

### benchmark
fibonacci e2e on CPU with 32 cores

| Benchmark                        | Median Time (s) | Median Change (%)                           |
|----------------------------------|------------------|----------------------------------------------|
| fibonacci_max_steps_1048576      | 2.4700           | -9.10% (Performance has improved)            |
| fibonacci_max_steps_2097152      | 4.5991           | -11.88% (Performance has improved)           |
| fibonacci_max_steps_4194304      | 8.9772           | -9.07% (Performance has improved)            |