### PR TITLE
Double range check

### DIFF
--- a/ceno_zkvm/src/instructions/riscv/rv32im.rs
+++ b/ceno_zkvm/src/instructions/riscv/rv32im.rs
@@ -31,8 +31,8 @@ use crate::{
     scheme::constants::DYNAMIC_RANGE_MAX_BITS,
     structs::{ZKVMConstraintSystem, ZKVMFixedTraces, ZKVMWitnesses},
     tables::{
-        AndTableCircuit, DynamicRangeTableCircuit, LtuTableCircuit, OrTableCircuit, TableCircuit,
-        XorTableCircuit,
+        AndTableCircuit, DoubleU8TableCircuit, DynamicRangeTableCircuit, LtuTableCircuit,
+        OrTableCircuit, TableCircuit, XorTableCircuit,
     },
 };
 use ceno_emul::{
@@ -121,6 +121,7 @@ pub struct Rv32imConfig<E: ExtensionField> {
     pub keccak_config: <KeccakInstruction<E> as Instruction<E>>::InstructionConfig,
     // Tables.
     pub dynamic_range_config: <DynamicRangeTableCircuit<E, 18> as TableCircuit<E>>::TableConfig,
+    pub double_u8_range_config: <DoubleU8TableCircuit<E> as TableCircuit<E>>::TableConfig,
     pub and_table_config: <AndTableCircuit<E> as TableCircuit<E>>::TableConfig,
     pub or_table_config: <OrTableCircuit<E> as TableCircuit<E>>::TableConfig,
     pub xor_table_config: <XorTableCircuit<E> as TableCircuit<E>>::TableConfig,
@@ -196,6 +197,7 @@ impl<E: ExtensionField> Rv32imConfig<E> {
         // tables
         let dynamic_range_config =
             cs.register_table_circuit::<DynamicRangeTableCircuit<E, DYNAMIC_RANGE_MAX_BITS>>();
+        let double_u8_range_config = cs.register_table_circuit::<DoubleU8TableCircuit<E>>();
         let and_table_config = cs.register_table_circuit::<AndTableCircuit<E>>();
         let or_table_config = cs.register_table_circuit::<OrTableCircuit<E>>();
         let xor_table_config = cs.register_table_circuit::<XorTableCircuit<E>>();
@@ -261,6 +263,7 @@ impl<E: ExtensionField> Rv32imConfig<E> {
             keccak_config,
             // tables
             dynamic_range_config,
+            double_u8_range_config,
             and_table_config,
             or_table_config,
             xor_table_config,
@@ -335,9 +338,14 @@ impl<E: ExtensionField> Rv32imConfig<E> {
         fixed.register_opcode_circuit::<KeccakInstruction<E>>(cs, &self.keccak_config);
 
         // table
-        fixed.register_table_circuit::<DynamicRangeTableCircuit<E, 18>>(
+        fixed.register_table_circuit::<DynamicRangeTableCircuit<E, DYNAMIC_RANGE_MAX_BITS>>(
             cs,
             &self.dynamic_range_config,
+            &(),
+        );
+        fixed.register_table_circuit::<DoubleU8TableCircuit<E>>(
+            cs,
+            &self.double_u8_range_config,
             &(),
         );
         fixed.register_table_circuit::<AndTableCircuit<E>>(cs, &self.and_table_config, &());
@@ -466,9 +474,14 @@ impl<E: ExtensionField> Rv32imConfig<E> {
         cs: &ZKVMConstraintSystem<E>,
         witness: &mut ZKVMWitnesses<E>,
     ) -> Result<(), ZKVMError> {
-        witness.assign_table_circuit::<DynamicRangeTableCircuit<E, 18>>(
+        witness.assign_table_circuit::<DynamicRangeTableCircuit<E, DYNAMIC_RANGE_MAX_BITS>>(
             cs,
             &self.dynamic_range_config,
+            &(),
+        )?;
+        witness.assign_table_circuit::<DoubleU8TableCircuit<E>>(
+            cs,
+            &self.double_u8_range_config,
             &(),
         )?;
         witness.assign_table_circuit::<AndTableCircuit<E>>(cs, &self.and_table_config, &())?;

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -28,6 +28,7 @@ use crate::{
     scheme::constants::{NUM_FANIN, NUM_FANIN_LOGUP, SEL_DEGREE},
     structs::{ComposedConstrainSystem, PointAndEval, TowerProofs, VerifyingKey, ZKVMVerifyingKey},
     utils::{
+        eval_inner_repeated_incremental_vec, eval_outer_repeated_incremental_vec,
         eval_stacked_constant_vec, eval_stacked_wellform_address_vec, eval_wellform_address_vec,
     },
 };
@@ -551,6 +552,12 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
                         }
                         StructuralWitInType::StackedConstantSequence { .. } => {
                             eval_stacked_constant_vec(&rt_tower)
+                        }
+                        StructuralWitInType::InnerRepeatingIncrementalSequence { k, .. } => {
+                            eval_inner_repeated_incremental_vec(k as u64, &rt_tower)
+                        }
+                        StructuralWitInType::OuterRepeatingIncrementalSequence { k, .. } => {
+                            eval_outer_repeated_incremental_vec(k as u64, &rt_tower)
                         }
                     })
                     .collect_vec()

--- a/ceno_zkvm/src/tables/range.rs
+++ b/ceno_zkvm/src/tables/range.rs
@@ -3,4 +3,18 @@
 mod range_impl;
 
 mod range_circuit;
-pub use range_circuit::{DynamicRangeTableCircuit, RangeTable, RangeTableCircuit};
+pub use range_circuit::{
+    DoubleRangeTableCircuit, DynamicRangeTableCircuit, RangeTable, RangeTableCircuit,
+};
+
+use crate::ROMType;
+
+pub struct DoubleU8Table;
+impl RangeTable for DoubleU8Table {
+    const ROM_TYPE: ROMType = ROMType::DoubleU8;
+
+    fn len() -> usize {
+        1 << 16
+    }
+}
+pub type DoubleU8TableCircuit<E> = DoubleRangeTableCircuit<E, 8, 8, DoubleU8Table>;

--- a/ceno_zkvm/src/tables/range/range_circuit.rs
+++ b/ceno_zkvm/src/tables/range/range_circuit.rs
@@ -8,7 +8,10 @@ use crate::{
     circuit_builder::CircuitBuilder,
     error::ZKVMError,
     structs::{ProgramParams, ROMType},
-    tables::{RMMCollections, TableCircuit, range::range_impl::DynamicRangeTableConfig},
+    tables::{
+        RMMCollections, TableCircuit,
+        range::range_impl::{DoubleRangeTableConfig, DynamicRangeTableConfig},
+    },
 };
 use ff_ext::ExtensionField;
 use gkr_iop::tables::LookupTable;
@@ -114,5 +117,57 @@ impl<E: ExtensionField, const MAX_BITS: usize> TableCircuit<E>
         let multiplicity = &multiplicity[LookupTable::Dynamic as usize];
 
         Ok(config.assign_instances(num_witin, num_structural_witin, multiplicity, MAX_BITS)?)
+    }
+}
+
+pub struct DoubleRangeTableCircuit<E, const MAX_BITS_1: usize, const MAX_BITS_2: usize, R>(
+    PhantomData<(E, R)>,
+);
+
+impl<E: ExtensionField, const MAX_BITS_1: usize, const MAX_BITS_2: usize, R: RangeTable>
+    TableCircuit<E> for DoubleRangeTableCircuit<E, MAX_BITS_1, MAX_BITS_2, R>
+{
+    type TableConfig = DoubleRangeTableConfig;
+    type FixedInput = ();
+    type WitnessInput = ();
+
+    fn name() -> String {
+        format!("DOUBLE_RANGE_{:?}", R::ROM_TYPE)
+    }
+
+    fn construct_circuit(
+        cb: &mut CircuitBuilder<E>,
+        _params: &ProgramParams,
+    ) -> Result<DoubleRangeTableConfig, ZKVMError> {
+        Ok(cb.namespace(
+            || Self::name(),
+            |cb| DoubleRangeTableConfig::construct_circuit(cb, R::ROM_TYPE, MAX_BITS_1, MAX_BITS_2),
+        )?)
+    }
+
+    fn generate_fixed_traces(
+        _config: &DoubleRangeTableConfig,
+        _num_fixed: usize,
+        _input: &(),
+    ) -> RowMajorMatrix<E::BaseField> {
+        RowMajorMatrix::<E::BaseField>::new(0, 0, InstancePaddingStrategy::Default)
+    }
+
+    fn assign_instances(
+        config: &Self::TableConfig,
+        num_witin: usize,
+        num_structural_witin: usize,
+        multiplicity: &[HashMap<u64, usize>],
+        _input: &(),
+    ) -> Result<RMMCollections<E::BaseField>, ZKVMError> {
+        let multiplicity = &multiplicity[R::ROM_TYPE as usize];
+
+        Ok(config.assign_instances(
+            num_witin,
+            num_structural_witin,
+            multiplicity,
+            MAX_BITS_1,
+            MAX_BITS_2,
+        )?)
     }
 }

--- a/gkr_iop/src/circuit_builder.rs
+++ b/gkr_iop/src/circuit_builder.rs
@@ -874,6 +874,22 @@ impl<'a, E: ExtensionField> CircuitBuilder<'a, E> {
         )
     }
 
+    pub fn assert_double_u8<NR, N>(
+        &mut self,
+        name_fn: N,
+        a_expr: Expression<E>,
+        b_expr: Expression<E>,
+    ) -> Result<(), CircuitBuilderError>
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
+    {
+        self.namespace(
+            || "assert_double_u8",
+            |cb| cb.lk_record(name_fn, LookupTable::DoubleU8, vec![a_expr, b_expr]),
+        )
+    }
+
     pub fn assert_bit<NR, N>(
         &mut self,
         name_fn: N,

--- a/gkr_iop/src/tables/mod.rs
+++ b/gkr_iop/src/tables/mod.rs
@@ -8,6 +8,7 @@ use strum_macros::EnumIter;
 #[repr(usize)]
 pub enum LookupTable {
     Dynamic = 0, // Range type for all bits up to 18 bits
+    DoubleU8,    // Range type for two 8-bit checks toether
     And,         // a & b where a, b are bytes
     Or,          // a | b where a, b are bytes
     Xor,         // a ^ b where a, b are bytes

--- a/gkr_iop/src/utils/lk_multiplicity.rs
+++ b/gkr_iop/src/utils/lk_multiplicity.rs
@@ -187,6 +187,11 @@ impl LkMultiplicity {
         self.increment(LookupTable::Dynamic, (1 << bits) + v);
     }
 
+    #[inline(always)]
+    pub fn assert_double_u8(&mut self, a: u64, b: u64) {
+        self.increment(LookupTable::DoubleU8, (a << 8) + b);
+    }
+
     /// assert within range
     #[inline(always)]
     pub fn assert_ux_in_u16(&mut self, size: usize, v: u64) {

--- a/multilinear_extensions/src/expression.rs
+++ b/multilinear_extensions/src/expression.rs
@@ -1032,6 +1032,14 @@ pub enum StructuralWitInType {
     /// The corresponding evaluation vector is the sequence: [0, 0] + [1, 1] + [2] * 4 + [3] * 8 + ... + [max_value] * (2^max_value)
     /// The length of the vectors is 2^(max_value + 1)
     StackedConstantSequence { max_value: usize },
+    /// The corresponding evaluation vector is the sequence: [0, ..., 0, 1, ..., 1, ..., 2^(n-k-1)-1, ..., 2^(n-k-1)-1]
+    /// where each element is repeated by 2^k times
+    /// The total length of the vector is 2^n
+    InnerRepeatingIncrementalSequence { k: usize, n: usize },
+    /// The corresponding evaluation vector is the sequence: [0, ..., 2^k-1]
+    /// repeated by 2^(n-k) times
+    /// The total length of the vector is 2^n
+    OuterRepeatingIncrementalSequence { k: usize, n: usize },
 }
 
 impl StructuralWitInType {
@@ -1040,6 +1048,8 @@ impl StructuralWitInType {
             StructuralWitInType::EqualDistanceSequence { max_len, .. } => *max_len,
             StructuralWitInType::StackedIncrementalSequence { max_bits } => 1 << (max_bits + 1),
             StructuralWitInType::StackedConstantSequence { max_value } => 1 << (max_value + 1),
+            StructuralWitInType::InnerRepeatingIncrementalSequence { n, .. } => 1 << n,
+            StructuralWitInType::OuterRepeatingIncrementalSequence { n, .. } => 1 << n,
         }
     }
 }


### PR DESCRIPTION
To support checking the ranges of two integers by a single table lookup when the total number of bits is not very large. Currently supports checking two 8-bit integers.