### PR TITLE
Add Error enum to `multilinear_extensions`

### DIFF
--- a/multilinear_extensions/src/error.rs
+++ b/multilinear_extensions/src/error.rs
@@ -1,0 +1,6 @@
+/// Local error
+#[derive(Clone, Debug)]
+pub enum Error {
+    /// Partial points is greater than the number of variables
+    InvalidSizeOfPartialPoint,
+}

--- a/multilinear_extensions/src/lib.rs
+++ b/multilinear_extensions/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(strict_overflow_ops)]
 mod expression;
 pub use expression::{utils::monomialize_expr_to_wit_terms, *};
+mod error;
 pub mod macros;
 pub mod mle;
 pub mod smart_slice;
@@ -12,3 +13,8 @@ pub mod virtual_polys;
 
 #[cfg(test)]
 mod test;
+
+pub use error::Error;
+
+/// Result with local error
+pub type Result<T> = core::result::Result<T, Error>;

--- a/multilinear_extensions/src/mle.rs
+++ b/multilinear_extensions/src/mle.rs
@@ -492,12 +492,10 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
         list
     }
 
-    pub fn fix_variables(&self, partial_point: &[E]) -> Self {
-        // TODO: return error.
-        assert!(
-            partial_point.len() <= self.num_vars(),
-            "invalid size of partial point"
-        );
+    pub fn fix_variables(&self, partial_point: &[E]) -> crate::Result<Self> {
+        if partial_point.len() > self.num_vars() {
+            return Err(crate::Error::InvalidSizeOfPartialPoint);
+        }
         let mut poly = Cow::Borrowed(self);
 
         // evaluate single variable of partial point from left to right
@@ -519,7 +517,7 @@ impl<'a, E: ExtensionField> MultilinearExtension<'a, E> {
             }
         }
         assert!(poly.num_vars == self.num_vars() - partial_point.len(),);
-        poly.into_owned()
+        Ok(poly.into_owned())
     }
 
     /// Reduce the number of variables of `self` by fixing the

--- a/sumcheck/src/prover.rs
+++ b/sumcheck/src/prover.rs
@@ -449,7 +449,7 @@ impl<'a, E: ExtensionField> IOPProverState<'a, E> {
                     && matches!(poly_type, PolyMeta::Normal)
                 {
                     if !poly.is_mut() {
-                        *poly = Arc::new(poly.fix_variables(&[r]));
+                        *poly = Arc::new(poly.fix_variables(&[r]).unwrap());
                     } else {
                         let poly = Arc::get_mut(poly).unwrap();
                         poly.fix_variables_in_place(&[r])

--- a/whir/src/error.rs
+++ b/whir/src/error.rs
@@ -1,5 +1,13 @@
 #[derive(Clone, Debug)]
 pub enum Error {
+    /// See [`multilinear_extensions::Error`].
+    MultilinearExtensions(multilinear_extensions::Error),
     MmcsError(String),
     InvalidProof(String),
+}
+
+impl From<multilinear_extensions::Error> for Error {
+    fn from(value: multilinear_extensions::Error) -> Self {
+        Self::MultilinearExtensions(value)
+    }
 }

--- a/whir/src/sumcheck/mod.rs
+++ b/whir/src/sumcheck/mod.rs
@@ -132,7 +132,7 @@ mod tests {
         let folding_randomness = vec![F::from_canonical_u64(335), F::from_canonical_u64(222)];
 
         let new_eval_point = vec![F::from_canonical_u64(32); num_variables - folding_factor];
-        let folded_polynomial = polynomial.fix_variables(&folding_randomness);
+        let folded_polynomial = polynomial.fix_variables(&folding_randomness).unwrap();
         let new_fold_eval = folded_polynomial.evaluate(&new_eval_point);
 
         prover.compress(
@@ -189,7 +189,9 @@ mod tests {
 
         let sumcheck_poly_1 = prover.compute_sumcheck_polynomial(folding_factor);
 
-        let folded_poly_1 = polynomial.fix_variables(&folding_randomness_1.clone());
+        let folded_poly_1 = polynomial
+            .fix_variables(&folding_randomness_1.clone())
+            .unwrap();
         prover.compress(
             folding_factor,
             combination_randomness[0],
@@ -218,6 +220,7 @@ mod tests {
         let full_folding = [folding_randomness_1.clone(), folding_randomness_2.clone()].concat();
         let eval_coeff = match folded_poly_1
             .fix_variables(&folding_randomness_2)
+            .unwrap()
             .evaluations()
         {
             FieldType::Base(evals) => {
@@ -286,7 +289,9 @@ mod tests {
 
         let sumcheck_poly_1 = prover.compute_sumcheck_polynomial(folding_factor);
 
-        let folded_poly_1 = polynomial.fix_variables(&folding_randomness_1.clone());
+        let folded_poly_1 = polynomial
+            .fix_variables(&folding_randomness_1.clone())
+            .unwrap();
         prover.compress(
             folding_factor,
             combination_randomness_1[0],
@@ -299,7 +304,9 @@ mod tests {
 
         let sumcheck_poly_2 = prover.compute_sumcheck_polynomial(folding_factor);
 
-        let folded_poly_2 = folded_poly_1.fix_variables(&folding_randomness_2.clone());
+        let folded_poly_2 = folded_poly_1
+            .fix_variables(&folding_randomness_2.clone())
+            .unwrap();
         prover.compress(
             folding_factor,
             combination_randomness_2[0],
@@ -310,6 +317,7 @@ mod tests {
         let sumcheck_poly_3 = prover.compute_sumcheck_polynomial(folding_factor);
         let final_coeff = match folded_poly_2
             .fix_variables(&folding_randomness_3.clone())
+            .unwrap()
             .evaluations()
         {
             FieldType::Base(evals) => F::from_ref_base(&evals[0]),

--- a/whir/src/whir/batch/prover.rs
+++ b/whir/src/whir/batch/prover.rs
@@ -226,7 +226,7 @@ where
         // Fold the coefficients
         let folded_evaluations = round_state
             .evaluations
-            .fix_variables(&round_state.folding_randomness);
+            .fix_variables(&round_state.folding_randomness)?;
 
         let folded_evaluations_evals = match folded_evaluations.evaluations() {
             FieldType::Ext(evals) => evals,

--- a/whir/src/whir/fold.rs
+++ b/whir/src/whir/fold.rs
@@ -419,6 +419,7 @@ mod tests {
 
         let truth_value =
             poly.fix_variables(&folding_randomness)
+                .unwrap()
                 .evaluate(&expand_from_univariate(
                     root_of_unity.exp_u64(folding_factor_exp as u64 * index),
                     2,

--- a/whir/src/whir/prover.rs
+++ b/whir/src/whir/prover.rs
@@ -184,7 +184,7 @@ where
         // Fold the coefficients
         let folded_evaluations = round_state
             .evaluations
-            .fix_variables(&round_state.folding_randomness);
+            .fix_variables(&round_state.folding_randomness)?;
         let folded_evaluations_values = match folded_evaluations.evaluations() {
             FieldType::Ext(evals) => evals,
             _ => {


### PR DESCRIPTION
Fixes a TODO

```
// TODO: return error.
assert!(
    return Err(crate::Error::InvalidSizeOfPartialPoint);
    partial_point.len() <= self.num_vars(),
}
```