### PR TITLE
Feat: use `assert_ux_v2`

### DIFF
--- a/gkr_iop/src/gadgets/is_lt.rs
+++ b/gkr_iop/src/gadgets/is_lt.rs
@@ -193,14 +193,7 @@ impl InnerLtConfig {
         let remain_bits = max_bits % u16::BITS as usize;
         if remain_bits > 0 {
             let msl = cb.create_witin(|| "msl");
-            match remain_bits {
-                14 => cb.assert_ux::<_, _, 14>(|| name.clone(), msl.expr())?,
-                8 => cb.assert_ux::<_, _, 8>(|| name.clone(), msl.expr())?,
-                5 => cb.assert_ux::<_, _, 5>(|| name.clone(), msl.expr())?,
-                1 => cb.assert_bit(|| name.clone(), msl.expr())?,
-                // TODO refactor range table to support arbitrary range check
-                _ => tracing::info!("not implement {} bit range check", remain_bits),
-            }
+            cb.assert_ux_v2(|| name.clone(), msl.expr(), remain_bits)?;
             diff.push(msl);
         }
 
@@ -280,14 +273,7 @@ impl InnerLtConfig {
             let wit = self.diff.last().unwrap();
             // extract remaining bits limb from diff and assign to instance
             let val = (diff >> ((self.diff.len() - 1) * u16::BITS as usize)) & 0xffff;
-            match remain_bits {
-                14 => lkm.assert_ux::<14>(val),
-                8 => lkm.assert_ux::<8>(val),
-                5 => lkm.assert_ux::<5>(val),
-                1 => (), // there is nothing to do with bool check
-                // TODO refactor range table to support arbitrary range check
-                _ => tracing::info!("not implement {} bit range check", remain_bits),
-            }
+            lkm.assert_ux_v2(val, remain_bits);
             set_val!(instance, wit, val);
         }
         Ok(())


### PR DESCRIPTION
## Summary

Before this PR, the `InnerLtConfig` will print out a lot of `not implement u13 range table` [logs](https://github.com/scroll-tech/ceno/actions/runs/17395441323/job/49376401395#step:6:190). 
```text
INFO gkr_iop::gadgets::is_lt: not implement 13 bit range check
INFO gkr_iop::gadgets::is_lt: not implement 13 bit range check
INFO gkr_iop::gadgets::is_lt: not implement 13 bit range check
INFO gkr_iop::gadgets::is_lt: not implement 13 bit range check
INFO gkr_iop::gadgets::is_lt: not implement 13 bit range check
INFO gkr_iop::gadgets::is_lt: not implement 13 bit range check
INFO gkr_iop::gadgets::is_lt: not implement 13 bit range check
......
```
After this PR, we unify pass all the range checks to `LookupTable::Dynamic`.