### PR TITLE
refactor `mulh` to support opcode circuit migration to limb based style

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,29 +461,23 @@ dependencies = [
  "gkr_iop",
  "glob",
  "itertools 0.13.0",
- "keccakf",
  "mpcs",
  "multilinear_extensions",
  "ndarray",
- "num-traits",
  "p3",
  "parse-size",
- "paste",
  "poseidon",
  "pprof2",
  "prettytable-rs",
  "proptest",
  "rand",
- "rand_chacha",
  "rayon",
- "rkyv",
  "serde",
  "serde_json",
  "strum",
  "strum_macros",
  "sumcheck",
  "tempfile",
- "thread_local",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tiny-keccak",
@@ -1520,15 +1514,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
-]
-
-[[package]]
-name = "keccakf"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d4ade81a4c9327bf19dcd0bd45784b99f86243edca6be0de19fc2d3aa8a4de2"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]

--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -17,11 +17,9 @@ ceno_host = { path = "../ceno_host" }
 either.workspace = true
 ff_ext = { path = "../ff_ext" }
 gkr_iop = { path = "../gkr_iop" }
-keccakf = "0.1.2"
 mpcs = { path = "../mpcs" }
 multilinear_extensions = { version = "0", path = "../multilinear_extensions" }
 p3.workspace = true
-rand_chacha.workspace = true
 rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -31,11 +29,8 @@ witness = { path = "../witness" }
 
 itertools.workspace = true
 ndarray.workspace = true
-num-traits.workspace = true
-paste.workspace = true
 poseidon.workspace = true
 prettytable-rs.workspace = true
-rkyv.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 tracing.workspace = true
@@ -49,7 +44,6 @@ generic_static = "0.2"
 parse-size = "1.1"
 rand.workspace = true
 tempfile = "3.14"
-thread_local.workspace = true
 tiny-keccak.workspace = true
 
 [target.'cfg(unix)'.dependencies]
@@ -67,7 +61,7 @@ ceno-examples = { path = "../examples-builder" }
 glob = "0.3"
 
 [features]
-default = ["forbid_overflow"]
+default = ["forbid_overflow", "u16limb_circuit"]
 flamegraph = ["pprof2/flamegraph", "pprof2/criterion"]
 forbid_overflow = []
 jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
@@ -83,6 +77,7 @@ nightly-features = [
   "witness/nightly-features",
 ]
 sanity-check = ["mpcs/sanity-check"]
+u16limb_circuit = []
 
 [[bench]]
 harness = false

--- a/ceno_zkvm/src/instructions/riscv.rs
+++ b/ceno_zkvm/src/instructions/riscv.rs
@@ -18,7 +18,7 @@ pub mod ecall_base;
 pub mod jump;
 pub mod logic;
 pub mod logic_imm;
-pub mod mul;
+pub mod mulh;
 pub mod shift;
 pub mod shift_imm;
 pub mod slt;

--- a/ceno_zkvm/src/instructions/riscv/mulh.rs
+++ b/ceno_zkvm/src/instructions/riscv/mulh.rs
@@ -1,0 +1,298 @@
+use crate::instructions::riscv::RIVInstruction;
+use ceno_emul::InsnKind;
+
+mod mulh_circuit;
+mod mulh_circuit_v2;
+
+pub struct MulOp;
+impl RIVInstruction for MulOp {
+    const INST_KIND: InsnKind = InsnKind::MUL;
+}
+#[cfg(feature = "u16limb_circuit")]
+// TODO use mulh_circuit_v2
+pub type MulInstruction<E> = mulh_circuit::MulhInstructionBase<E, MulOp>;
+#[cfg(not(feature = "u16limb_circuit"))]
+pub type MulInstruction<E> = mulh_circuit::MulhInstructionBase<E, MulOp>;
+
+pub struct MulhOp;
+impl RIVInstruction for MulhOp {
+    const INST_KIND: InsnKind = InsnKind::MULH;
+}
+#[cfg(feature = "u16limb_circuit")]
+// TODO use mulh_circuit_v2
+pub type MulhInstruction<E> = mulh_circuit::MulhInstructionBase<E, MulhOp>;
+#[cfg(not(feature = "u16limb_circuit"))]
+pub type MulhInstruction<E> = mulh_circuit::MulhInstructionBase<E, MulhOp>;
+
+pub struct MulhuOp;
+impl RIVInstruction for MulhuOp {
+    const INST_KIND: InsnKind = InsnKind::MULHU;
+}
+
+#[cfg(feature = "u16limb_circuit")]
+// TODO use mulh_circuit_v2
+pub type MulhuInstruction<E> = mulh_circuit::MulhInstructionBase<E, MulhuOp>;
+#[cfg(not(feature = "u16limb_circuit"))]
+pub type MulhuInstruction<E> = mulh_circuit::MulhInstructionBase<E, MulhuOp>;
+
+pub struct MulhsuOp;
+impl RIVInstruction for MulhsuOp {
+    const INST_KIND: InsnKind = InsnKind::MULHSU;
+}
+#[cfg(feature = "u16limb_circuit")]
+// TODO use mulh_circuit_v2
+pub type MulhsuInstruction<E> = mulh_circuit::MulhInstructionBase<E, MulhsuOp>;
+#[cfg(not(feature = "u16limb_circuit"))]
+pub type MulhsuInstruction<E> = mulh_circuit::MulhInstructionBase<E, MulhsuOp>;
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        Value,
+        circuit_builder::{CircuitBuilder, ConstraintSystem},
+        instructions::{
+            Instruction,
+            riscv::{
+                RIVInstruction,
+                constants::UInt,
+                mulh::{MulOp, MulhInstruction, MulhsuInstruction, MulhuOp},
+            },
+        },
+        scheme::mock_prover::{MOCK_PC_START, MockProver},
+        structs::ProgramParams,
+        witness::LkMultiplicity,
+    };
+    use ceno_emul::{Change, InsnKind, StepRecord, encode_rv32};
+    use ff_ext::GoldilocksExt2;
+    use gkr_iop::circuit_builder::DebugIndex;
+    use multilinear_extensions::Expression;
+
+    #[test]
+    fn test_opcode_mul() {
+        verify_mulu::<MulOp>("basic", 2, 11);
+        verify_mulu::<MulOp>("2 * 0", 2, 0);
+        verify_mulu::<MulOp>("0 * 0", 0, 0);
+        verify_mulu::<MulOp>("0 * 2", 0, 2);
+        verify_mulu::<MulOp>("0 * u32::MAX", 0, u32::MAX);
+        verify_mulu::<MulOp>("u32::MAX", u32::MAX, u32::MAX);
+        verify_mulu::<MulOp>("u16::MAX", u16::MAX as u32, u16::MAX as u32);
+    }
+
+    #[test]
+    fn test_opcode_mulhu() {
+        verify_mulu::<MulhuOp>("basic", 2, 11);
+        verify_mulu::<MulhuOp>("2 * 0", 2, 0);
+        verify_mulu::<MulhuOp>("0 * 0", 0, 0);
+        verify_mulu::<MulhuOp>("0 * 2", 0, 2);
+        verify_mulu::<MulhuOp>("0 * u32::MAX", 0, u32::MAX);
+        verify_mulu::<MulhuOp>("u32::MAX", u32::MAX, u32::MAX);
+        verify_mulu::<MulhuOp>("u16::MAX", u16::MAX as u32, u16::MAX as u32);
+    }
+
+    fn verify_mulu<I: RIVInstruction>(name: &'static str, rs1: u32, rs2: u32) {
+        #[cfg(feature = "u16limb_circuit")]
+        // TODO use mulh_circuit_v2
+        use super::mulh_circuit::MulhInstructionBase;
+        #[cfg(not(feature = "u16limb_circuit"))]
+        use super::mulh_circuit::MulhInstructionBase;
+
+        let mut cs = ConstraintSystem::<GoldilocksExt2>::new(|| "riscv");
+        let mut cb = CircuitBuilder::new(&mut cs);
+        let config = cb
+            .namespace(
+                || format!("{:?}_({name})", I::INST_KIND),
+                |cb| {
+                    Ok(MulhInstructionBase::<GoldilocksExt2, I>::construct_circuit(
+                        cb,
+                        &ProgramParams::default(),
+                    ))
+                },
+            )
+            .unwrap()
+            .unwrap();
+
+        let outcome = match I::INST_KIND {
+            InsnKind::MUL => rs1.wrapping_mul(rs2),
+            InsnKind::MULHU => {
+                let a = Value::<'_, u32>::new_unchecked(rs1);
+                let b = Value::<'_, u32>::new_unchecked(rs2);
+                let value_mul = a.mul_hi(&b, &mut LkMultiplicity::default(), true);
+                value_mul.as_hi_value::<u32>().as_u32()
+            }
+            _ => unreachable!("Unsupported instruction kind"),
+        };
+
+        // values assignment
+        let insn_code = encode_rv32(I::INST_KIND, 2, 3, 4, 0);
+        let (raw_witin, lkm) = MulhInstructionBase::<GoldilocksExt2, I>::assign_instances(
+            &config,
+            cb.cs.num_witin as usize,
+            cb.cs.num_structural_witin as usize,
+            vec![StepRecord::new_r_instruction(
+                3,
+                MOCK_PC_START,
+                insn_code,
+                rs1,
+                rs2,
+                Change::new(0, outcome),
+                0,
+            )],
+        )
+        .unwrap();
+
+        // verify value write to register, which is only hi
+        let expected_rd_written =
+            UInt::from_const_unchecked(Value::new_unchecked(outcome).as_u16_limbs().to_vec());
+        let rd_written_expr = cb.get_debug_expr(DebugIndex::RdWrite as usize)[0].clone();
+        cb.require_equal(
+            || "assert_rd_written",
+            rd_written_expr,
+            expected_rd_written.value(),
+        )
+        .unwrap();
+
+        MockProver::assert_satisfied_raw(&cb, raw_witin, &[insn_code], None, Some(lkm));
+    }
+
+    #[test]
+    fn test_opcode_mulh() {
+        let test_cases = vec![
+            (2, 11),
+            (7, 0),
+            (0, 5),
+            (0, -3),
+            (-19, 0),
+            (0, 0),
+            (-12, -31),
+            (2, -1),
+            (1, i32::MIN),
+            (i32::MAX, -1),
+            (i32::MAX, i32::MIN),
+            (i32::MAX, i32::MAX),
+            (i32::MIN, i32::MIN),
+        ];
+        test_cases
+            .into_iter()
+            .for_each(|(rs1, rs2)| verify_mulh(rs1, rs2));
+    }
+
+    fn verify_mulh(rs1: i32, rs2: i32) {
+        let mut cs = ConstraintSystem::<GoldilocksExt2>::new(|| "riscv");
+        let mut cb = CircuitBuilder::new(&mut cs);
+        let config = cb
+            .namespace(
+                || "mulh",
+                |cb| {
+                    Ok(MulhInstruction::construct_circuit(
+                        cb,
+                        &ProgramParams::default(),
+                    ))
+                },
+            )
+            .unwrap()
+            .unwrap();
+
+        let signed_prod_high = ((rs1 as i64).wrapping_mul(rs2 as i64) >> 32) as u32;
+
+        // values assignment
+        let insn_code = encode_rv32(InsnKind::MULH, 2, 3, 4, 0);
+        let (raw_witin, lkm) = MulhInstruction::assign_instances(
+            &config,
+            cb.cs.num_witin as usize,
+            cb.cs.num_structural_witin as usize,
+            vec![StepRecord::new_r_instruction(
+                3,
+                MOCK_PC_START,
+                insn_code,
+                rs1 as u32,
+                rs2 as u32,
+                Change::new(0, signed_prod_high),
+                0,
+            )],
+        )
+        .unwrap();
+
+        // verify value written to register
+        let rd_written_expr = cb.get_debug_expr(DebugIndex::RdWrite as usize)[0].clone();
+        cb.require_equal(
+            || "assert_rd_written",
+            rd_written_expr,
+            Expression::from(signed_prod_high),
+        )
+        .unwrap();
+
+        MockProver::assert_satisfied_raw(&cb, raw_witin, &[insn_code], None, Some(lkm));
+    }
+
+    #[test]
+    fn test_opcode_mulhsu() {
+        let test_cases = vec![
+            (0, 0),
+            (0, 5),
+            (0, u32::MAX),
+            (7, 0),
+            (2, 11),
+            (91, u32::MAX),
+            (i32::MAX, 0),
+            (i32::MAX, 2),
+            (i32::MAX, u32::MAX),
+            (-4, 0),
+            (-1, 3),
+            (-1000, u32::MAX),
+            (i32::MIN, 0),
+            (i32::MIN, 21),
+            (i32::MIN, u32::MAX),
+        ];
+        test_cases
+            .into_iter()
+            .for_each(|(rs1, rs2)| verify_mulhsu(rs1, rs2));
+    }
+
+    fn verify_mulhsu(rs1: i32, rs2: u32) {
+        let mut cs = ConstraintSystem::<GoldilocksExt2>::new(|| "riscv");
+        let mut cb = CircuitBuilder::new(&mut cs);
+        let config = cb
+            .namespace(
+                || "mulhsu",
+                |cb| {
+                    Ok(MulhsuInstruction::construct_circuit(
+                        cb,
+                        &ProgramParams::default(),
+                    ))
+                },
+            )
+            .unwrap()
+            .unwrap();
+
+        let signed_unsigned_prod_high = ((rs1 as i64).wrapping_mul(rs2 as i64) >> 32) as u32;
+
+        // values assignment
+        let insn_code = encode_rv32(InsnKind::MULHSU, 2, 3, 4, 0);
+        let (raw_witin, lkm) = MulhsuInstruction::assign_instances(
+            &config,
+            cb.cs.num_witin as usize,
+            cb.cs.num_structural_witin as usize,
+            vec![StepRecord::new_r_instruction(
+                3,
+                MOCK_PC_START,
+                insn_code,
+                rs1 as u32,
+                rs2,
+                Change::new(0, signed_unsigned_prod_high),
+                0,
+            )],
+        )
+        .unwrap();
+
+        // verify value written to register
+        let rd_written_expr = cb.get_debug_expr(DebugIndex::RdWrite as usize)[0].clone();
+        cb.require_equal(
+            || "assert_rd_written",
+            rd_written_expr,
+            Expression::from(signed_unsigned_prod_high),
+        )
+        .unwrap();
+
+        MockProver::assert_satisfied_raw(&cb, raw_witin, &[insn_code], None, Some(lkm));
+    }
+}

--- a/ceno_zkvm/src/instructions/riscv/mulh/mulh_circuit_v2.rs
+++ b/ceno_zkvm/src/instructions/riscv/mulh/mulh_circuit_v2.rs
@@ -1,0 +1,41 @@
+use crate::{
+    circuit_builder::CircuitBuilder,
+    error::ZKVMError,
+    instructions::{Instruction, riscv::RIVInstruction},
+    structs::ProgramParams,
+    witness::LkMultiplicity,
+};
+use ceno_emul::StepRecord;
+use ff_ext::ExtensionField;
+
+use std::marker::PhantomData;
+
+pub struct MulhInstructionBase<E, I>(PhantomData<(E, I)>);
+
+pub struct MulhConfig<E: ExtensionField> {
+    phantom: PhantomData<E>,
+}
+
+impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for MulhInstructionBase<E, I> {
+    type InstructionConfig = MulhConfig<E>;
+
+    fn name() -> String {
+        format!("{:?}", I::INST_KIND)
+    }
+
+    fn construct_circuit(
+        _circuit_builder: &mut CircuitBuilder<E>,
+        _params: &ProgramParams,
+    ) -> Result<MulhConfig<E>, ZKVMError> {
+        unimplemented!()
+    }
+
+    fn assign_instance(
+        _config: &Self::InstructionConfig,
+        _instance: &mut [<E as ExtensionField>::BaseField],
+        _lk_multiplicity: &mut LkMultiplicity,
+        _step: &StepRecord,
+    ) -> Result<(), ZKVMError> {
+        unimplemented!()
+    }
+}

--- a/ceno_zkvm/src/instructions/riscv/rv32im.rs
+++ b/ceno_zkvm/src/instructions/riscv/rv32im.rs
@@ -11,7 +11,7 @@ use crate::{
             ecall::KeccakInstruction,
             logic::{AndInstruction, OrInstruction, XorInstruction},
             logic_imm::{AndiInstruction, OriInstruction, XoriInstruction},
-            mul::MulhuInstruction,
+            mulh::MulhuInstruction,
             shift::{SllInstruction, SrlInstruction},
             shift_imm::{SlliInstruction, SraiInstruction, SrliInstruction},
             slti::SltiInstruction,
@@ -35,7 +35,7 @@ use dummy::LargeEcallDummy;
 use ecall::EcallDummy;
 use ff_ext::ExtensionField;
 use itertools::{Itertools, izip};
-use mul::{MulInstruction, MulhInstruction, MulhsuInstruction};
+use mulh::{MulInstruction, MulhInstruction, MulhsuInstruction};
 use shift::SraInstruction;
 use slt::{SltInstruction, SltuInstruction};
 use slti::SltiuInstruction;


### PR DESCRIPTION
This PR introduce `u16limb_circuit` feature so we can deal with the babybear migration on MUL/MULH/... with one by one strategy. 

The strategy is we implement new limb-style circuit to support prime field < u32, compared with our current constrain which only work in field > u32, following e.g. [openvm mul](https://github.com/openvm-org/openvm/blob/main/extensions/rv32im/circuit/src/mul/core.rs). We test on Goldilock field first and merge to master. Later we switch to babybear field by default with the ready constraints.

`mul` is a shared circuit module for MUL/MULH/... opcodes circuit implementation. This PR rename `mul` into `mulh` follow our naming convention. Besides this PR introduce "mulh_circuit_v2.rs" to host limb based circuit implementation.
 