### PR TITLE
fix ceno cli

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -181,3 +181,10 @@ jobs:
       - name: Test install Ceno cli
         run: |
           cargo make cli
+
+      - name: Run Ceno cli example proof
+        working-directory: ceno_cli/example
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/target
+        run: |
+          cargo ceno prove --platform=ceno --hints 10 --public-io 4

--- a/ceno_cli/example/src/main.rs
+++ b/ceno_cli/example/src/main.rs
@@ -28,5 +28,5 @@ fn main() {
         panic!();
     }
 
-    ceno_rt::commit::<Archived<u32>, _>(&cnt_primes);
+    ceno_rt::commit(&cnt_primes);
 }

--- a/ceno_cli/src/utils.rs
+++ b/ceno_cli/src/utils.rs
@@ -86,6 +86,8 @@ pub fn get_rust_flags() -> String {
         "-Zlocation-detail=none",
         "-C",
         "passes=lower-atomic",
+        "--cfg",
+        "getrandom_backend=\"custom\"",
     ];
 
     let mut rust_flags = std::env::var("RUSTFLAGS").unwrap_or_else(|_| String::new());


### PR DESCRIPTION
cli tool failed long time ago after bump getrandom version. In new tool, we need to add

https://github.com/scroll-tech/ceno/blob/9037fe519a673a63435b00bae533b8f95928d81b/examples/.cargo/config.toml#L28-L29

to make new getrandom patch work 