### PR TITLE
fix heap value limb size mismatch

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -65,6 +65,23 @@ jobs:
           RUSTFLAGS: "-C opt-level=3"
         run: cargo run --release --package ceno_zkvm --no-default-features --features goldilocks --bin e2e -- --field=goldilocks --platform=ceno --hints=10 --public-io=4191 examples/target/riscv32im-ceno-zkvm-elf/release/examples/fibonacci
 
+      - name: Run Guest Heap Alloc (debug)
+        env:
+          RUST_LOG: debug
+          RUSTFLAGS: "-C opt-level=3"
+          MOCK_PROVING: 1
+        run: cargo run --package ceno_zkvm --features sanity-check --bin e2e -- --platform=ceno examples/target/riscv32im-ceno-zkvm-elf/debug/examples/ceno_rt_alloc
+
+      - name: Run Guest Heap Alloc (release)
+        env:
+          RUSTFLAGS: "-C opt-level=3"
+        run: cargo run --release --package ceno_zkvm --bin e2e -- --platform=ceno examples/target/riscv32im-ceno-zkvm-elf/release/examples/ceno_rt_alloc
+
+      - name: Run Guest Heap Alloc (release + goldilocks)
+        env:
+          RUSTFLAGS: "-C opt-level=3"
+        run: cargo run --release --package ceno_zkvm --no-default-features --features goldilocks --bin e2e -- --field=goldilocks --platform=ceno examples/target/riscv32im-ceno-zkvm-elf/release/examples/ceno_rt_alloc
+
       - name: Run keccak_syscall (release)
         env:
           RUSTFLAGS: "-C opt-level=3"

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -1147,7 +1147,7 @@ Hints:
                             .into()
                         };
 
-                    for ((w_rlc_expr, annotation), (_, w_exprs)) in (cs
+                    for ((w_rlc_expr, annotation), _) in (cs
                         .w_expressions
                         .iter()
                         .chain(cs.w_table_expressions.iter().map(|expr| &expr.expr)))
@@ -1173,35 +1173,6 @@ Hints:
                         let write_rlc_records =
                             filter_mle_by_selector_mle(write_rlc_records, w_selector.clone());
 
-                        if $ram_type == RAMType::GlobalState {
-                            // w_exprs = [GlobalState, pc, timestamp]
-                            assert_eq!(w_exprs.len(), 3);
-                            let w = w_exprs
-                                .into_iter()
-                                .skip(1)
-                                .map(|expr| {
-                                    let v = wit_infer_by_expr(
-                                        expr,
-                                        cs.num_witin,
-                                        cs.num_structural_witin,
-                                        cs.num_fixed as WitnessId,
-                                        fixed,
-                                        witness,
-                                        structural_witness,
-                                        &pi_mles,
-                                        &challenges,
-                                    );
-                                    filter_mle_by_selector_mle(v, w_selector.clone())
-                                })
-                                .collect_vec();
-                            // convert [[pc], [timestamp]] into [[pc, timestamp]]
-                            let w = (0..w[0].len())
-                                // TODO: use transpose
-                                .map(|row| w.iter().map(|w| w[row]).collect_vec())
-                                .collect_vec();
-
-                            assert!(gs.insert(circuit_name.clone(), w).is_none());
-                        };
                         let mut records = vec![];
                         for (row, record_rlc) in enumerate(write_rlc_records) {
                             // TODO: report error
@@ -1241,7 +1212,7 @@ Hints:
                             )
                             .into()
                         };
-                    for ((r_expr, annotation), _) in (cs
+                    for ((r_rlc_expr, annotation), (_, r_exprs)) in (cs
                         .r_expressions
                         .iter()
                         .chain(cs.r_table_expressions.iter().map(|expr| &expr.expr)))
@@ -1254,7 +1225,7 @@ Hints:
                     .filter(|((_, _), (ram_type, _))| *ram_type == $ram_type)
                     {
                         let read_records = wit_infer_by_expr(
-                            r_expr,
+                            r_rlc_expr,
                             cs.num_witin,
                             cs.num_structural_witin,
                             cs.num_fixed as WitnessId,
@@ -1266,6 +1237,36 @@ Hints:
                         );
                         let read_records =
                             filter_mle_by_selector_mle(read_records, r_selector.clone());
+
+                        if $ram_type == RAMType::GlobalState {
+                            // r_exprs = [GlobalState, pc, timestamp]
+                            assert_eq!(r_exprs.len(), 3);
+                            let r = r_exprs
+                                .into_iter()
+                                .skip(1)
+                                .map(|expr| {
+                                    let v = wit_infer_by_expr(
+                                        expr,
+                                        cs.num_witin,
+                                        cs.num_structural_witin,
+                                        cs.num_fixed as WitnessId,
+                                        fixed,
+                                        witness,
+                                        structural_witness,
+                                        &pi_mles,
+                                        &challenges,
+                                    );
+                                    filter_mle_by_selector_mle(v, r_selector.clone())
+                                })
+                                .collect_vec();
+                            // convert [[pc], [timestamp]] into [[pc, timestamp]]
+                            let r = (0..r[0].len())
+                                // TODO: use transpose
+                                .map(|row| r.iter().map(|r| r[row]).collect_vec())
+                                .collect_vec();
+
+                            assert!(gs.insert(circuit_name.clone(), r).is_none());
+                        };
 
                         let mut records = vec![];
                         for (row, record) in enumerate(read_records) {

--- a/ceno_zkvm/src/tables/ram.rs
+++ b/ceno_zkvm/src/tables/ram.rs
@@ -15,7 +15,7 @@ pub struct HeapTable;
 
 impl DynVolatileRamTable for HeapTable {
     const RAM_TYPE: RAMType = RAMType::Memory;
-    const V_LIMBS: usize = 1; // See `MemoryExpr`.
+    const V_LIMBS: usize = UINT_LIMBS;
     const ZERO_INIT: bool = true;
     const DESCENDING: bool = false;
 

--- a/ceno_zkvm/src/uint.rs
+++ b/ceno_zkvm/src/uint.rs
@@ -635,7 +635,7 @@ impl ValueMul {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Value<'a, T: Into<u64> + From<u32> + Copy + Default> {
     val: T,
     pub limbs: Cow<'a, [u16]>,


### PR DESCRIPTION
There is a bug from previous PR https://github.com/scroll-tech/ceno/pull/998/ where the `HeapTable` are missing of update memory value. `StackTable` and `HintTable` no such problem.

After #998 actually guest program with heap allocation will failed in e2e. However we only have `fibonacci` and `keccak` in e2e so actually the bug didn't capture.

Thus, this PR also add a heap allocation in e2e ci.

