### PR TITLE
cleanup complex padding logic in local-finalize-circuit

### DIFF
--- a/ceno_zkvm/src/instructions/riscv/rv32im/mmu.rs
+++ b/ceno_zkvm/src/instructions/riscv/rv32im/mmu.rs
@@ -12,8 +12,7 @@ use crate::{
 use ceno_emul::{Addr, IterAddresses, WORD_SIZE, Word};
 use ff_ext::ExtensionField;
 use itertools::{Itertools, chain};
-use std::{collections::HashSet, iter::zip, ops::Range, sync::Arc};
-use witness::InstancePaddingStrategy;
+use std::{collections::HashSet, iter::zip, ops::Range};
 
 pub struct MmuConfig<E: ExtensionField> {
     /// Initialization of registers.
@@ -162,48 +161,15 @@ impl<E: ExtensionField> MmuConfig<E> {
         heap_final: &[MemFinalRecord],
     ) -> Result<(), ZKVMError> {
         let all_records = vec![
-            (
-                PubIOTable::name(),
-                InstancePaddingStrategy::Default,
-                io_final,
-            ),
-            (
-                RegTable::name(),
-                InstancePaddingStrategy::Default,
-                reg_final,
-            ),
-            (
-                StaticMemTable::name(),
-                InstancePaddingStrategy::Default,
-                static_mem_final,
-            ),
-            (
-                StackTable::name(),
-                InstancePaddingStrategy::Custom({
-                    let params = cs.params.clone();
-                    Arc::new(move |row: u64, _: u64| StackTable::addr(&params, row as usize) as u64)
-                }),
-                stack_final,
-            ),
-            (
-                HintsTable::name(),
-                InstancePaddingStrategy::Custom({
-                    let params = cs.params.clone();
-                    Arc::new(move |row: u64, _: u64| HintsTable::addr(&params, row as usize) as u64)
-                }),
-                hints_final,
-            ),
-            (
-                HeapTable::name(),
-                InstancePaddingStrategy::Custom({
-                    let params = cs.params.clone();
-                    Arc::new(move |row: u64, _: u64| HeapTable::addr(&params, row as usize) as u64)
-                }),
-                heap_final,
-            ),
+            (PubIOTable::name(), io_final),
+            (RegTable::name(), reg_final),
+            (StaticMemTable::name(), static_mem_final),
+            (StackTable::name(), stack_final),
+            (HintsTable::name(), hints_final),
+            (HeapTable::name(), heap_final),
         ]
         .into_iter()
-        .filter(|(_, _, record)| !record.is_empty())
+        .filter(|(_, record)| !record.is_empty())
         .collect_vec();
 
         witness.assign_table_circuit::<LocalFinalCircuit<E>>(

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -28,7 +28,7 @@ use std::{
 };
 use sumcheck::structs::{IOPProof, IOPProverMessage};
 use tracing::Level;
-use witness::{InstancePaddingStrategy, RowMajorMatrix};
+use witness::RowMajorMatrix;
 
 /// proof that the sum of N=2^n EC points is equal to `sum`
 /// in one layer instead of GKR layered circuit approach
@@ -458,10 +458,7 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
     pub fn assign_shared_circuit(
         &mut self,
         cs: &ZKVMConstraintSystem<E>,
-        (shard_ctx, final_mem): &(
-            &ShardContext,
-            &[(&'static str, InstancePaddingStrategy, &[MemFinalRecord])],
-        ),
+        (shard_ctx, final_mem): &(&ShardContext, &[(&'static str, &[MemFinalRecord])]),
         config: &<ShardRamCircuit<E> as TableCircuit<E>>::TableConfig,
     ) -> Result<(), ZKVMError> {
         let perm = <E::BaseField as PoseidonField>::get_default_perm();
@@ -474,7 +471,7 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
         let non_first_shard_records = if shard_ctx.is_first_shard() {
             final_mem
                 .par_iter()
-                .flat_map(|(mem_name, _, final_mem)| {
+                .flat_map(|(mem_name, final_mem)| {
                     final_mem.par_iter().filter_map(|mem_record| {
                         // prepare cross shard writes record for those record which not accessed in first record
                         // but access in future shard

--- a/ceno_zkvm/src/tables/mod.rs
+++ b/ceno_zkvm/src/tables/mod.rs
@@ -50,7 +50,7 @@ pub trait TableCircuit<E: ExtensionField> {
         let lk_table_len = cb.cs.lk_table_expressions.len() * 2;
 
         let selector = cb.create_placeholder_structural_witin(|| "selector");
-        let selector_type = SelectorType::Whole(selector.expr());
+        let selector_type = SelectorType::Prefix(selector.expr());
 
         // all shared the same selector
         let (out_evals, mut chip) = (

--- a/ceno_zkvm/src/tables/ram/ram_circuit.rs
+++ b/ceno_zkvm/src/tables/ram/ram_circuit.rs
@@ -289,7 +289,7 @@ impl<E: ExtensionField, const V_LIMBS: usize> TableCircuit<E> for LocalFinalRamC
     type FixedInput = ();
     type WitnessInput<'a> = (
         &'a ShardContext<'a>,
-        &'a [(&'static str, InstancePaddingStrategy, &'a [MemFinalRecord])],
+        &'a [(&'static str, &'a [MemFinalRecord])],
     );
 
     fn name() -> String {

--- a/ceno_zkvm/src/tables/ram/ram_impl.rs
+++ b/ceno_zkvm/src/tables/ram/ram_impl.rs
@@ -7,9 +7,7 @@ use rayon::iter::{
     IntoParallelRefMutIterator, ParallelExtend, ParallelIterator,
 };
 use std::marker::PhantomData;
-use witness::{
-    InstancePaddingStrategy, RowMajorMatrix, next_pow2_instance_padding, set_fixed_val, set_val,
-};
+use witness::{InstancePaddingStrategy, RowMajorMatrix, set_fixed_val, set_val};
 
 use super::{
     MemInitRecord,
@@ -24,7 +22,6 @@ use crate::{
     tables::ram::ram_circuit::DynVolatileRamTableConfigTrait,
 };
 use ff_ext::FieldInto;
-use gkr_iop::RAMType;
 use multilinear_extensions::{
     Expression, Fixed, StructuralWitIn, StructuralWitInType, ToExpr, WitIn,
 };
@@ -334,19 +331,19 @@ impl<DVRAM: DynVolatileRamTable + Send + Sync + Clone> DynVolatileRamTableConfig
         }
         assert_eq!(num_structural_witin, 2);
 
-        let num_instances_padded = next_pow2_instance_padding(final_mem.len());
-        assert!(num_instances_padded <= DVRAM::max_len(&config.params));
+        let num_instances = final_mem.len();
+        assert!(num_instances <= DVRAM::max_len(&config.params));
         assert!(DVRAM::max_len(&config.params).is_power_of_two());
 
         // got some duplicated code segment to simplify parallel assignment flow
         if let Some(init_v) = config.init_v.as_ref() {
             let mut witness = RowMajorMatrix::<F>::new(
-                num_instances_padded,
+                num_instances,
                 num_witin,
                 InstancePaddingStrategy::Default,
             );
             let mut structural_witness = RowMajorMatrix::<F>::new(
-                num_instances_padded,
+                num_instances,
                 num_structural_witin,
                 InstancePaddingStrategy::Default,
             );
@@ -384,13 +381,15 @@ impl<DVRAM: DynVolatileRamTable + Send + Sync + Clone> DynVolatileRamTableConfig
                         config.addr,
                         DVRAM::addr(&config.params, i) as u64
                     );
-                    *structural_row.last_mut().unwrap() = F::ONE;
+                    if i < num_instances {
+                        *structural_row.last_mut().unwrap() = F::ONE;
+                    }
                 });
 
             Ok([witness, structural_witness])
         } else {
             let mut structural_witness = RowMajorMatrix::<F>::new(
-                num_instances_padded,
+                num_instances,
                 num_structural_witin,
                 InstancePaddingStrategy::Default,
             );
@@ -415,7 +414,9 @@ impl<DVRAM: DynVolatileRamTable + Send + Sync + Clone> DynVolatileRamTableConfig
                         config.addr,
                         DVRAM::addr(&config.params, i) as u64
                     );
-                    *structural_row.last_mut().unwrap() = F::ONE;
+                    if i < num_instances {
+                        *structural_row.last_mut().unwrap() = F::ONE;
+                    }
                 });
             Ok([RowMajorMatrix::empty(), structural_witness])
         }
@@ -481,7 +482,7 @@ impl<const V_LIMBS: usize> LocalFinalRAMTableConfig<V_LIMBS> {
         shard_ctx: &ShardContext,
         num_witin: usize,
         num_structural_witin: usize,
-        final_mem: &[(&'static str, InstancePaddingStrategy, &[MemFinalRecord])],
+        final_mem: &[(&'static str, &[MemFinalRecord])],
     ) -> Result<[RowMajorMatrix<F>; 2], CircuitBuilderError> {
         assert!(num_structural_witin == 0 || num_structural_witin == 1);
         let num_structural_witin = num_structural_witin.max(1);
@@ -492,35 +493,12 @@ impl<const V_LIMBS: usize> LocalFinalRAMTableConfig<V_LIMBS> {
         };
 
         // collect each raw mem belong to this shard, BEFORE padding length
-        let current_shard_mems_len: Vec<usize> = final_mem
+        let mem_lens: Vec<usize> = final_mem
             .par_iter()
-            .map(|(_, _, mem)| mem.par_iter().filter(is_current_shard_mem_record).count())
+            .map(|(_, mem)| mem.par_iter().filter(is_current_shard_mem_record).count())
             .collect();
 
-        // deal with non-pow2 padding for first shard
-        // format Vec<(pad_len, pad_start_index)>
-        let padding_info = if shard_ctx.is_first_shard() {
-            final_mem
-                .iter()
-                .map(|(_, _, mem)| {
-                    assert!(!mem.is_empty());
-                    (
-                        next_pow2_instance_padding(mem.len()) - mem.len(),
-                        mem.len(),
-                        mem[0].ram_type,
-                    )
-                })
-                .collect_vec()
-        } else {
-            vec![(0, 0, RAMType::Undefined); final_mem.len()]
-        };
-
         // calculate mem length
-        let mem_lens = current_shard_mems_len
-            .iter()
-            .zip_eq(&padding_info)
-            .map(|(raw_len, (pad_len, _, _))| raw_len + pad_len)
-            .collect_vec();
         let total_records = mem_lens.iter().sum();
 
         let mut witness =
@@ -562,67 +540,30 @@ impl<const V_LIMBS: usize> LocalFinalRAMTableConfig<V_LIMBS> {
             .par_iter_mut()
             .zip_eq(structural_witness_mut_slices.par_iter_mut())
             .zip_eq(final_mem.par_iter())
-            .zip_eq(padding_info.par_iter())
-            .for_each(
-                |(
-                    ((witness, structural_witness), (_, padding_strategy, final_mem)),
-                    (pad_size, pad_start_index, ram_type),
-                )| {
-                    let mem_record_count = witness
-                        .chunks_mut(num_witin)
-                        .zip_eq(structural_witness.chunks_mut(num_structural_witin))
-                        .zip(final_mem.iter().filter(is_current_shard_mem_record))
-                        .map(|((row, structural_row), rec)| {
-                            if self.final_v.len() == 1 {
-                                // Assign value directly.
-                                set_val!(row, self.final_v[0], rec.value as u64);
-                            } else {
-                                // Assign value limbs.
-                                self.final_v.iter().enumerate().for_each(|(l, limb)| {
-                                    let val = (rec.value >> (l * LIMB_BITS)) & LIMB_MASK;
-                                    set_val!(row, limb, val as u64);
-                                });
-                            }
-                            let shard_cycle = rec.cycle - current_shard_offset_cycle;
-                            set_val!(row, self.final_cycle, shard_cycle);
-
-                            set_val!(row, self.ram_type, rec.ram_type as u64);
-                            set_val!(row, self.addr_subset, rec.addr as u64);
-                            *structural_row.last_mut().unwrap() = F::ONE;
-                        })
-                        .count();
-
-                    if *pad_size > 0 && shard_ctx.is_first_shard() {
-                        match padding_strategy {
-                            InstancePaddingStrategy::Custom(pad_func) => {
-                                witness[mem_record_count * num_witin..]
-                                    .chunks_mut(num_witin)
-                                    .zip_eq(
-                                        structural_witness
-                                            [mem_record_count * num_structural_witin..]
-                                            .chunks_mut(num_structural_witin),
-                                    )
-                                    .zip_eq(
-                                        std::iter::successors(Some(*pad_start_index), |n| {
-                                            Some(*n + 1)
-                                        })
-                                        .take(*pad_size),
-                                    )
-                                    .for_each(|((row, structural_row), pad_index)| {
-                                        set_val!(
-                                            row,
-                                            self.addr_subset,
-                                            pad_func(pad_index as u64, self.addr_subset.id as u64)
-                                        );
-                                        set_val!(row, self.ram_type, *ram_type as u64);
-                                        *structural_row.last_mut().unwrap() = F::ONE;
-                                    });
-                            }
-                            _ => unimplemented!(),
+            .for_each(|((witness, structural_witness), (_, final_mem))| {
+                witness
+                    .chunks_mut(num_witin)
+                    .zip_eq(structural_witness.chunks_mut(num_structural_witin))
+                    .zip(final_mem.iter().filter(is_current_shard_mem_record))
+                    .for_each(|((row, structural_row), rec)| {
+                        if self.final_v.len() == 1 {
+                            // Assign value directly.
+                            set_val!(row, self.final_v[0], rec.value as u64);
+                        } else {
+                            // Assign value limbs.
+                            self.final_v.iter().enumerate().for_each(|(l, limb)| {
+                                let val = (rec.value >> (l * LIMB_BITS)) & LIMB_MASK;
+                                set_val!(row, limb, val as u64);
+                            });
                         }
-                    }
-                },
-            );
+                        let shard_cycle = rec.cycle - current_shard_offset_cycle;
+                        set_val!(row, self.final_cycle, shard_cycle);
+
+                        set_val!(row, self.ram_type, rec.ram_type as u64);
+                        set_val!(row, self.addr_subset, rec.addr as u64);
+                        *structural_row.last_mut().unwrap() = F::ONE;
+                    });
+            });
 
         Ok([witness, structural_witness])
     }


### PR DESCRIPTION
previously in first shard to balance r/w consistent for heap/stack, local finalize circuit implement complex logic to absorb those padding but no read logic into read set. 

Since right now table circuit also relax the limitation and num_instances doesn't need to be power of 2. We can change selector from `whole` to `prefix`, exclude padding zero into local `write set`, so we can clean up local finalized circuit `read set` padding logic

### testing
e2e verified in proving `23587691`.