### PR TITLE
report execution failed when vm trapped

### DIFF
--- a/ceno_emul/src/vm_state.rs
+++ b/ceno_emul/src/vm_state.rs
@@ -129,7 +129,7 @@ impl<T: Tracer> VMState<T> {
     fn step(&mut self) -> Result<T::Record> {
         crate::rv32im::step(self)?;
         let step = self.tracer.advance();
-        if T::is_busy_loop(&step) && !self.halted() {
+        if self.tracer.is_busy_loop(&step) && !self.halted() {
             Err(anyhow!("Stuck in loop {}", "{}"))
         } else {
             Ok(step)

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -698,7 +698,10 @@ pub fn emulate_program<'a>(
     }
 
     let exit_code = info_span!("[ceno] emulator.preflight-execute").in_scope(|| {
-        let _ = vm.iter_until_halt().take(max_steps).count();
+        vm.iter_until_halt()
+            .take(max_steps)
+            .try_for_each(|step| step.map(|_| ()))
+            .unwrap_or_else(|err| panic!("emulator trapped before halt: {err}"));
         vm.halted_state().map(|halt_state| halt_state.exit_code)
     });
 


### PR DESCRIPTION
`let _ = vm.iter_until_halt().take(max_steps).count();` will keep calling `next()` even emulator halt.
This PR add termination mechanism