### PR TITLE
memory value to limb 2

### DIFF
--- a/ceno_zkvm/src/chip_handler.rs
+++ b/ceno_zkvm/src/chip_handler.rs
@@ -49,8 +49,9 @@ pub trait RegisterChipOperations<E: ExtensionField, NR: Into<String>, N: FnOnce(
 /// The common representation of a memory address.
 pub type AddressExpr<E> = Expression<E>;
 
-/// The common representation of a memory value.
-pub type MemoryExpr<E> = Expression<E>;
+/// The common representation of a register value.
+/// Format: `[u16; UINT_LIMBS]`, least-significant-first.
+pub type MemoryExpr<E> = [Expression<E>; UINT_LIMBS];
 
 pub trait MemoryChipOperations<E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> {
     fn memory_read(

--- a/ceno_zkvm/src/chip_handler/general.rs
+++ b/ceno_zkvm/src/chip_handler/general.rs
@@ -21,7 +21,7 @@ pub trait PublicIOQuery {
     fn query_init_cycle(&mut self) -> Result<Instance, CircuitBuilderError>;
     fn query_end_pc(&mut self) -> Result<Instance, CircuitBuilderError>;
     fn query_end_cycle(&mut self) -> Result<Instance, CircuitBuilderError>;
-    fn query_public_io(&mut self) -> Result<Instance, CircuitBuilderError>;
+    fn query_public_io(&mut self) -> Result<[Instance; UINT_LIMBS], CircuitBuilderError>;
 }
 
 impl<'a, E: ExtensionField> InstFetch<E> for CircuitBuilder<'a, E> {
@@ -60,7 +60,11 @@ impl<'a, E: ExtensionField> PublicIOQuery for CircuitBuilder<'a, E> {
         self.cs.query_instance(|| "end_cycle", END_CYCLE_IDX)
     }
 
-    fn query_public_io(&mut self) -> Result<Instance, CircuitBuilderError> {
-        self.cs.query_instance(|| "public_io", PUBLIC_IO_IDX)
+    fn query_public_io(&mut self) -> Result<[Instance; UINT_LIMBS], CircuitBuilderError> {
+        Ok([
+            self.cs.query_instance(|| "public_io_low", PUBLIC_IO_IDX)?,
+            self.cs
+                .query_instance(|| "public_io_high", PUBLIC_IO_IDX + 1)?,
+        ])
     }
 }

--- a/ceno_zkvm/src/chip_handler/memory.rs
+++ b/ceno_zkvm/src/chip_handler/memory.rs
@@ -24,14 +24,14 @@ impl<E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> MemoryChipOperation
             // READ (a, v, t)
             let read_record = [
                 vec![RAMType::Memory.into(), memory_addr.clone()],
-                vec![value.clone()],
+                value.to_vec(),
                 vec![prev_ts.clone()],
             ]
             .concat();
             // Write (a, v, t)
             let write_record = [
                 vec![RAMType::Memory.into(), memory_addr.clone()],
-                vec![value],
+                value.to_vec(),
                 vec![ts.clone()],
             ]
             .concat();
@@ -66,14 +66,14 @@ impl<E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> MemoryChipOperation
             // READ (a, v, t)
             let read_record = [
                 vec![RAMType::Memory.into(), memory_addr.clone()],
-                vec![prev_values],
+                prev_values.to_vec(),
                 vec![prev_ts.clone()],
             ]
             .concat();
             // Write (a, v, t)
             let write_record = [
                 vec![RAMType::Memory.into(), memory_addr.clone()],
-                vec![value],
+                value.to_vec(),
                 vec![ts.clone()],
             ]
             .concat();

--- a/ceno_zkvm/src/chip_handler/memory.rs
+++ b/ceno_zkvm/src/chip_handler/memory.rs
@@ -2,7 +2,6 @@ use crate::{
     chip_handler::{AddressExpr, MemoryChipOperations, MemoryExpr},
     circuit_builder::CircuitBuilder,
     gadgets::AssertLtConfig,
-    instructions::riscv::constants::UINT_LIMBS,
     structs::RAMType,
 };
 use ff_ext::ExtensionField;
@@ -20,37 +19,14 @@ impl<E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> MemoryChipOperation
         ts: Expression<E>,
         value: MemoryExpr<E>,
     ) -> Result<(Expression<E>, AssertLtConfig), CircuitBuilderError> {
-        self.namespace(name_fn, |cb| {
-            // READ (a, v, t)
-            let read_record = [
-                vec![RAMType::Memory.into(), memory_addr.clone()],
-                value.to_vec(),
-                vec![prev_ts.clone()],
-            ]
-            .concat();
-            // Write (a, v, t)
-            let write_record = [
-                vec![RAMType::Memory.into(), memory_addr.clone()],
-                value.to_vec(),
-                vec![ts.clone()],
-            ]
-            .concat();
-            cb.read_record(|| "read_record", RAMType::Memory, read_record)?;
-            cb.write_record(|| "write_record", RAMType::Memory, write_record)?;
-
-            // assert prev_ts < current_ts
-            let lt_cfg = AssertLtConfig::construct_circuit(
-                cb,
-                || "prev_ts < ts",
-                prev_ts,
-                ts.clone(),
-                UINT_LIMBS,
-            )?;
-
-            let next_ts = ts + 1;
-
-            Ok((next_ts, lt_cfg))
-        })
+        self.ram_type_read(
+            name_fn,
+            RAMType::Memory,
+            memory_addr.clone(),
+            prev_ts,
+            ts,
+            value,
+        )
     }
 
     fn memory_write(
@@ -62,35 +38,14 @@ impl<E: ExtensionField, NR: Into<String>, N: FnOnce() -> NR> MemoryChipOperation
         prev_values: MemoryExpr<E>,
         value: MemoryExpr<E>,
     ) -> Result<(Expression<E>, AssertLtConfig), CircuitBuilderError> {
-        self.namespace(name_fn, |cb| {
-            // READ (a, v, t)
-            let read_record = [
-                vec![RAMType::Memory.into(), memory_addr.clone()],
-                prev_values.to_vec(),
-                vec![prev_ts.clone()],
-            ]
-            .concat();
-            // Write (a, v, t)
-            let write_record = [
-                vec![RAMType::Memory.into(), memory_addr.clone()],
-                value.to_vec(),
-                vec![ts.clone()],
-            ]
-            .concat();
-            cb.read_record(|| "read_record", RAMType::Memory, read_record)?;
-            cb.write_record(|| "write_record", RAMType::Memory, write_record)?;
-
-            let lt_cfg = AssertLtConfig::construct_circuit(
-                cb,
-                || "prev_ts < ts",
-                prev_ts,
-                ts.clone(),
-                UINT_LIMBS,
-            )?;
-
-            let next_ts = ts + 1;
-
-            Ok((next_ts, lt_cfg))
-        })
+        self.ram_type_write(
+            name_fn,
+            RAMType::Memory,
+            memory_addr.clone(),
+            prev_ts,
+            ts,
+            prev_values,
+            value,
+        )
     }
 }

--- a/ceno_zkvm/src/instructions/riscv/ecall/keccak.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/keccak.rs
@@ -114,8 +114,8 @@ impl<E: ExtensionField> Instruction<E> for KeccakInstruction<E> {
                     // mem address := state_ptr + i
                     state_ptr.0.prev_value.value()
                         + E::BaseField::from_canonical_u32(i as u32).expr(),
-                    val_before.expr(),
-                    val_after.expr(),
+                    val_before.clone(),
+                    val_after.clone(),
                     vm_state.ts,
                 )
             })

--- a/ceno_zkvm/src/instructions/riscv/insn_base.rs
+++ b/ceno_zkvm/src/instructions/riscv/insn_base.rs
@@ -262,7 +262,7 @@ impl<E: ExtensionField> ReadMEM<E> {
     pub fn construct_circuit(
         circuit_builder: &mut CircuitBuilder<E>,
         mem_addr: AddressExpr<E>,
-        mem_read: Expression<E>,
+        mem_read: MemoryExpr<E>,
         cur_ts: WitIn,
     ) -> Result<Self, ZKVMError> {
         let prev_ts = circuit_builder.create_witin(|| "prev_ts");

--- a/ceno_zkvm/src/instructions/riscv/memory/gadget.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/gadget.rs
@@ -87,7 +87,7 @@ impl<E: ExtensionField, const N_ZEROS: usize> MemWordUtil<E, N_ZEROS> {
                 )?;
 
                 cb.condition_require_equal(
-                    || "expected_limb = select(low_bits[0], rs2_limb_bytes[1] ++ prev_limb_bytes[0], prev_limb_bytes[1] ++ rs2_limb_bytes[0])",
+                    || "expected_limb = select(low_bits[0], rs2_limb_bytes[0] ++ prev_limb_bytes[0], prev_limb_bytes[1] ++ rs2_limb_bytes[0])",
                     low_bits[0].clone(),
                     expected_limb.expr(),
                     (rs2_limb_bytes[0].expr() << 8) + prev_limb_bytes[0].expr(),
@@ -107,12 +107,12 @@ impl<E: ExtensionField, const N_ZEROS: usize> MemWordUtil<E, N_ZEROS> {
                 .as_ref()
                 .map_either(|witin| witin.expr(), |expr| expr.expr())
                 .into_inner(),
-            &E::BaseField::ZERO.expr(),
+            &prev_limbs[1],
         );
 
         let lo_limb = cb.select(
             &low_bits[1],
-            &E::BaseField::ZERO.expr(),
+            &prev_limbs[0],
             &expected_limb
                 .as_ref()
                 .map_either(|witin| witin.expr(), |expr| expr.expr())

--- a/ceno_zkvm/src/instructions/riscv/memory/gadget.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/gadget.rs
@@ -115,14 +115,14 @@ impl<E: ExtensionField, const N_ZEROS: usize> MemWordChange<E, N_ZEROS> {
 
         let hi_limb_change = cb.select(
             &low_bits[1],
-            &(expected_limb_change.expr() - prev_limbs[1].expr()),
+            &expected_limb_change.expr(),
             &E::BaseField::ZERO.expr(),
         );
 
         let lo_limb_change = cb.select(
             &low_bits[1],
             &E::BaseField::ZERO.expr(),
-            &(expected_limb_change.expr() - prev_limbs[0].expr()),
+            &expected_limb_change.expr(),
         );
 
         Ok(MemWordChange {

--- a/ceno_zkvm/src/instructions/riscv/memory/load.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/load.rs
@@ -82,7 +82,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for LoadInstruction<E,
         let rs1_read = UInt::new_unchecked(|| "rs1_read", circuit_builder)?; // unsigned 32-bit value
         let imm = circuit_builder.create_witin(|| "imm"); // signed 12-bit value
         // Memory initialization is not guaranteed to contain u32. Range-check it here.
-        let memory_read = UInt::new(|| "memory_read", circuit_builder)?;
+        let memory_read = UInt::new_unchecked(|| "memory_read", circuit_builder)?;
 
         let memory_addr = match I::INST_KIND {
             InsnKind::LW => MemAddr::construct_align4(circuit_builder),
@@ -202,7 +202,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for LoadInstruction<E,
     ) -> Result<(), ZKVMError> {
         let rs1 = Value::new_unchecked(step.rs1().unwrap().value);
         let memory_value = step.memory_op().unwrap().value.before;
-        let memory_read = Value::new(memory_value, lk_multiplicity);
+        let memory_read = Value::new_unchecked(memory_value);
         // imm is signed 12-bit value
         let imm = InsnRecord::imm_internal(&step.insn());
         let unaligned_addr =

--- a/ceno_zkvm/src/instructions/riscv/memory/load.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/load.rs
@@ -81,7 +81,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for LoadInstruction<E,
     ) -> Result<Self::InstructionConfig, ZKVMError> {
         let rs1_read = UInt::new_unchecked(|| "rs1_read", circuit_builder)?; // unsigned 32-bit value
         let imm = circuit_builder.create_witin(|| "imm"); // signed 12-bit value
-        // Memory initialization is not guaranteed to contain u32. Range-check it here.
+        // skip read range check, assuming constraint in write.
         let memory_read = UInt::new_unchecked(|| "memory_read", circuit_builder)?;
 
         let memory_addr = match I::INST_KIND {

--- a/ceno_zkvm/src/scheme.rs
+++ b/ceno_zkvm/src/scheme.rs
@@ -12,7 +12,13 @@ use std::{
 use sumcheck::structs::IOPProverMessage;
 
 use crate::{
-    instructions::{Instruction, riscv::ecall::HaltInstruction},
+    instructions::{
+        Instruction,
+        riscv::{
+            constants::{LIMB_BITS, LIMB_MASK, UINT_LIMBS},
+            ecall::HaltInstruction,
+        },
+    },
     structs::{TowerProofs, ZKVMVerifyingKey},
 };
 
@@ -94,11 +100,24 @@ impl PublicValues {
             vec![E::BaseField::from_canonical_u64(self.init_cycle)],
             vec![E::BaseField::from_canonical_u32(self.end_pc)],
             vec![E::BaseField::from_canonical_u64(self.end_cycle)],
-            self.public_io
-                .iter()
-                .map(|e| E::BaseField::from_canonical_u32(*e))
-                .collect(),
         ]
+        .into_iter()
+        .chain(
+            // public io processed into UINT_LIMBS column
+            (0..UINT_LIMBS)
+                .map(|limb_index| {
+                    self.public_io
+                        .iter()
+                        .map(|value| {
+                            E::BaseField::from_canonical_u16(
+                                ((value >> (limb_index * LIMB_BITS)) & LIMB_MASK) as u16,
+                            )
+                        })
+                        .collect_vec()
+                })
+                .collect_vec(),
+        )
+        .collect::<Vec<_>>()
     }
 }
 

--- a/ceno_zkvm/src/tables/ram.rs
+++ b/ceno_zkvm/src/tables/ram.rs
@@ -39,7 +39,7 @@ pub struct StackTable;
 
 impl DynVolatileRamTable for StackTable {
     const RAM_TYPE: RAMType = RAMType::Memory;
-    const V_LIMBS: usize = 1; // See `MemoryExpr`.
+    const V_LIMBS: usize = UINT_LIMBS;
     const ZERO_INIT: bool = true;
     const DESCENDING: bool = true;
 
@@ -54,15 +54,15 @@ impl DynVolatileRamTable for StackTable {
         params.platform.stack.start
     }
 
+    fn name() -> &'static str {
+        "StackTable"
+    }
+
     fn max_len(params: &ProgramParams) -> usize {
         let max_size = (Self::offset_addr(params) - Self::end_addr(params))
             .div_ceil(WORD_SIZE as u32) as Addr
             + 1;
         1 << (u32::BITS - 1 - max_size.leading_zeros()) // prev_power_of_2
-    }
-
-    fn name() -> &'static str {
-        "StackTable"
     }
 }
 
@@ -72,7 +72,7 @@ pub type StackCircuit<E> = DynVolatileRamCircuit<E, StackTable>;
 pub struct HintsTable;
 impl DynVolatileRamTable for HintsTable {
     const RAM_TYPE: RAMType = RAMType::Memory;
-    const V_LIMBS: usize = 1; // See `MemoryExpr`.
+    const V_LIMBS: usize = UINT_LIMBS;
     const ZERO_INIT: bool = false;
     const DESCENDING: bool = false;
 
@@ -96,7 +96,7 @@ pub struct RegTable;
 
 impl NonVolatileTable for RegTable {
     const RAM_TYPE: RAMType = RAMType::Register;
-    const V_LIMBS: usize = UINT_LIMBS; // See `RegisterExpr`.
+    const V_LIMBS: usize = UINT_LIMBS;
     const WRITABLE: bool = true;
 
     fn name() -> &'static str {
@@ -115,15 +115,15 @@ pub struct StaticMemTable;
 
 impl NonVolatileTable for StaticMemTable {
     const RAM_TYPE: RAMType = RAMType::Memory;
-    const V_LIMBS: usize = 1; // See `MemoryExpr`.
+    const V_LIMBS: usize = UINT_LIMBS;
     const WRITABLE: bool = true;
-
-    fn len(params: &ProgramParams) -> usize {
-        params.static_memory_len
-    }
 
     fn name() -> &'static str {
         "StaticMemTable"
+    }
+
+    fn len(params: &ProgramParams) -> usize {
+        params.static_memory_len
     }
 }
 
@@ -134,15 +134,15 @@ pub struct PubIOTable;
 
 impl NonVolatileTable for PubIOTable {
     const RAM_TYPE: RAMType = RAMType::Memory;
-    const V_LIMBS: usize = 1; // See `MemoryExpr`.
+    const V_LIMBS: usize = UINT_LIMBS;
     const WRITABLE: bool = false;
-
-    fn len(params: &ProgramParams) -> usize {
-        params.pubio_len
-    }
 
     fn name() -> &'static str {
         "PubIOTable"
+    }
+
+    fn len(params: &ProgramParams) -> usize {
+        params.pubio_len
     }
 }
 

--- a/ceno_zkvm/src/tables/ram/ram_impl.rs
+++ b/ceno_zkvm/src/tables/ram/ram_impl.rs
@@ -206,7 +206,7 @@ impl<NVRAM: NonVolatileTable + Send + Sync + Clone> PubIOTableConfig<NVRAM> {
         let init_table = [
             vec![(NVRAM::RAM_TYPE as usize).into()],
             vec![Expression::Fixed(addr)],
-            vec![init_v.expr_as_instance()],
+            init_v.iter().map(|v| v.expr_as_instance()).collect_vec(),
             vec![Expression::ZERO], // Initial cycle.
         ]
         .concat();
@@ -215,7 +215,7 @@ impl<NVRAM: NonVolatileTable + Send + Sync + Clone> PubIOTableConfig<NVRAM> {
             // a v t
             vec![(NVRAM::RAM_TYPE as usize).into()],
             vec![Expression::Fixed(addr)],
-            vec![init_v.expr_as_instance()],
+            init_v.iter().map(|v| v.expr_as_instance()).collect_vec(),
             vec![final_cycle.expr()],
         ]
         .concat();

--- a/ceno_zkvm/src/uint.rs
+++ b/ceno_zkvm/src/uint.rs
@@ -150,7 +150,7 @@ impl<const M: usize, const C: usize, E: ExtensionField> UIntLimbs<M, C, E> {
 
     /// take vector of primative type and instantiate witnesses
     pub fn from_const_unchecked<T: Into<u64>>(limbs: Vec<T>) -> Self {
-        assert!(limbs.len() == Self::NUM_LIMBS);
+        assert_eq!(limbs.len(), Self::NUM_LIMBS);
         UIntLimbs {
             limbs: UintLimb::Expression(
                 limbs
@@ -558,7 +558,8 @@ impl<E: ExtensionField> UIntLimbs<32, 16, E> {
 
     /// Return a value suitable for memory read/write. From [u16; 2] limbs
     pub fn memory_expr(&self) -> MemoryExpr<E> {
-        self.value()
+        let u16_limbs = self.expr();
+        u16_limbs.try_into().expect("two limbs with M=32 and C=16")
     }
 }
 

--- a/ceno_zkvm/src/uint.rs
+++ b/ceno_zkvm/src/uint.rs
@@ -470,7 +470,7 @@ impl<const M: usize, const C: usize, E: ExtensionField> UIntLimbs<M, C, E> {
     pub fn as_lo_hi<const M2: usize>(
         &self,
     ) -> Result<(UIntLimbs<M2, C, E>, UIntLimbs<M2, C, E>), CircuitBuilderError> {
-        assert!(M == 2 * M2);
+        assert_eq!(M, 2 * M2);
         let mut self_lo = self.expr();
         let self_hi = self_lo.split_off(self_lo.len() / 2);
         Ok((

--- a/gkr_iop/src/circuit_builder.rs
+++ b/gkr_iop/src/circuit_builder.rs
@@ -383,12 +383,6 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         record: Vec<Expression<E>>,
     ) -> Result<(), CircuitBuilderError> {
         let rlc_record = self.rlc_chip_record(record.clone());
-        assert_eq!(
-            rlc_record.degree(),
-            1,
-            "rlc read_record degree ({})",
-            name_fn().into()
-        );
         self.r_expressions.push(rlc_record);
         let path = self.ns.compute_path(name_fn().into());
         self.r_expressions_namespace_map.push(path);
@@ -405,12 +399,6 @@ impl<E: ExtensionField> ConstraintSystem<E> {
         record: Vec<Expression<E>>,
     ) -> Result<(), CircuitBuilderError> {
         let rlc_record = self.rlc_chip_record(record.clone());
-        assert_eq!(
-            rlc_record.degree(),
-            1,
-            "rlc write_record degree ({})",
-            name_fn().into()
-        );
         self.w_expressions.push(rlc_record);
         let path = self.ns.compute_path(name_fn().into());
         self.w_expressions_namespace_map.push(path);

--- a/gkr_iop/src/circuit_builder.rs
+++ b/gkr_iop/src/circuit_builder.rs
@@ -1138,6 +1138,7 @@ pub fn expansion_expr<E: ExtensionField, const SIZE: usize>(
 
 pub enum DebugIndex {
     RdWrite = 0,
+    MemWrite = 1,
 }
 
 impl<E: ExtensionField> CircuitBuilder<'_, E> {


### PR DESCRIPTION
To close #996 


```diff
+---------------+---------------+---------+-------+-----------+--------+------------+---------------------+
| opcode_name   | num_instances | lookups | reads | witnesses | writes | 0_expr_deg | 0_expr_sumcheck_deg |
+---------------+---------------+---------+-------+-----------+--------+------------+---------------------+
-| LB            | 0             | 14      | 4     | 28        | 4      | [1: 4]     | [2: 5]              |
+| LB            | 0             | 12      | 4     | 28        | 4      | [1: 4]     | [2: 5]              |
-| LBU           | 0             | 13      | 4     | 27        | 4      | [1: 4]     | [2: 4]              |
+| LBU           | 0             | 11      | 4     | 27        | 4      | [1: 4]     | [2: 4]              |
-| LH            | 0             | 12      | 4     | 25        | 4      | [1: 4]     | [2: 3]              |
+| LH            | 0             | 10      | 4     | 25        | 4      | [1: 4]     | [2: 3]              |
-| LHU           | 0             | 11      | 4     | 24        | 4      | [1: 4]     | [2: 2]              |
+| LHU           | 0             | 9       | 4     | 24        | 4      | [1: 4]     | [2: 2]              |
-| LW            | 0             | 11      | 4     | 22        | 4      | [1: 4]     | []                  |
+| LW            | 0             | 9       | 4     | 22        | 4      | [1: 4]     | []                  |
-| SB            | 0             | 15      | 4     | 29        | 4      | [1: 4]     | [2: 5]              |
+| SB            | 0             | 15      | 4     | 28        | 4      | [1: 4]     | [2: 4]              |
-| SH            | 0             | 11      | 4     | 24        | 4      | [1: 4]     | [2: 2]              |
+| SH            | 0             | 11      | 4     | 23        | 4      | [1: 4]     | [2: 1]              |
+---------------+---------------+---------+-------+-----------+--------+------------+---------------------+

```

### benchmark
e2e fibonacci benchmark shows no significant change due to fibonacci not heavily use memory read/write

| Benchmark                        | Median Time (s) | Median Change (%)                           |
|----------------------------------|------------------|----------------------------------------------|
| fibonacci_max_steps_1048576      | 2.4492           | -1.07% (Change within noise threshold)       |
| fibonacci_max_steps_2097152      | 4.5536           | -1.56% (Performance has improved)            |
| fibonacci_max_steps_4194304      | 9.0004           | -0.19% (No change in performance detected)   |