### PR TITLE
unify logup sum across table/non-table chip

### DIFF
--- a/ceno_recursion/src/zkvm_verifier/verifier.rs
+++ b/ceno_recursion/src/zkvm_verifier/verifier.rs
@@ -278,37 +278,35 @@ pub fn verify_zkvm_proof<C: Config<F = F>>(
                 );
                 chip_challenger.observe(builder, chip_proof.idx_felt);
 
-                if !circuit_vk.get_cs().is_with_lk_table() {
-                    // getting the number of dummy padding item that we used in this opcode circuit
-                    let num_lks: Var<C::N> =
-                        builder.eval(C::N::from_canonical_usize(chip_vk.get_cs().num_lks()));
+                // getting the number of dummy padding item that we used in this opcode circuit
+                let num_lks: Var<C::N> =
+                    builder.eval(C::N::from_canonical_usize(chip_vk.get_cs().num_lks()));
 
-                    // each padding instance contribute to (2^rotation_vars) dummy lookup padding
-                    let next_pow2_instance: Var<C::N> =
-                        pow_2(builder, chip_proof.log2_num_instances.get_var());
-                    let num_padded_instance: Var<C::N> =
-                        builder.eval(next_pow2_instance - chip_proof.sum_num_instances.clone());
-                    let rotation_var: Var<C::N> = builder.constant(C::N::from_canonical_usize(
-                        1 << circuit_vk.get_cs().rotation_vars().unwrap_or(0),
+                // each padding instance contribute to (2^rotation_vars) dummy lookup padding
+                let next_pow2_instance: Var<C::N> =
+                    pow_2(builder, chip_proof.log2_num_instances.get_var());
+                let num_padded_instance: Var<C::N> =
+                    builder.eval(next_pow2_instance - chip_proof.sum_num_instances.clone());
+                let rotation_var: Var<C::N> = builder.constant(C::N::from_canonical_usize(
+                    1 << circuit_vk.get_cs().rotation_vars().unwrap_or(0),
+                ));
+                let rotation_subgroup_size: Var<C::N> =
+                    builder.constant(C::N::from_canonical_usize(
+                        circuit_vk.get_cs().rotation_subgroup_size().unwrap_or(0),
                     ));
-                    let rotation_subgroup_size: Var<C::N> =
-                        builder.constant(C::N::from_canonical_usize(
-                            circuit_vk.get_cs().rotation_subgroup_size().unwrap_or(0),
-                        ));
-                    builder.assign(&num_padded_instance, num_padded_instance * rotation_var);
+                builder.assign(&num_padded_instance, num_padded_instance * rotation_var);
 
-                    // each instance contribute to (2^rotation_vars - rotated) dummy lookup padding
-                    let num_instance_non_selected: Var<C::N> = builder.eval(
-                        chip_proof.sum_num_instances.clone()
-                            * (rotation_var - rotation_subgroup_size - C::N::ONE),
-                    );
-                    let new_multiplicity: Var<C::N> =
-                        builder.eval(num_lks * (num_padded_instance + num_instance_non_selected));
-                    builder.assign(
-                        &dummy_table_item_multiplicity,
-                        dummy_table_item_multiplicity + new_multiplicity,
-                    );
-                }
+                // each instance contribute to (2^rotation_vars - rotated) dummy lookup padding
+                let num_instance_non_selected: Var<C::N> = builder.eval(
+                    chip_proof.sum_num_instances.clone()
+                        * (rotation_var - rotation_subgroup_size - C::N::ONE),
+                );
+                let new_multiplicity: Var<C::N> =
+                    builder.eval(num_lks * (num_padded_instance + num_instance_non_selected));
+                builder.assign(
+                    &dummy_table_item_multiplicity,
+                    dummy_table_item_multiplicity + new_multiplicity,
+                );
 
                 builder.cycle_tracker_start("Verify chip proof");
                 let (
@@ -348,11 +346,7 @@ pub fn verify_zkvm_proof<C: Config<F = F>>(
                         builder.assign(&chip_logup_sum, chip_logup_sum + p2 * q2.inverse());
                     });
 
-                if circuit_vk.get_cs().is_with_lk_table() {
-                    builder.assign(&logup_sum, logup_sum - chip_logup_sum);
-                } else {
-                    builder.assign(&logup_sum, logup_sum + chip_logup_sum);
-                }
+                builder.assign(&logup_sum, logup_sum + chip_logup_sum);
 
                 let point_clone: Array<C, Ext<C::F, C::EF>> =
                     builder.eval(input_opening_point.clone());

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -365,23 +365,23 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
                 .sum::<E>();
 
             transcript.append_field_element(&E::BaseField::from_canonical_u64(*index as u64));
-            if circuit_vk.get_cs().is_with_lk_table() {
-                logup_sum -= chip_logup_sum;
-            } else {
-                // getting the number of dummy padding item that we used in this opcode circuit
-                let num_lks = circuit_vk.get_cs().num_lks();
-                // each padding instance contribute to (2^rotation_vars) dummy lookup padding
-                let num_padded_instance = (next_pow2_instance_padding(num_instance) - num_instance)
-                    * (1 << circuit_vk.get_cs().rotation_vars().unwrap_or(0));
-                // each instance contribute to (2^rotation_vars - rotated) dummy lookup padding
-                let num_instance_non_selected = num_instance
-                    * ((1 << circuit_vk.get_cs().rotation_vars().unwrap_or(0))
-                        - (circuit_vk.get_cs().rotation_subgroup_size().unwrap_or(0) + 1));
-                dummy_table_item_multiplicity +=
-                    num_lks * (num_padded_instance + num_instance_non_selected);
 
-                logup_sum += chip_logup_sum;
-            };
+            // compute logup_sum padding
+            // getting the number of dummy padding item that we used in this opcode circuit
+            let num_lks = circuit_vk.get_cs().num_lks();
+            // each padding instance contribute to (2^rotation_vars) dummy lookup padding
+            let num_padded_instance = (next_pow2_instance_padding(num_instance) - num_instance)
+                * (1 << circuit_vk.get_cs().rotation_vars().unwrap_or(0));
+            // each instance contribute to (2^rotation_vars - rotated) dummy lookup padding
+            let num_instance_non_selected = num_instance
+                * ((1 << circuit_vk.get_cs().rotation_vars().unwrap_or(0))
+                    - (circuit_vk.get_cs().rotation_subgroup_size().unwrap_or(0) + 1));
+            dummy_table_item_multiplicity +=
+                num_lks * (num_padded_instance + num_instance_non_selected);
+
+            // accumulate logup_sum
+            logup_sum += chip_logup_sum;
+
             let (input_opening_point, chip_shard_ec_sum, wits_in_evals, fixed_in_evals) = self
                 .verify_chip_proof(
                     circuit_name,

--- a/gkr_iop/src/circuit_builder.rs
+++ b/gkr_iop/src/circuit_builder.rs
@@ -1,3 +1,4 @@
+use ff_ext::ExtensionField;
 use itertools::{Itertools, chain};
 use multilinear_extensions::{
     Expression, Fixed, Instance, StructuralWitIn, StructuralWitInType, ToExpr, WitIn, WitnessId,
@@ -5,8 +6,6 @@ use multilinear_extensions::{
 };
 use serde::de::DeserializeOwned;
 use std::{collections::HashMap, iter::once, marker::PhantomData};
-
-use ff_ext::ExtensionField;
 
 use crate::{
     RAMType, error::CircuitBuilderError, gkr::layer::ROTATION_OPENING_COUNT,

--- a/gkr_iop/src/gkr/layer.rs
+++ b/gkr_iop/src/gkr/layer.rs
@@ -428,12 +428,23 @@ impl<E: ExtensionField> Layer<E> {
         if let Some(lk_selector) = cb.cs.lk_selector.as_ref() {
             // process lookup records
             let evals = Self::dedup_last_selector_evals(lk_selector, &mut expr_evals);
-            for (idx, ((lookup, name), lookup_eval)) in (cb
+            for (idx, (((is_negate, lookup), name), lookup_eval)) in (cb
                 .cs
                 .lk_expressions
                 .iter()
-                .chain(cb.cs.lk_table_expressions.iter().map(|t| &t.multiplicity))
-                .chain(cb.cs.lk_table_expressions.iter().map(|t| &t.values)))
+                .map(|expr| (false, expr))
+                .chain(
+                    cb.cs
+                        .lk_table_expressions
+                        .iter()
+                        .map(|t| (true, &t.multiplicity)),
+                )
+                .chain(
+                    cb.cs
+                        .lk_table_expressions
+                        .iter()
+                        .map(|t| (false, &t.values)),
+                ))
             .zip_eq(if cb.cs.lk_table_expressions.is_empty() {
                 Either::Left(cb.cs.lk_expressions_namespace_map.iter())
             } else {
@@ -448,13 +459,35 @@ impl<E: ExtensionField> Layer<E> {
             .zip_eq(&lookup_evals)
             .enumerate()
             {
-                expressions.push(lookup - cb.cs.chip_record_alpha.clone());
-                evals.push(EvalExpression::<E>::Linear(
-                    // evaluation = claim * one - alpha (padding)
-                    *lookup_eval,
-                    E::BaseField::ONE.expr().into(),
-                    cb.cs.chip_record_alpha.clone().neg().into(),
-                ));
+                // Encode lookup constraints in the canonical form: `sel * expression = evaluation`.
+                //
+                // Non-negated lookup:
+                //   claim = sel * lookup + (1 - sel) * padding
+                //   => claim - padding = sel * (lookup - padding)
+                //   so we use `expression = lookup - padding` and `evaluation = claim - padding`.
+                //
+                // Negated lookup (`-lookup` used by multiplicity path):
+                //   claim - padding = sel * (-lookup - padding)
+                //   => padding - claim = sel * (lookup + padding)
+                //   so we use `expression = lookup + padding` and `evaluation = padding - claim`.
+                if is_negate {
+                    expressions.push(lookup + cb.cs.chip_record_alpha.clone());
+                    evals.push(EvalExpression::<E>::Linear(
+                        // evaluation = alpha (padding) - claim * one
+                        *lookup_eval,
+                        E::BaseField::ONE.neg().expr().into(),
+                        cb.cs.chip_record_alpha.clone().into(),
+                    ));
+                } else {
+                    expressions.push(lookup - cb.cs.chip_record_alpha.clone());
+                    evals.push(EvalExpression::<E>::Linear(
+                        // evaluation = claim * one - alpha (padding)
+                        *lookup_eval,
+                        E::BaseField::ONE.expr().into(),
+                        cb.cs.chip_record_alpha.clone().neg().into(),
+                    ));
+                };
+
                 expr_names.push(format!("{}/{idx}", name));
             }
         }

--- a/gkr_iop/src/gkr/layer/zerocheck_layer.rs
+++ b/gkr_iop/src/gkr/layer/zerocheck_layer.rs
@@ -121,13 +121,15 @@ impl<E: ExtensionField> ZerocheckLayer<E> for Layer<E> {
                 let sel_expr = sel_type.selector_expr();
                 let expr = match out_eval {
                     EvalExpression::Linear(_, a, b) => {
-                        assert_eq!(
-                            a.as_ref().clone(),
-                            E::BaseField::ONE.expr(),
-                            "need to extend expression to support a.inverse()"
-                        );
-                        // sel * exp - b
-                        sel_expr.clone() * expr + b.as_ref().neg().clone()
+                        // See `gkr_iop/src/gkr/layer.rs` for the +/-1 linear-coefficient derivation.
+                        let coeff = a.as_ref();
+                        if *coeff == E::BaseField::ONE.expr() {
+                            sel_expr.clone() * expr + b.as_ref().neg().clone()
+                        } else if *coeff == E::BaseField::ONE.neg().expr() {
+                            b.as_ref().clone() - sel_expr.clone() * expr
+                        } else {
+                            panic!("unsupported linear eval coefficient: expected +/-1")
+                        }
                     }
                     EvalExpression::Single(_) => sel_expr.clone() * expr,
                     EvalExpression::Zero => Expression::ZERO,


### PR DESCRIPTION
Previously logup sum for chips might be `add` or `sub` depends on chip kind.
This PR unify all operation to `add` so verifier flow become unify and simple

## design rationales
We encode the unification when derive claim tower and gkr-iop circuit. For logup `table`, we toggle `multiplicity` with negative while non-table it's remain same as usual

This design keep multiplicity in gkr-iop layer remain positive, and the optional negate are encoded in expression directly

