### PR TITLE
fix keccak failed with 1 instance

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -148,6 +148,12 @@ jobs:
           CENO_CROSS_SHARD_LIMIT: 32
         run: cargo run --release --package ceno_zkvm --features sanity-check --bin e2e -- --platform=ceno --max-cycle-per-shard=20000 --hints=10 --public-io=4191 examples/target/riscv32im-ceno-zkvm-elf/release/examples/fibonacci
 
+      - name: Run aggregation e2e
+        env:
+          RUSTFLAGS: "-C opt-level=3"
+        run: |
+          cargo run --release --package ceno_recursion --bin e2e -- --platform=ceno --max-cycle-per-shard=1600 examples/target/riscv32im-ceno-zkvm-elf/release/examples/keccak_syscall
+
       - name: Install cargo make
         run: |
           cargo make --version || cargo install cargo-make

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,17 +46,17 @@ jobs:
         run: |
           cargo make --version || cargo install cargo-make
 
-      - name: Run aggregation tests
-        env:
-          RUSTFLAGS: "" # cleanup RUSTFLAGS and avoid target-cpu=native
-        run: |
-          cargo run --release --package ceno_zkvm --bin e2e -- \
-            --platform=ceno --max-cycle-per-shard=1600 \
-            examples/target/riscv32im-ceno-zkvm-elf/release/examples/keccak_syscall
-          mkdir -p ceno_recursion/src/imported
-          mv proof.bin ceno_recursion/src/imported/
-          mv vk.bin ceno_recursion/src/imported/
-          cargo test --release --package ceno_recursion --tests -- --ignored
+      #      - name: Run aggregation tests
+      #        env:
+      #          RUSTFLAGS: "" # cleanup RUSTFLAGS and avoid target-cpu=native
+      #        run: |
+      #          cargo run --release --package ceno_zkvm --bin e2e -- \
+      #            --platform=ceno --max-cycle-per-shard=1600 \
+      #            examples/target/riscv32im-ceno-zkvm-elf/release/examples/keccak_syscall
+      #          mkdir -p ceno_recursion/src/imported
+      #          mv proof.bin ceno_recursion/src/imported/
+      #          mv vk.bin ceno_recursion/src/imported/
+      #          cargo test --release --package ceno_recursion --tests -- --ignored
 
       - name: run test
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2222,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "ff_ext"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.13#89aa6add9f4d16cd2f10ec81f7c11d4507400c9b"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.15#9be620b18900138d0b89569759fc2b3b9451b49e"
 dependencies = [
  "once_cell",
  "p3",
@@ -3271,7 +3271,7 @@ dependencies = [
 [[package]]
 name = "mpcs"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.13#89aa6add9f4d16cd2f10ec81f7c11d4507400c9b"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.15#9be620b18900138d0b89569759fc2b3b9451b49e"
 dependencies = [
  "bincode",
  "clap",
@@ -3295,7 +3295,7 @@ dependencies = [
 [[package]]
 name = "multilinear_extensions"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.13#89aa6add9f4d16cd2f10ec81f7c11d4507400c9b"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.15#9be620b18900138d0b89569759fc2b3b9451b49e"
 dependencies = [
  "either",
  "ff_ext",
@@ -4526,7 +4526,7 @@ dependencies = [
 [[package]]
 name = "p3"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.13#89aa6add9f4d16cd2f10ec81f7c11d4507400c9b"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.15#9be620b18900138d0b89569759fc2b3b9451b49e"
 dependencies = [
  "p3-air",
  "p3-baby-bear",
@@ -5094,7 +5094,7 @@ dependencies = [
 [[package]]
 name = "poseidon"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.13#89aa6add9f4d16cd2f10ec81f7c11d4507400c9b"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.15#9be620b18900138d0b89569759fc2b3b9451b49e"
 dependencies = [
  "ff_ext",
  "p3",
@@ -6187,7 +6187,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.13#89aa6add9f4d16cd2f10ec81f7c11d4507400c9b"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.15#9be620b18900138d0b89569759fc2b3b9451b49e"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6312,7 +6312,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.13#89aa6add9f4d16cd2f10ec81f7c11d4507400c9b"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.15#9be620b18900138d0b89569759fc2b3b9451b49e"
 dependencies = [
  "either",
  "ff_ext",
@@ -6330,7 +6330,7 @@ dependencies = [
 [[package]]
 name = "sumcheck_macro"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.13#89aa6add9f4d16cd2f10ec81f7c11d4507400c9b"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.15#9be620b18900138d0b89569759fc2b3b9451b49e"
 dependencies = [
  "itertools 0.13.0",
  "p3",
@@ -6761,7 +6761,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.13#89aa6add9f4d16cd2f10ec81f7c11d4507400c9b"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.15#9be620b18900138d0b89569759fc2b3b9451b49e"
 dependencies = [
  "ff_ext",
  "itertools 0.13.0",
@@ -7043,7 +7043,7 @@ dependencies = [
 [[package]]
 name = "whir"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.13#89aa6add9f4d16cd2f10ec81f7c11d4507400c9b"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.15#9be620b18900138d0b89569759fc2b3b9451b49e"
 dependencies = [
  "bincode",
  "clap",
@@ -7330,7 +7330,7 @@ dependencies = [
 [[package]]
 name = "witness"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.13#89aa6add9f4d16cd2f10ec81f7c11d4507400c9b"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.15#9be620b18900138d0b89569759fc2b3b9451b49e"
 dependencies = [
  "ff_ext",
  "multilinear_extensions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,16 +24,16 @@ repository = "https://github.com/scroll-tech/ceno"
 version = "0.1.0"
 
 [workspace.dependencies]
-ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "ff_ext", tag = "v1.0.0-alpha.13" }
-mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "mpcs", tag = "v1.0.0-alpha.13" }
-multilinear_extensions = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "multilinear_extensions", tag = "v1.0.0-alpha.13" }
-p3 = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "p3", tag = "v1.0.0-alpha.13" }
-poseidon = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "poseidon", tag = "v1.0.0-alpha.13" }
-sp1-curves = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sp1-curves", tag = "v1.0.0-alpha.13" }
-sumcheck = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sumcheck", tag = "v1.0.0-alpha.13" }
-transcript = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "transcript", tag = "v1.0.0-alpha.13" }
-whir = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "whir", tag = "v1.0.0-alpha.13" }
-witness = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "witness", tag = "v1.0.0-alpha.13" }
+ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "ff_ext", tag = "v1.0.0-alpha.15" }
+mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "mpcs", tag = "v1.0.0-alpha.15" }
+multilinear_extensions = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "multilinear_extensions", tag = "v1.0.0-alpha.15" }
+p3 = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "p3", tag = "v1.0.0-alpha.15" }
+poseidon = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "poseidon", tag = "v1.0.0-alpha.15" }
+sp1-curves = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sp1-curves", tag = "v1.0.0-alpha.15" }
+sumcheck = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sumcheck", tag = "v1.0.0-alpha.15" }
+transcript = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "transcript", tag = "v1.0.0-alpha.15" }
+whir = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "whir", tag = "v1.0.0-alpha.15" }
+witness = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "witness", tag = "v1.0.0-alpha.15" }
 
 alloy-primitives = "1.3"
 anyhow = { version = "1.0", default-features = false }
@@ -101,14 +101,14 @@ lto = "thin"
 # [patch."ssh://git@github.com/scroll-tech/ceno-gpu.git"]
 # ceno_gpu = { path = "../ceno-gpu/cuda_hal", package = "cuda_hal", default-features = false, features=["bb31"] }
 
-# [patch."https://github.com/scroll-tech/gkr-backend"]
-# ff_ext = { path = "../gkr-backend/crates/ff_ext", package = "ff_ext" }
-# mpcs = { path = "../gkr-backend/crates/mpcs", package = "mpcs" }
-# multilinear_extensions = { path = "../gkr-backend/crates/multilinear_extensions", package = "multilinear_extensions" }
-# p3 = { path = "../gkr-backend/crates/p3", package = "p3" }
-# poseidon = { path = "../gkr-backend/crates/poseidon", package = "poseidon" }
-# sp1-curves = { path = "../gkr-backend/crates/curves", package = "sp1-curves" }
-# sumcheck = { path = "../gkr-backend/crates/sumcheck", package = "sumcheck" }
-# transcript = { path = "../gkr-backend/crates/transcript", package = "transcript" }
-# whir = { path = "../gkr-backend/crates/whir", package = "whir" }
-# witness = { path = "../gkr-backend/crates/witness", package = "witness" }
+#[patch."https://github.com/scroll-tech/gkr-backend"]
+#ff_ext = { path = "../gkr-backend/crates/ff_ext", package = "ff_ext" }
+#mpcs = { path = "../gkr-backend/crates/mpcs", package = "mpcs" }
+#multilinear_extensions = { path = "../gkr-backend/crates/multilinear_extensions", package = "multilinear_extensions" }
+#p3 = { path = "../gkr-backend/crates/p3", package = "p3" }
+#poseidon = { path = "../gkr-backend/crates/poseidon", package = "poseidon" }
+#sp1-curves = { path = "../gkr-backend/crates/curves", package = "sp1-curves" }
+#sumcheck = { path = "../gkr-backend/crates/sumcheck", package = "sumcheck" }
+#transcript = { path = "../gkr-backend/crates/transcript", package = "transcript" }
+#whir = { path = "../gkr-backend/crates/whir", package = "whir" }
+#witness = { path = "../gkr-backend/crates/witness", package = "witness" }

--- a/ceno_zkvm/benches/lookup_keccakf.rs
+++ b/ceno_zkvm/benches/lookup_keccakf.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use ceno_zkvm::precompiles::{run_faster_keccakf, setup_lookup_keccak_gkr_circuit};
+use ceno_zkvm::precompiles::{run_lookup_keccakf, setup_lookup_keccak_gkr_circuit};
 use criterion::*;
 use ff_ext::BabyBearExt4;
 
@@ -41,7 +41,7 @@ fn keccak_f_fn(c: &mut Criterion) {
                         let circuit =
                             setup_lookup_keccak_gkr_circuit().expect("setup circuit error");
                         #[allow(clippy::unit_arg)]
-                        let _ = run_faster_keccakf::<BabyBearExt4, BasefoldDefault<BabyBearExt4>>(
+                        let _ = run_lookup_keccakf::<BabyBearExt4, BasefoldDefault<BabyBearExt4>>(
                             circuit,
                             black_box(states),
                             false,

--- a/ceno_zkvm/src/bin/lookup_keccak.rs
+++ b/ceno_zkvm/src/bin/lookup_keccak.rs
@@ -1,4 +1,4 @@
-use ceno_zkvm::precompiles::{run_faster_keccakf, setup_lookup_keccak_gkr_circuit};
+use ceno_zkvm::precompiles::{run_lookup_keccakf, setup_lookup_keccak_gkr_circuit};
 use clap::{Parser, command};
 use ff_ext::GoldilocksExt2;
 use itertools::Itertools;
@@ -71,7 +71,7 @@ fn main() {
         .map(|_| std::array::from_fn(|_| rng.next_u64()))
         .collect_vec();
     let circuit_setup = setup_lookup_keccak_gkr_circuit();
-    let proof = run_faster_keccakf::<E, Pcs>(
+    let proof = run_lookup_keccakf::<E, Pcs>(
         circuit_setup.expect("setup circuit error"),
         states,
         true,

--- a/ceno_zkvm/src/instructions/riscv/ecall/keccak.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/keccak.rs
@@ -184,20 +184,21 @@ impl<E: ExtensionField> Instruction<E> for KeccakInstruction<E> {
         let nthreads = max_usable_threads();
         let num_instance_per_batch = steps.len().div_ceil(nthreads).max(1);
 
-        let mut raw_witin = RowMajorMatrix::<E::BaseField>::new(
-            config.layout.phase1_witin_rmm_height(steps.len()),
+        let mut raw_witin = RowMajorMatrix::<E::BaseField>::new_by_rotation(
+            steps.len(),
+            KECCAK_ROUNDS.next_power_of_two().ilog2() as usize,
             num_witin,
             InstancePaddingStrategy::Default,
         );
-        let mut raw_structural_witin = RowMajorMatrix::<E::BaseField>::new(
-            config.layout.phase1_witin_rmm_height(steps.len()),
+        let mut raw_structural_witin = RowMajorMatrix::<E::BaseField>::new_by_rotation(
+            steps.len(),
+            KECCAK_ROUNDS.next_power_of_two().ilog2() as usize,
             num_structural_witin,
             InstancePaddingStrategy::Default,
         );
 
         // each instance are composed of KECCAK_ROUNDS.next_power_of_two()
-        let raw_witin_iter = raw_witin
-            .par_batch_iter_mut(num_instance_per_batch * KECCAK_ROUNDS.next_power_of_two());
+        let raw_witin_iter = raw_witin.par_batch_iter_mut(num_instance_per_batch);
         let shard_ctx_vec = shard_ctx.get_forked();
 
         // 1st pass: assign witness outside of gkr-iop scope

--- a/ceno_zkvm/src/precompiles/mod.rs
+++ b/ceno_zkvm/src/precompiles/mod.rs
@@ -7,7 +7,7 @@ pub use lookup_keccakf::{
     AND_LOOKUPS, KECCAK_INPUT32_SIZE, KECCAK_OUT_EVAL_SIZE, KeccakInstance, KeccakLayout,
     KeccakParams, KeccakStateInstance, KeccakTrace, KeccakWitInstance, RANGE_LOOKUPS,
     ROUNDS as KECCAK_ROUNDS, ROUNDS_CEIL_LOG2 as KECCAK_ROUNDS_CEIL_LOG2, XOR_LOOKUPS,
-    run_faster_keccakf, setup_gkr_circuit as setup_lookup_keccak_gkr_circuit,
+    run_lookup_keccakf, setup_gkr_circuit as setup_lookup_keccak_gkr_circuit,
 };
 
 pub use bitwise_keccakf::{

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -172,7 +172,6 @@ impl<
             let num_instances = chip_inputs
                 .iter()
                 .flat_map(|chip_input| &chip_input.num_instances)
-                .map(|num_instance| num_instance >> pk.get_cs().rotation_vars().unwrap_or(0))
                 .collect_vec();
 
             if num_instances.is_empty() {
@@ -189,22 +188,7 @@ impl<
 
         // extract chip meta info before consuming witnesses
         // (circuit_name, num_instances)
-        let name_and_instances = witnesses
-            .get_witnesses_name_instance()
-            .into_iter()
-            .map(|(name, instances)| {
-                let pk = self.pk.circuit_pks.get(&name).unwrap();
-                (
-                    name,
-                    instances
-                        .into_iter()
-                        .map(|num_instance| {
-                            num_instance >> pk.get_cs().rotation_vars().unwrap_or(0)
-                        })
-                        .collect_vec(),
-                )
-            })
-            .collect_vec();
+        let name_and_instances = witnesses.get_witnesses_name_instance();
 
         let commit_to_traces_span = entered_span!("batch commit to traces", profiling_1 = true);
         let mut wits_rmms = BTreeMap::new();

--- a/gkr_iop/src/selector.rs
+++ b/gkr_iop/src/selector.rs
@@ -2,6 +2,7 @@ use std::iter::repeat_n;
 
 use rayon::iter::IndexedParallelIterator;
 
+use crate::{gkr::booleanhypercube::CYCLIC_POW2_5, utils::eq_eval_less_or_equal_than};
 use ff_ext::ExtensionField;
 use multilinear_extensions::{
     Expression, WitnessId,
@@ -15,8 +16,7 @@ use rayon::{
     slice::ParallelSliceMut,
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-
-use crate::{gkr::booleanhypercube::CYCLIC_POW2_5, utils::eq_eval_less_or_equal_than};
+use witness::next_pow2_instance_padding;
 
 /// Provide context for selector's instantiation at runtime
 #[derive(Clone, Debug)]
@@ -154,7 +154,10 @@ impl<E: ExtensionField> SelectorType<E> {
             }
             // compute true and false mle eq(1; b[..5]) * sel(y; b[5..]), and eq(1; b[..5]) * (eq() - sel(y; b[5..]))
             SelectorType::OrderedSparse32 { indices, .. } => {
-                assert_eq!(out_point.len(), ceil_log2(ctx.num_instances) + 5);
+                assert_eq!(
+                    out_point.len(),
+                    next_pow2_instance_padding(ctx.num_instances).ilog2() as usize + 5
+                );
 
                 let mut sel = build_eq_x_r_vec(out_point);
                 sel.par_chunks_exact_mut(CYCLIC_POW2_5.len())


### PR DESCRIPTION
Keccak (with 1 row span into rotation 32) got some legacy bug of padding. 
In short, before fixed, rmm padding logic is `next_pow2(instance * rotation)`, but the correct logic should be `next_pow2(instance) * rotation`

To reproduce the bug, set ITERATIONS = 1

https://github.com/scroll-tech/ceno/blob/81e45aad132a5938485db405e46bb0b6173e08c2/examples/examples/keccak_syscall.rs#L8


Previous bug is not always trigger because it depends on `next_pow2(instance * rotation)` == `next_pow2(instance) * rotation` or not

This PR also encaptulate rotation logic in rmm, so the prover flow got less confusion in order to deal with rotation logic
