### PR TITLE
optimize iop_verifier_state_verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4105,6 +4105,7 @@ source = "git+https://github.com/scroll-tech/openvm.git?branch=feat%2Fv1.4.1-scr
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
+ "metrics",
  "num-bigint 0.4.6",
  "num-integer",
  "openvm-circuit",
@@ -4137,6 +4138,7 @@ dependencies = [
  "cfg-if",
  "itertools 0.14.0",
  "lazy_static",
+ "metrics",
  "openvm-circuit",
  "openvm-native-circuit",
  "openvm-native-compiler",
@@ -4506,6 +4508,7 @@ dependencies = [
  "openvm-platform",
  "openvm-stark-backend",
  "rrs-lib",
+ "rustc-demangle",
  "thiserror 1.0.69",
 ]
 

--- a/ceno_recursion/Cargo.toml
+++ b/ceno_recursion/Cargo.toml
@@ -52,7 +52,7 @@ name = "e2e_aggregate"
 path = "src/bin/e2e_aggregate.rs"
 
 [features]
-bench-metrics = ["openvm-circuit/metrics"]
+bench-metrics = ["openvm-sdk/metrics"]
 default = ["parallel", "nightly-features"]
 gpu = ["ceno_zkvm/gpu", "openvm-circuit/cuda", "openvm-native-circuit/cuda", "dep:openvm-cuda-backend"]
 nightly-features = [
@@ -60,3 +60,4 @@ nightly-features = [
   "openvm-stark-sdk/nightly-features",
 ]
 parallel = ["openvm-stark-backend/parallel"]
+perf-metrics = ["openvm-sdk/perf-metrics"]

--- a/ceno_recursion/src/arithmetics/mod.rs
+++ b/ceno_recursion/src/arithmetics/mod.rs
@@ -927,7 +927,7 @@ impl<C: Config> UniPolyExtrapolator<C> {
         res
     }
 
-    fn extrapolate_uni_poly_deg_1(
+    pub fn extrapolate_uni_poly_deg_1(
         &self,
         builder: &mut Builder<C>,
         p_i_0: Ext<C::F, C::EF>,
@@ -946,7 +946,7 @@ impl<C: Config> UniPolyExtrapolator<C> {
         builder.eval(l * (t0 + t1))
     }
 
-    fn extrapolate_uni_poly_deg_2(
+    pub fn extrapolate_uni_poly_deg_2(
         &self,
         builder: &mut Builder<C>,
         p_i_0: Ext<C::F, C::EF>,
@@ -970,7 +970,7 @@ impl<C: Config> UniPolyExtrapolator<C> {
         builder.eval(l * (t0 + t1 + t2))
     }
 
-    fn extrapolate_uni_poly_deg_3(
+    pub fn extrapolate_uni_poly_deg_3(
         &self,
         builder: &mut Builder<C>,
         p_i_0: Ext<C::F, C::EF>,
@@ -998,7 +998,7 @@ impl<C: Config> UniPolyExtrapolator<C> {
         builder.eval(l * (t0 + t1 + t2 + t3))
     }
 
-    fn extrapolate_uni_poly_deg_4(
+    pub fn extrapolate_uni_poly_deg_4(
         &self,
         builder: &mut Builder<C>,
         p_i_0: Ext<C::F, C::EF>,

--- a/ceno_recursion/src/transcript/mod.rs
+++ b/ceno_recursion/src/transcript/mod.rs
@@ -5,6 +5,8 @@ use openvm_native_recursion::challenger::{
 };
 use openvm_stark_backend::p3_field::FieldAlgebra;
 
+use crate::arithmetics::challenger_multi_observe;
+
 pub fn transcript_observe_label<C: Config>(
     builder: &mut Builder<C>,
     challenger: &mut DuplexChallengerVariable<C>,
@@ -15,6 +17,27 @@ pub fn transcript_observe_label<C: Config>(
         let f: Felt<C::F> = builder.constant(C::F::from_canonical_u64(n.to_canonical_u64()));
         challenger.observe(builder, f);
     }
+}
+
+pub fn transcript_label_as_array<C: Config>(
+    builder: &mut Builder<C>,
+    label: &[u8],
+) -> Array<C, Felt<C::F>> {
+    let label_f = <BabyBearExt4 as CenoExtensionField>::BaseField::bytes_to_field_elements(label);
+    let arr: Array<C, Felt<C::F>> = builder.dyn_array(label_f.len());
+    for (idx, n) in label_f.into_iter().enumerate() {
+        let f: Felt<C::F> = builder.constant(C::F::from_canonical_u64(n.to_canonical_u64()));
+        builder.set_value(&arr, idx, f);
+    }
+    arr
+}
+
+pub fn transcript_observe_label_felts<C: Config>(
+    builder: &mut Builder<C>,
+    challenger: &mut DuplexChallengerVariable<C>,
+    label_felts: &Array<C, Felt<C::F>>,
+) {
+    challenger_multi_observe(builder, challenger, label_felts);
 }
 
 pub fn transcript_check_pow_witness<C: Config>(

--- a/ceno_recursion/src/zkvm_verifier/verifier.rs
+++ b/ceno_recursion/src/zkvm_verifier/verifier.rs
@@ -953,8 +953,6 @@ pub fn verify_gkr_circuit<C: Config>(
             });
 
         // sigma = \sum_b sel(b) * zero_expr(b)
-        let max_degree = builder.constant(C::F::from_canonical_usize(layer.max_expr_degree + 1));
-
         let max_num_variables_f = builder.unsafe_cast_var_to_felt(max_num_variables.get_var());
 
         let (in_point, expected_evaluation) = iop_verifier_state_verify(
@@ -963,7 +961,7 @@ pub fn verify_gkr_circuit<C: Config>(
             &sigma,
             &proof,
             max_num_variables_f,
-            max_degree,
+            layer.max_expr_degree + 1,
             unipoly_extrapolator,
         );
 
@@ -1204,7 +1202,6 @@ pub fn verify_rotation<C: Config>(
     let sigma: Ext<C::F, C::EF> = builder.constant(C::EF::ZERO);
 
     let max_num_variables = builder.unsafe_cast_var_to_felt(max_num_variables.get_var());
-    let max_degree: Felt<C::F> = builder.constant(C::F::TWO);
 
     let (origin_point, expected_evaluation) = iop_verifier_state_verify(
         builder,
@@ -1212,7 +1209,7 @@ pub fn verify_rotation<C: Config>(
         &sigma,
         proof,
         max_num_variables,
-        max_degree,
+        2,
         unipoly_extrapolator,
     );
 
@@ -1756,7 +1753,6 @@ pub fn verify_ecc_proof<C: Config>(
 
     let one_ext: Ext<C::F, C::EF> = builder.constant(C::EF::ONE);
     let zero_ext: Ext<C::F, C::EF> = builder.constant(C::EF::ZERO);
-    let three_f: Felt<C::F> = builder.constant(C::F::from_canonical_u32(3));
     let num_vars_f = builder.unsafe_cast_var_to_felt(num_vars.get_var());
     let (rt, sumcheck_expected_evaluation) = iop_verifier_state_verify(
         builder,
@@ -1764,7 +1760,7 @@ pub fn verify_ecc_proof<C: Config>(
         &zero_ext,
         &proof.zerocheck_proof,
         num_vars_f,
-        three_f,
+        3,
         unipoly_extrapolator,
     );
 


### PR DESCRIPTION
### design rationales
- [x] move string label `observe` into `multi-observe`
- [x] optimize `start`, `end` offset computation for prover message
- [x] refactor sumcheck `max_degree` to compile-time information

tested on `23817600` shard-id = 0. below is the recursion cycles breakdown

| Metric                         | Before (cycles) | After (cycles) | After (with more multi-observe) | Improvement (After) | Improvement (more Multi-observe) |
|--------------------------------|-----------------|----------------|----------------------------------|---------------------|-----------------------------|
| ADD (tower proof)              | 23,045          | 19,715         | 19,655                           | 14.45%              | 14.71%                      |
| ADDI (tower proof)             | 33,943          | 28,585         | 28,509                           | 15.79%              | 16.01%                      |
| Ecall_Keccak (tower proof)     | 153,182         | 150,284        | 150,228                          | 1.89%               | 1.93%                       |
| Verify Ceno ZKVM Proof (total) | 2,783,943       | 2,609,701      | 2,606,725                        | 6.26%               | 6.37%                       |