### PR TITLE
chore: Reduce the size of some error enums

### DIFF
--- a/ceno_zkvm/src/error.rs
+++ b/ceno_zkvm/src/error.rs
@@ -3,7 +3,7 @@ use mpcs::Error;
 
 #[derive(Debug)]
 pub enum UtilError {
-    UIntError(String),
+    UIntError(Box<str>),
 }
 
 #[derive(Debug)]
@@ -12,12 +12,12 @@ pub enum ZKVMError {
     CircuitBuilderError(CircuitBuilderError),
     BackendError(BackendError),
     UtilError(UtilError),
-    WitnessNotFound(String),
-    InvalidWitness(String),
-    InvalidProof(String),
-    VKNotFound(String),
-    FixedTraceNotFound(String),
-    VerifyError(String),
+    WitnessNotFound(Box<str>),
+    InvalidWitness(Box<str>),
+    InvalidProof(Box<str>),
+    VKNotFound(Box<str>),
+    FixedTraceNotFound(Box<str>),
+    VerifyError(Box<str>),
     PCSError(Error),
 }
 

--- a/ceno_zkvm/src/keygen.rs
+++ b/ceno_zkvm/src/keygen.rs
@@ -25,7 +25,7 @@ impl<E: ExtensionField> ZKVMConstraintSystem<E> {
                     .circuit_fixed_traces
                     .remove(&c_name)
                     .flatten()
-                    .ok_or(ZKVMError::FixedTraceNotFound(c_name.clone()))?;
+                    .ok_or(ZKVMError::FixedTraceNotFound(c_name.clone().into()))?;
                 fixed_traces.insert(circuit_index, fixed_trace_rmm);
             };
 

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -205,7 +205,7 @@ impl<
             |(mut points, mut evaluations), (index, (circuit_name, pk))| {
                 let num_instances = *wits_instances
                     .get(circuit_name)
-                    .ok_or(ZKVMError::WitnessNotFound(circuit_name.to_string()))?;
+                    .ok_or(ZKVMError::WitnessNotFound(circuit_name.to_string().into()))?;
                 let cs = pk.get_cs();
                 if num_instances == 0 {
                     // we need to drain respective fixed when num_instances is 0

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -65,9 +65,9 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         // require ecall/halt proof to exist, depending whether we expect a halt.
         let has_halt = vm_proof.has_halt(&self.vk);
         if has_halt != expect_halt {
-            return Err(ZKVMError::VerifyError(format!(
-                "ecall/halt mismatch: expected {expect_halt} != {has_halt}",
-            )));
+            return Err(ZKVMError::VerifyError(
+                format!("ecall/halt mismatch: expected {expect_halt} != {has_halt}",).into(),
+            ));
         }
 
         self.verify_proof_validity(vm_proof, transcript)
@@ -89,10 +89,13 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         // subset of that of self.vk.circuit_vks
         for chip_idx in vm_proof.chip_proofs.keys() {
             if *chip_idx >= self.vk.circuit_vks.len() {
-                return Err(ZKVMError::VKNotFound(format!(
-                    "chip index {chip_idx} not found in vk set [0..{})",
-                    self.vk.circuit_vks.len()
-                )));
+                return Err(ZKVMError::VKNotFound(
+                    format!(
+                        "chip index {chip_idx} not found in vk set [0..{})",
+                        self.vk.circuit_vks.len()
+                    )
+                    .into(),
+                ));
             }
         }
 
@@ -110,9 +113,9 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
             .enumerate()
             .try_for_each(|(i, (raw, eval))| {
                 if raw.len() == 1 && E::from(raw[0]) != *eval {
-                    Err(ZKVMError::VerifyError(format!(
-                        "pub input on index {i} mismatch  {raw:?} != {eval:?}"
-                    )))
+                    Err(ZKVMError::VerifyError(
+                        format!("pub input on index {i} mismatch  {raw:?} != {eval:?}").into(),
+                    ))
                 } else {
                     Ok(())
                 }
@@ -163,31 +166,40 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
             if proof.wits_in_evals.len() != circuit_vk.get_cs().num_witin()
                 || proof.fixed_in_evals.len() != circuit_vk.get_cs().num_fixed()
             {
-                return Err(ZKVMError::InvalidProof(format!(
-                    "witness/fixed evaluations length mismatch: ({}, {}) != ({}, {})",
-                    proof.wits_in_evals.len(),
-                    proof.fixed_in_evals.len(),
-                    circuit_vk.get_cs().num_witin(),
-                    circuit_vk.get_cs().num_fixed(),
-                )));
+                return Err(ZKVMError::InvalidProof(
+                    format!(
+                        "witness/fixed evaluations length mismatch: ({}, {}) != ({}, {})",
+                        proof.wits_in_evals.len(),
+                        proof.fixed_in_evals.len(),
+                        circuit_vk.get_cs().num_witin(),
+                        circuit_vk.get_cs().num_fixed(),
+                    )
+                    .into(),
+                ));
             }
             if proof.r_out_evals.len() != circuit_vk.get_cs().num_reads()
                 || proof.w_out_evals.len() != circuit_vk.get_cs().num_writes()
             {
-                return Err(ZKVMError::InvalidProof(format!(
-                    "read/write evaluations length mismatch: ({}, {}) != ({}, {})",
-                    proof.r_out_evals.len(),
-                    proof.w_out_evals.len(),
-                    circuit_vk.get_cs().num_reads(),
-                    circuit_vk.get_cs().num_writes(),
-                )));
+                return Err(ZKVMError::InvalidProof(
+                    format!(
+                        "read/write evaluations length mismatch: ({}, {}) != ({}, {})",
+                        proof.r_out_evals.len(),
+                        proof.w_out_evals.len(),
+                        circuit_vk.get_cs().num_reads(),
+                        circuit_vk.get_cs().num_writes(),
+                    )
+                    .into(),
+                ));
             }
             if proof.lk_out_evals.len() != circuit_vk.get_cs().num_lks() {
-                return Err(ZKVMError::InvalidProof(format!(
-                    "lookup evaluations length mismatch: {} != {}",
-                    proof.lk_out_evals.len(),
-                    circuit_vk.get_cs().num_lks(),
-                )));
+                return Err(ZKVMError::InvalidProof(
+                    format!(
+                        "lookup evaluations length mismatch: {} != {}",
+                        proof.lk_out_evals.len(),
+                        circuit_vk.get_cs().num_lks(),
+                    )
+                    .into(),
+                ));
             }
 
             let chip_logup_sum = proof
@@ -257,10 +269,9 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
 
         // check logup relation across all proofs
         if logup_sum != E::ZERO {
-            return Err(ZKVMError::VerifyError(format!(
-                "logup_sum({:?}) != 0",
-                logup_sum
-            )));
+            return Err(ZKVMError::VerifyError(
+                format!("logup_sum({:?}) != 0", logup_sum).into(),
+            ));
         }
 
         #[cfg(debug_assertions)]
@@ -580,9 +591,10 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
                     .map(|point_and_eval| point_and_eval.eval),
             ) {
                 if expected_eval != &eval {
-                    return Err(ZKVMError::VerifyError(format!(
-                        "table {name} evaluation mismatch {expected_eval:?} != {eval:?}"
-                    )));
+                    return Err(ZKVMError::VerifyError(
+                        format!("table {name} evaluation mismatch {expected_eval:?} != {eval:?}")
+                            .into(),
+                    ));
                 }
             }
             rt_tower
@@ -673,9 +685,10 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
             let expected_eval = poly.evaluate(&input_opening_point[..poly.num_vars()]);
             let eval = pi[idx];
             if expected_eval != eval {
-                return Err(ZKVMError::VerifyError(format!(
-                    "pub input on index {idx} mismatch  {expected_eval:?} != {eval:?}"
-                )));
+                return Err(ZKVMError::VerifyError(
+                    format!("pub input on index {idx} mismatch  {expected_eval:?} != {eval:?}")
+                        .into(),
+                ));
             }
             tracing::trace!(
                 "[table {name}] verified public inputs on index {idx} with point {:?}",

--- a/ceno_zkvm/src/uint.rs
+++ b/ceno_zkvm/src/uint.rs
@@ -505,13 +505,16 @@ impl<const M: usize, const C: usize, E: ExtensionField> TryFrom<Vec<WitIn>> for 
 
     fn try_from(limbs: Vec<WitIn>) -> Result<Self, Self::Error> {
         if limbs.len() != Self::NUM_LIMBS {
-            return Err(UtilError::UIntError(format!(
-                "cannot construct UIntLimbs<{}, {}> from {} cells, requires {} cells",
-                M,
-                C,
-                limbs.len(),
-                Self::NUM_LIMBS
-            )));
+            return Err(UtilError::UIntError(
+                format!(
+                    "cannot construct UIntLimbs<{}, {}> from {} cells, requires {} cells",
+                    M,
+                    C,
+                    limbs.len(),
+                    Self::NUM_LIMBS
+                )
+                .into(),
+            ));
         }
 
         Ok(Self {

--- a/ceno_zkvm/src/uint/arithmetic.rs
+++ b/ceno_zkvm/src/uint/arithmetic.rs
@@ -30,7 +30,9 @@ impl<const M: usize, const C: usize, E: ExtensionField> UIntLimbs<M, C, E> {
             Self::NUM_LIMBS,
         )?;
         let Some(carries) = &c.carries else {
-            return Err(CircuitBuilderError::CircuitError("empty carry".to_string()));
+            return Err(CircuitBuilderError::CircuitError(
+                "empty carry".to_string().into(),
+            ));
         };
         carries.iter().enumerate().try_for_each(|(i, carry)| {
             circuit_builder.assert_bit(|| format!("carry_{i}_in_as_bit"), carry.expr())

--- a/gkr_iop/src/error.rs
+++ b/gkr_iop/src/error.rs
@@ -4,13 +4,13 @@ use thiserror::Error;
 #[derive(Clone, Debug, Error)]
 pub enum BackendError {
     #[error("layer verification failed: {0:?}, {1:?}")]
-    LayerVerificationFailed(String, VerifierError),
+    LayerVerificationFailed(Box<str>, VerifierError),
     #[error("circuit build faile")]
-    CircuitError(String),
+    CircuitError(Box<str>),
 }
 
 #[derive(Clone, Debug, Error)]
 pub enum CircuitBuilderError {
     #[error("circuit build faile")]
-    CircuitError(String),
+    CircuitError(Box<str>),
 }

--- a/gkr_iop/src/gkr/layer/linear_layer.rs
+++ b/gkr_iop/src/gkr/layer/linear_layer.rs
@@ -65,8 +65,11 @@ impl<E: ExtensionField> LinearLayer<E> for Layer<E> {
                 .unwrap();
             if *sigma != got {
                 return Err(BackendError::LayerVerificationFailed(
-                    self.name.clone(),
-                    VerifierError::ClaimNotMatch(format!("{}", *sigma), format!("{}", got)),
+                    self.name.clone().into(),
+                    VerifierError::ClaimNotMatch(
+                        format!("{}", *sigma).into(),
+                        format!("{}", got).into(),
+                    ),
                 ));
             }
         }

--- a/gkr_iop/src/gkr/layer/sumcheck_layer.rs
+++ b/gkr_iop/src/gkr/layer/sumcheck_layer.rs
@@ -114,10 +114,10 @@ impl<E: ExtensionField> SumcheckLayer<E> for Layer<E> {
 
         if got_claim != expected_evaluation {
             return Err(BackendError::LayerVerificationFailed(
-                "sumcheck verify failed".to_string(),
+                "sumcheck verify failed".to_string().into(),
                 VerifierError::ClaimNotMatch(
-                    format!("{}", expected_evaluation),
-                    format!("{}", got_claim),
+                    format!("{}", expected_evaluation).into(),
+                    format!("{}", got_claim).into(),
                 ),
             ));
         }

--- a/gkr_iop/src/gkr/layer/zerocheck_layer.rs
+++ b/gkr_iop/src/gkr/layer/zerocheck_layer.rs
@@ -309,10 +309,10 @@ impl<E: ExtensionField> ZerocheckLayer<E> for Layer<E> {
 
         if got_claim != expected_evaluation {
             return Err(BackendError::LayerVerificationFailed(
-                self.name.clone(),
+                self.name.clone().into(),
                 VerifierError::ClaimNotMatch(
-                    format!("{}", expected_evaluation),
-                    format!("{}", got_claim),
+                    format!("{}", expected_evaluation).into(),
+                    format!("{}", got_claim).into(),
                 ),
             ));
         }
@@ -401,10 +401,10 @@ fn verify_rotation<E: ExtensionField>(
 
     if got_claim != expected_evaluation {
         return Err(BackendError::LayerVerificationFailed(
-            "rotation verify failed".to_string(),
+            "rotation verify failed".to_string().into(),
             VerifierError::ClaimNotMatch(
-                format!("{}", expected_evaluation),
-                format!("{}", got_claim),
+                format!("{}", expected_evaluation).into(),
+                format!("{}", got_claim).into(),
             ),
         ));
     }

--- a/sumcheck/src/structs.rs
+++ b/sumcheck/src/structs.rs
@@ -76,5 +76,5 @@ pub struct SumCheckSubClaim<E: ExtensionField> {
 #[derive(Clone, Debug, Error)]
 pub enum VerifierError {
     #[error("Claim not match: expect: {0:?}, got: {1:?}")]
-    ClaimNotMatch(String, String),
+    ClaimNotMatch(Box<str>, Box<str>),
 }


### PR DESCRIPTION
A large enum used in several places can cause a negative runtime impact. In fact, this is so common that the community created several lints to prevent such a scenario.

- [large_enum_variant](https://rust-lang.github.io/rust-clippy/master/?groups=perf#large_enum_variant)
- [result_large_err](https://rust-lang.github.io/rust-clippy/master/?groups=perf#result_large_err)
- [variant_size_differences](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/types/static.VARIANT_SIZE_DIFFERENCES.html)

This PR cuts ~16 bytes from 4 different structures through the use of `Box<str>`, which doesn't change any intended behavior.
