### PR TITLE
fix lk-multiplicity deep_clone bug

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,7 @@ name: Integrations
 on:
   merge_group:
   pull_request:
-    types: [synchronize, opened, reopened, ready_for_review]
+    types: [ synchronize, opened, reopened, ready_for_review ]
   push:
     branches:
       - master
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   skip_check:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [ self-hosted, Linux, X64 ]
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -27,14 +27,14 @@ jobs:
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule", "merge_group"]'
 
   integration:
-    needs: [skip_check]
+    needs: [ skip_check ]
     if: |
       github.event.pull_request.draft == false &&
       (github.event.action == 'ready_for_review' || needs.skip_check.outputs.should_skip != 'true')
 
     name: Integration testing
     timeout-minutes: 30
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [ self-hosted, Linux, X64 ]
 
     steps:
       - uses: actions/checkout@v4
@@ -52,7 +52,8 @@ jobs:
         env:
           RUST_LOG: debug
           RUSTFLAGS: "-C opt-level=3"
-        run: cargo run --package ceno_zkvm --bin e2e -- --platform=ceno --hints=10 --public-io=4191 examples/target/riscv32im-ceno-zkvm-elf/debug/examples/fibonacci
+          MOCK_PROVING: 1
+        run: cargo run --package ceno_zkvm --features sanity-check --bin e2e -- --platform=ceno --hints=10 --public-io=4191 examples/target/riscv32im-ceno-zkvm-elf/debug/examples/fibonacci
 
       - name: Run fibonacci (release)
         env:

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -449,7 +449,6 @@ pub fn generate_witness<E: ExtensionField>(
     system_config: &ConstraintSystemConfig<E>,
     emul_result: EmulationResult,
     program: &Program,
-    is_mock_proving: bool,
 ) -> ZKVMWitnesses<E> {
     let mut zkvm_witness = ZKVMWitnesses::default();
     // assign opcode circuits
@@ -465,7 +464,7 @@ pub fn generate_witness<E: ExtensionField>(
         .dummy_config
         .assign_opcode_circuit(&system_config.zkvm_cs, &mut zkvm_witness, dummy_records)
         .unwrap();
-    zkvm_witness.finalize_lk_multiplicities(is_mock_proving);
+    zkvm_witness.finalize_lk_multiplicities();
 
     // assign table circuits
     system_config
@@ -723,17 +722,12 @@ pub fn run_e2e_with_checkpoint<
                 // When we run e2e and halt before generate_witness, this implies we are going to
                 // benchmark generate_witness performance. So we skip mock proving check on
                 // `generate_witness` to avoid it affecting the benchmark result.
-                _ = generate_witness(&ctx.system_config, emul_result, &ctx.program, false)
+                _ = generate_witness(&ctx.system_config, emul_result, &ctx.program)
             })),
         };
     }
 
-    let zkvm_witness = generate_witness(
-        &ctx.system_config,
-        emul_result,
-        &ctx.program,
-        is_mock_proving,
-    );
+    let zkvm_witness = generate_witness(&ctx.system_config, emul_result, &ctx.program);
 
     let mut prover = ZKVMProver::new(pk, device);
 
@@ -803,12 +797,7 @@ pub fn run_e2e_proof<
     let pi = emul_result.pi.clone();
 
     // Generate witness
-    let zkvm_witness = generate_witness(
-        &ctx.system_config,
-        emul_result,
-        &ctx.program,
-        is_mock_proving,
-    );
+    let zkvm_witness = generate_witness(&ctx.system_config, emul_result, &ctx.program);
 
     // proving
     let mut prover = ZKVMProver::new(pk, device);

--- a/ceno_zkvm/src/instructions/riscv/div.rs
+++ b/ceno_zkvm/src/instructions/riscv/div.rs
@@ -604,11 +604,13 @@ mod test {
         let expected_errors: &[_] = if is_ok { &[] } else { &[name] };
         MockProver::assert_with_expected_errors(
             &cb,
+            &[],
             &raw_witin
                 .to_mles()
                 .into_iter()
                 .map(|v| v.into())
                 .collect_vec(),
+            &[],
             &[insn_code],
             expected_errors,
             None,

--- a/ceno_zkvm/src/instructions/riscv/ecall/keccak.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/keccak.rs
@@ -5,6 +5,7 @@ use ff_ext::ExtensionField;
 use gkr_iop::{
     ProtocolBuilder, ProtocolWitnessGenerator,
     gkr::{GKRCircuit, layer::Layer},
+    utils::lk_multiplicity::Multiplicity,
 };
 use itertools::{Itertools, izip};
 use multilinear_extensions::{ToExpr, util::max_usable_threads};
@@ -164,7 +165,7 @@ impl<E: ExtensionField> Instruction<E> for KeccakInstruction<E> {
         num_witin: usize,
         num_structural_witin: usize,
         steps: Vec<StepRecord>,
-    ) -> Result<(RMMCollections<E::BaseField>, LkMultiplicity), ZKVMError> {
+    ) -> Result<(RMMCollections<E::BaseField>, Multiplicity<u64>), ZKVMError> {
         let mut lk_multiplicity = LkMultiplicity::default();
         if steps.is_empty() {
             return Ok((
@@ -172,7 +173,7 @@ impl<E: ExtensionField> Instruction<E> for KeccakInstruction<E> {
                     RowMajorMatrix::new(0, num_witin, InstancePaddingStrategy::Default),
                     RowMajorMatrix::new(0, num_structural_witin, InstancePaddingStrategy::Default),
                 ],
-                lk_multiplicity,
+                lk_multiplicity.into_finalize_result(),
             ));
         }
         let nthreads = max_usable_threads();
@@ -279,6 +280,9 @@ impl<E: ExtensionField> Instruction<E> for KeccakInstruction<E> {
 
         raw_witin.padding_by_strategy();
         raw_structural_witin.padding_by_strategy();
-        Ok(([raw_witin, raw_structural_witin], lk_multiplicity))
+        Ok((
+            [raw_witin, raw_structural_witin],
+            lk_multiplicity.into_finalize_result(),
+        ))
     }
 }

--- a/ceno_zkvm/src/instructions/riscv/insn_base.rs
+++ b/ceno_zkvm/src/instructions/riscv/insn_base.rs
@@ -560,11 +560,13 @@ mod test {
         }
         MockProver::assert_with_expected_errors(
             &cb,
+            &[],
             &raw_witin
                 .to_mles()
                 .into_iter()
                 .map(|v| v.into())
                 .collect_vec(),
+            &[],
             &[],
             if is_ok { &[] } else { &["mid_u14"] },
             None,

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -1213,10 +1213,8 @@ Hints:
                         .filter(|(read, _)| !$writes.contains(read))
                         .take(10)
                         .for_each(|(_, row)| {
-                            let pc =
-                                gs_of_circuit.map_or(0, |gs| gs[*row][0].to_canonical_u64());
-                            let ts =
-                                gs_of_circuit.map_or(0, |gs| gs[*row][1].to_canonical_u64());
+                            let pc = gs_of_circuit.map_or(0, |gs| gs[*row][0].to_canonical_u64());
+                            let ts = gs_of_circuit.map_or(0, |gs| gs[*row][1].to_canonical_u64());
                             tracing::error!(
                                 "{} at row {} (pc={:x},ts={}) not found in {:?} writes",
                                 annotation,
@@ -1251,10 +1249,8 @@ Hints:
                         .filter(|(write, _)| !$reads.contains(write))
                         .take(10)
                         .for_each(|(_, row)| {
-                            let pc =
-                                gs_of_circuit.map_or(0, |gs| gs[*row][0].to_canonical_u64());
-                            let ts =
-                                gs_of_circuit.map_or(0, |gs| gs[*row][1].to_canonical_u64());
+                            let pc = gs_of_circuit.map_or(0, |gs| gs[*row][0].to_canonical_u64());
+                            let ts = gs_of_circuit.map_or(0, |gs| gs[*row][1].to_canonical_u64());
                             tracing::error!(
                                 "{} at row {} (pc={:x},ts={}) not found in {:?} reads",
                                 annotation,
@@ -1343,7 +1339,7 @@ where
     K: LkMultiplicityKey + Default + Ord,
 {
     // Compare each LK Multiplicity.
-    izip!(ROMType::iter(), &lkm_a.0, &lkm_b.0)
+    izip!(ROMType::iter(), &lkm_a, &lkm_b)
         .flat_map(|(rom_type, a_map, b_map)| {
             // We use a BTreeSet, instead of a HashSet, to ensure deterministic order.
             let keys: BTreeSet<_> = chain!(a_map.keys(), b_map.keys()).collect();

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -695,11 +695,7 @@ impl<'a, E: ExtensionField + Hash> MockProver<E> {
                         let mut arg_eval = arg_eval
                             .get_ext_field_vec()
                             .iter()
-                            .map(|v| {
-                                let v = v.to_canonical_u64_vec();
-                                assert!(v[1..].iter().all(|x| *x == 0));
-                                v[0]
-                            })
+                            .map(E::to_canonical_u64)
                             .take(num_instances)
                             .collect_vec();
 
@@ -1027,7 +1023,7 @@ Hints:
                         lkm_tables.set_count(
                             *rom_type,
                             key,
-                            multiplicity.to_canonical_u64_vec()[0] as usize,
+                            multiplicity.to_canonical_u64() as usize,
                         );
                     }
                 }
@@ -1218,9 +1214,9 @@ Hints:
                         .take(10)
                         .for_each(|(_, row)| {
                             let pc =
-                                gs_of_circuit.map_or(0, |gs| gs[*row][0].to_canonical_u64_vec()[0]);
+                                gs_of_circuit.map_or(0, |gs| gs[*row][0].to_canonical_u64());
                             let ts =
-                                gs_of_circuit.map_or(0, |gs| gs[*row][1].to_canonical_u64_vec()[0]);
+                                gs_of_circuit.map_or(0, |gs| gs[*row][1].to_canonical_u64());
                             tracing::error!(
                                 "{} at row {} (pc={:x},ts={}) not found in {:?} writes",
                                 annotation,
@@ -1256,9 +1252,9 @@ Hints:
                         .take(10)
                         .for_each(|(_, row)| {
                             let pc =
-                                gs_of_circuit.map_or(0, |gs| gs[*row][0].to_canonical_u64_vec()[0]);
+                                gs_of_circuit.map_or(0, |gs| gs[*row][0].to_canonical_u64());
                             let ts =
-                                gs_of_circuit.map_or(0, |gs| gs[*row][1].to_canonical_u64_vec()[0]);
+                                gs_of_circuit.map_or(0, |gs| gs[*row][1].to_canonical_u64());
                             tracing::error!(
                                 "{} at row {} (pc={:x},ts={}) not found in {:?} reads",
                                 annotation,

--- a/ceno_zkvm/src/scheme/tests.rs
+++ b/ceno_zkvm/src/scheme/tests.rs
@@ -314,7 +314,7 @@ fn test_single_add_instance_e2e() {
     zkvm_witness
         .assign_opcode_circuit::<HaltInstruction<E>>(&zkvm_cs, &halt_config, halt_records)
         .unwrap();
-    zkvm_witness.finalize_lk_multiplicities(false);
+    zkvm_witness.finalize_lk_multiplicities();
     zkvm_witness
         .assign_table_circuit::<U16TableCircuit<E>>(&zkvm_cs, &u16_range_config, &())
         .unwrap();

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -322,19 +322,14 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
     }
 
     // merge the multiplicities in each opcode circuit into one
-    pub fn finalize_lk_multiplicities(&mut self, is_keep_raw_lk_mlts: bool) {
+    pub fn finalize_lk_multiplicities(&mut self) {
         assert!(self.combined_lk_mlt.is_none());
         assert!(!self.lk_mlts.is_empty());
 
         let mut combined_lk_mlt = vec![];
         let keys = self.lk_mlts.keys().cloned().collect_vec();
         for name in keys {
-            let lk_mlt = if is_keep_raw_lk_mlts {
-                // mock prover needs the lk_mlt for processing, so we do not remove it
-                self.lk_mlts.get(&name).cloned().unwrap()
-            } else {
-                self.lk_mlts.remove(&name).unwrap()
-            };
+            let lk_mlt = self.lk_mlts.get(&name).unwrap();
 
             if combined_lk_mlt.is_empty() {
                 combined_lk_mlt = lk_mlt.to_vec();

--- a/ceno_zkvm/src/tables/program.rs
+++ b/ceno_zkvm/src/tables/program.rs
@@ -246,7 +246,7 @@ mod tests {
             &config,
             cb.cs.num_witin as usize,
             cb.cs.num_structural_witin as usize,
-            &lkm,
+            &lkm.0,
             &program,
         )
         .unwrap();

--- a/ceno_zkvm/src/tables/ram/ram_impl.rs
+++ b/ceno_zkvm/src/tables/ram/ram_impl.rs
@@ -479,7 +479,7 @@ mod tests {
             &config,
             cb.cs.num_witin as usize,
             cb.cs.num_structural_witin as usize,
-            &lkm,
+            &lkm.0,
             &input,
         )
         .unwrap();

--- a/ceno_zkvm/src/uint/arithmetic.rs
+++ b/ceno_zkvm/src/uint/arithmetic.rs
@@ -773,7 +773,7 @@ mod tests {
                 .require_equal(|| "assert_g", &mut cb, &uint_e)
                 .unwrap();
 
-            MockProver::assert_satisfied(&cb, &witness_values, &[], None, None);
+            MockProver::assert_satisfied(&cb, &witness_values, &[], &[], None, None);
         }
 
         #[test]
@@ -823,7 +823,7 @@ mod tests {
                 .require_equal(|| "assert_g", &mut cb, &uint_g)
                 .unwrap();
 
-            MockProver::assert_satisfied(&cb, &witness_values, &[], None, None);
+            MockProver::assert_satisfied(&cb, &witness_values, &[], &[], None, None);
         }
 
         #[test]
@@ -862,7 +862,7 @@ mod tests {
                 .require_equal(|| "assert_e", &mut cb, &uint_e)
                 .unwrap();
 
-            MockProver::assert_satisfied(&cb, &witness_values, &[], None, None);
+            MockProver::assert_satisfied(&cb, &witness_values, &[], &[], None, None);
         }
 
         #[test]
@@ -901,7 +901,7 @@ mod tests {
                 .require_equal(|| "assert_e", &mut cb, &uint_e)
                 .unwrap();
 
-            MockProver::assert_satisfied(&cb, &witness_values, &[], None, None);
+            MockProver::assert_satisfied(&cb, &witness_values, &[], &[], None, None);
         }
 
         #[test]
@@ -938,7 +938,7 @@ mod tests {
                 .require_equal(|| "assert_g", &mut cb, &uint_c)
                 .unwrap();
 
-            MockProver::assert_satisfied(&cb, &witness_values, &[], None, None);
+            MockProver::assert_satisfied(&cb, &witness_values, &[], &[], None, None);
         }
     }
 }

--- a/ff_ext/src/lib.rs
+++ b/ff_ext/src/lib.rs
@@ -146,4 +146,11 @@ pub trait ExtensionField:
 
     /// Convert a field elements to a u64 vector
     fn to_canonical_u64_vec(&self) -> Vec<u64>;
+
+    /// retrive first field elements to u64
+    fn to_canonical_u64(&self) -> u64 {
+        let res = self.to_canonical_u64_vec();
+        assert!(res[1..].iter().all(|v| *v == 0));
+        res[0]
+    }
 }

--- a/gkr_iop/src/utils/lk_multiplicity.rs
+++ b/gkr_iop/src/utils/lk_multiplicity.rs
@@ -5,7 +5,7 @@ use std::{
     fmt::Debug,
     hash::Hash,
     mem::{self},
-    ops::AddAssign,
+    ops::{AddAssign, Deref, DerefMut},
     sync::Arc,
 };
 use thread_local::ThreadLocal;
@@ -19,6 +19,20 @@ pub type MultiplicityRaw<K> = [HashMap<K, usize>; mem::variant_count::<LookupTab
 
 #[derive(Clone, Default, Debug)]
 pub struct Multiplicity<K>(pub MultiplicityRaw<K>);
+
+impl<K> Deref for Multiplicity<K> {
+    type Target = MultiplicityRaw<K>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<K> DerefMut for Multiplicity<K> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
 
 /// A lock-free thread safe struct to count logup multiplicity for each ROM type
 /// Lock-free by thread-local such that each thread will only have its local copy
@@ -34,7 +48,7 @@ where
     K: Copy + Clone + Debug + Default + Eq + Hash + Send,
 {
     fn add_assign(&mut self, rhs: Self) {
-        *self += Multiplicity(rhs.into_finalize_result());
+        *self += Multiplicity(rhs.into_finalize_result().0);
     }
 }
 
@@ -91,12 +105,12 @@ where
 
 impl<K: Copy + Clone + Debug + Default + Eq + Hash + Send> LkMultiplicityRaw<K> {
     /// Merge result from multiple thread local to single result.
-    pub fn into_finalize_result(self) -> MultiplicityRaw<K> {
+    pub fn into_finalize_result(self) -> Multiplicity<K> {
         let mut results = Multiplicity::default();
         for y in Arc::try_unwrap(self.multiplicity).unwrap() {
             results += y.into_inner();
         }
-        results.0
+        results
     }
 
     pub fn increment(&mut self, rom_type: LookupTable, key: K) {
@@ -113,17 +127,6 @@ impl<K: Copy + Clone + Debug + Default + Eq + Hash + Send> LkMultiplicityRaw<K> 
             table.remove(&key);
         } else {
             table.insert(key, count);
-        }
-    }
-
-    /// Clone inner, expensive operation.
-    pub fn deep_clone(&self) -> Self {
-        let multiplicity = self.multiplicity.get_or_default();
-        let deep_cloned = multiplicity.borrow().clone();
-        let thread_local = ThreadLocal::new();
-        thread_local.get_or(|| RefCell::new(deep_cloned));
-        LkMultiplicityRaw {
-            multiplicity: Arc::new(thread_local),
         }
     }
 }
@@ -212,6 +215,6 @@ mod tests {
         }
         let res = lkm.into_finalize_result();
         // check multiplicity counts of assert_byte
-        assert_eq!(res[LookupTable::U8 as usize][&8], thread_count);
+        assert_eq!(res.0[LookupTable::U8 as usize][&8], thread_count);
     }
 }

--- a/gkr_iop/src/utils/lk_multiplicity.rs
+++ b/gkr_iop/src/utils/lk_multiplicity.rs
@@ -34,6 +34,47 @@ impl<K> DerefMut for Multiplicity<K> {
     }
 }
 
+/// for consuming the wrapper
+impl<K> IntoIterator for Multiplicity<K>
+where
+    MultiplicityRaw<K>: IntoIterator,
+{
+    type Item = <MultiplicityRaw<K> as IntoIterator>::Item;
+    type IntoIter = <MultiplicityRaw<K> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+/// for immutable references
+impl<'a, K> IntoIterator for &'a Multiplicity<K>
+where
+    &'a MultiplicityRaw<K>: IntoIterator,
+{
+    type Item = <&'a MultiplicityRaw<K> as IntoIterator>::Item;
+    type IntoIter = <&'a MultiplicityRaw<K> as IntoIterator>::IntoIter;
+
+    #[allow(clippy::into_iter_on_ref)]
+    fn into_iter(self) -> Self::IntoIter {
+        (&self.0).into_iter()
+    }
+}
+
+/// for mutable references
+impl<'a, K> IntoIterator for &'a mut Multiplicity<K>
+where
+    &'a mut MultiplicityRaw<K>: IntoIterator,
+{
+    type Item = <&'a mut MultiplicityRaw<K> as IntoIterator>::Item;
+    type IntoIter = <&'a mut MultiplicityRaw<K> as IntoIterator>::IntoIter;
+
+    #[allow(clippy::into_iter_on_ref)]
+    fn into_iter(self) -> Self::IntoIter {
+        (&mut self.0).into_iter()
+    }
+}
+
 /// A lock-free thread safe struct to count logup multiplicity for each ROM type
 /// Lock-free by thread-local such that each thread will only have its local copy
 /// struct is cloneable, for internallly it use Arc so the clone will be low cost
@@ -215,6 +256,6 @@ mod tests {
         }
         let res = lkm.into_finalize_result();
         // check multiplicity counts of assert_byte
-        assert_eq!(res.0[LookupTable::U8 as usize][&8], thread_count);
+        assert_eq!(res[LookupTable::U8 as usize][&8], thread_count);
     }
 }


### PR DESCRIPTION
Current master branch e2e failed when `MOCK_PROVING=1` was set.

The root cause is arised from `Multiplicity::deep_clone` which only clone current thread `ThreadLocal` and discard all the other thread result. When test on `mock_prover`  with small data + single thread, everything works fine, however it got failed when run in multi-thread mode. 

To fixed it, we can convert Multiplicity to single thread at the end of `assign_instances`, then we use pure clone.

This PR also fix several issues of mock_prover, and add `MOCK_PROVING=1` to ci for debug build.

### benchmark 
e2e fibonacci remain the same
| Benchmark                        | Median Time (s) | Median Change (%)                |
|----------------------------------|------------------|-----------------------------------|
| fibonacci_max_steps_1048576      | 2.4446           | -1.25% (Change within noise threshold) |
| fibonacci_max_steps_2097152      | 4.6252           | -0.01% (No change in performance detected) |
| fibonacci_max_steps_4194304      | 8.9366           | -0.90% (No change in performance detected) |