### PR TITLE
migrate opcode with one field less_than to general u16 limb constraints

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,7 @@ name: Integrations
 on:
   merge_group:
   pull_request:
-    types: [synchronize, opened, reopened, ready_for_review]
+    types: [ synchronize, opened, reopened, ready_for_review ]
   push:
     branches:
       - master
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   skip_check:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [ self-hosted, Linux, X64 ]
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -27,14 +27,14 @@ jobs:
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule", "merge_group"]'
 
   integration:
-    needs: [skip_check]
+    needs: [ skip_check ]
     if: |
       github.event.pull_request.draft == false &&
       (github.event.action == 'ready_for_review' || needs.skip_check.outputs.should_skip != 'true')
 
     name: Integration testing
     timeout-minutes: 30
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [ self-hosted, Linux, X64 ]
 
     steps:
       - uses: actions/checkout@v4
@@ -53,6 +53,13 @@ jobs:
           RUST_LOG: debug
           RUSTFLAGS: "-C opt-level=3"
         run: cargo run --package ceno_zkvm --bin e2e -- --platform=ceno --hints=10 --public-io=4191 examples/target/riscv32im-ceno-zkvm-elf/debug/examples/fibonacci
+
+      - name: Run fibonacci (debug) + feature u16limb_circuit
+        env:
+          RUST_LOG: debug
+          RUSTFLAGS: "-C opt-level=3"
+        run: cargo run --package ceno_zkvm --features u16limb_circuit --bin e2e -- --platform=ceno --hints=10 --public-io=4191 examples/target/riscv32im-ceno-zkvm-elf/debug/examples/fibonacci
+
 
       - name: Run fibonacci (release)
         env:

--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -67,7 +67,7 @@ ceno-examples = { path = "../examples-builder" }
 glob = "0.3"
 
 [features]
-default = ["forbid_overflow", "u16limb_circuit"]
+default = ["forbid_overflow"]
 flamegraph = ["pprof2/flamegraph", "pprof2/criterion"]
 forbid_overflow = []
 jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]

--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -67,7 +67,7 @@ ceno-examples = { path = "../examples-builder" }
 glob = "0.3"
 
 [features]
-default = ["forbid_overflow"]
+default = ["forbid_overflow", "u16limb_circuit"]
 flamegraph = ["pprof2/flamegraph", "pprof2/criterion"]
 forbid_overflow = []
 jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
@@ -83,6 +83,7 @@ nightly-features = [
   "witness/nightly-features",
 ]
 sanity-check = ["mpcs/sanity-check"]
+u16limb_circuit = []
 
 [[bench]]
 harness = false

--- a/ceno_zkvm/src/gadgets/mod.rs
+++ b/ceno_zkvm/src/gadgets/mod.rs
@@ -2,6 +2,7 @@ mod div;
 mod is_lt;
 mod signed;
 mod signed_ext;
+mod signed_limbs;
 
 pub use div::DivConfig;
 pub use gkr_iop::gadgets::{
@@ -10,3 +11,4 @@ pub use gkr_iop::gadgets::{
 pub use is_lt::{AssertSignedLtConfig, SignedLtConfig};
 pub use signed::Signed;
 pub use signed_ext::SignedExtendConfig;
+pub use signed_limbs::{UIntLimbsLT, UIntLimbsLTConfig};

--- a/ceno_zkvm/src/gadgets/signed_limbs.rs
+++ b/ceno_zkvm/src/gadgets/signed_limbs.rs
@@ -1,3 +1,4 @@
+/// circuit implementation refer from https://github.com/openvm-org/openvm/blob/ca36de3803213da664b03d111801ab903d55e360/extensions/rv32im/circuit/src/branch_lt/core.rs
 use crate::{
     circuit_builder::CircuitBuilder,
     error::ZKVMError,

--- a/ceno_zkvm/src/gadgets/signed_limbs.rs
+++ b/ceno_zkvm/src/gadgets/signed_limbs.rs
@@ -11,6 +11,10 @@ use p3::field::FieldAlgebra;
 use std::{array, marker::PhantomData};
 use witness::set_val;
 
+/// gadget for comparing two `UInt` values, supporting both signed and unsigned modes.
+///
+/// this configuration structure allows flexible comparison logic depending on whether
+/// the operands should be interpreted as signed or unsigned integers.
 pub struct UIntLimbsLTConfig<E: ExtensionField> {
     // Most significant limb of a and b respectively as a field element, will be range
     // checked to be within [-32768, 32767) if signed and [0, 65536) if unsigned.
@@ -151,7 +155,7 @@ impl<E: ExtensionField> UIntLimbsLT<E> {
         b: &[u16],
         is_signed: bool,
     ) -> Result<(), CircuitBuilderError> {
-        let (cmp_lt, diff_idx, a_sign, b_sign) = run_cmp(is_signed, a, b);
+        let (cmp_lt, diff_idx, is_a_neg, is_b_neg) = run_cmp(is_signed, a, b);
         config
             .diff_marker
             .iter()
@@ -161,9 +165,9 @@ impl<E: ExtensionField> UIntLimbsLT<E> {
             });
         set_val!(instance, config.cmp_lt, cmp_lt as u64);
 
-        // We range check (read_rs1_msb_f + 128) and (read_rs2_msb_f + 128) if signed,
-        // read_rs1_msb_f and read_rs2_msb_f if not
-        let (a_msb_f, a_msb_range) = if a_sign {
+        // We range check (read_rs1_msb_f + 2^(LIMB_BITS - 1)) and (read_rs2_msb_f + 2^(LIMB_BITS - 1)) if negative,
+        // otherwise read_rs1_msb_f and read_rs2_msb_f
+        let (a_msb_f, a_msb_range) = if is_a_neg {
             (
                 -E::BaseField::from_canonical_u32((1 << LIMB_BITS) - a[UINT_LIMBS - 1] as u32),
                 a[UINT_LIMBS - 1] - (1 << (LIMB_BITS - 1)),
@@ -174,7 +178,7 @@ impl<E: ExtensionField> UIntLimbsLT<E> {
                 a[UINT_LIMBS - 1] + ((is_signed as u16) << (LIMB_BITS - 1)),
             )
         };
-        let (b_msb_f, b_msb_range) = if b_sign {
+        let (b_msb_f, b_msb_range) = if is_b_neg {
             (
                 -E::BaseField::from_canonical_u32((1 << LIMB_BITS) - b[UINT_LIMBS - 1] as u32),
                 b[UINT_LIMBS - 1] - (1 << (LIMB_BITS - 1)),
@@ -218,15 +222,15 @@ impl<E: ExtensionField> UIntLimbsLT<E> {
     }
 }
 
-// returns (cmp_lt, diff_idx, x_sign, y_sign)
+// returns (cmp_lt, diff_idx, is_x_neg, is_y_neg)
 // cmp_lt = true if a < b else false
 pub fn run_cmp(signed: bool, x: &[u16], y: &[u16]) -> (bool, usize, bool, bool) {
-    let x_sign = (x[UINT_LIMBS - 1] >> (LIMB_BITS - 1) == 1) && signed;
-    let y_sign = (y[UINT_LIMBS - 1] >> (LIMB_BITS - 1) == 1) && signed;
+    let is_x_neg = (x[UINT_LIMBS - 1] >> (LIMB_BITS - 1) == 1) && signed;
+    let is_y_neg = (y[UINT_LIMBS - 1] >> (LIMB_BITS - 1) == 1) && signed;
     for i in (0..UINT_LIMBS).rev() {
         if x[i] != y[i] {
-            return ((x[i] < y[i]) ^ x_sign ^ y_sign, i, x_sign, y_sign);
+            return ((x[i] < y[i]) ^ is_x_neg ^ is_y_neg, i, is_x_neg, is_y_neg);
         }
     }
-    (false, UINT_LIMBS, x_sign, y_sign)
+    (false, UINT_LIMBS, is_x_neg, is_y_neg)
 }

--- a/ceno_zkvm/src/gadgets/signed_limbs.rs
+++ b/ceno_zkvm/src/gadgets/signed_limbs.rs
@@ -1,0 +1,231 @@
+use crate::{
+    circuit_builder::CircuitBuilder,
+    error::ZKVMError,
+    instructions::riscv::constants::{LIMB_BITS, UINT_LIMBS, UInt},
+};
+use ff_ext::{ExtensionField, FieldInto, SmallField};
+use gkr_iop::error::CircuitBuilderError;
+use multilinear_extensions::{Expression, ToExpr, WitIn};
+use p3::field::FieldAlgebra;
+use std::{array, marker::PhantomData};
+use witness::set_val;
+
+pub struct UIntLimbsLTConfig<E: ExtensionField> {
+    // Most significant limb of a and b respectively as a field element, will be range
+    // checked to be within [-32768, 32767) if signed and [0, 65536) if unsigned.
+    pub a_msb_f: WitIn,
+    pub b_msb_f: WitIn,
+
+    // 1 at the most significant index i such that a[i] != b[i], otherwise 0. If such
+    // an i exists, diff_val = a[i] - b[i].
+    pub diff_marker: [WitIn; UINT_LIMBS],
+    pub diff_val: WitIn,
+
+    // 1 if a < b, 0 otherwise.
+    pub cmp_lt: WitIn,
+    phantom: PhantomData<E>,
+}
+
+impl<E: ExtensionField> UIntLimbsLTConfig<E> {
+    pub fn is_lt(&self) -> Expression<E> {
+        self.cmp_lt.expr()
+    }
+}
+
+pub struct UIntLimbsLT<E: ExtensionField> {
+    phantom: PhantomData<E>,
+}
+
+impl<E: ExtensionField> UIntLimbsLT<E> {
+    pub fn construct_circuit(
+        circuit_builder: &mut CircuitBuilder<E>,
+        a: &UInt<E>,
+        b: &UInt<E>,
+        is_signed: bool,
+    ) -> Result<UIntLimbsLTConfig<E>, ZKVMError> {
+        // 1 if a < b, 0 otherwise.
+        let cmp_lt = circuit_builder.create_bit(|| "cmp_lt")?;
+
+        let a_expr = a.expr();
+        let b_expr = b.expr();
+
+        let a_msb_f = circuit_builder.create_witin(|| "a_msb_f");
+        let b_msb_f = circuit_builder.create_witin(|| "b_msb_f");
+        let diff_marker: [WitIn; UINT_LIMBS] = array::from_fn(|i| {
+            circuit_builder
+                .create_bit(|| format!("diff_maker_{i}"))
+                .expect("create_bit_error")
+        });
+        let diff_val = circuit_builder.create_witin(|| "diff_val");
+
+        // Check if a_msb_f and b_msb_f are signed values of a[NUM_LIMBS - 1] and b[NUM_LIMBS - 1] in prime field F.
+        let a_diff = a_expr[UINT_LIMBS - 1].expr() - a_msb_f.expr();
+        let b_diff = b_expr[UINT_LIMBS - 1].expr() - b_msb_f.expr();
+
+        circuit_builder.require_zero(
+            || "a_diff",
+            a_diff.expr()
+                * (E::BaseField::from_canonical_u32(1 << LIMB_BITS).expr() - a_diff.expr()),
+        )?;
+        circuit_builder.require_zero(
+            || "b_diff",
+            b_diff.expr()
+                * (E::BaseField::from_canonical_u32(1 << LIMB_BITS).expr() - b_diff.expr()),
+        )?;
+
+        let mut prefix_sum = Expression::ZERO;
+
+        for i in (0..UINT_LIMBS).rev() {
+            let diff = (if i == UINT_LIMBS - 1 {
+                b_msb_f.expr() - a_msb_f.expr()
+            } else {
+                b_expr[i].expr() - a_expr[i].expr()
+            }) * (E::BaseField::from_canonical_u8(2).expr() * cmp_lt.expr()
+                - E::BaseField::ONE.expr());
+            prefix_sum += diff_marker[i].expr();
+            circuit_builder.require_zero(
+                || format!("prefix_diff_zero_{i}"),
+                (E::BaseField::ONE.expr() - prefix_sum.expr()) * diff.clone(),
+            )?;
+            circuit_builder.condition_require_zero(
+                || format!("diff_maker_conditional_equal_{i}"),
+                diff_marker[i].expr(),
+                diff_val.expr() - diff.expr(),
+            )?;
+        }
+
+        // - If x != y, then prefix_sum = 1 so marker[i] must be 1 iff i is the first index where diff != 0.
+        //   Constrains that diff == diff_val where diff_val is non-zero.
+        // - If x == y, then prefix_sum = 0 and cmp_lt = 0.
+        //   Here, prefix_sum cannot be 1 because all diff are zero, making diff == diff_val fails.
+
+        circuit_builder.assert_bit(|| "prefix_sum_bit", prefix_sum.expr())?;
+        circuit_builder.condition_require_zero(
+            || "cmp_lt_conditional_zero",
+            E::BaseField::ONE.expr() - prefix_sum.expr(),
+            cmp_lt.expr(),
+        )?;
+
+        // Range check to ensure diff_val is non-zero.
+        circuit_builder.assert_ux::<_, _, LIMB_BITS>(
+            || "diff_val is non-zero",
+            prefix_sum.expr() * (diff_val.expr() - E::BaseField::ONE.expr()),
+        )?;
+
+        circuit_builder.assert_ux::<_, _, LIMB_BITS>(
+            || "a_msb_f_signed_range_check",
+            a_msb_f.expr()
+                + if is_signed {
+                    E::BaseField::from_canonical_u32(1 << (LIMB_BITS - 1)).expr()
+                } else {
+                    Expression::ZERO
+                },
+        )?;
+
+        circuit_builder.assert_ux::<_, _, LIMB_BITS>(
+            || "b_msb_f_signed_range_check",
+            b_msb_f.expr()
+                + if is_signed {
+                    E::BaseField::from_canonical_u32(1 << (LIMB_BITS - 1)).expr()
+                } else {
+                    Expression::ZERO
+                },
+        )?;
+
+        Ok(UIntLimbsLTConfig {
+            a_msb_f,
+            b_msb_f,
+            diff_marker,
+            diff_val,
+            cmp_lt,
+            phantom: PhantomData,
+        })
+    }
+
+    pub fn assign(
+        config: &UIntLimbsLTConfig<E>,
+        instance: &mut [E::BaseField],
+        lkm: &mut gkr_iop::utils::lk_multiplicity::LkMultiplicity,
+        a: &[u16],
+        b: &[u16],
+        is_signed: bool,
+    ) -> Result<(), CircuitBuilderError> {
+        let (cmp_lt, diff_idx, a_sign, b_sign) = run_cmp(is_signed, a, b);
+        config
+            .diff_marker
+            .iter()
+            .enumerate()
+            .for_each(|(i, witin)| {
+                set_val!(instance, witin, (i == diff_idx) as u64);
+            });
+        set_val!(instance, config.cmp_lt, cmp_lt as u64);
+
+        // We range check (read_rs1_msb_f + 128) and (read_rs2_msb_f + 128) if signed,
+        // read_rs1_msb_f and read_rs2_msb_f if not
+        let (a_msb_f, a_msb_range) = if a_sign {
+            (
+                -E::BaseField::from_canonical_u32((1 << LIMB_BITS) - a[UINT_LIMBS - 1] as u32),
+                a[UINT_LIMBS - 1] - (1 << (LIMB_BITS - 1)),
+            )
+        } else {
+            (
+                E::BaseField::from_canonical_u16(a[UINT_LIMBS - 1]),
+                a[UINT_LIMBS - 1] + ((is_signed as u16) << (LIMB_BITS - 1)),
+            )
+        };
+        let (b_msb_f, b_msb_range) = if b_sign {
+            (
+                -E::BaseField::from_canonical_u32((1 << LIMB_BITS) - b[UINT_LIMBS - 1] as u32),
+                b[UINT_LIMBS - 1] - (1 << (LIMB_BITS - 1)),
+            )
+        } else {
+            (
+                E::BaseField::from_canonical_u16(b[UINT_LIMBS - 1]),
+                b[UINT_LIMBS - 1] + ((is_signed as u16) << (LIMB_BITS - 1)),
+            )
+        };
+
+        set_val!(instance, config.a_msb_f, a_msb_f);
+        set_val!(instance, config.b_msb_f, b_msb_f);
+
+        let diff_val = if diff_idx == UINT_LIMBS {
+            0
+        } else if diff_idx == (UINT_LIMBS - 1) {
+            if cmp_lt {
+                b_msb_f - a_msb_f
+            } else {
+                a_msb_f - b_msb_f
+            }
+            .to_canonical_u64() as u16
+        } else if cmp_lt {
+            b[diff_idx] - a[diff_idx]
+        } else {
+            a[diff_idx] - b[diff_idx]
+        };
+        set_val!(instance, config.diff_val, diff_val as u64);
+
+        if diff_idx != UINT_LIMBS {
+            lkm.assert_ux::<LIMB_BITS>((diff_val - 1) as u64);
+        } else {
+            lkm.assert_ux::<LIMB_BITS>(0);
+        }
+
+        lkm.assert_ux::<LIMB_BITS>(a_msb_range as u64);
+        lkm.assert_ux::<LIMB_BITS>(b_msb_range as u64);
+
+        Ok(())
+    }
+}
+
+// returns (cmp_lt, diff_idx, x_sign, y_sign)
+// cmp_lt = true if a < b else false
+pub fn run_cmp(signed: bool, x: &[u16], y: &[u16]) -> (bool, usize, bool, bool) {
+    let x_sign = (x[UINT_LIMBS - 1] >> (LIMB_BITS - 1) == 1) && signed;
+    let y_sign = (y[UINT_LIMBS - 1] >> (LIMB_BITS - 1) == 1) && signed;
+    for i in (0..UINT_LIMBS).rev() {
+        if x[i] != y[i] {
+            return ((x[i] < y[i]) ^ x_sign ^ y_sign, i, x_sign, y_sign);
+        }
+    }
+    (false, UINT_LIMBS, x_sign, y_sign)
+}

--- a/ceno_zkvm/src/instructions/riscv/branch.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch.rs
@@ -32,7 +32,7 @@ impl RIVInstruction for BltuOp {
 }
 #[cfg(feature = "u16limb_circuit")]
 // TODO use branch_circuit_v2
-pub type BltuInstruction<E> = branch_circuit::BranchCircuit<E, BltuOp>;
+pub type BltuInstruction<E> = branch_circuit_v2::BranchCircuit<E, BltuOp>;
 #[cfg(not(feature = "u16limb_circuit"))]
 pub type BltuInstruction<E> = branch_circuit::BranchCircuit<E, BltuOp>;
 
@@ -42,7 +42,7 @@ impl RIVInstruction for BgeuOp {
 }
 #[cfg(feature = "u16limb_circuit")]
 // TODO use branch_circuit_v2
-pub type BgeuInstruction<E> = branch_circuit::BranchCircuit<E, BgeuOp>;
+pub type BgeuInstruction<E> = branch_circuit_v2::BranchCircuit<E, BgeuOp>;
 #[cfg(not(feature = "u16limb_circuit"))]
 pub type BgeuInstruction<E> = branch_circuit::BranchCircuit<E, BgeuOp>;
 
@@ -52,9 +52,9 @@ impl RIVInstruction for BltOp {
 }
 #[cfg(feature = "u16limb_circuit")]
 // TODO use branch_circuit_v2
-pub type BltInstruction<E> = branch_circuit::BranchCircuit<E, BltOp>;
-#[cfg(not(feature = "u16limb_circuit"))]
 pub type BltInstruction<E> = branch_circuit_v2::BranchCircuit<E, BltOp>;
+#[cfg(not(feature = "u16limb_circuit"))]
+pub type BltInstruction<E> = branch_circuit::BranchCircuit<E, BltOp>;
 
 pub struct BgeOp;
 impl RIVInstruction for BgeOp {
@@ -62,6 +62,6 @@ impl RIVInstruction for BgeOp {
 }
 #[cfg(feature = "u16limb_circuit")]
 // TODO use branch_circuit_v2
-pub type BgeInstruction<E> = branch_circuit::BranchCircuit<E, BgeOp>;
-#[cfg(not(feature = "u16limb_circuit"))]
 pub type BgeInstruction<E> = branch_circuit_v2::BranchCircuit<E, BgeOp>;
+#[cfg(not(feature = "u16limb_circuit"))]
+pub type BgeInstruction<E> = branch_circuit::BranchCircuit<E, BgeOp>;

--- a/ceno_zkvm/src/instructions/riscv/branch.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch.rs
@@ -1,9 +1,8 @@
-mod branch_circuit;
-
 use super::RIVInstruction;
-use branch_circuit::BranchCircuit;
 use ceno_emul::InsnKind;
 
+mod branch_circuit;
+mod branch_circuit_v2;
 #[cfg(test)]
 mod test;
 
@@ -11,34 +10,58 @@ pub struct BeqOp;
 impl RIVInstruction for BeqOp {
     const INST_KIND: InsnKind = InsnKind::BEQ;
 }
-pub type BeqInstruction<E> = BranchCircuit<E, BeqOp>;
+#[cfg(feature = "u16limb_circuit")]
+// TODO use branch_circuit_v2
+pub type BeqInstruction<E> = branch_circuit::BranchCircuit<E, BeqOp>;
+#[cfg(not(feature = "u16limb_circuit"))]
+pub type BeqInstruction<E> = branch_circuit::BranchCircuit<E, BeqOp>;
 
 pub struct BneOp;
 impl RIVInstruction for BneOp {
     const INST_KIND: InsnKind = InsnKind::BNE;
 }
-pub type BneInstruction<E> = BranchCircuit<E, BneOp>;
+#[cfg(feature = "u16limb_circuit")]
+// TODO use branch_circuit_v2
+pub type BneInstruction<E> = branch_circuit::BranchCircuit<E, BneOp>;
+#[cfg(not(feature = "u16limb_circuit"))]
+pub type BneInstruction<E> = branch_circuit::BranchCircuit<E, BneOp>;
 
 pub struct BltuOp;
 impl RIVInstruction for BltuOp {
     const INST_KIND: InsnKind = InsnKind::BLTU;
 }
-pub type BltuInstruction<E> = BranchCircuit<E, BltuOp>;
+#[cfg(feature = "u16limb_circuit")]
+// TODO use branch_circuit_v2
+pub type BltuInstruction<E> = branch_circuit::BranchCircuit<E, BltuOp>;
+#[cfg(not(feature = "u16limb_circuit"))]
+pub type BltuInstruction<E> = branch_circuit::BranchCircuit<E, BltuOp>;
 
 pub struct BgeuOp;
 impl RIVInstruction for BgeuOp {
     const INST_KIND: InsnKind = InsnKind::BGEU;
 }
-pub type BgeuInstruction<E> = BranchCircuit<E, BgeuOp>;
+#[cfg(feature = "u16limb_circuit")]
+// TODO use branch_circuit_v2
+pub type BgeuInstruction<E> = branch_circuit::BranchCircuit<E, BgeuOp>;
+#[cfg(not(feature = "u16limb_circuit"))]
+pub type BgeuInstruction<E> = branch_circuit::BranchCircuit<E, BgeuOp>;
 
 pub struct BltOp;
 impl RIVInstruction for BltOp {
     const INST_KIND: InsnKind = InsnKind::BLT;
 }
-pub type BltInstruction<E> = BranchCircuit<E, BltOp>;
+#[cfg(feature = "u16limb_circuit")]
+// TODO use branch_circuit_v2
+pub type BltInstruction<E> = branch_circuit::BranchCircuit<E, BltOp>;
+#[cfg(not(feature = "u16limb_circuit"))]
+pub type BltInstruction<E> = branch_circuit_v2::BranchCircuit<E, BltOp>;
 
 pub struct BgeOp;
 impl RIVInstruction for BgeOp {
     const INST_KIND: InsnKind = InsnKind::BGE;
 }
-pub type BgeInstruction<E> = BranchCircuit<E, BgeOp>;
+#[cfg(feature = "u16limb_circuit")]
+// TODO use branch_circuit_v2
+pub type BgeInstruction<E> = branch_circuit::BranchCircuit<E, BgeOp>;
+#[cfg(not(feature = "u16limb_circuit"))]
+pub type BgeInstruction<E> = branch_circuit_v2::BranchCircuit<E, BgeOp>;

--- a/ceno_zkvm/src/instructions/riscv/branch.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch.rs
@@ -10,20 +10,12 @@ pub struct BeqOp;
 impl RIVInstruction for BeqOp {
     const INST_KIND: InsnKind = InsnKind::BEQ;
 }
-#[cfg(feature = "u16limb_circuit")]
-// TODO use branch_circuit_v2
-pub type BeqInstruction<E> = branch_circuit::BranchCircuit<E, BeqOp>;
-#[cfg(not(feature = "u16limb_circuit"))]
 pub type BeqInstruction<E> = branch_circuit::BranchCircuit<E, BeqOp>;
 
 pub struct BneOp;
 impl RIVInstruction for BneOp {
     const INST_KIND: InsnKind = InsnKind::BNE;
 }
-#[cfg(feature = "u16limb_circuit")]
-// TODO use branch_circuit_v2
-pub type BneInstruction<E> = branch_circuit::BranchCircuit<E, BneOp>;
-#[cfg(not(feature = "u16limb_circuit"))]
 pub type BneInstruction<E> = branch_circuit::BranchCircuit<E, BneOp>;
 
 pub struct BltuOp;
@@ -31,7 +23,6 @@ impl RIVInstruction for BltuOp {
     const INST_KIND: InsnKind = InsnKind::BLTU;
 }
 #[cfg(feature = "u16limb_circuit")]
-// TODO use branch_circuit_v2
 pub type BltuInstruction<E> = branch_circuit_v2::BranchCircuit<E, BltuOp>;
 #[cfg(not(feature = "u16limb_circuit"))]
 pub type BltuInstruction<E> = branch_circuit::BranchCircuit<E, BltuOp>;
@@ -41,7 +32,6 @@ impl RIVInstruction for BgeuOp {
     const INST_KIND: InsnKind = InsnKind::BGEU;
 }
 #[cfg(feature = "u16limb_circuit")]
-// TODO use branch_circuit_v2
 pub type BgeuInstruction<E> = branch_circuit_v2::BranchCircuit<E, BgeuOp>;
 #[cfg(not(feature = "u16limb_circuit"))]
 pub type BgeuInstruction<E> = branch_circuit::BranchCircuit<E, BgeuOp>;
@@ -51,7 +41,6 @@ impl RIVInstruction for BltOp {
     const INST_KIND: InsnKind = InsnKind::BLT;
 }
 #[cfg(feature = "u16limb_circuit")]
-// TODO use branch_circuit_v2
 pub type BltInstruction<E> = branch_circuit_v2::BranchCircuit<E, BltOp>;
 #[cfg(not(feature = "u16limb_circuit"))]
 pub type BltInstruction<E> = branch_circuit::BranchCircuit<E, BltOp>;
@@ -61,7 +50,6 @@ impl RIVInstruction for BgeOp {
     const INST_KIND: InsnKind = InsnKind::BGE;
 }
 #[cfg(feature = "u16limb_circuit")]
-// TODO use branch_circuit_v2
 pub type BgeInstruction<E> = branch_circuit_v2::BranchCircuit<E, BgeOp>;
 #[cfg(not(feature = "u16limb_circuit"))]
 pub type BgeInstruction<E> = branch_circuit::BranchCircuit<E, BgeOp>;

--- a/ceno_zkvm/src/instructions/riscv/branch/branch_circuit_v2.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch/branch_circuit_v2.rs
@@ -2,23 +2,18 @@ use crate::{
     Value,
     circuit_builder::CircuitBuilder,
     error::ZKVMError,
+    gadgets::{UIntLimbsLT, UIntLimbsLTConfig},
     instructions::{
         Instruction,
-        riscv::{
-            RIVInstruction,
-            b_insn::BInstructionConfig,
-            constants::{LIMB_BITS, UINT_LIMBS, UInt},
-        },
+        riscv::{RIVInstruction, b_insn::BInstructionConfig, constants::UInt},
     },
     structs::ProgramParams,
     witness::LkMultiplicity,
 };
 use ceno_emul::{InsnKind, StepRecord};
-use ff_ext::{ExtensionField, FieldInto, SmallField};
-use multilinear_extensions::{Expression, ToExpr, WitIn};
-use p3::field::FieldAlgebra;
-use std::{array, marker::PhantomData};
-use witness::set_val;
+use ff_ext::ExtensionField;
+use multilinear_extensions::Expression;
+use std::marker::PhantomData;
 
 pub struct BranchCircuit<E, I>(PhantomData<(E, I)>);
 
@@ -27,19 +22,7 @@ pub struct BranchConfig<E: ExtensionField> {
     pub read_rs1: UInt<E>,
     pub read_rs2: UInt<E>,
 
-    // Most significant limb of a and b respectively as a field element, will be range
-    // checked to be within [-128, 127) if signed and [0, 256) if unsigned.
-    pub read_rs1_msb_f: WitIn,
-    pub read_rs2_msb_f: WitIn,
-
-    // 1 at the most significant index i such that read_rs1[i] != read_rs2[i], otherwise 0. If such
-    // an i exists, diff_val = read_rs2[i] - read_rs1[i].
-    pub diff_marker: [WitIn; UINT_LIMBS],
-    pub diff_val: WitIn,
-
-    // 1 if read_rs1 < read_rs2, 0 otherwise.
-    pub cmp_lt: WitIn,
-
+    pub uint_lt_config: UIntLimbsLTConfig<E>,
     phantom: PhantomData<E>,
 }
 
@@ -55,138 +38,18 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BranchCircuit<E, I
         circuit_builder: &mut CircuitBuilder<E>,
         _param: &ProgramParams,
     ) -> Result<Self::InstructionConfig, ZKVMError> {
-        // 1 if a < b, 0 otherwise.
-        let cmp_lt = circuit_builder.create_bit(|| "cmp_lt")?;
-
         let read_rs1 = UInt::new_unchecked(|| "rs1_limbs", circuit_builder)?;
         let read_rs2 = UInt::new_unchecked(|| "rs2_limbs", circuit_builder)?;
 
-        let read_rs1_expr = read_rs1.expr();
-        let read_rs2_expr = read_rs2.expr();
-
-        let read_rs1_msb_f = circuit_builder.create_witin(|| "read_rs1_msb_f");
-        let read_rs2_msb_f = circuit_builder.create_witin(|| "read_rs2_msb_f");
-        let diff_marker: [WitIn; UINT_LIMBS] = array::from_fn(|i| {
-            circuit_builder
-                .create_bit(|| format!("diff_maker_{i}"))
-                .expect("create_bit_error")
-        });
-        let diff_val = circuit_builder.create_witin(|| "diff_val");
-
-        // Check if read_rs1_msb_f and read_rs2_msb_f are signed values of read_rs1[NUM_LIMBS - 1] and read_rs2[NUM_LIMBS - 1] in prime field F.
-        let read_rs1_diff = read_rs1_expr[UINT_LIMBS - 1].expr() - read_rs1_msb_f.expr();
-        let read_rs2_diff = read_rs2_expr[UINT_LIMBS - 1].expr() - read_rs2_msb_f.expr();
-
-        circuit_builder.require_zero(
-            || "read_rs1_diff",
-            read_rs1_diff.expr()
-                * (E::BaseField::from_canonical_u32(1 << LIMB_BITS).expr() - read_rs1_diff.expr()),
-        )?;
-        circuit_builder.require_zero(
-            || "read_rs2_diff",
-            read_rs2_diff.expr()
-                * (E::BaseField::from_canonical_u32(1 << LIMB_BITS).expr() - read_rs2_diff.expr()),
-        )?;
-
-        let mut prefix_sum = Expression::ZERO;
-
-        for i in (0..UINT_LIMBS).rev() {
-            let diff = (if i == UINT_LIMBS - 1 {
-                read_rs2_msb_f.expr() - read_rs1_msb_f.expr()
-            } else {
-                read_rs2_expr[i].expr() - read_rs1_expr[i].expr()
-            }) * (E::BaseField::from_canonical_u8(2).expr() * cmp_lt.expr()
-                - E::BaseField::ONE.expr());
-            prefix_sum += diff_marker[i].expr();
-            circuit_builder.require_zero(
-                || format!("prefix_diff_zero_{i}"),
-                (E::BaseField::ONE.expr() - prefix_sum.expr()) * diff.clone(),
-            )?;
-            circuit_builder.condition_require_zero(
-                || format!("diff_maker_conditional_equal_{i}"),
-                diff_marker[i].expr(),
-                diff_val.expr() - diff.expr(),
-            )?;
-        }
-
-        // - If x != y, then prefix_sum = 1 so marker[i] must be 1 iff i is the first index where diff != 0.
-        //   Constrains that diff == diff_val where diff_val is non-zero.
-        // - If x == y, then prefix_sum = 0 and cmp_lt = 0.
-        //   Here, prefix_sum cannot be 1 because all diff are zero, making diff == diff_val fails.
-
-        circuit_builder.assert_bit(|| "prefix_sum_bit", prefix_sum.expr())?;
-        circuit_builder.condition_require_zero(
-            || "cmp_lt_conditional_zero",
-            E::BaseField::ONE.expr() - prefix_sum.expr(),
-            cmp_lt.expr(),
-        )?;
-
-        // Range check to ensure diff_val is non-zero.
-        circuit_builder.assert_ux::<_, _, LIMB_BITS>(
-            || "diff_val is non-zero",
-            prefix_sum.expr() * (diff_val.expr() - E::BaseField::ONE.expr()),
-        )?;
-
-        let branch_taken_bit = match I::INST_KIND {
-            InsnKind::BLT => {
-                // Check if read_rs1_msb_f and read_rs2_msb_f are in [-32768, 32767) if signed, [0, 65536) if unsigned.
-                circuit_builder.assert_ux::<_, _, LIMB_BITS>(
-                    || "read_rs1_msb_f_signed_range_check",
-                    read_rs1_msb_f.expr()
-                        + E::BaseField::from_canonical_u32(1 << (LIMB_BITS - 1)).expr(),
-                )?;
-
-                circuit_builder.assert_ux::<_, _, LIMB_BITS>(
-                    || "read_rs2_msb_f_signed_range_check",
-                    read_rs2_msb_f.expr()
-                        + E::BaseField::from_canonical_u32(1 << (LIMB_BITS - 1)).expr(),
-                )?;
-                cmp_lt.expr()
-            }
-            InsnKind::BGE => {
-                // Check if read_rs1_msb_f and read_rs2_msb_f are in [-128, 127) if signed, [0, 256) if unsigned.
-                circuit_builder.assert_ux::<_, _, LIMB_BITS>(
-                    || "read_rs1_msb_f_signed_range_check",
-                    read_rs1_msb_f.expr()
-                        + E::BaseField::from_canonical_u32(1 << (LIMB_BITS - 1)).expr(),
-                )?;
-
-                circuit_builder.assert_ux::<_, _, LIMB_BITS>(
-                    || "read_rs2_msb_f_signed_range_check",
-                    read_rs2_msb_f.expr()
-                        + E::BaseField::from_canonical_u32(1 << (LIMB_BITS - 1)).expr(),
-                )?;
-                Expression::ONE - cmp_lt.expr()
-            }
-            InsnKind::BLTU => {
-                // Check if read_rs1_msb_f and read_rs2_msb_f are in [-128, 127) if signed, [0, 256) if unsigned.
-                circuit_builder.assert_ux::<_, _, LIMB_BITS>(
-                    || "read_rs1_msb_f_signed_range_check",
-                    read_rs1_msb_f.expr(),
-                )?;
-
-                circuit_builder.assert_ux::<_, _, LIMB_BITS>(
-                    || "read_rs2_msb_f_signed_range_check",
-                    read_rs2_msb_f.expr(),
-                )?;
-                cmp_lt.expr()
-            }
-            InsnKind::BGEU => {
-                // Check if read_rs1_msb_f and read_rs2_msb_f are in [-128, 127) if signed, [0, 256) if unsigned.
-                circuit_builder.assert_ux::<_, _, LIMB_BITS>(
-                    || "read_rs1_msb_f_signed_range_check",
-                    read_rs1_msb_f.expr(),
-                )?;
-
-                circuit_builder.assert_ux::<_, _, LIMB_BITS>(
-                    || "read_rs2_msb_f_signed_range_check",
-                    read_rs2_msb_f.expr(),
-                )?;
-                Expression::ONE - cmp_lt.expr()
-            }
-            _ => unreachable!("Unsupported instruction kind {:?}", I::INST_KIND),
+        let is_signed = matches!(I::INST_KIND, InsnKind::BLT | InsnKind::BGE);
+        let is_ge = matches!(I::INST_KIND, InsnKind::BGEU | InsnKind::BGE);
+        let uint_lt_config =
+            UIntLimbsLT::<E>::construct_circuit(circuit_builder, &read_rs1, &read_rs2, is_signed)?;
+        let branch_taken_bit = if is_ge {
+            Expression::ONE - uint_lt_config.is_lt()
+        } else {
+            uint_lt_config.is_lt()
         };
-
         let b_insn = BInstructionConfig::construct_circuit(
             circuit_builder,
             I::INST_KIND,
@@ -199,12 +62,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BranchCircuit<E, I
             b_insn,
             read_rs1,
             read_rs2,
-
-            read_rs1_msb_f,
-            read_rs2_msb_f,
-            diff_marker,
-            diff_val,
-            cmp_lt,
+            uint_lt_config,
             phantom: Default::default(),
         })
     }
@@ -226,97 +84,15 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BranchCircuit<E, I
         config.read_rs1.assign_limbs(instance, rs1_limbs);
         config.read_rs2.assign_limbs(instance, rs2_limbs);
 
-        let (cmp_result, diff_idx, rs1_sign, rs2_sign) =
-            run_cmp::<E>(step.insn.kind, rs1_limbs, rs2_limbs);
-        config
-            .diff_marker
-            .iter()
-            .enumerate()
-            .for_each(|(i, witin)| {
-                set_val!(instance, witin, (i == diff_idx) as u64);
-            });
-
         let is_signed = matches!(step.insn().kind, InsnKind::BLT | InsnKind::BGE);
-        let is_ge = matches!(step.insn().kind, InsnKind::BGE | InsnKind::BGEU);
-
-        let cmp_lt = cmp_result ^ is_ge;
-        set_val!(instance, config.cmp_lt, cmp_lt as u64);
-
-        // We range check (read_rs1_msb_f + 128) and (read_rs2_msb_f + 128) if signed,
-        // read_rs1_msb_f and read_rs2_msb_f if not
-        let (read_rs1_msb_f, a_msb_range) = if rs1_sign {
-            (
-                -E::BaseField::from_canonical_u32(
-                    (1 << LIMB_BITS) - rs1_limbs[UINT_LIMBS - 1] as u32,
-                ),
-                rs1_limbs[UINT_LIMBS - 1] - (1 << (LIMB_BITS - 1)),
-            )
-        } else {
-            (
-                E::BaseField::from_canonical_u16(rs1_limbs[UINT_LIMBS - 1]),
-                rs1_limbs[UINT_LIMBS - 1] + ((is_signed as u16) << (LIMB_BITS - 1)),
-            )
-        };
-        let (read_rs2_msb_f, b_msb_range) = if rs2_sign {
-            (
-                -E::BaseField::from_canonical_u32(
-                    (1 << LIMB_BITS) - rs2_limbs[UINT_LIMBS - 1] as u32,
-                ),
-                rs2_limbs[UINT_LIMBS - 1] - (1 << (LIMB_BITS - 1)),
-            )
-        } else {
-            (
-                E::BaseField::from_canonical_u16(rs2_limbs[UINT_LIMBS - 1]),
-                rs2_limbs[UINT_LIMBS - 1] + ((is_signed as u16) << (LIMB_BITS - 1)),
-            )
-        };
-
-        set_val!(instance, config.read_rs1_msb_f, read_rs1_msb_f);
-        set_val!(instance, config.read_rs2_msb_f, read_rs2_msb_f);
-
-        let diff_val = if diff_idx == UINT_LIMBS {
-            0
-        } else if diff_idx == (UINT_LIMBS - 1) {
-            if cmp_lt {
-                read_rs2_msb_f - read_rs1_msb_f
-            } else {
-                read_rs1_msb_f - read_rs2_msb_f
-            }
-            .to_canonical_u64() as u16
-        } else if cmp_lt {
-            rs2_limbs[diff_idx] - rs1_limbs[diff_idx]
-        } else {
-            rs1_limbs[diff_idx] - rs2_limbs[diff_idx]
-        };
-        set_val!(instance, config.diff_val, diff_val as u64);
-
-        if diff_idx != UINT_LIMBS {
-            lk_multiplicity.assert_ux::<LIMB_BITS>((diff_val - 1) as u64);
-        } else {
-            lk_multiplicity.assert_ux::<LIMB_BITS>(0);
-        }
-
-        lk_multiplicity.assert_ux::<LIMB_BITS>(a_msb_range as u64);
-        lk_multiplicity.assert_ux::<LIMB_BITS>(b_msb_range as u64);
-
+        UIntLimbsLT::<E>::assign(
+            &config.uint_lt_config,
+            instance,
+            lk_multiplicity,
+            rs1_limbs,
+            rs2_limbs,
+            is_signed,
+        )?;
         Ok(())
     }
-}
-
-// returns (cmp_result, diff_idx, x_sign, y_sign)
-pub(super) fn run_cmp<E: ExtensionField>(
-    local_opcode: InsnKind,
-    x: &[u16],
-    y: &[u16],
-) -> (bool, usize, bool, bool) {
-    let signed = matches!(local_opcode, InsnKind::BLT | InsnKind::BGE);
-    let ge_op = matches!(local_opcode, InsnKind::BGE | InsnKind::BGEU);
-    let x_sign = (x[UINT_LIMBS - 1] >> (LIMB_BITS - 1) == 1) && signed;
-    let y_sign = (y[UINT_LIMBS - 1] >> (LIMB_BITS - 1) == 1) && signed;
-    for i in (0..UINT_LIMBS).rev() {
-        if x[i] != y[i] {
-            return ((x[i] < y[i]) ^ x_sign ^ y_sign ^ ge_op, i, x_sign, y_sign);
-        }
-    }
-    (ge_op, UINT_LIMBS, x_sign, y_sign)
 }

--- a/ceno_zkvm/src/instructions/riscv/branch/branch_circuit_v2.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch/branch_circuit_v2.rs
@@ -7,7 +7,7 @@ use crate::{
         riscv::{
             RIVInstruction,
             b_insn::BInstructionConfig,
-            constants::{UINT_LIMBS, UInt},
+            constants::{LIMB_BITS, UINT_LIMBS, UInt},
         },
     },
     structs::ProgramParams,
@@ -17,7 +17,8 @@ use ceno_emul::{InsnKind, StepRecord};
 use ff_ext::ExtensionField;
 use gkr_iop::gadgets::{IsEqualConfig, IsLtConfig};
 use multilinear_extensions::{Expression, ToExpr, WitIn};
-use std::{array, marker::PhantomData};
+use p3::field::FieldAlgebra;
+use std::{array, marker::PhantomData, ops::Neg};
 
 pub struct BranchCircuit<E, I>(PhantomData<(E, I)>);
 
@@ -35,6 +36,10 @@ pub struct BranchConfig<E: ExtensionField> {
     // an i exists, diff_val = read_rs2[i] - read_rs1[i].
     pub diff_marker: [WitIn; UINT_LIMBS],
     pub diff_val: WitIn,
+
+    // 1 if read_rs1 < read_rs2, 0 otherwise.
+    pub cmp_lt: WitIn,
+
     phantom: PhantomData<E>,
 }
 
@@ -47,8 +52,11 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BranchCircuit<E, I
 
     fn construct_circuit(
         circuit_builder: &mut CircuitBuilder<E>,
-        param: &ProgramParams,
+        _param: &ProgramParams,
     ) -> Result<Self::InstructionConfig, ZKVMError> {
+        // 1 if a < b, 0 otherwise.
+        let cmp_lt = circuit_builder.create_bit(|| "cmp_lt")?;
+
         let read_rs1 = UInt::new_unchecked(|| "rs1_limbs", circuit_builder)?;
         let read_rs2 = UInt::new_unchecked(|| "rs2_limbs", circuit_builder)?;
 
@@ -57,80 +65,123 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BranchCircuit<E, I
 
         let read_rs1_msb_f = circuit_builder.create_witin(|| "read_rs1_msb_f");
         let read_rs2_msb_f = circuit_builder.create_witin(|| "read_rs2_msb_f");
-        let diff_marker: [WitIn; UINT_LIMBS] =
-            array::from_fn(|_| circuit_builder.create_witin(|| "diff_maker"));
+        let diff_marker: [WitIn; UINT_LIMBS] = array::from_fn(|_| {
+            circuit_builder
+                .create_bit(|| "diff_maker")
+                .expect("create_bit_error")
+        });
         let diff_val = circuit_builder.create_witin(|| "diff_val");
 
-        // Check if a_msb_f and b_msb_f are signed values of read_rs1[NUM_LIMBS - 1] and read_rs2[NUM_LIMBS - 1] in prime field F.
-        let a_diff = read_rs1_expr[UINT_LIMBS - 1].expr() - read_rs1_msb_f.expr();
-        let b_diff = read_rs2_expr[UINT_LIMBS - 1].expr() - read_rs2_msb_f.expr();
+        // Check if read_rs1_msb_f and read_rs2_msb_f are signed values of read_rs1[NUM_LIMBS - 1] and read_rs2[NUM_LIMBS - 1] in prime field F.
+        let read_rs1_diff = read_rs1_expr[UINT_LIMBS - 1].expr() - read_rs1_msb_f.expr();
+        let read_rs2_diff = read_rs2_expr[UINT_LIMBS - 1].expr() - read_rs2_msb_f.expr();
 
-        let (branch_taken_bit, is_equal, is_signed_lt, is_unsigned_lt) = match I::INST_KIND {
-            InsnKind::BEQ => {
-                let equal = IsEqualConfig::construct_circuit(
-                    circuit_builder,
-                    || "rs1!=rs2",
-                    read_rs2.value(),
-                    read_rs1.value(),
-                )?;
-                (equal.expr(), Some(equal), None, None)
-            }
-            InsnKind::BNE => {
-                let equal = IsEqualConfig::construct_circuit(
-                    circuit_builder,
-                    || "rs1==rs2",
-                    read_rs2.value(),
-                    read_rs1.value(),
-                )?;
-                (Expression::ONE - equal.expr(), Some(equal), None, None)
-            }
+        circuit_builder.require_zero(
+            || "read_rs1_diff",
+            read_rs1_diff.expr()
+                * (E::BaseField::from_canonical_u32(1 << LIMB_BITS).expr() - read_rs1_diff.expr()),
+        )?;
+        circuit_builder.require_zero(
+            || "read_rs2_diff",
+            read_rs2_diff.expr()
+                * (E::BaseField::from_canonical_u32(1 << LIMB_BITS).expr() - read_rs2_diff.expr()),
+        )?;
+
+        let mut prefix_sum = Expression::ZERO;
+
+        for i in (0..UINT_LIMBS).rev() {
+            let diff = (if i == UINT_LIMBS - 1 {
+                read_rs2_msb_f.expr() - read_rs1_msb_f.expr()
+            } else {
+                read_rs2_expr[i].expr() - read_rs1_expr[i].expr()
+            }) * (E::BaseField::from_canonical_u8(2).expr() * cmp_lt.expr()
+                - E::BaseField::ONE.expr());
+            prefix_sum += diff_marker[i].expr();
+            circuit_builder.require_zero(
+                || format!("prefix_diff_zero_{i}"),
+                (prefix_sum.clone() * diff.clone()).neg(),
+            )?;
+            circuit_builder.condition_require_zero(
+                || format!("diff_maker_conditional_equal_{i}"),
+                diff_marker[i].expr(),
+                diff_val.expr() - diff.expr(),
+            )?;
+        }
+
+        // - If x != y, then prefix_sum = 1 so marker[i] must be 1 iff i is the first index where diff != 0.
+        //   Constrains that diff == diff_val where diff_val is non-zero.
+        // - If x == y, then prefix_sum = 0 and cmp_lt = 0.
+        //   Here, prefix_sum cannot be 1 because all diff are zero, making diff == diff_val fails.
+
+        circuit_builder.assert_bit(|| "prefix_sum_bit", prefix_sum.expr())?;
+        circuit_builder.condition_require_zero(
+            || "cmp_lt_conditional_zero",
+            prefix_sum.expr().neg(),
+            cmp_lt.expr(),
+        )?;
+
+        // Range check to ensure diff_val is non-zero.
+        circuit_builder.assert_ux::<_, _, 8>(
+            || "diff_val is non-zero",
+            prefix_sum.expr() * (diff_val.expr() - E::BaseField::ONE.expr()),
+        )?;
+
+        let branch_taken_bit = match I::INST_KIND {
             InsnKind::BLT => {
-                let signed_lt = SignedLtConfig::construct_circuit(
-                    circuit_builder,
-                    || "rs1<rs2",
-                    &read_rs1,
-                    &read_rs2,
+                // Check if read_rs1_msb_f and read_rs2_msb_f are in [-128, 127) if signed, [0, 256) if unsigned.
+                circuit_builder.assert_ux::<_, _, 8>(
+                    || "read_rs1_msb_f_signed_range_check",
+                    read_rs1_msb_f.expr()
+                        + E::BaseField::from_canonical_u32(1 << (LIMB_BITS - 1)).expr(),
                 )?;
-                (signed_lt.expr(), None, Some(signed_lt), None)
+
+                circuit_builder.assert_ux::<_, _, 8>(
+                    || "read_rs2_msb_f_signed_range_check",
+                    read_rs2_msb_f.expr()
+                        + E::BaseField::from_canonical_u32(1 << (LIMB_BITS - 1)).expr(),
+                )?;
+                cmp_lt.expr()
             }
             InsnKind::BGE => {
-                let signed_lt = SignedLtConfig::construct_circuit(
-                    circuit_builder,
-                    || "rs1>=rs2",
-                    &read_rs1,
-                    &read_rs2,
+                // Check if read_rs1_msb_f and read_rs2_msb_f are in [-128, 127) if signed, [0, 256) if unsigned.
+                circuit_builder.assert_ux::<_, _, 8>(
+                    || "read_rs1_msb_f_signed_range_check",
+                    read_rs1_msb_f.expr()
+                        + E::BaseField::from_canonical_u32(1 << (LIMB_BITS - 1)).expr(),
                 )?;
-                (
-                    Expression::ONE - signed_lt.expr(),
-                    None,
-                    Some(signed_lt),
-                    None,
-                )
+
+                circuit_builder.assert_ux::<_, _, 8>(
+                    || "read_rs2_msb_f_signed_range_check",
+                    read_rs2_msb_f.expr()
+                        + E::BaseField::from_canonical_u32(1 << (LIMB_BITS - 1)).expr(),
+                )?;
+                Expression::ONE - cmp_lt.expr()
             }
             InsnKind::BLTU => {
-                let unsigned_lt = IsLtConfig::construct_circuit(
-                    circuit_builder,
-                    || "rs1<rs2",
-                    read_rs1.value(),
-                    read_rs2.value(),
-                    UINT_LIMBS,
+                // Check if read_rs1_msb_f and read_rs2_msb_f are in [-128, 127) if signed, [0, 256) if unsigned.
+                circuit_builder.assert_ux::<_, _, 8>(
+                    || "read_rs1_msb_f_signed_range_check",
+                    read_rs1_msb_f.expr(),
                 )?;
-                (unsigned_lt.expr(), None, None, Some(unsigned_lt))
+
+                circuit_builder.assert_ux::<_, _, 8>(
+                    || "read_rs2_msb_f_signed_range_check",
+                    read_rs2_msb_f.expr(),
+                )?;
+                cmp_lt.expr()
             }
             InsnKind::BGEU => {
-                let unsigned_lt = IsLtConfig::construct_circuit(
-                    circuit_builder,
-                    || "rs1 >= rs2",
-                    read_rs1.value(),
-                    read_rs2.value(),
-                    UINT_LIMBS,
+                // Check if read_rs1_msb_f and read_rs2_msb_f are in [-128, 127) if signed, [0, 256) if unsigned.
+                circuit_builder.assert_ux::<_, _, 8>(
+                    || "read_rs1_msb_f_signed_range_check",
+                    read_rs1_msb_f.expr(),
                 )?;
-                (
-                    Expression::ONE - unsigned_lt.expr(),
-                    None,
-                    None,
-                    Some(unsigned_lt),
-                )
+
+                circuit_builder.assert_ux::<_, _, 8>(
+                    || "read_rs2_msb_f_signed_range_check",
+                    read_rs2_msb_f.expr(),
+                )?;
+                Expression::ONE - cmp_lt.expr()
             }
             _ => unreachable!("Unsupported instruction kind {:?}", I::INST_KIND),
         };
@@ -143,13 +194,18 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BranchCircuit<E, I
             branch_taken_bit,
         )?;
 
-        // Ok(BranchConfig {
-        //     b_insn,
-        //     read_rs1,
-        //     read_rs2,
-        //     ..
-        // })
-        todo!()
+        Ok(BranchConfig {
+            b_insn,
+            read_rs1,
+            read_rs2,
+
+            read_rs1_msb_f,
+            read_rs2_msb_f,
+            diff_marker,
+            diff_val,
+            cmp_lt,
+            phantom: Default::default(),
+        })
     }
 
     fn assign_instance(

--- a/ceno_zkvm/src/instructions/riscv/branch/branch_circuit_v2.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch/branch_circuit_v2.rs
@@ -33,7 +33,6 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BranchCircuit<E, I
         format!("{:?}", I::INST_KIND)
     }
 
-    /// circuit implementation refer from https://github.com/openvm-org/openvm/blob/ca36de3803213da664b03d111801ab903d55e360/extensions/rv32im/circuit/src/branch_lt/core.rs
     fn construct_circuit(
         circuit_builder: &mut CircuitBuilder<E>,
         _param: &ProgramParams,

--- a/ceno_zkvm/src/instructions/riscv/branch/branch_circuit_v2.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch/branch_circuit_v2.rs
@@ -1,0 +1,163 @@
+use crate::{
+    circuit_builder::CircuitBuilder,
+    error::ZKVMError,
+    gadgets::SignedLtConfig,
+    instructions::{
+        Instruction,
+        riscv::{
+            RIVInstruction,
+            b_insn::BInstructionConfig,
+            constants::{UINT_LIMBS, UInt},
+        },
+    },
+    structs::ProgramParams,
+    witness::LkMultiplicity,
+};
+use ceno_emul::{InsnKind, StepRecord};
+use ff_ext::ExtensionField;
+use gkr_iop::gadgets::{IsEqualConfig, IsLtConfig};
+use multilinear_extensions::{Expression, ToExpr, WitIn};
+use std::{array, marker::PhantomData};
+
+pub struct BranchCircuit<E, I>(PhantomData<(E, I)>);
+
+pub struct BranchConfig<E: ExtensionField> {
+    pub b_insn: BInstructionConfig<E>,
+    pub read_rs1: UInt<E>,
+    pub read_rs2: UInt<E>,
+
+    // Most significant limb of a and b respectively as a field element, will be range
+    // checked to be within [-128, 127) if signed and [0, 256) if unsigned.
+    pub read_rs1_msb_f: WitIn,
+    pub read_rs2_msb_f: WitIn,
+
+    // 1 at the most significant index i such that read_rs1[i] != read_rs2[i], otherwise 0. If such
+    // an i exists, diff_val = read_rs2[i] - read_rs1[i].
+    pub diff_marker: [WitIn; UINT_LIMBS],
+    pub diff_val: WitIn,
+    phantom: PhantomData<E>,
+}
+
+impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for BranchCircuit<E, I> {
+    type InstructionConfig = BranchConfig<E>;
+
+    fn name() -> String {
+        todo!()
+    }
+
+    fn construct_circuit(
+        circuit_builder: &mut CircuitBuilder<E>,
+        param: &ProgramParams,
+    ) -> Result<Self::InstructionConfig, ZKVMError> {
+        let read_rs1 = UInt::new_unchecked(|| "rs1_limbs", circuit_builder)?;
+        let read_rs2 = UInt::new_unchecked(|| "rs2_limbs", circuit_builder)?;
+
+        let read_rs1_expr = read_rs1.expr();
+        let read_rs2_expr = read_rs2.expr();
+
+        let read_rs1_msb_f = circuit_builder.create_witin(|| "read_rs1_msb_f");
+        let read_rs2_msb_f = circuit_builder.create_witin(|| "read_rs2_msb_f");
+        let diff_marker: [WitIn; UINT_LIMBS] =
+            array::from_fn(|_| circuit_builder.create_witin(|| "diff_maker"));
+        let diff_val = circuit_builder.create_witin(|| "diff_val");
+
+        // Check if a_msb_f and b_msb_f are signed values of read_rs1[NUM_LIMBS - 1] and read_rs2[NUM_LIMBS - 1] in prime field F.
+        let a_diff = read_rs1_expr[UINT_LIMBS - 1].expr() - read_rs1_msb_f.expr();
+        let b_diff = read_rs2_expr[UINT_LIMBS - 1].expr() - read_rs2_msb_f.expr();
+
+        let (branch_taken_bit, is_equal, is_signed_lt, is_unsigned_lt) = match I::INST_KIND {
+            InsnKind::BEQ => {
+                let equal = IsEqualConfig::construct_circuit(
+                    circuit_builder,
+                    || "rs1!=rs2",
+                    read_rs2.value(),
+                    read_rs1.value(),
+                )?;
+                (equal.expr(), Some(equal), None, None)
+            }
+            InsnKind::BNE => {
+                let equal = IsEqualConfig::construct_circuit(
+                    circuit_builder,
+                    || "rs1==rs2",
+                    read_rs2.value(),
+                    read_rs1.value(),
+                )?;
+                (Expression::ONE - equal.expr(), Some(equal), None, None)
+            }
+            InsnKind::BLT => {
+                let signed_lt = SignedLtConfig::construct_circuit(
+                    circuit_builder,
+                    || "rs1<rs2",
+                    &read_rs1,
+                    &read_rs2,
+                )?;
+                (signed_lt.expr(), None, Some(signed_lt), None)
+            }
+            InsnKind::BGE => {
+                let signed_lt = SignedLtConfig::construct_circuit(
+                    circuit_builder,
+                    || "rs1>=rs2",
+                    &read_rs1,
+                    &read_rs2,
+                )?;
+                (
+                    Expression::ONE - signed_lt.expr(),
+                    None,
+                    Some(signed_lt),
+                    None,
+                )
+            }
+            InsnKind::BLTU => {
+                let unsigned_lt = IsLtConfig::construct_circuit(
+                    circuit_builder,
+                    || "rs1<rs2",
+                    read_rs1.value(),
+                    read_rs2.value(),
+                    UINT_LIMBS,
+                )?;
+                (unsigned_lt.expr(), None, None, Some(unsigned_lt))
+            }
+            InsnKind::BGEU => {
+                let unsigned_lt = IsLtConfig::construct_circuit(
+                    circuit_builder,
+                    || "rs1 >= rs2",
+                    read_rs1.value(),
+                    read_rs2.value(),
+                    UINT_LIMBS,
+                )?;
+                (
+                    Expression::ONE - unsigned_lt.expr(),
+                    None,
+                    None,
+                    Some(unsigned_lt),
+                )
+            }
+            _ => unreachable!("Unsupported instruction kind {:?}", I::INST_KIND),
+        };
+
+        let b_insn = BInstructionConfig::construct_circuit(
+            circuit_builder,
+            I::INST_KIND,
+            read_rs1.register_expr(),
+            read_rs2.register_expr(),
+            branch_taken_bit,
+        )?;
+
+        // Ok(BranchConfig {
+        //     b_insn,
+        //     read_rs1,
+        //     read_rs2,
+        //     ..
+        // })
+        todo!()
+    }
+
+    fn assign_instance(
+        _config: &Self::InstructionConfig,
+        _instance: &mut [E::BaseField],
+        _lk_multiplicity: &mut LkMultiplicity,
+        _step: &StepRecord,
+    ) -> Result<(), ZKVMError> {
+        todo!()
+    }
+}

--- a/ceno_zkvm/src/instructions/riscv/branch/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch/test.rs
@@ -118,7 +118,6 @@ fn impl_bltu_circuit(taken: bool, a: u32, b: u32) -> Result<(), ZKVMError> {
     };
 
     let insn_code = encode_rv32(InsnKind::BLTU, 2, 3, 0, -8);
-    println!("{:?}", insn_code);
     let (raw_witin, lkm) = BltuInstruction::assign_instances(
         &config,
         circuit_builder.cs.num_witin as usize,

--- a/ceno_zkvm/src/instructions/riscv/slt.rs
+++ b/ceno_zkvm/src/instructions/riscv/slt.rs
@@ -1,139 +1,27 @@
-use std::marker::PhantomData;
+mod slt_circuit;
+mod slt_circuit_v2;
 
-use ceno_emul::{InsnKind, SWord, StepRecord};
-use ff_ext::ExtensionField;
+use ceno_emul::InsnKind;
 
-use super::{
-    RIVInstruction,
-    constants::{UINT_LIMBS, UInt},
-    r_insn::RInstructionConfig,
-};
-use crate::{
-    circuit_builder::CircuitBuilder,
-    error::ZKVMError,
-    gadgets::{IsLtConfig, SignedLtConfig},
-    instructions::Instruction,
-    structs::ProgramParams,
-    uint::Value,
-    witness::LkMultiplicity,
-};
-
-pub struct SetLessThanInstruction<E, I>(PhantomData<(E, I)>);
+use super::RIVInstruction;
 
 pub struct SltOp;
 impl RIVInstruction for SltOp {
     const INST_KIND: InsnKind = InsnKind::SLT;
 }
-pub type SltInstruction<E> = SetLessThanInstruction<E, SltOp>;
+#[cfg(feature = "u16limb_circuit")]
+pub type SltInstruction<E> = slt_circuit_v2::SetLessThanInstruction<E, SltOp>;
+#[cfg(not(feature = "u16limb_circuit"))]
+pub type SltInstruction<E> = slt_circuit::SetLessThanInstruction<E, SltOp>;
 
 pub struct SltuOp;
 impl RIVInstruction for SltuOp {
     const INST_KIND: InsnKind = InsnKind::SLTU;
 }
-pub type SltuInstruction<E> = SetLessThanInstruction<E, SltuOp>;
-
-/// This config handles R-Instructions that represent registers values as 2 * u16.
-pub struct SetLessThanConfig<E: ExtensionField> {
-    r_insn: RInstructionConfig<E>,
-
-    rs1_read: UInt<E>,
-    rs2_read: UInt<E>,
-    #[cfg_attr(not(test), allow(dead_code))]
-    rd_written: UInt<E>,
-
-    deps: SetLessThanDependencies<E>,
-}
-
-enum SetLessThanDependencies<E: ExtensionField> {
-    Slt { signed_lt: SignedLtConfig<E> },
-    Sltu { is_lt: IsLtConfig },
-}
-
-impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for SetLessThanInstruction<E, I> {
-    type InstructionConfig = SetLessThanConfig<E>;
-
-    fn name() -> String {
-        format!("{:?}", I::INST_KIND)
-    }
-
-    fn construct_circuit(
-        cb: &mut CircuitBuilder<E>,
-        _params: &ProgramParams,
-    ) -> Result<Self::InstructionConfig, ZKVMError> {
-        // If rs1_read < rs2_read, rd_written = 1. Otherwise rd_written = 0
-        let rs1_read = UInt::new_unchecked(|| "rs1_read", cb)?;
-        let rs2_read = UInt::new_unchecked(|| "rs2_read", cb)?;
-
-        let (deps, rd_written) = match I::INST_KIND {
-            InsnKind::SLT => {
-                let signed_lt =
-                    SignedLtConfig::construct_circuit(cb, || "rs1 < rs2", &rs1_read, &rs2_read)?;
-                let rd_written = UInt::from_exprs_unchecked(vec![signed_lt.expr()]);
-                (SetLessThanDependencies::Slt { signed_lt }, rd_written)
-            }
-            InsnKind::SLTU => {
-                let is_lt = IsLtConfig::construct_circuit(
-                    cb,
-                    || "rs1 < rs2",
-                    rs1_read.value(),
-                    rs2_read.value(),
-                    UINT_LIMBS,
-                )?;
-                let rd_written = UInt::from_exprs_unchecked(vec![is_lt.expr()]);
-                (SetLessThanDependencies::Sltu { is_lt }, rd_written)
-            }
-            _ => unreachable!(),
-        };
-
-        let r_insn = RInstructionConfig::<E>::construct_circuit(
-            cb,
-            I::INST_KIND,
-            rs1_read.register_expr(),
-            rs2_read.register_expr(),
-            rd_written.register_expr(),
-        )?;
-
-        Ok(SetLessThanConfig {
-            r_insn,
-            rs1_read,
-            rs2_read,
-            rd_written,
-            deps,
-        })
-    }
-
-    fn assign_instance(
-        config: &Self::InstructionConfig,
-        instance: &mut [<E as ExtensionField>::BaseField],
-        lkm: &mut LkMultiplicity,
-        step: &StepRecord,
-    ) -> Result<(), ZKVMError> {
-        config.r_insn.assign_instance(instance, lkm, step)?;
-
-        let rs1 = step.rs1().unwrap().value;
-        let rs2 = step.rs2().unwrap().value;
-
-        let rs1_read = Value::new_unchecked(rs1);
-        let rs2_read = Value::new_unchecked(rs2);
-        config
-            .rs1_read
-            .assign_limbs(instance, rs1_read.as_u16_limbs());
-        config
-            .rs2_read
-            .assign_limbs(instance, rs2_read.as_u16_limbs());
-
-        match &config.deps {
-            SetLessThanDependencies::Slt { signed_lt } => {
-                signed_lt.assign_instance(instance, lkm, rs1 as SWord, rs2 as SWord)?
-            }
-            SetLessThanDependencies::Sltu { is_lt } => {
-                is_lt.assign_instance(instance, lkm, rs1.into(), rs2.into())?
-            }
-        }
-
-        Ok(())
-    }
-}
+#[cfg(feature = "u16limb_circuit")]
+pub type SltuInstruction<E> = slt_circuit_v2::SetLessThanInstruction<E, SltuOp>;
+#[cfg(not(feature = "u16limb_circuit"))]
+pub type SltuInstruction<E> = slt_circuit::SetLessThanInstruction<E, SltuOp>;
 
 #[cfg(test)]
 mod test {
@@ -144,10 +32,16 @@ mod test {
 
     use super::*;
     use crate::{
+        Value,
         circuit_builder::{CircuitBuilder, ConstraintSystem},
-        instructions::Instruction,
+        instructions::{Instruction, riscv::constants::UInt},
         scheme::mock_prover::{MOCK_PC_START, MockProver},
+        structs::ProgramParams,
     };
+    #[cfg(not(feature = "u16limb_circuit"))]
+    use slt_circuit::SetLessThanInstruction;
+    #[cfg(feature = "u16limb_circuit")]
+    use slt_circuit_v2::SetLessThanInstruction;
 
     fn verify<I: RIVInstruction>(name: &'static str, rs1: Word, rs2: Word, rd: Word) {
         let mut cs = ConstraintSystem::<GoldilocksExt2>::new(|| "riscv");
@@ -232,7 +126,6 @@ mod test {
         let mut rng = rand::thread_rng();
         let a: i32 = rng.next_u32() as i32;
         let b: i32 = rng.next_u32() as i32;
-        println!("random: {} <? {}", a, b); // For debugging, do not delete.
         verify::<SltOp>("random 1", a as Word, b as Word, (a < b) as u32);
         verify::<SltOp>("random 2", b as Word, a as Word, (a >= b) as u32);
     }

--- a/ceno_zkvm/src/instructions/riscv/slt/slt_circuit.rs
+++ b/ceno_zkvm/src/instructions/riscv/slt/slt_circuit.rs
@@ -1,0 +1,124 @@
+use crate::{
+    Value,
+    error::ZKVMError,
+    gadgets::SignedLtConfig,
+    instructions::{
+        Instruction,
+        riscv::{
+            RIVInstruction,
+            constants::{UINT_LIMBS, UInt},
+            r_insn::RInstructionConfig,
+        },
+    },
+    structs::ProgramParams,
+    witness::LkMultiplicity,
+};
+use ceno_emul::{InsnKind, SWord, StepRecord};
+use ff_ext::ExtensionField;
+use gkr_iop::{circuit_builder::CircuitBuilder, gadgets::IsLtConfig};
+use std::marker::PhantomData;
+
+pub struct SetLessThanInstruction<E, I>(PhantomData<(E, I)>);
+
+/// This config handles R-Instructions that represent registers values as 2 * u16.
+pub struct SetLessThanConfig<E: ExtensionField> {
+    r_insn: RInstructionConfig<E>,
+
+    rs1_read: UInt<E>,
+    rs2_read: UInt<E>,
+    #[allow(dead_code)]
+    pub(crate) rd_written: UInt<E>,
+
+    deps: SetLessThanDependencies<E>,
+}
+
+enum SetLessThanDependencies<E: ExtensionField> {
+    Slt { signed_lt: SignedLtConfig<E> },
+    Sltu { is_lt: IsLtConfig },
+}
+
+impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for SetLessThanInstruction<E, I> {
+    type InstructionConfig = SetLessThanConfig<E>;
+
+    fn name() -> String {
+        format!("{:?}", I::INST_KIND)
+    }
+
+    fn construct_circuit(
+        cb: &mut CircuitBuilder<E>,
+        _params: &ProgramParams,
+    ) -> Result<Self::InstructionConfig, ZKVMError> {
+        // If rs1_read < rs2_read, rd_written = 1. Otherwise rd_written = 0
+        let rs1_read = UInt::new_unchecked(|| "rs1_read", cb)?;
+        let rs2_read = UInt::new_unchecked(|| "rs2_read", cb)?;
+
+        let (deps, rd_written) = match I::INST_KIND {
+            InsnKind::SLT => {
+                let signed_lt =
+                    SignedLtConfig::construct_circuit(cb, || "rs1 < rs2", &rs1_read, &rs2_read)?;
+                let rd_written = UInt::from_exprs_unchecked(vec![signed_lt.expr()]);
+                (SetLessThanDependencies::Slt { signed_lt }, rd_written)
+            }
+            InsnKind::SLTU => {
+                let is_lt = IsLtConfig::construct_circuit(
+                    cb,
+                    || "rs1 < rs2",
+                    rs1_read.value(),
+                    rs2_read.value(),
+                    UINT_LIMBS,
+                )?;
+                let rd_written = UInt::from_exprs_unchecked(vec![is_lt.expr()]);
+                (SetLessThanDependencies::Sltu { is_lt }, rd_written)
+            }
+            _ => unreachable!(),
+        };
+
+        let r_insn = RInstructionConfig::<E>::construct_circuit(
+            cb,
+            I::INST_KIND,
+            rs1_read.register_expr(),
+            rs2_read.register_expr(),
+            rd_written.register_expr(),
+        )?;
+
+        Ok(SetLessThanConfig {
+            r_insn,
+            rs1_read,
+            rs2_read,
+            rd_written,
+            deps,
+        })
+    }
+
+    fn assign_instance(
+        config: &Self::InstructionConfig,
+        instance: &mut [<E as ExtensionField>::BaseField],
+        lkm: &mut LkMultiplicity,
+        step: &StepRecord,
+    ) -> Result<(), ZKVMError> {
+        config.r_insn.assign_instance(instance, lkm, step)?;
+
+        let rs1 = step.rs1().unwrap().value;
+        let rs2 = step.rs2().unwrap().value;
+
+        let rs1_read = Value::new_unchecked(rs1);
+        let rs2_read = Value::new_unchecked(rs2);
+        config
+            .rs1_read
+            .assign_limbs(instance, rs1_read.as_u16_limbs());
+        config
+            .rs2_read
+            .assign_limbs(instance, rs2_read.as_u16_limbs());
+
+        match &config.deps {
+            SetLessThanDependencies::Slt { signed_lt } => {
+                signed_lt.assign_instance(instance, lkm, rs1 as SWord, rs2 as SWord)?
+            }
+            SetLessThanDependencies::Sltu { is_lt } => {
+                is_lt.assign_instance(instance, lkm, rs1.into(), rs2.into())?
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/ceno_zkvm/src/instructions/riscv/slt/slt_circuit_v2.rs
+++ b/ceno_zkvm/src/instructions/riscv/slt/slt_circuit_v2.rs
@@ -22,7 +22,7 @@ pub struct SetLessThanConfig<E: ExtensionField> {
 
     rs1_read: UInt<E>,
     rs2_read: UInt<E>,
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[allow(dead_code)]
     pub(crate) rd_written: UInt<E>,
 
     uint_lt_config: UIntLimbsLTConfig<E>,

--- a/ceno_zkvm/src/instructions/riscv/slt/slt_circuit_v2.rs
+++ b/ceno_zkvm/src/instructions/riscv/slt/slt_circuit_v2.rs
@@ -1,0 +1,107 @@
+use crate::{
+    Value,
+    circuit_builder::CircuitBuilder,
+    error::ZKVMError,
+    gadgets::{UIntLimbsLT, UIntLimbsLTConfig},
+    instructions::{
+        Instruction,
+        riscv::{RIVInstruction, constants::UInt, r_insn::RInstructionConfig},
+    },
+    structs::ProgramParams,
+    witness::LkMultiplicity,
+};
+use ceno_emul::{InsnKind, StepRecord};
+use ff_ext::ExtensionField;
+use std::marker::PhantomData;
+
+pub struct SetLessThanInstruction<E, I>(PhantomData<(E, I)>);
+
+/// This config handles R-Instructions that represent registers values as 2 * u16.
+pub struct SetLessThanConfig<E: ExtensionField> {
+    r_insn: RInstructionConfig<E>,
+
+    rs1_read: UInt<E>,
+    rs2_read: UInt<E>,
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) rd_written: UInt<E>,
+
+    uint_lt_config: UIntLimbsLTConfig<E>,
+}
+impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for SetLessThanInstruction<E, I> {
+    type InstructionConfig = SetLessThanConfig<E>;
+
+    fn name() -> String {
+        format!("{:?}", I::INST_KIND)
+    }
+
+    fn construct_circuit(
+        cb: &mut CircuitBuilder<E>,
+        _params: &ProgramParams,
+    ) -> Result<Self::InstructionConfig, ZKVMError> {
+        // If rs1_read < rs2_read, rd_written = 1. Otherwise rd_written = 0
+        let rs1_read = UInt::new_unchecked(|| "rs1_read", cb)?;
+        let rs2_read = UInt::new_unchecked(|| "rs2_read", cb)?;
+
+        let (rd_written, uint_lt_config) = match I::INST_KIND {
+            InsnKind::SLT => {
+                let config = UIntLimbsLT::construct_circuit(cb, &rs1_read, &rs2_read, true)?;
+                let rd_written = UInt::from_exprs_unchecked(vec![config.is_lt()]);
+                (rd_written, config)
+            }
+            InsnKind::SLTU => {
+                let config = UIntLimbsLT::construct_circuit(cb, &rs1_read, &rs2_read, false)?;
+                let rd_written = UInt::from_exprs_unchecked(vec![config.is_lt()]);
+                (rd_written, config)
+            }
+            _ => unreachable!(),
+        };
+
+        let r_insn = RInstructionConfig::<E>::construct_circuit(
+            cb,
+            I::INST_KIND,
+            rs1_read.register_expr(),
+            rs2_read.register_expr(),
+            rd_written.register_expr(),
+        )?;
+
+        Ok(SetLessThanConfig {
+            r_insn,
+            rs1_read,
+            rs2_read,
+            rd_written,
+            uint_lt_config,
+        })
+    }
+
+    fn assign_instance(
+        config: &Self::InstructionConfig,
+        instance: &mut [<E as ExtensionField>::BaseField],
+        lkm: &mut LkMultiplicity,
+        step: &StepRecord,
+    ) -> Result<(), ZKVMError> {
+        config.r_insn.assign_instance(instance, lkm, step)?;
+
+        let rs1 = step.rs1().unwrap().value;
+        let rs2 = step.rs2().unwrap().value;
+
+        let rs1_read = Value::new_unchecked(rs1);
+        let rs2_read = Value::new_unchecked(rs2);
+        config
+            .rs1_read
+            .assign_limbs(instance, rs1_read.as_u16_limbs());
+        config
+            .rs2_read
+            .assign_limbs(instance, rs2_read.as_u16_limbs());
+
+        let is_signed = matches!(step.insn().kind, InsnKind::SLT);
+        UIntLimbsLT::<E>::assign(
+            &config.uint_lt_config,
+            instance,
+            lkm,
+            rs1_read.as_u16_limbs(),
+            rs2_read.as_u16_limbs(),
+            is_signed,
+        )?;
+        Ok(())
+    }
+}

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -45,7 +45,7 @@ use std::{
 use strum::IntoEnumIterator;
 use tiny_keccak::{Hasher, Keccak};
 
-const MAX_CONSTRAINT_DEGREE: usize = 2;
+const MAX_CONSTRAINT_DEGREE: usize = 3;
 const MOCK_PROGRAM_SIZE: usize = 32;
 pub const MOCK_PC_START: ByteAddr = ByteAddr({
     // This needs to be a static, because otherwise the compiler complains

--- a/gkr_iop/src/circuit_builder.rs
+++ b/gkr_iop/src/circuit_builder.rs
@@ -265,12 +265,6 @@ impl<E: ExtensionField> ConstraintSystem<E> {
                 .chain(record.clone())
                 .collect(),
         );
-        assert_eq!(
-            rlc_record.degree(),
-            1,
-            "rlc lk_record degree ({})",
-            name_fn().into()
-        );
         self.lk_expressions.push(rlc_record);
         let path = self.ns.compute_path(name_fn().into());
         self.lk_expressions_namespace_map.push(path);


### PR DESCRIPTION
To close #1005 

- branch implementation follow from [openvm branch_lt](https://github.com/openvm-org/openvm/blob/ca36de3803213da664b03d111801ab903d55e360/extensions/rv32im/circuit/src/branch_lt/core.rs)

### scope
- break down circuit into `xxxxx_circuit.rs` and `xxxxx_circuit_v2.rs`, each control via feature `u16limbs_circuit`.
- implement new `UIntLimbsLT` gadget to deal with UInt comparison for signed/unsigned

### circuit stats
```diff
+---------------+---------------+---------+-------+-----------+--------+------------+---------------------+
| opcode_name   | num_instances | lookups | reads | witnesses | writes | 0_expr_deg | 0_expr_sumcheck_deg |
+---------------+---------------+---------+-------+-----------+--------+------------+---------------------+
- | BGE           | 0             | 9       | 3     | 21        | 3      | [1: 3]     | [2: 4]              |
+ | BGE           | 0             | 8       | 3     | 22        | 3      | [1: 2]     | [3: 4,2: 8]         |
- | BGEU          | 0             | 7       | 3     | 19        | 3      | [1: 3]     | [2: 2]              |
+ | BGEU          | 0             | 8       | 3     | 22        | 3      | [1: 2]     | [2: 8,3: 4]         |
- | BLT           | 0             | 9       | 3     | 21        | 3      | [1: 3]     | [2: 4]              |
+ | BLT           | 0             | 8       | 3     | 22        | 3      | [1: 2]     | [2: 8,3: 4]         |
- | BLTU          | 0             | 7       | 3     | 19        | 3      | [1: 3]     | [2: 2]              |
+ | BLTU          | 0             | 8       | 3     | 22        | 3      | [1: 2]     | [2: 8,3: 4]         |
- | SLT           | 0             | 11      | 4     | 25        | 4      | [1: 4]     | [2: 3]              |
+ | SLT           | 0             | 10      | 4     | 26        | 4      | [1: 3]     | [3: 4,2: 7]         |
- | SLTU          | 0             | 9       | 4     | 23        | 4      | [1: 4]     | [2: 1]              |
+ | SLTU          | 0             | 10      | 4     | 26        | 4      | [1: 3]     | [2: 7,3: 4]         |
+---------------+---------------+---------+-------+-----------+--------+------------+---------------------+
```


### benchmark 
e2e benchmark with fibonacci + goldilock got to be slow is expected, because there got to be more columns and constrains.

> however when run in babybear probably it got to be fast on CPU due to well support of AVX512

| Benchmark                        | Median Time (s) | Median Change (%)                           |
|----------------------------------|------------------|----------------------------------------------|
| fibonacci_max_steps_1048576      | 2.5501           | +3.01% (Performance has regressed)           |
| fibonacci_max_steps_2097152      | 4.7194           | +2.02% (Performance has regressed)           |
| fibonacci_max_steps_4194304      | 9.5424           | +5.82% (Performance has regressed)           |

### proof size
1.67mb -> 1.68mb
    