### PR TITLE
ecc quark gpu prover

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,8 +127,8 @@ lto = "thin"
 #ceno_crypto_primitives = { path = "../ceno-patch/crypto-primitives", package = "ceno_crypto_primitives" }
 #ceno_syscall = { path = "../ceno-patch/syscall", package = "ceno_syscall" }
 
-# [patch."https://github.com/scroll-tech/ceno-gpu-mock.git"]
-# ceno_gpu = { path = "../ceno-gpu/cuda_hal", package = "cuda_hal", default-features = false, features=["bb31"] }
+#[patch."https://github.com/scroll-tech/ceno-gpu-mock.git"]
+#ceno_gpu = { path = "../ceno-gpu/cuda_hal", package = "cuda_hal", default-features = false, features = ["bb31"] }
 
 #[patch."https://github.com/scroll-tech/gkr-backend"]
 #ff_ext = { path = "../gkr-backend/crates/ff_ext", package = "ff_ext" }

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1865,7 +1865,7 @@ fn create_proofs_streaming<
                 {
                     let mut proofs = Vec::new();
                     let mut proof_err = None;
-                    let mut rx = rx;
+                    let rx = rx;
                     while let Ok((zkvm_witness, shard_ctx, pi)) = rx.recv() {
                         if is_mock_proving {
                             MockProver::assert_satisfied_full(

--- a/ceno_zkvm/src/scheme/gpu/util.rs
+++ b/ceno_zkvm/src/scheme/gpu/util.rs
@@ -1,0 +1,262 @@
+use std::{any::TypeId, sync::Arc};
+
+use ceno_gpu::{
+    Buffer, CudaHal,
+    bb31::{CudaHalBB31, GpuFieldType, GpuPolynomial},
+    common::mle::filter_mle_even_odd_batch,
+};
+use ff_ext::ExtensionField;
+use gkr_iop::{
+    error::BackendError,
+    gpu::{BB31Base, MultilinearExtensionGpu},
+};
+use multilinear_extensions::{Expression, WitnessId, mle::MultilinearExtension};
+use p3::field::{FieldAlgebra, PrimeField32};
+use transcript::{BasicTranscript, Transcript};
+
+use crate::{
+    error::ZKVMError,
+    scheme::septic_curve::{SepticExtension, SymbolicSepticExtension},
+};
+
+use crate::scheme::gpu::BB31Ext;
+
+pub fn expect_basic_transcript<E: ExtensionField, T: Transcript<E>>(
+    transcript: &mut T,
+) -> &mut BasicTranscript<BB31Ext> {
+    let actual = std::any::type_name::<T>();
+    let expected = std::any::type_name::<BasicTranscript<BB31Ext>>();
+    assert_eq!(
+        actual, expected,
+        "GPU backend requires BasicTranscript<BB31Ext>; got {actual}"
+    );
+    unsafe { &mut *(transcript as *mut T as *mut BasicTranscript<BB31Ext>) }
+}
+
+pub fn read_septic_value_from_gpu<'a, E: ExtensionField>(
+    polys: &[Arc<MultilinearExtensionGpu<'a, E>>],
+    index: usize,
+) -> Result<SepticExtension<E::BaseField>, ZKVMError> {
+    let coords = polys
+        .iter()
+        .map(|poly| read_base_value_from_gpu(poly, index))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(coords.into())
+}
+
+fn read_base_value_from_gpu<'a, E: ExtensionField>(
+    poly: &Arc<MultilinearExtensionGpu<'a, E>>,
+    index: usize,
+) -> Result<E::BaseField, ZKVMError> {
+    match &poly.mle {
+        GpuFieldType::Base(base_poly) => {
+            let buffer = base_poly.evaluations();
+            let raw = buffer
+                .get(index)
+                .map_err(|e| hal_to_backend_error(format!("failed to read GPU buffer: {e:?}")))?;
+            let canonical = raw.as_canonical_u32();
+            Ok(E::BaseField::from_canonical_u32(canonical))
+        }
+        GpuFieldType::Ext(_) => Err(hal_to_backend_error(
+            "expected base-field polynomial for final-sum extraction",
+        )),
+        GpuFieldType::Unreachable => {
+            Err(hal_to_backend_error("unreachable GPU polynomial variant"))
+        }
+    }
+}
+
+pub fn batch_mles_take_half<'a, E: ExtensionField>(
+    polynomials: &[Arc<MultilinearExtensionGpu<'a, E>>],
+    chunk_index: usize,
+) -> Result<Vec<Arc<MultilinearExtensionGpu<'a, E>>>, ZKVMError> {
+    if polynomials.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    debug_assert!(
+        chunk_index < 2,
+        "only two chunks are supported when splitting in half"
+    );
+    debug_assert_eq!(
+        TypeId::of::<E::BaseField>(),
+        TypeId::of::<BB31Base>(),
+        "GPU backend only supports BabyBear base field"
+    );
+
+    polynomials
+        .iter()
+        .map(|poly| {
+            let gpu_poly = match &poly.mle {
+                GpuFieldType::Base(base) => base
+                    .as_view_chunk(2)
+                    .into_iter()
+                    .nth(chunk_index)
+                    .expect("chunk index must be valid"),
+                GpuFieldType::Ext(_) => {
+                    return Err(hal_to_backend_error(
+                        "expected base-field polynomial for EC witness splitting",
+                    ));
+                }
+                GpuFieldType::Unreachable => {
+                    return Err(hal_to_backend_error("unreachable GPU polynomial variant"));
+                }
+            };
+            let gpu_mle = MultilinearExtensionGpu::from_ceno_gpu_base(gpu_poly);
+            Ok(Arc::new(gpu_mle))
+        })
+        .collect()
+}
+
+pub fn symbolic_from_mle<'a, E: ExtensionField>(
+    registry: &mut WitnessRegistry<'a, E>,
+    polys: &[Arc<MultilinearExtensionGpu<'a, E>>],
+) -> SymbolicSepticExtension<E> {
+    SymbolicSepticExtension::new(
+        polys
+            .iter()
+            .cloned()
+            .map(|poly| registry.register(poly))
+            .collect(),
+    )
+}
+
+#[derive(Default)]
+pub struct WitnessRegistry<'a, E: ExtensionField> {
+    gpu_mles: Vec<Arc<MultilinearExtensionGpu<'a, E>>>,
+}
+
+impl<'a, E: ExtensionField> WitnessRegistry<'a, E> {
+    pub fn register(&mut self, mle: Arc<MultilinearExtensionGpu<'a, E>>) -> Expression<E> {
+        let idx_u16 = u16::try_from(self.gpu_mles.len())
+            .expect("witness identifier overflow in EC sum quark");
+        self.gpu_mles.push(mle);
+        Expression::WitIn(idx_u16 as WitnessId)
+    }
+
+    pub fn gpu_refs(&self) -> Vec<&MultilinearExtensionGpu<'a, E>> {
+        self.gpu_mles.iter().map(|arc| arc.as_ref()).collect()
+    }
+}
+
+pub fn hal_to_backend_error(message: impl Into<String>) -> ZKVMError {
+    ZKVMError::BackendError(BackendError::CircuitError(message.into().into_boxed_str()))
+}
+
+pub fn mle_host_to_gpu<'a, E: ExtensionField>(
+    cuda_hal: &CudaHalBB31,
+    mle: &MultilinearExtension<'a, E>,
+) -> Arc<MultilinearExtensionGpu<'static, E>> {
+    if TypeId::of::<E::BaseField>() != TypeId::of::<BB31Base>() {
+        panic!("GPU backend only supports BabyBear base field");
+    }
+    let gpu = MultilinearExtensionGpu::from_ceno(cuda_hal, mle);
+    Arc::new(unsafe {
+        std::mem::transmute::<MultilinearExtensionGpu<'_, E>, MultilinearExtensionGpu<'static, E>>(
+            gpu,
+        )
+    })
+}
+
+pub fn mle_filter_even_odd_batch<'a, E: ExtensionField>(
+    cuda_hal: &CudaHalBB31,
+    requests: &[(&[Arc<MultilinearExtensionGpu<'a, E>>], bool)],
+) -> Result<Vec<Vec<Arc<MultilinearExtensionGpu<'static, E>>>>, ZKVMError> {
+    if requests.iter().all(|(polys, _)| polys.is_empty()) {
+        return Ok(vec![Vec::new(); requests.len()]);
+    }
+
+    debug_assert_eq!(
+        TypeId::of::<E::BaseField>(),
+        TypeId::of::<BB31Base>(),
+        "GPU backend only supports Babybear base field"
+    );
+
+    let mut flattened_refs = Vec::new();
+    let mut flags = Vec::new();
+    let mut result_num_vars = Vec::new();
+
+    let expected_len = requests
+        .first()
+        .map(|(polys, _)| polys.len())
+        .unwrap_or_default();
+    assert!(
+        requests
+            .iter()
+            .all(|(polys, _)| polys.len() == expected_len),
+        "all filter requests must contain the same number of MLEs"
+    );
+
+    for (polys, flag) in requests {
+        for poly in *polys {
+            let num_vars = poly
+                .mle
+                .num_vars()
+                .checked_sub(1)
+                .expect("polynomial must have at least one variable");
+            result_num_vars.push(num_vars);
+            flattened_refs.push(&poly.mle);
+            flags.push(*flag);
+        }
+    }
+
+    if flattened_refs.is_empty() {
+        return Ok(vec![Vec::new(); requests.len()]);
+    }
+
+    let stride = 1usize << result_num_vars[0];
+    assert!(
+        flattened_refs
+            .iter()
+            .zip(result_num_vars.iter())
+            .all(|(poly, vars)| poly.num_vars() == vars + 1),
+        "all MLEs must share the same number of variables before filtering"
+    );
+
+    let mut output_buffers = flattened_refs
+        .iter()
+        .map(|_| {
+            cuda_hal
+                .alloc_elems_on_device(stride, false)
+                .map_err(|e| hal_to_backend_error(format!("failed to allocate GPU buffer: {e:?}")))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let flattened_refs: Vec<&GpuFieldType<'static>> =
+        unsafe { std::mem::transmute(flattened_refs) };
+
+    filter_mle_even_odd_batch::<
+        CudaHalBB31,
+        BB31Ext,
+        BB31Base,
+        GpuFieldType<'static>,
+        GpuPolynomial<'static>,
+    >(cuda_hal, flattened_refs, &flags, &mut output_buffers)
+    .map_err(|e| hal_to_backend_error(format!("GPU filter kernel failed: {e:?}")))?;
+
+    let mut outputs = Vec::with_capacity(requests.len());
+    let mut idx = 0;
+    for _ in requests {
+        let mut segment = Vec::with_capacity(expected_len);
+        for _ in 0..expected_len {
+            let buf = output_buffers
+                .get(idx)
+                .expect("missing buffer for filter result")
+                .clone();
+            let num_vars = result_num_vars[idx];
+            let gpu_poly = GpuPolynomial::new(buf, num_vars);
+            let gpu_mle = MultilinearExtensionGpu::from_ceno_gpu_base(gpu_poly);
+            let gpu_mle_static = unsafe {
+                std::mem::transmute::<
+                    MultilinearExtensionGpu<'_, E>,
+                    MultilinearExtensionGpu<'static, E>,
+                >(gpu_mle)
+            };
+            segment.push(Arc::new(gpu_mle_static));
+            idx += 1;
+        }
+        outputs.push(segment);
+    }
+
+    Ok(outputs)
+}

--- a/gkr_iop/src/gpu/mod.rs
+++ b/gkr_iop/src/gpu/mod.rs
@@ -370,7 +370,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>
                 let (coeffs, indices, size_info) = extract_mle_relationships_from_monomial_terms(
                     expr,
                     &layer_wits.iter().map(|mle| mle.as_ref()).collect_vec(),
-                    &pub_io_evals,
+                    pub_io_evals,
                     challenges,
                 );
                 let coeffs_gl64: Vec<BB31Ext> = unsafe { std::mem::transmute(coeffs) };


### PR DESCRIPTION
To close #1232 

Move ecc quark major mles of septic curve and sumcheck to GPU. selector remain in cpu as its overhead are negligible, due to the num rows in ecc quark are relatively small, .e.g ~2^21.

### benchmark on larger block `24169100 `

> `23817600` block are relative `small` where only 14 shards, thus we can only see ~2s e2e different

24169100 with 24 shards and each have shard proofs

| Stage / Component                       | Before Time | After Time |
|----------------------------------------|-------------|------------|
| reth-block (block 24169100)             | 249 s       | 240 s      |
| app.prove                              | 169 s       | 160 s      |
| prove_ec_sum_quark (shard id 0)   | 640 ms      | 49.2 ms    |
| prove_ec_sum_quark (shard id 1)   | 682 ms      | 49.6 ms    |
| prove_ec_sum_quark (shard id 2)   | 650 ms      | 50.6 ms    |
| prove_ec_sum_quark (shard id 3)   | 355 ms      | 28.3 ms    |
...