### PR TITLE
Remove unnecessary heap allocations

### DIFF
--- a/mpcs/src/util.rs
+++ b/mpcs/src/util.rs
@@ -103,19 +103,22 @@ pub(crate) fn codeword_fold_with_challenge<E: ExtensionField>(
 
 #[cfg(any(test, feature = "benchmark"))]
 pub mod test {
-    #[cfg(test)]
-    use crate::util::{base_to_usize, u32_to_field};
     use ff_ext::FromUniformBytes;
-    use p3::field::FieldAlgebra;
-    #[cfg(test)]
-    type E = ff_ext::GoldilocksExt2;
-    #[cfg(test)]
-    type F = p3::goldilocks::Goldilocks;
     use rand::{
         CryptoRng, RngCore, SeedableRng,
         rngs::{OsRng, StdRng},
     };
     use std::{array, iter, ops::Range};
+    #[cfg(test)]
+    use {
+        crate::util::{base_to_usize, u32_to_field},
+        p3::field::FieldAlgebra,
+    };
+
+    #[cfg(test)]
+    type E = ff_ext::GoldilocksExt2;
+    #[cfg(test)]
+    type F = p3::goldilocks::Goldilocks;
 
     pub fn std_rng() -> impl RngCore + CryptoRng {
         StdRng::from_seed(Default::default())

--- a/whir/src/whir/verifier.rs
+++ b/whir/src/whir/verifier.rs
@@ -383,7 +383,7 @@ where
 
             let ood_points = &round_proof.ood_points;
             let stir_challenges_points = &round_proof.stir_challenges_points;
-            let stir_challenges: Vec<_> = ood_points
+            let sum_of_claims: E = ood_points
                 .iter()
                 .chain(stir_challenges_points)
                 .cloned()
@@ -392,10 +392,6 @@ where
                     // TODO:
                     // Maybe refactor outside
                 })
-                .collect();
-
-            let sum_of_claims: E = stir_challenges
-                .into_iter()
                 .map(|point| eq_eval(&point, &folding_randomness))
                 .zip(&round_proof.combination_randomness)
                 .map(|(point, rand)| point * *rand)


### PR DESCRIPTION
It is not necessary to collect into `Vec` to perform a simple `sum` operation