### PR TITLE
profiling & optimise generate_witness

### DIFF
--- a/ceno_zkvm/src/instructions.rs
+++ b/ceno_zkvm/src/instructions.rs
@@ -98,7 +98,7 @@ pub trait Instruction<E: ExtensionField> {
         shard_ctx: &mut ShardContext,
         num_witin: usize,
         num_structural_witin: usize,
-        steps: Vec<StepRecord>,
+        steps: Vec<&StepRecord>,
     ) -> Result<(RMMCollections<E::BaseField>, Multiplicity<u64>), ZKVMError> {
         // TODO: selector is the only structural witness
         // this is workaround, as call `construct_circuit` will not initialized selector

--- a/ceno_zkvm/src/instructions/riscv/arith.rs
+++ b/ceno_zkvm/src/instructions/riscv/arith.rs
@@ -190,7 +190,7 @@ mod test {
             &mut ShardContext::default(),
             cb.cs.num_witin as usize,
             cb.cs.num_structural_witin as usize,
-            vec![StepRecord::new_r_instruction(
+            vec![&StepRecord::new_r_instruction(
                 3,
                 MOCK_PC_START,
                 insn_code,

--- a/ceno_zkvm/src/instructions/riscv/arith_imm.rs
+++ b/ceno_zkvm/src/instructions/riscv/arith_imm.rs
@@ -67,7 +67,7 @@ mod test {
             &mut ShardContext::default(),
             cb.cs.num_witin as usize,
             cb.cs.num_structural_witin as usize,
-            vec![StepRecord::new_i_instruction(
+            vec![&StepRecord::new_i_instruction(
                 3,
                 Change::new(MOCK_PC_START, MOCK_PC_START + PC_STEP_SIZE),
                 insn_code,

--- a/ceno_zkvm/src/instructions/riscv/auipc.rs
+++ b/ceno_zkvm/src/instructions/riscv/auipc.rs
@@ -245,7 +245,7 @@ mod tests {
             &mut ShardContext::default(),
             cb.cs.num_witin as usize,
             cb.cs.num_structural_witin as usize,
-            vec![StepRecord::new_i_instruction(
+            vec![&StepRecord::new_i_instruction(
                 3,
                 Change::new(MOCK_PC_START, MOCK_PC_START + PC_STEP_SIZE),
                 insn_code,

--- a/ceno_zkvm/src/instructions/riscv/branch/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/branch/test.rs
@@ -43,7 +43,7 @@ fn impl_opcode_beq(equal: bool) {
         &mut ShardContext::default(),
         cb.cs.num_witin as usize,
         cb.cs.num_structural_witin as usize,
-        vec![StepRecord::new_b_instruction(
+        vec![&StepRecord::new_b_instruction(
             3,
             Change::new(MOCK_PC_START, MOCK_PC_START + pc_offset),
             insn_code,
@@ -84,7 +84,7 @@ fn impl_opcode_bne(equal: bool) {
         &mut ShardContext::default(),
         cb.cs.num_witin as usize,
         cb.cs.num_structural_witin as usize,
-        vec![StepRecord::new_b_instruction(
+        vec![&StepRecord::new_b_instruction(
             3,
             Change::new(MOCK_PC_START, MOCK_PC_START + pc_offset),
             insn_code,
@@ -128,7 +128,7 @@ fn impl_bltu_circuit(taken: bool, a: u32, b: u32) -> Result<(), ZKVMError> {
         &mut ShardContext::default(),
         circuit_builder.cs.num_witin as usize,
         circuit_builder.cs.num_structural_witin as usize,
-        vec![StepRecord::new_b_instruction(
+        vec![&StepRecord::new_b_instruction(
             12,
             Change::new(MOCK_PC_START, pc_after),
             insn_code,
@@ -173,7 +173,7 @@ fn impl_bgeu_circuit(taken: bool, a: u32, b: u32) -> Result<(), ZKVMError> {
         &mut ShardContext::default(),
         circuit_builder.cs.num_witin as usize,
         circuit_builder.cs.num_structural_witin as usize,
-        vec![StepRecord::new_b_instruction(
+        vec![&StepRecord::new_b_instruction(
             12,
             Change::new(MOCK_PC_START, pc_after),
             insn_code,
@@ -225,7 +225,7 @@ fn impl_blt_circuit<E: ExtensionField>(taken: bool, a: i32, b: i32) -> Result<()
         &mut ShardContext::default(),
         circuit_builder.cs.num_witin as usize,
         circuit_builder.cs.num_structural_witin as usize,
-        vec![StepRecord::new_b_instruction(
+        vec![&StepRecord::new_b_instruction(
             12,
             Change::new(MOCK_PC_START, pc_after),
             insn_code,
@@ -277,7 +277,7 @@ fn impl_bge_circuit<E: ExtensionField>(taken: bool, a: i32, b: i32) -> Result<()
         &mut ShardContext::default(),
         circuit_builder.cs.num_witin as usize,
         circuit_builder.cs.num_structural_witin as usize,
-        vec![StepRecord::new_b_instruction(
+        vec![&StepRecord::new_b_instruction(
             12,
             Change::new(MOCK_PC_START, pc_after),
             insn_code,

--- a/ceno_zkvm/src/instructions/riscv/div.rs
+++ b/ceno_zkvm/src/instructions/riscv/div.rs
@@ -183,7 +183,7 @@ mod test {
             &mut ShardContext::default(),
             cb.cs.num_witin as usize,
             cb.cs.num_structural_witin as usize,
-            vec![StepRecord::new_r_instruction(
+            vec![&StepRecord::new_r_instruction(
                 3,
                 MOCK_PC_START,
                 insn_code,

--- a/ceno_zkvm/src/instructions/riscv/dummy/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/dummy/test.rs
@@ -38,7 +38,7 @@ fn test_dummy_ecall() {
         &mut ShardContext::default(),
         cb.cs.num_witin as usize,
         cb.cs.num_structural_witin as usize,
-        vec![step],
+        vec![&step],
     )
     .unwrap();
 
@@ -68,7 +68,7 @@ fn test_dummy_keccak() {
         &mut ShardContext::default(),
         cb.cs.num_witin as usize,
         cb.cs.num_structural_witin as usize,
-        vec![step],
+        vec![&step],
     )
     .unwrap();
 
@@ -96,7 +96,7 @@ fn test_dummy_r() {
         &mut ShardContext::default(),
         cb.cs.num_witin as usize,
         cb.cs.num_structural_witin as usize,
-        vec![StepRecord::new_r_instruction(
+        vec![&StepRecord::new_r_instruction(
             3,
             MOCK_PC_START,
             insn_code,
@@ -132,7 +132,7 @@ fn test_dummy_b() {
         &mut ShardContext::default(),
         cb.cs.num_witin as usize,
         cb.cs.num_structural_witin as usize,
-        vec![StepRecord::new_b_instruction(
+        vec![&StepRecord::new_b_instruction(
             3,
             Change::new(MOCK_PC_START, MOCK_PC_START + 8_usize),
             insn_code,

--- a/ceno_zkvm/src/instructions/riscv/ecall/keccak.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/keccak.rs
@@ -169,7 +169,7 @@ impl<E: ExtensionField> Instruction<E> for KeccakInstruction<E> {
         shard_ctx: &mut ShardContext,
         num_witin: usize,
         num_structural_witin: usize,
-        steps: Vec<StepRecord>,
+        steps: Vec<&StepRecord>,
     ) -> Result<(RMMCollections<E::BaseField>, Multiplicity<u64>), ZKVMError> {
         let mut lk_multiplicity = LkMultiplicity::default();
         if steps.is_empty() {

--- a/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_add.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_add.rs
@@ -221,7 +221,7 @@ impl<E: ExtensionField, EC: EllipticCurve> Instruction<E>
         shard_ctx: &mut ShardContext,
         num_witin: usize,
         num_structural_witin: usize,
-        steps: Vec<StepRecord>,
+        steps: Vec<&StepRecord>,
     ) -> Result<(RMMCollections<E::BaseField>, Multiplicity<u64>), ZKVMError> {
         let syscall_code = match EC::CURVE_TYPE {
             CurveType::Secp256k1 => SECP256K1_ADD,

--- a/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_decompress.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_decompress.rs
@@ -222,7 +222,7 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> Instruction<E
         shard_ctx: &mut ShardContext,
         num_witin: usize,
         num_structural_witin: usize,
-        steps: Vec<StepRecord>,
+        steps: Vec<&StepRecord>,
     ) -> Result<(RMMCollections<E::BaseField>, Multiplicity<u64>), ZKVMError> {
         let syscall_code = match EC::CURVE_TYPE {
             CurveType::Secp256k1 => SECP256K1_DECOMPRESS,

--- a/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_double.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_double.rs
@@ -193,7 +193,7 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> Instruction<E
         shard_ctx: &mut ShardContext,
         num_witin: usize,
         num_structural_witin: usize,
-        steps: Vec<StepRecord>,
+        steps: Vec<&StepRecord>,
     ) -> Result<(RMMCollections<E::BaseField>, Multiplicity<u64>), ZKVMError> {
         let syscall_code = match EC::CURVE_TYPE {
             CurveType::Secp256k1 => SECP256K1_DOUBLE,

--- a/ceno_zkvm/src/instructions/riscv/jump/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/jump/test.rs
@@ -46,7 +46,7 @@ fn verify_test_opcode_jal<E: ExtensionField>(pc_offset: i32) {
         &mut ShardContext::default(),
         cb.cs.num_witin as usize,
         cb.cs.num_structural_witin as usize,
-        vec![StepRecord::new_j_instruction(
+        vec![&StepRecord::new_j_instruction(
             4,
             Change::new(MOCK_PC_START, new_pc),
             insn_code,
@@ -122,7 +122,7 @@ fn verify_test_opcode_jalr<E: ExtensionField>(rs1_read: Word, imm: i32) {
         &mut ShardContext::default(),
         cb.cs.num_witin as usize,
         cb.cs.num_structural_witin as usize,
-        vec![StepRecord::new_i_instruction(
+        vec![&StepRecord::new_i_instruction(
             4,
             Change::new(MOCK_PC_START, new_pc),
             insn_code,

--- a/ceno_zkvm/src/instructions/riscv/logic/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/logic/test.rs
@@ -35,7 +35,7 @@ fn test_opcode_and() {
         &mut ShardContext::default(),
         cb.cs.num_witin as usize,
         cb.cs.num_structural_witin as usize,
-        vec![StepRecord::new_r_instruction(
+        vec![&StepRecord::new_r_instruction(
             3,
             MOCK_PC_START,
             insn_code,
@@ -78,7 +78,7 @@ fn test_opcode_or() {
         &mut ShardContext::default(),
         cb.cs.num_witin as usize,
         cb.cs.num_structural_witin as usize,
-        vec![StepRecord::new_r_instruction(
+        vec![&StepRecord::new_r_instruction(
             3,
             MOCK_PC_START,
             insn_code,
@@ -121,7 +121,7 @@ fn test_opcode_xor() {
         &mut ShardContext::default(),
         cb.cs.num_witin as usize,
         cb.cs.num_structural_witin as usize,
-        vec![StepRecord::new_r_instruction(
+        vec![&StepRecord::new_r_instruction(
             3,
             MOCK_PC_START,
             insn_code,

--- a/ceno_zkvm/src/instructions/riscv/logic_imm/logic_imm_circuit.rs
+++ b/ceno_zkvm/src/instructions/riscv/logic_imm/logic_imm_circuit.rs
@@ -232,7 +232,7 @@ mod test {
             &config,
             cb.cs.num_witin as usize,
             cb.cs.num_structural_witin as usize,
-            vec![StepRecord::new_i_instruction(
+            vec![&StepRecord::new_i_instruction(
                 3,
                 Change::new(MOCK_PC_START, MOCK_PC_START + PC_STEP_SIZE),
                 insn_code,

--- a/ceno_zkvm/src/instructions/riscv/logic_imm/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/logic_imm/test.rs
@@ -74,7 +74,7 @@ fn verify<I: LogicOp>(name: &'static str, rs1_read: u32, imm: u32, expected_rd_w
         &mut ShardContext::default(),
         cb.cs.num_witin as usize,
         cb.cs.num_structural_witin as usize,
-        vec![StepRecord::new_i_instruction(
+        vec![&StepRecord::new_i_instruction(
             3,
             Change::new(MOCK_PC_START, MOCK_PC_START + PC_STEP_SIZE),
             insn_code,

--- a/ceno_zkvm/src/instructions/riscv/lui.rs
+++ b/ceno_zkvm/src/instructions/riscv/lui.rs
@@ -159,7 +159,7 @@ mod tests {
             &mut ShardContext::default(),
             cb.cs.num_witin as usize,
             cb.cs.num_structural_witin as usize,
-            vec![StepRecord::new_i_instruction(
+            vec![&StepRecord::new_i_instruction(
                 3,
                 Change::new(MOCK_PC_START, MOCK_PC_START + PC_STEP_SIZE),
                 insn_code,

--- a/ceno_zkvm/src/instructions/riscv/memory/test.rs
+++ b/ceno_zkvm/src/instructions/riscv/memory/test.rs
@@ -106,7 +106,7 @@ fn impl_opcode_store<E: ExtensionField + Hash, I: RIVInstruction, Inst: Instruct
         &mut ShardContext::default(),
         cb.cs.num_witin as usize,
         cb.cs.num_structural_witin as usize,
-        vec![StepRecord::new_s_instruction(
+        vec![&StepRecord::new_s_instruction(
             12,
             MOCK_PC_START,
             insn_code,
@@ -168,7 +168,7 @@ fn impl_opcode_load<E: ExtensionField + Hash, I: RIVInstruction, Inst: Instructi
         &mut ShardContext::default(),
         cb.cs.num_witin as usize,
         cb.cs.num_structural_witin as usize,
-        vec![StepRecord::new_im_instruction(
+        vec![&StepRecord::new_im_instruction(
             12,
             MOCK_PC_START,
             insn_code,

--- a/ceno_zkvm/src/instructions/riscv/mulh.rs
+++ b/ceno_zkvm/src/instructions/riscv/mulh.rs
@@ -143,7 +143,7 @@ mod test {
             &mut ShardContext::default(),
             cb.cs.num_witin as usize,
             cb.cs.num_structural_witin as usize,
-            vec![StepRecord::new_r_instruction(
+            vec![&StepRecord::new_r_instruction(
                 3,
                 MOCK_PC_START,
                 insn_code,
@@ -222,7 +222,7 @@ mod test {
             &mut ShardContext::default(),
             cb.cs.num_witin as usize,
             cb.cs.num_structural_witin as usize,
-            vec![StepRecord::new_r_instruction(
+            vec![&StepRecord::new_r_instruction(
                 3,
                 MOCK_PC_START,
                 insn_code,
@@ -306,7 +306,7 @@ mod test {
             &mut ShardContext::default(),
             cb.cs.num_witin as usize,
             cb.cs.num_structural_witin as usize,
-            vec![StepRecord::new_r_instruction(
+            vec![&StepRecord::new_r_instruction(
                 3,
                 MOCK_PC_START,
                 insn_code,

--- a/ceno_zkvm/src/instructions/riscv/rv32im.rs
+++ b/ceno_zkvm/src/instructions/riscv/rv32im.rs
@@ -407,14 +407,14 @@ impl<E: ExtensionField> Rv32imConfig<E> {
         fixed.register_table_circuit::<PowTableCircuit<E>>(cs, &self.pow_config, &());
     }
 
-    pub fn assign_opcode_circuit(
+    pub fn assign_opcode_circuit<'a>(
         &self,
         cs: &ZKVMConstraintSystem<E>,
         shard_ctx: &mut ShardContext,
         witness: &mut ZKVMWitnesses<E>,
-        steps: Vec<StepRecord>,
-    ) -> Result<GroupedSteps, ZKVMError> {
-        let mut all_records: BTreeMap<InsnKind, Vec<StepRecord>> = InsnKind::iter()
+        steps: &'a [StepRecord],
+    ) -> Result<GroupedSteps<'a>, ZKVMError> {
+        let mut all_records: BTreeMap<InsnKind, Vec<&StepRecord>> = InsnKind::iter()
             .map(|insn_kind| (insn_kind, Vec::new()))
             .collect();
         let mut halt_records = Vec::new();
@@ -425,7 +425,7 @@ impl<E: ExtensionField> Rv32imConfig<E> {
         let mut secp256k1_double_records = Vec::new();
         let mut secp256k1_decompress_records = Vec::new();
 
-        steps.into_iter().for_each(|record| {
+        steps.iter().for_each(|record| {
             let insn_kind = record.insn.kind;
             match insn_kind {
                 // ecall / halt
@@ -607,7 +607,7 @@ impl<E: ExtensionField> Rv32imConfig<E> {
 }
 
 /// Opaque type to pass unimplemented instructions from Rv32imConfig to DummyExtraConfig.
-pub struct GroupedSteps(BTreeMap<InsnKind, Vec<StepRecord>>);
+pub struct GroupedSteps<'a>(BTreeMap<InsnKind, Vec<&'a StepRecord>>);
 
 /// Fake version of what is missing in Rv32imConfig, for some tests.
 pub struct DummyExtraConfig<E: ExtensionField> {

--- a/ceno_zkvm/src/instructions/riscv/shift.rs
+++ b/ceno_zkvm/src/instructions/riscv/shift.rs
@@ -177,7 +177,7 @@ mod tests {
             &mut ShardContext::default(),
             cb.cs.num_witin as usize,
             cb.cs.num_structural_witin as usize,
-            vec![StepRecord::new_r_instruction(
+            vec![&StepRecord::new_r_instruction(
                 3,
                 MOCK_PC_START,
                 insn_code,

--- a/ceno_zkvm/src/instructions/riscv/shift_imm.rs
+++ b/ceno_zkvm/src/instructions/riscv/shift_imm.rs
@@ -174,7 +174,7 @@ mod test {
             &mut ShardContext::default(),
             cb.cs.num_witin as usize,
             cb.cs.num_structural_witin as usize,
-            vec![StepRecord::new_i_instruction(
+            vec![&StepRecord::new_i_instruction(
                 3,
                 Change::new(MOCK_PC_START, MOCK_PC_START + PC_STEP_SIZE),
                 insn_code,

--- a/ceno_zkvm/src/instructions/riscv/slt.rs
+++ b/ceno_zkvm/src/instructions/riscv/slt.rs
@@ -76,7 +76,7 @@ mod test {
             &mut ShardContext::default(),
             cb.cs.num_witin as usize,
             cb.cs.num_structural_witin as usize,
-            vec![StepRecord::new_r_instruction(
+            vec![&StepRecord::new_r_instruction(
                 3,
                 MOCK_PC_START,
                 insn_code,

--- a/ceno_zkvm/src/instructions/riscv/slti.rs
+++ b/ceno_zkvm/src/instructions/riscv/slti.rs
@@ -189,7 +189,7 @@ mod test {
             &mut ShardContext::default(),
             cb.cs.num_witin as usize,
             cb.cs.num_structural_witin as usize,
-            vec![StepRecord::new_i_instruction(
+            vec![&StepRecord::new_i_instruction(
                 3,
                 Change::new(MOCK_PC_START, MOCK_PC_START + PC_STEP_SIZE),
                 insn_code,

--- a/ceno_zkvm/src/scheme/tests.rs
+++ b/ceno_zkvm/src/scheme/tests.rs
@@ -147,7 +147,7 @@ fn test_rw_lk_expression_combination() {
                 &zkvm_cs,
                 &mut shard_ctx,
                 &config,
-                vec![StepRecord::default(); num_instances],
+                vec![&StepRecord::default(); num_instances],
             )
             .unwrap();
 
@@ -330,7 +330,7 @@ fn test_single_add_instance_e2e() {
         .collect::<Vec<_>>();
     let mut add_records = vec![];
     let mut halt_records = vec![];
-    all_records.into_iter().for_each(|record| {
+    all_records.iter().for_each(|record| {
         let kind = record.insn().kind;
         match kind {
             ADD => add_records.push(record),

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -364,7 +364,7 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
         cs: &ZKVMConstraintSystem<E>,
         shard_ctx: &mut ShardContext,
         config: &OC::InstructionConfig,
-        records: Vec<StepRecord>,
+        records: Vec<&StepRecord>,
     ) -> Result<(), ZKVMError> {
         assert!(self.combined_lk_mlt.is_none());
 


### PR DESCRIPTION
### design rationale
use reference and do not take ownership of step record vector

| Step                               | Before               | After                |
|------------------------------------|-----------------------|----------------------|
| Skip non-shard records             | 24.845921383s         | 1.542µs             |
| Collect filtered steps             | 30.817523328s         | 7.809µs             |
| assign_opcode_circuit              | 4.553334073s          | 1.47729622s         |
| assign_dummy_config                | 1.741857ms            | 1.091978ms          |
| assign_table_circuit (phase 1)     | 51.533204ms           | 28.655562ms         |
| assign_init_table_circuit          | 6.654075ms            | 7.665851ms          |
| assign_continuation_circuit        | 15.458877297s         | 15.57436659s        |
| assign_table_circuit (phase 2)     | 12.22376ms            | 11.287688ms         |
| update pi shard_rw_sum             | 8.02µs                | 8.141µs             |

### raw log (1st shard of proving one ethereum mainnet block)
before
```

DEBUG ceno_zkvm::e2e: first shard cycle range 4..64413368
DEBUG ceno_zkvm::e2e: drop 0 records as not belong to current shard take 24.845921383s
DEBUG ceno_zkvm::e2e: collect filter step in 30.817523328s
DEBUG ceno_zkvm::e2e: 0th shard collect 16103341 steps
DEBUG ceno_zkvm::e2e: assign_opcode_circuit finish in 4.553334073s
DEBUG ceno_zkvm::e2e: assign_dummy_config finish in 1.741857ms
DEBUG ceno_zkvm::e2e: assign_table_circuit finish in 51.533204ms
DEBUG ceno_zkvm::e2e: assign_init_table_circuit finish in 6.654075ms

DEBUG ceno_zkvm::tables::shard_ram: 663291 local reads / 0 local writes in global chip
DEBUG ceno_zkvm::tables::shard_ram: 1048576 local reads / 0 local writes in global chip
DEBUG ceno_zkvm::e2e: assign_continuation_circuit finish in 15.458877297s
DEBUG ceno_zkvm::e2e: assign_table_circuit finish in 12.22376ms
DEBUG ceno_zkvm::e2e: update pi shard_rw_sum finish in 8.02µs

```

after 

```
DEBUG ceno_zkvm::e2e: first shard cycle range 4..64413368
DEBUG ceno_zkvm::e2e: skip 0 records as not belong to current shard take 1.542µs
DEBUG ceno_zkvm::e2e: collect filter step in 7.809µs
DEBUG ceno_zkvm::e2e: 0th shard collect 16103341 steps
DEBUG ceno_zkvm::e2e: assign_opcode_circuit finish in 1.47729622s
DEBUG ceno_zkvm::e2e: assign_dummy_config finish in 1.091978ms
DEBUG ceno_zkvm::e2e: assign_table_circuit finish in 28.655562ms
DEBUG ceno_zkvm::e2e: assign_init_table_circuit finish in 7.665851ms

DEBUG ceno_zkvm::tables::shard_ram: 663291 local reads / 0 local writes in global chip
DEBUG ceno_zkvm::tables::shard_ram: 1048576 local reads / 0 local writes in global chip
DEBUG ceno_zkvm::e2e: assign_continuation_circuit finish in 15.57436659s
DEBUG ceno_zkvm::e2e: assign_table_circuit finish in 11.287688ms
DEBUG ceno_zkvm::e2e: update pi shard_rw_sum finish in 8.141µs
```