### PR TITLE
misc: remove dead n_challenges field

### DIFF
--- a/ceno_recursion/src/zkvm_verifier/verifier.rs
+++ b/ceno_recursion/src/zkvm_verifier/verifier.rs
@@ -812,13 +812,11 @@ pub fn verify_gkr_circuit<C: Config>(
 
     for (i, layer) in gkr_circuit.layers.iter().enumerate() {
         let layer_proof = builder.get(&gkr_proof.layer_proofs, i);
-        let layer_challenges: Array<C, Ext<C::F, C::EF>> =
-            generate_layer_challenges(builder, challenger, challenges, layer.n_challenges);
         let eval_and_dedup_points: Array<C, ClaimAndPoint<C>> = extract_claim_and_point(
             builder,
             layer,
             claims,
-            &layer_challenges,
+            challenges,
             &layer_proof.has_rotation,
         );
 
@@ -1680,33 +1678,6 @@ pub fn extract_claim_and_point<C: Config>(
                 );
             }
         });
-
-    r
-}
-
-pub fn generate_layer_challenges<C: Config>(
-    builder: &mut Builder<C>,
-    challenger: &mut DuplexChallengerVariable<C>,
-    challenges: &Array<C, Ext<C::F, C::EF>>,
-    n_challenges: usize,
-) -> Array<C, Ext<C::F, C::EF>> {
-    let r = builder.dyn_array(n_challenges + 2);
-
-    let alpha = builder.get(challenges, 0);
-    let beta = builder.get(challenges, 1);
-
-    builder.set(&r, 0, alpha);
-    builder.set(&r, 1, beta);
-
-    // TODO: skip if n_challenges <= 2
-    transcript_observe_label(builder, challenger, b"layer challenge");
-    let c = gen_alpha_pows(builder, challenger, Usize::from(n_challenges));
-
-    for i in 0..n_challenges {
-        let idx = i + 2;
-        let e = builder.get(&c, i);
-        builder.set(&r, idx, e);
-    }
 
     r
 }

--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -75,7 +75,13 @@ glob = "0.3"
 
 [features]
 bigint-rug = ["sp1-curves/bigint-rug"]
-default = ["forbid_overflow", "nightly-features", "u16limb_circuit", "parallel", "bigint-rug"]
+default = [
+  "forbid_overflow",
+  "nightly-features",
+  "u16limb_circuit",
+  "parallel",
+  "bigint-rug",
+]
 flamegraph = ["pprof2/flamegraph", "pprof2/criterion"]
 forbid_overflow = []
 goldilocks = ["forbid_overflow", "nightly-features", "parallel", "bigint-rug"]
@@ -91,7 +97,12 @@ nightly-features = [
   "transcript/nightly-features",
   "witness/nightly-features",
 ]
-parallel = ["whir/parallel", "p3/parallel", "multilinear_extensions/parallel", "mpcs/parallel"]
+parallel = [
+  "whir/parallel",
+  "p3/parallel",
+  "multilinear_extensions/parallel",
+  "mpcs/parallel",
+]
 sanity-check = ["mpcs/sanity-check"]
 u16limb_circuit = ["ceno_emul/u16limb_circuit"]
 

--- a/ceno_zkvm/src/instructions.rs
+++ b/ceno_zkvm/src/instructions.rs
@@ -65,7 +65,7 @@ pub trait Instruction<E: ExtensionField> {
                 // zero_record
                 (0..zero_len).collect_vec(),
             ],
-            Chip::new_from_cb(cb, 0),
+            Chip::new_from_cb(cb),
         );
 
         // register selector to legacy constrain system
@@ -74,7 +74,7 @@ pub trait Instruction<E: ExtensionField> {
         cb.cs.lk_selector = Some(selector_type.clone());
         cb.cs.zero_selector = Some(selector_type.clone());
 
-        let layer = Layer::from_circuit_builder(cb, format!("{}_main", Self::name()), 0, out_evals);
+        let layer = Layer::from_circuit_builder(cb, format!("{}_main", Self::name()), out_evals);
         chip.add_layer(layer);
 
         Ok((config, chip.gkr_circuit()))

--- a/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp.rs
@@ -293,7 +293,7 @@ fn build_fp_op_circuit<E: ExtensionField, P: FpOpField + NumWords>(
 
     let (out_evals, mut chip) = layout.finalize(cb);
     let layer =
-        Layer::from_circuit_builder(cb, layer_name.to_string(), layout.n_challenges, out_evals);
+        Layer::from_circuit_builder(cb, layer_name.to_string(), out_evals);
     chip.add_layer(layer);
 
     Ok((

--- a/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp.rs
@@ -292,8 +292,7 @@ fn build_fp_op_circuit<E: ExtensionField, P: FpOpField + NumWords>(
     );
 
     let (out_evals, mut chip) = layout.finalize(cb);
-    let layer =
-        Layer::from_circuit_builder(cb, layer_name.to_string(), out_evals);
+    let layer = Layer::from_circuit_builder(cb, layer_name.to_string(), out_evals);
     chip.add_layer(layer);
 
     Ok((

--- a/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp2_add.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp2_add.rs
@@ -210,8 +210,7 @@ fn build_fp2_add_circuit<E: ExtensionField, P: FpOpField + Fp2AddSpec + NumWords
     );
 
     let (out_evals, mut chip) = layout.finalize(cb);
-    let layer =
-        Layer::from_circuit_builder(cb, "fp2_add".to_string(), out_evals);
+    let layer = Layer::from_circuit_builder(cb, "fp2_add".to_string(), out_evals);
     chip.add_layer(layer);
 
     Ok((

--- a/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp2_add.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp2_add.rs
@@ -211,7 +211,7 @@ fn build_fp2_add_circuit<E: ExtensionField, P: FpOpField + Fp2AddSpec + NumWords
 
     let (out_evals, mut chip) = layout.finalize(cb);
     let layer =
-        Layer::from_circuit_builder(cb, "fp2_add".to_string(), layout.n_challenges, out_evals);
+        Layer::from_circuit_builder(cb, "fp2_add".to_string(), out_evals);
     chip.add_layer(layer);
 
     Ok((

--- a/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp2_mul.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp2_mul.rs
@@ -208,8 +208,7 @@ fn build_fp2_mul_circuit<E: ExtensionField, P: FpOpField + Fp2MulSpec + NumWords
     );
 
     let (out_evals, mut chip) = layout.finalize(cb);
-    let layer =
-        Layer::from_circuit_builder(cb, "fp2_mul".to_string(), out_evals);
+    let layer = Layer::from_circuit_builder(cb, "fp2_mul".to_string(), out_evals);
     chip.add_layer(layer);
 
     Ok((

--- a/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp2_mul.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp2_mul.rs
@@ -209,7 +209,7 @@ fn build_fp2_mul_circuit<E: ExtensionField, P: FpOpField + Fp2MulSpec + NumWords
 
     let (out_evals, mut chip) = layout.finalize(cb);
     let layer =
-        Layer::from_circuit_builder(cb, "fp2_mul".to_string(), layout.n_challenges, out_evals);
+        Layer::from_circuit_builder(cb, "fp2_mul".to_string(), out_evals);
     chip.add_layer(layer);
 
     Ok((

--- a/ceno_zkvm/src/instructions/riscv/ecall/keccak.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/keccak.rs
@@ -134,7 +134,7 @@ impl<E: ExtensionField> Instruction<E> for KeccakInstruction<E> {
 
         let (out_evals, mut chip) = layout.finalize(cb);
 
-        let layer = Layer::from_circuit_builder(cb, Self::name(), layout.n_challenges, out_evals);
+        let layer = Layer::from_circuit_builder(cb, Self::name(), out_evals);
         chip.add_layer(layer);
 
         let circuit = chip.gkr_circuit();

--- a/ceno_zkvm/src/instructions/riscv/ecall/sha_extend.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/sha_extend.rs
@@ -132,7 +132,7 @@ impl<E: ExtensionField> Instruction<E> for ShaExtendInstruction<E> {
 
         let (out_evals, mut chip) = layout.finalize(cb);
 
-        let layer = Layer::from_circuit_builder(cb, Self::name(), layout.n_challenges, out_evals);
+        let layer = Layer::from_circuit_builder(cb, Self::name(), out_evals);
         chip.add_layer(layer);
 
         let circuit = chip.gkr_circuit();

--- a/ceno_zkvm/src/instructions/riscv/ecall/uint256.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/uint256.rs
@@ -179,12 +179,8 @@ impl<E: ExtensionField> Instruction<E> for Uint256MulInstruction<E> {
 
         let (out_evals, mut chip) = layout.finalize(cb);
 
-        let layer = Layer::from_circuit_builder(
-            cb,
-            "uint256_mul".to_string(),
-            layout.n_challenges,
-            out_evals,
-        );
+        let layer =
+            Layer::from_circuit_builder(cb, "uint256_mul".to_string(), out_evals);
         chip.add_layer(layer);
 
         let circuit = chip.gkr_circuit();
@@ -508,7 +504,7 @@ impl<E: ExtensionField, Spec: Uint256InvSpec> Instruction<E> for Uint256InvInstr
 
         let (out_evals, mut chip) = layout.finalize(cb);
 
-        let layer = Layer::from_circuit_builder(cb, Spec::name(), layout.n_challenges, out_evals);
+        let layer = Layer::from_circuit_builder(cb, Spec::name(), out_evals);
         chip.add_layer(layer);
 
         let circuit = chip.gkr_circuit();

--- a/ceno_zkvm/src/instructions/riscv/ecall/uint256.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/uint256.rs
@@ -179,8 +179,7 @@ impl<E: ExtensionField> Instruction<E> for Uint256MulInstruction<E> {
 
         let (out_evals, mut chip) = layout.finalize(cb);
 
-        let layer =
-            Layer::from_circuit_builder(cb, "uint256_mul".to_string(), out_evals);
+        let layer = Layer::from_circuit_builder(cb, "uint256_mul".to_string(), out_evals);
         chip.add_layer(layer);
 
         let circuit = chip.gkr_circuit();

--- a/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_add.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_add.rs
@@ -179,8 +179,7 @@ impl<E: ExtensionField, EC: EllipticCurve> Instruction<E>
 
         let (out_evals, mut chip) = layout.finalize(cb);
 
-        let layer =
-            Layer::from_circuit_builder(cb, "weierstrass_add".to_string(), out_evals);
+        let layer = Layer::from_circuit_builder(cb, "weierstrass_add".to_string(), out_evals);
         chip.add_layer(layer);
 
         let circuit = chip.gkr_circuit();

--- a/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_add.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_add.rs
@@ -179,12 +179,8 @@ impl<E: ExtensionField, EC: EllipticCurve> Instruction<E>
 
         let (out_evals, mut chip) = layout.finalize(cb);
 
-        let layer = Layer::from_circuit_builder(
-            cb,
-            "weierstrass_add".to_string(),
-            layout.n_challenges,
-            out_evals,
-        );
+        let layer =
+            Layer::from_circuit_builder(cb, "weierstrass_add".to_string(), out_evals);
         chip.add_layer(layer);
 
         let circuit = chip.gkr_circuit();

--- a/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_decompress.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_decompress.rs
@@ -180,12 +180,8 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> Instruction<E
 
         let (out_evals, mut chip) = layout.finalize(cb);
 
-        let layer = Layer::from_circuit_builder(
-            cb,
-            "weierstrass_decompress".to_string(),
-            layout.n_challenges,
-            out_evals,
-        );
+        let layer =
+            Layer::from_circuit_builder(cb, "weierstrass_decompress".to_string(), out_evals);
         chip.add_layer(layer);
 
         let circuit = chip.gkr_circuit();

--- a/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_double.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_double.rs
@@ -152,12 +152,8 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> Instruction<E
 
         let (out_evals, mut chip) = layout.finalize(cb);
 
-        let layer = Layer::from_circuit_builder(
-            cb,
-            "weierstrass_double".to_string(),
-            layout.n_challenges,
-            out_evals,
-        );
+        let layer =
+            Layer::from_circuit_builder(cb, "weierstrass_double".to_string(), out_evals);
         chip.add_layer(layer);
 
         let circuit = chip.gkr_circuit();

--- a/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_double.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_double.rs
@@ -152,8 +152,7 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> Instruction<E
 
         let (out_evals, mut chip) = layout.finalize(cb);
 
-        let layer =
-            Layer::from_circuit_builder(cb, "weierstrass_double".to_string(), out_evals);
+        let layer = Layer::from_circuit_builder(cb, "weierstrass_double".to_string(), out_evals);
         chip.add_layer(layer);
 
         let circuit = chip.gkr_circuit();

--- a/ceno_zkvm/src/lib.rs
+++ b/ceno_zkvm/src/lib.rs
@@ -8,7 +8,7 @@ pub mod instructions;
 pub mod scheme;
 pub mod tables;
 pub use utils::u64vec;
-mod chip_handler;
+pub mod chip_handler;
 pub mod circuit_builder;
 pub mod e2e;
 pub mod gadgets;
@@ -18,7 +18,7 @@ pub mod state;
 pub mod stats;
 pub mod structs;
 mod uint;
-mod utils;
+pub mod utils;
 #[cfg(all(feature = "jemalloc", unix, not(test)))]
 pub use utils::print_allocated_bytes;
 mod witness;

--- a/ceno_zkvm/src/precompiles/bitwise_keccakf.rs
+++ b/ceno_zkvm/src/precompiles/bitwise_keccakf.rs
@@ -392,7 +392,7 @@ fn output32_layer<E: ExtensionField>(
         }
     }
 
-    system.into_layer("Round 23: final".to_string(), in_evals.to_vec(), 0)
+    system.into_layer("Round 23: final".to_string(), in_evals.to_vec())
 }
 
 fn iota_layer<E: ExtensionField>(
@@ -424,7 +424,6 @@ fn iota_layer<E: ExtensionField>(
     system.into_layer(
         format!("Round {round_id}: Iota:: compute output"),
         iota_in_evals.to_vec(),
-        0,
     )
 }
 
@@ -476,7 +475,6 @@ fn rho_pi_and_chi_layer<E: ExtensionField>(
     system.into_layer(
         format!("Round {round_id}: Chi:: apply rho, pi and chi"),
         in_evals.to_vec(),
-        0,
     )
 }
 
@@ -505,7 +503,6 @@ fn theta_third_layer<E: ExtensionField>(
     system.into_layer(
         format!("Round {round_id}: Theta::compute output"),
         in_evals.to_vec(),
-        0,
     )
 }
 
@@ -534,7 +531,6 @@ fn theta_second_layer<E: ExtensionField>(
     system.into_layer(
         format!("Round {round_id}: Theta::compute D[x][z]"),
         in_evals.to_vec(),
-        0,
     )
 }
 
@@ -579,7 +575,6 @@ fn theta_first_layer<E: ExtensionField>(
     system.into_layer(
         format!("Round {round_id}: Theta::compute C[x][z]"),
         in_evals.to_vec(),
-        0,
     )
 }
 
@@ -651,7 +646,6 @@ fn keccak_first_layer<E: ExtensionField>(
     system.into_layer(
         "Round 0: Theta::compute C[x][z], build 32-bit input".to_string(),
         in_evals.to_vec(),
-        0,
     )
 }
 
@@ -664,7 +658,6 @@ impl<E: ExtensionField> KeccakLayout<E> {
         let mut chip = Chip {
             n_fixed: 0,
             n_committed: STATE_SIZE,
-            n_challenges: 0,
             n_evaluations: KECCAK_ALL_IN_EVAL_SIZE + KECCAK_OUT_EVAL_SIZE,
             layers: vec![],
             final_out_evals: unsafe {
@@ -799,10 +792,6 @@ impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
     }
 
     fn n_fixed(&self) -> usize {
-        0
-    }
-
-    fn n_challenges(&self) -> usize {
         0
     }
 

--- a/ceno_zkvm/src/precompiles/fptower/fp.rs
+++ b/ceno_zkvm/src/precompiles/fptower/fp.rs
@@ -108,7 +108,6 @@ pub struct FpOpLayout<E: ExtensionField, P: FpOpField> {
     pub n_fixed: usize,
     pub n_committed: usize,
     pub n_structural_witin: usize,
-    pub n_challenges: usize,
 }
 
 impl<E: ExtensionField, P: FpOpField> FpOpLayout<E, P> {
@@ -146,7 +145,6 @@ impl<E: ExtensionField, P: FpOpField> FpOpLayout<E, P> {
             n_fixed: 0,
             n_committed: 0,
             n_structural_witin: 0,
-            n_challenges: 0,
         }
     }
 
@@ -230,7 +228,6 @@ impl<E: ExtensionField, P: FpOpField> ProtocolBuilder<E> for FpOpLayout<E, P> {
         self.n_fixed = cb.cs.num_fixed;
         self.n_committed = cb.cs.num_witin as usize;
         self.n_structural_witin = cb.cs.num_structural_witin as usize;
-        self.n_challenges = 0;
 
         cb.cs.r_selector = Some(self.selector_type_layout.sel_all.clone());
         cb.cs.w_selector = Some(self.selector_type_layout.sel_all.clone());
@@ -249,7 +246,7 @@ impl<E: ExtensionField, P: FpOpField> ProtocolBuilder<E> for FpOpLayout<E, P> {
                 (r_len + w_len..r_len + w_len + lk_len).collect_vec(),
                 (0..zero_len).collect_vec(),
             ],
-            Chip::new_from_cb(cb, self.n_challenges),
+            Chip::new_from_cb(cb),
         )
     }
 }
@@ -335,7 +332,7 @@ mod tests {
             FpOpLayout::<E, P>::build_layer_logic(&mut cb, ()).expect("build_layer_logic failed");
         let (out_evals, mut chip) = layout.finalize(&mut cb);
         let layer =
-            Layer::from_circuit_builder(&cb, "fp_op".to_string(), layout.n_challenges, out_evals);
+            Layer::from_circuit_builder(&cb, "fp_op".to_string(), out_evals);
         chip.add_layer(layer);
         let gkr_circuit = chip.gkr_circuit();
 

--- a/ceno_zkvm/src/precompiles/fptower/fp.rs
+++ b/ceno_zkvm/src/precompiles/fptower/fp.rs
@@ -331,8 +331,7 @@ mod tests {
         let mut layout =
             FpOpLayout::<E, P>::build_layer_logic(&mut cb, ()).expect("build_layer_logic failed");
         let (out_evals, mut chip) = layout.finalize(&mut cb);
-        let layer =
-            Layer::from_circuit_builder(&cb, "fp_op".to_string(), out_evals);
+        let layer = Layer::from_circuit_builder(&cb, "fp_op".to_string(), out_evals);
         chip.add_layer(layer);
         let gkr_circuit = chip.gkr_circuit();
 

--- a/ceno_zkvm/src/precompiles/fptower/fp2_addsub.rs
+++ b/ceno_zkvm/src/precompiles/fptower/fp2_addsub.rs
@@ -115,7 +115,6 @@ pub struct Fp2AddSubAssignLayout<E: ExtensionField, P: FpOpField> {
     pub n_fixed: usize,
     pub n_committed: usize,
     pub n_structural_witin: usize,
-    pub n_challenges: usize,
 }
 
 impl<E: ExtensionField, P: FpOpField> Fp2AddSubAssignLayout<E, P> {
@@ -155,7 +154,6 @@ impl<E: ExtensionField, P: FpOpField> Fp2AddSubAssignLayout<E, P> {
             n_fixed: 0,
             n_committed: 0,
             n_structural_witin: 0,
-            n_challenges: 0,
         }
     }
 
@@ -254,7 +252,6 @@ impl<E: ExtensionField, P: FpOpField> ProtocolBuilder<E> for Fp2AddSubAssignLayo
         self.n_fixed = cb.cs.num_fixed;
         self.n_committed = cb.cs.num_witin as usize;
         self.n_structural_witin = cb.cs.num_structural_witin as usize;
-        self.n_challenges = 0;
 
         cb.cs.r_selector = Some(self.selector_type_layout.sel_all.clone());
         cb.cs.w_selector = Some(self.selector_type_layout.sel_all.clone());
@@ -273,7 +270,7 @@ impl<E: ExtensionField, P: FpOpField> ProtocolBuilder<E> for Fp2AddSubAssignLayo
                 (r_len + w_len..r_len + w_len + lk_len).collect_vec(),
                 (0..zero_len).collect_vec(),
             ],
-            Chip::new_from_cb(cb, self.n_challenges),
+            Chip::new_from_cb(cb),
         )
     }
 }
@@ -364,7 +361,6 @@ mod tests {
         let layer = Layer::from_circuit_builder(
             &cb,
             "fp2_addsub".to_string(),
-            layout.n_challenges,
             out_evals,
         );
         chip.add_layer(layer);

--- a/ceno_zkvm/src/precompiles/fptower/fp2_addsub.rs
+++ b/ceno_zkvm/src/precompiles/fptower/fp2_addsub.rs
@@ -358,11 +358,7 @@ mod tests {
         let mut layout = Fp2AddSubAssignLayout::<E, P>::build_layer_logic(&mut cb, ())
             .expect("build_layer_logic failed");
         let (out_evals, mut chip) = layout.finalize(&mut cb);
-        let layer = Layer::from_circuit_builder(
-            &cb,
-            "fp2_addsub".to_string(),
-            out_evals,
-        );
+        let layer = Layer::from_circuit_builder(&cb, "fp2_addsub".to_string(), out_evals);
         chip.add_layer(layer);
         let gkr_circuit = chip.gkr_circuit();
 

--- a/ceno_zkvm/src/precompiles/fptower/fp2_mul.rs
+++ b/ceno_zkvm/src/precompiles/fptower/fp2_mul.rs
@@ -387,8 +387,7 @@ mod tests {
         let mut layout = Fp2MulAssignLayout::<E, P>::build_layer_logic(&mut cb, ())
             .expect("build_layer_logic failed");
         let (out_evals, mut chip) = layout.finalize(&mut cb);
-        let layer =
-            Layer::from_circuit_builder(&cb, "fp2_mul".to_string(), out_evals);
+        let layer = Layer::from_circuit_builder(&cb, "fp2_mul".to_string(), out_evals);
         chip.add_layer(layer);
         let gkr_circuit = chip.gkr_circuit();
 

--- a/ceno_zkvm/src/precompiles/fptower/fp2_mul.rs
+++ b/ceno_zkvm/src/precompiles/fptower/fp2_mul.rs
@@ -116,7 +116,6 @@ pub struct Fp2MulAssignLayout<E: ExtensionField, P: FpOpField> {
     pub n_fixed: usize,
     pub n_committed: usize,
     pub n_structural_witin: usize,
-    pub n_challenges: usize,
 }
 
 impl<E: ExtensionField, P: FpOpField> Fp2MulAssignLayout<E, P> {
@@ -159,7 +158,6 @@ impl<E: ExtensionField, P: FpOpField> Fp2MulAssignLayout<E, P> {
             n_fixed: 0,
             n_committed: 0,
             n_structural_witin: 0,
-            n_challenges: 0,
         }
     }
 
@@ -283,7 +281,6 @@ impl<E: ExtensionField, P: FpOpField> ProtocolBuilder<E> for Fp2MulAssignLayout<
         self.n_fixed = cb.cs.num_fixed;
         self.n_committed = cb.cs.num_witin as usize;
         self.n_structural_witin = cb.cs.num_structural_witin as usize;
-        self.n_challenges = 0;
 
         cb.cs.r_selector = Some(self.selector_type_layout.sel_all.clone());
         cb.cs.w_selector = Some(self.selector_type_layout.sel_all.clone());
@@ -302,7 +299,7 @@ impl<E: ExtensionField, P: FpOpField> ProtocolBuilder<E> for Fp2MulAssignLayout<
                 (r_len + w_len..r_len + w_len + lk_len).collect_vec(),
                 (0..zero_len).collect_vec(),
             ],
-            Chip::new_from_cb(cb, self.n_challenges),
+            Chip::new_from_cb(cb),
         )
     }
 }
@@ -391,7 +388,7 @@ mod tests {
             .expect("build_layer_logic failed");
         let (out_evals, mut chip) = layout.finalize(&mut cb);
         let layer =
-            Layer::from_circuit_builder(&cb, "fp2_mul".to_string(), layout.n_challenges, out_evals);
+            Layer::from_circuit_builder(&cb, "fp2_mul".to_string(), out_evals);
         chip.add_layer(layer);
         let gkr_circuit = chip.gkr_circuit();
 

--- a/ceno_zkvm/src/precompiles/lookup_keccakf.rs
+++ b/ceno_zkvm/src/precompiles/lookup_keccakf.rs
@@ -976,11 +976,7 @@ pub fn setup_gkr_circuit<E: ExtensionField>()
 
     let (out_evals, mut chip) = layout.finalize(&mut cb);
 
-    let layer = Layer::from_circuit_builder(
-        &cb,
-        "lookup_keccak".to_string(),
-        out_evals,
-    );
+    let layer = Layer::from_circuit_builder(&cb, "lookup_keccak".to_string(), out_evals);
     chip.add_layer(layer);
 
     Ok((

--- a/ceno_zkvm/src/precompiles/lookup_keccakf.rs
+++ b/ceno_zkvm/src/precompiles/lookup_keccakf.rs
@@ -157,7 +157,6 @@ pub struct KeccakLayout<E: ExtensionField> {
     pub n_fixed: usize,
     pub n_committed: usize,
     pub n_structural_witin: usize,
-    pub n_challenges: usize,
 }
 
 const ROTATION_WITNESS_LEN: usize = 196;
@@ -250,7 +249,6 @@ impl<E: ExtensionField> KeccakLayout<E> {
             n_fixed: 0,
             n_committed: 0,
             n_structural_witin: STRUCTURAL_WITIN,
-            n_challenges: 0,
         }
     }
 }
@@ -517,7 +515,6 @@ impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
     fn finalize(&mut self, cb: &mut CircuitBuilder<E>) -> (OutEvalGroups, Chip<E>) {
         self.n_fixed = cb.cs.num_fixed;
         self.n_committed = cb.cs.num_witin as usize;
-        self.n_challenges = 0;
 
         // register selector to legacy constrain system
         cb.cs.r_selector = Some(self.selector_type_layout.sel_first.clone().unwrap());
@@ -541,7 +538,7 @@ impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
                 // zero_record
                 (0..zero_len).collect_vec(),
             ],
-            Chip::new_from_cb(cb, self.n_challenges),
+            Chip::new_from_cb(cb),
         )
     }
 
@@ -551,10 +548,6 @@ impl<E: ExtensionField> ProtocolBuilder<E> for KeccakLayout<E> {
 
     fn n_fixed(&self) -> usize {
         unimplemented!("retrieve from constrain system")
-    }
-
-    fn n_challenges(&self) -> usize {
-        0
     }
 
     fn n_evaluations(&self) -> usize {
@@ -986,7 +979,6 @@ pub fn setup_gkr_circuit<E: ExtensionField>()
     let layer = Layer::from_circuit_builder(
         &cb,
         "lookup_keccak".to_string(),
-        layout.n_challenges,
         out_evals,
     );
     chip.add_layer(layer);

--- a/ceno_zkvm/src/precompiles/sha256/extend.rs
+++ b/ceno_zkvm/src/precompiles/sha256/extend.rs
@@ -389,11 +389,7 @@ mod tests {
         let mut layout =
             ShaExtendLayout::<E>::build_layer_logic(&mut cb, ()).expect("build_layer_logic failed");
         let (out_evals, mut chip) = layout.finalize(&mut cb);
-        let layer = Layer::from_circuit_builder(
-            &cb,
-            "sha_extend".to_string(),
-            out_evals,
-        );
+        let layer = Layer::from_circuit_builder(&cb, "sha_extend".to_string(), out_evals);
         chip.add_layer(layer);
         let gkr_circuit = chip.gkr_circuit();
 

--- a/ceno_zkvm/src/precompiles/sha256/extend.rs
+++ b/ceno_zkvm/src/precompiles/sha256/extend.rs
@@ -132,7 +132,6 @@ pub struct ShaExtendLayout<E: ExtensionField> {
     pub n_fixed: usize,
     pub n_committed: usize,
     pub n_structural_witin: usize,
-    pub n_challenges: usize,
 }
 
 impl<E: ExtensionField> ShaExtendLayout<E> {
@@ -193,7 +192,6 @@ impl<E: ExtensionField> ShaExtendLayout<E> {
             n_fixed: 0,
             n_committed: 0,
             n_structural_witin: 6,
-            n_challenges: 0,
         }
     }
 }
@@ -272,7 +270,6 @@ impl<E: ExtensionField> ProtocolBuilder<E> for ShaExtendLayout<E> {
         self.n_fixed = cb.cs.num_fixed;
         self.n_committed = cb.cs.num_witin as usize;
         self.n_structural_witin = cb.cs.num_structural_witin as usize;
-        self.n_challenges = 0;
 
         cb.cs.r_selector = Some(self.selector_type_layout.sel_all.clone());
         cb.cs.w_selector = Some(self.selector_type_layout.sel_all.clone());
@@ -291,7 +288,7 @@ impl<E: ExtensionField> ProtocolBuilder<E> for ShaExtendLayout<E> {
                 (r_len + w_len..r_len + w_len + lk_len).collect_vec(),
                 (0..zero_len).collect_vec(),
             ],
-            Chip::new_from_cb(cb, self.n_challenges),
+            Chip::new_from_cb(cb),
         )
     }
 }
@@ -395,7 +392,6 @@ mod tests {
         let layer = Layer::from_circuit_builder(
             &cb,
             "sha_extend".to_string(),
-            layout.n_challenges,
             out_evals,
         );
         chip.add_layer(layer);

--- a/ceno_zkvm/src/precompiles/uint256.rs
+++ b/ceno_zkvm/src/precompiles/uint256.rs
@@ -110,7 +110,6 @@ pub struct Uint256MulLayout<E: ExtensionField> {
     pub n_fixed: usize,
     pub n_committed: usize,
     pub n_structural_witin: usize,
-    pub n_challenges: usize,
 }
 
 impl<E: ExtensionField> Uint256MulLayout<E> {
@@ -153,7 +152,6 @@ impl<E: ExtensionField> Uint256MulLayout<E> {
             output32_exprs,
             n_fixed: 0,
             n_committed: 0,
-            n_challenges: 0,
             n_structural_witin: 0,
         }
     }
@@ -285,7 +283,6 @@ impl<E: ExtensionField> ProtocolBuilder<E> for Uint256MulLayout<E> {
         self.n_fixed = cb.cs.num_fixed;
         self.n_committed = cb.cs.num_witin as usize;
         self.n_structural_witin = cb.cs.num_structural_witin as usize;
-        self.n_challenges = 0;
 
         // register selector to legacy constrain system
         cb.cs.r_selector = Some(self.selector_type_layout.sel_all.clone());
@@ -309,7 +306,7 @@ impl<E: ExtensionField> ProtocolBuilder<E> for Uint256MulLayout<E> {
                 // zero_record
                 (0..zero_len).collect_vec(),
             ],
-            Chip::new_from_cb(cb, self.n_challenges),
+            Chip::new_from_cb(cb),
         )
     }
 
@@ -318,10 +315,6 @@ impl<E: ExtensionField> ProtocolBuilder<E> for Uint256MulLayout<E> {
     }
 
     fn n_fixed(&self) -> usize {
-        todo!()
-    }
-
-    fn n_challenges(&self) -> usize {
         todo!()
     }
 
@@ -416,7 +409,6 @@ pub struct Uint256InvLayout<E: ExtensionField, Spec: Uint256InvSpec> {
     pub n_fixed: usize,
     pub n_committed: usize,
     pub n_structural_witin: usize,
-    pub n_challenges: usize,
     phantom: PhantomData<Spec::P>,
 }
 
@@ -450,7 +442,6 @@ impl<E: ExtensionField, Spec: Uint256InvSpec> Uint256InvLayout<E, Spec> {
             output32_exprs,
             n_fixed: 0,
             n_committed: 0,
-            n_challenges: 0,
             n_structural_witin: 0,
             phantom: Default::default(),
         }
@@ -536,7 +527,6 @@ impl<E: ExtensionField, Spec: Uint256InvSpec> ProtocolBuilder<E> for Uint256InvL
         self.n_fixed = cb.cs.num_fixed;
         self.n_committed = cb.cs.num_witin as usize;
         self.n_structural_witin = cb.cs.num_structural_witin as usize;
-        self.n_challenges = 0;
 
         // register selector to legacy constrain system
         cb.cs.r_selector = Some(self.selector_type_layout.sel_all.clone());
@@ -560,7 +550,7 @@ impl<E: ExtensionField, Spec: Uint256InvSpec> ProtocolBuilder<E> for Uint256InvL
                 // zero_record
                 (0..zero_len).collect_vec(),
             ],
-            Chip::new_from_cb(cb, self.n_challenges),
+            Chip::new_from_cb(cb),
         )
     }
 
@@ -569,10 +559,6 @@ impl<E: ExtensionField, Spec: Uint256InvSpec> ProtocolBuilder<E> for Uint256InvL
     }
 
     fn n_fixed(&self) -> usize {
-        todo!()
-    }
-
-    fn n_challenges(&self) -> usize {
         todo!()
     }
 
@@ -710,7 +696,6 @@ pub fn setup_uint256mul_gkr_circuit<E: ExtensionField>()
     let layer = Layer::from_circuit_builder(
         &cb,
         "weierstrass_add".to_string(),
-        layout.n_challenges,
         out_evals,
     );
     chip.add_layer(layer);

--- a/ceno_zkvm/src/precompiles/uint256.rs
+++ b/ceno_zkvm/src/precompiles/uint256.rs
@@ -693,11 +693,7 @@ pub fn setup_uint256mul_gkr_circuit<E: ExtensionField>()
 
     let (out_evals, mut chip) = layout.finalize(&mut cb);
 
-    let layer = Layer::from_circuit_builder(
-        &cb,
-        "weierstrass_add".to_string(),
-        out_evals,
-    );
+    let layer = Layer::from_circuit_builder(&cb, "weierstrass_add".to_string(), out_evals);
     chip.add_layer(layer);
 
     Ok((

--- a/ceno_zkvm/src/precompiles/weierstrass/weierstrass_add.rs
+++ b/ceno_zkvm/src/precompiles/weierstrass/weierstrass_add.rs
@@ -111,7 +111,6 @@ pub struct WeierstrassAddAssignLayout<E: ExtensionField, EC: EllipticCurve> {
     pub n_fixed: usize,
     pub n_committed: usize,
     pub n_structural_witin: usize,
-    pub n_challenges: usize,
 }
 
 impl<E: ExtensionField, EC: EllipticCurve> WeierstrassAddAssignLayout<E, EC> {
@@ -160,7 +159,6 @@ impl<E: ExtensionField, EC: EllipticCurve> WeierstrassAddAssignLayout<E, EC> {
             output32_exprs,
             n_fixed: 0,
             n_committed: 0,
-            n_challenges: 0,
             n_structural_witin: 0,
         }
     }
@@ -330,7 +328,6 @@ impl<E: ExtensionField, EC: EllipticCurve> ProtocolBuilder<E>
         self.n_fixed = cb.cs.num_fixed;
         self.n_committed = cb.cs.num_witin as usize;
         self.n_structural_witin = cb.cs.num_structural_witin as usize;
-        self.n_challenges = 0;
 
         // register selector to legacy constrain system
         cb.cs.r_selector = Some(self.selector_type_layout.sel_all.clone());
@@ -354,7 +351,7 @@ impl<E: ExtensionField, EC: EllipticCurve> ProtocolBuilder<E>
                 // zero_record
                 (0..zero_len).collect_vec(),
             ],
-            Chip::new_from_cb(cb, self.n_challenges),
+            Chip::new_from_cb(cb),
         )
     }
 
@@ -363,10 +360,6 @@ impl<E: ExtensionField, EC: EllipticCurve> ProtocolBuilder<E>
     }
 
     fn n_fixed(&self) -> usize {
-        todo!()
-    }
-
-    fn n_challenges(&self) -> usize {
         todo!()
     }
 
@@ -513,7 +506,6 @@ pub fn setup_gkr_circuit<E: ExtensionField, EC: EllipticCurve>()
     let layer = Layer::from_circuit_builder(
         &cb,
         "weierstrass_add".to_string(),
-        layout.n_challenges,
         out_evals,
     );
     chip.add_layer(layer);

--- a/ceno_zkvm/src/precompiles/weierstrass/weierstrass_add.rs
+++ b/ceno_zkvm/src/precompiles/weierstrass/weierstrass_add.rs
@@ -503,11 +503,7 @@ pub fn setup_gkr_circuit<E: ExtensionField, EC: EllipticCurve>()
 
     let (out_evals, mut chip) = layout.finalize(&mut cb);
 
-    let layer = Layer::from_circuit_builder(
-        &cb,
-        "weierstrass_add".to_string(),
-        out_evals,
-    );
+    let layer = Layer::from_circuit_builder(&cb, "weierstrass_add".to_string(), out_evals);
     chip.add_layer(layer);
 
     Ok((

--- a/ceno_zkvm/src/precompiles/weierstrass/weierstrass_decompress.rs
+++ b/ceno_zkvm/src/precompiles/weierstrass/weierstrass_decompress.rs
@@ -121,7 +121,6 @@ pub struct WeierstrassDecompressLayout<E: ExtensionField, EC: EllipticCurve> {
     pub n_fixed: usize,
     pub n_committed: usize,
     pub n_structural_witin: usize,
-    pub n_challenges: usize,
 }
 
 impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters>
@@ -182,7 +181,6 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters>
             n_fixed: 0,
             n_committed: 0,
             n_structural_witin: 0,
-            n_challenges: 0,
         }
     }
 
@@ -340,7 +338,6 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> ProtocolBuild
         self.n_fixed = cb.cs.num_fixed;
         self.n_committed = cb.cs.num_witin as usize;
         self.n_structural_witin = cb.cs.num_structural_witin as usize;
-        self.n_challenges = 0;
 
         // register selector to legacy constrain system
         cb.cs.r_selector = Some(self.selector_type_layout.sel_all.clone());
@@ -364,7 +361,7 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> ProtocolBuild
                 // zero_record
                 (0..zero_len).collect_vec(),
             ],
-            Chip::new_from_cb(cb, self.n_challenges),
+            Chip::new_from_cb(cb),
         )
     }
 
@@ -373,10 +370,6 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> ProtocolBuild
     }
 
     fn n_fixed(&self) -> usize {
-        todo!()
-    }
-
-    fn n_challenges(&self) -> usize {
         todo!()
     }
 
@@ -511,7 +504,6 @@ pub fn setup_gkr_circuit<E: ExtensionField, EC: EllipticCurve + WeierstrassParam
     let layer = Layer::from_circuit_builder(
         &cb,
         "weierstrass_decompress".to_string(),
-        layout.n_challenges,
         out_evals,
     );
     chip.add_layer(layer);

--- a/ceno_zkvm/src/precompiles/weierstrass/weierstrass_decompress.rs
+++ b/ceno_zkvm/src/precompiles/weierstrass/weierstrass_decompress.rs
@@ -501,11 +501,7 @@ pub fn setup_gkr_circuit<E: ExtensionField, EC: EllipticCurve + WeierstrassParam
 
     let (out_evals, mut chip) = layout.finalize(&mut cb);
 
-    let layer = Layer::from_circuit_builder(
-        &cb,
-        "weierstrass_decompress".to_string(),
-        out_evals,
-    );
+    let layer = Layer::from_circuit_builder(&cb, "weierstrass_decompress".to_string(), out_evals);
     chip.add_layer(layer);
 
     Ok((

--- a/ceno_zkvm/src/precompiles/weierstrass/weierstrass_double.rs
+++ b/ceno_zkvm/src/precompiles/weierstrass/weierstrass_double.rs
@@ -508,11 +508,7 @@ pub fn setup_gkr_circuit<E: ExtensionField, EC: EllipticCurve + WeierstrassParam
 
     let (out_evals, mut chip) = layout.finalize(&mut cb);
 
-    let layer = Layer::from_circuit_builder(
-        &cb,
-        "weierstrass_double".to_string(),
-        out_evals,
-    );
+    let layer = Layer::from_circuit_builder(&cb, "weierstrass_double".to_string(), out_evals);
     chip.add_layer(layer);
 
     Ok((

--- a/ceno_zkvm/src/precompiles/weierstrass/weierstrass_double.rs
+++ b/ceno_zkvm/src/precompiles/weierstrass/weierstrass_double.rs
@@ -111,7 +111,6 @@ pub struct WeierstrassDoubleAssignLayout<E: ExtensionField, EC: EllipticCurve> {
     pub n_fixed: usize,
     pub n_committed: usize,
     pub n_structural_witin: usize,
-    pub n_challenges: usize,
 }
 
 impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters>
@@ -158,7 +157,6 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters>
             output32_exprs,
             n_fixed: 0,
             n_committed: 0,
-            n_challenges: 0,
             n_structural_witin: 0,
         }
     }
@@ -358,7 +356,6 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> ProtocolBuild
         self.n_fixed = cb.cs.num_fixed;
         self.n_committed = cb.cs.num_witin as usize;
         self.n_structural_witin = cb.cs.num_structural_witin as usize;
-        self.n_challenges = 0;
 
         // register selector to legacy constrain system
         cb.cs.r_selector = Some(self.selector_type_layout.sel_all.clone());
@@ -382,7 +379,7 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> ProtocolBuild
                 // zero_record
                 (0..zero_len).collect_vec(),
             ],
-            Chip::new_from_cb(cb, self.n_challenges),
+            Chip::new_from_cb(cb),
         )
     }
 
@@ -391,10 +388,6 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> ProtocolBuild
     }
 
     fn n_fixed(&self) -> usize {
-        todo!()
-    }
-
-    fn n_challenges(&self) -> usize {
         todo!()
     }
 
@@ -518,7 +511,6 @@ pub fn setup_gkr_circuit<E: ExtensionField, EC: EllipticCurve + WeierstrassParam
     let layer = Layer::from_circuit_builder(
         &cb,
         "weierstrass_double".to_string(),
-        layout.n_challenges,
         out_evals,
     );
     chip.add_layer(layer);

--- a/ceno_zkvm/src/tables/mod.rs
+++ b/ceno_zkvm/src/tables/mod.rs
@@ -64,7 +64,7 @@ pub trait TableCircuit<E: ExtensionField> {
                 // zero_record
                 vec![],
             ],
-            Chip::new_from_cb(cb, 0),
+            Chip::new_from_cb(cb),
         );
 
         // register selector to legacy constrain system
@@ -78,7 +78,7 @@ pub trait TableCircuit<E: ExtensionField> {
             cb.cs.lk_selector = Some(selector_type.clone());
         }
 
-        let layer = Layer::from_circuit_builder(cb, Self::name(), 0, out_evals);
+        let layer = Layer::from_circuit_builder(cb, Self::name(), out_evals);
         chip.add_layer(layer);
 
         Ok((config, Some(chip.gkr_circuit())))

--- a/ceno_zkvm/src/tables/ram/ram_circuit.rs
+++ b/ceno_zkvm/src/tables/ram/ram_circuit.rs
@@ -302,13 +302,13 @@ impl<E: ExtensionField, const V_LIMBS: usize> TableCircuit<E> for LocalFinalRamC
                 // zero_record
                 vec![],
             ],
-            Chip::new_from_cb(cb, 0),
+            Chip::new_from_cb(cb),
         );
 
         // register selector to legacy constrain system
         cb.cs.r_selector = Some(selector_type.clone());
 
-        let layer = Layer::from_circuit_builder(cb, Self::name(), 0, out_evals);
+        let layer = Layer::from_circuit_builder(cb, Self::name(), out_evals);
         chip.add_layer(layer);
 
         Ok((config, Some(chip.gkr_circuit())))

--- a/ceno_zkvm/src/tables/range/range_circuit.rs
+++ b/ceno_zkvm/src/tables/range/range_circuit.rs
@@ -125,13 +125,13 @@ impl<E: ExtensionField, const MAX_BITS_1: usize, const MAX_BITS_2: usize, R: Ran
                 // zero_record
                 vec![],
             ],
-            Chip::new_from_cb(cb, 0),
+            Chip::new_from_cb(cb),
         );
 
         // register selector to legacy constrain system
         cb.cs.lk_selector = Some(selector_type.clone());
 
-        let layer = Layer::from_circuit_builder(cb, Self::name(), 0, out_evals);
+        let layer = Layer::from_circuit_builder(cb, Self::name(), out_evals);
         chip.add_layer(layer);
 
         Ok((config, Some(chip.gkr_circuit())))

--- a/ceno_zkvm/src/tables/shard_ram.rs
+++ b/ceno_zkvm/src/tables/shard_ram.rs
@@ -452,10 +452,10 @@ impl<E: ExtensionField> TableCircuit<E> for ShardRamCircuit<E> {
                 // zero_record
                 (0..zero_len).collect_vec(),
             ],
-            Chip::new_from_cb(cb, 0),
+            Chip::new_from_cb(cb),
         );
 
-        let layer = Layer::from_circuit_builder(cb, format!("{}_main", Self::name()), 0, out_evals);
+        let layer = Layer::from_circuit_builder(cb, format!("{}_main", Self::name()), out_evals);
         chip.add_layer(layer);
 
         Ok((config, Some(chip.gkr_circuit())))

--- a/gkr_iop/src/chip.rs
+++ b/gkr_iop/src/chip.rs
@@ -18,9 +18,6 @@ pub struct Chip<E: ExtensionField> {
     /// The number of base inputs committed in the whole protocol.
     pub n_committed: usize,
 
-    /// The number of challenges generated through the whole protocols
-    /// (except the ones inside sumcheck protocols).
-    pub n_challenges: usize,
     /// All input evaluations generated at the end of layer protocols will be stored
     /// in a vector and this is the length.
     pub n_evaluations: usize,
@@ -32,11 +29,10 @@ pub struct Chip<E: ExtensionField> {
 }
 
 impl<E: ExtensionField> Chip<E> {
-    pub fn new_from_cb(cb: &CircuitBuilder<E>, n_challenges: usize) -> Chip<E> {
+    pub fn new_from_cb(cb: &CircuitBuilder<E>) -> Chip<E> {
         Self {
             n_fixed: cb.cs.num_fixed,
             n_committed: cb.cs.num_witin as usize,
-            n_challenges,
             n_evaluations: cb.cs.w_expressions.len()
                 + cb.cs.r_expressions.len()
                 + cb.cs.lk_expressions.len()

--- a/gkr_iop/src/chip/protocol.rs
+++ b/gkr_iop/src/chip/protocol.rs
@@ -9,7 +9,6 @@ impl<E: ExtensionField> Chip<E> {
     pub fn gkr_circuit(&self) -> GKRCircuit<E> {
         GKRCircuit {
             layers: self.layers.clone(),
-            n_challenges: self.n_challenges,
             n_evaluations: self.n_evaluations,
             final_out_evals: self.final_out_evals.clone(),
         }

--- a/gkr_iop/src/gkr.rs
+++ b/gkr_iop/src/gkr.rs
@@ -83,7 +83,6 @@ impl<E: ExtensionField> GKRCircuit<E> {
         let mut running_evals = out_evals.to_vec();
         // running evals is a global referable within chip
         running_evals.resize(self.n_evaluations, PointAndEval::default());
-        let mut challenges = challenges.to_vec();
         let span = entered_span!("layer_proof", profiling_2 = true);
         let (sumcheck_proofs, rt): (Vec<_>, Vec<_>) = izip!(&self.layers, circuit_wit.layers)
             .enumerate()
@@ -96,7 +95,7 @@ impl<E: ExtensionField> GKRCircuit<E> {
                     layer_wit,
                     &mut running_evals,
                     pub_io_evals,
-                    &mut challenges,
+                    challenges,
                     transcript,
                     selector_ctxs,
                 );
@@ -131,7 +130,6 @@ impl<E: ExtensionField> GKRCircuit<E> {
     {
         let GKRProof(sumcheck_proofs) = gkr_proof;
 
-        let mut challenges = challenges.to_vec();
         let mut evaluations = out_evals.to_vec();
         evaluations.resize(self.n_evaluations, PointAndEval::default());
         let rt = izip!(&self.layers, sumcheck_proofs).enumerate().try_fold(
@@ -143,7 +141,7 @@ impl<E: ExtensionField> GKRCircuit<E> {
                     layer_proof,
                     &mut evaluations,
                     pub_io_evals,
-                    &mut challenges,
+                    challenges,
                     transcript,
                     selector_ctxs,
                 )?;

--- a/gkr_iop/src/gkr.rs
+++ b/gkr_iop/src/gkr.rs
@@ -25,7 +25,6 @@ pub struct GKRCircuit<E: ExtensionField> {
     pub layers: Vec<Layer<E>>,
     pub final_out_evals: Vec<usize>,
 
-    pub n_challenges: usize,
     pub n_evaluations: usize,
 }
 

--- a/gkr_iop/src/gkr/layer.rs
+++ b/gkr_iop/src/gkr/layer.rs
@@ -75,8 +75,6 @@ pub struct Layer<E: ExtensionField> {
     pub max_expr_degree: usize,
     /// keep all structural witin which could be evaluated succinctly without PCS
     pub structural_witins: Vec<StructuralWitIn>,
-    /// num challenges dedicated to this layer.
-    pub n_challenges: usize,
     /// Expressions to prove in this layer. For zerocheck and linear layers,
     /// each expression corresponds to an output. While in sumcheck, there
     /// is only 1 expression, which corresponds to the sum of all outputs.
@@ -145,7 +143,6 @@ impl<E: ExtensionField> Layer<E> {
         n_instance: usize,
         // exprs concat zero/non-zero expression.
         exprs: Vec<Expression<E>>,
-        n_challenges: usize,
         in_eval_expr: Vec<usize>,
         // first tuple value is eq
         out_sel_and_eval_exprs: Vec<ExprEvalType<E>>,
@@ -175,7 +172,6 @@ impl<E: ExtensionField> Layer<E> {
                     n_instance,
                     max_expr_degree,
                     structural_witins,
-                    n_challenges,
                     exprs,
                     exprs_with_selector_out_eval_monomial_form: vec![],
                     in_eval_expr,
@@ -210,7 +206,6 @@ impl<E: ExtensionField> Layer<E> {
         transcript: &mut T,
         selector_ctxs: &[SelectorContext],
     ) -> (LayerProof<E>, Point<E>) {
-        self.update_challenges(challenges, transcript);
         let mut eval_and_dedup_points = self.extract_claim_and_point(claims, challenges);
 
         let (sumcheck_layer_proof, point) = match self.ty {
@@ -258,7 +253,6 @@ impl<E: ExtensionField> Layer<E> {
         transcript: &mut Trans,
         selector_ctxs: &[SelectorContext],
     ) -> Result<Point<E>, BackendError> {
-        self.update_challenges(challenges, transcript);
         let mut eval_and_dedup_points = self.extract_claim_and_point(claims, challenges);
 
         let LayerClaims { in_point, evals } = match self.ty {
@@ -318,17 +312,6 @@ impl<E: ExtensionField> Layer<E> {
             .collect_vec()
     }
 
-    // generate layer challenge by order, starting from index 2
-    // as challenge id 0, 1 are occupied
-    fn update_challenges(&self, challenges: &mut Vec<E>, transcript: &mut impl Transcript<E>) {
-        if challenges.len() <= self.n_challenges + 2 {
-            challenges.resize(self.n_challenges + 2, E::default());
-        };
-        challenges[2..].copy_from_slice(
-            &transcript.sample_and_append_challenge_pows(self.n_challenges, b"layer challenge"),
-        );
-    }
-
     fn update_claims(&self, claims: &mut [PointAndEval<E>], evals: &[E], point: &Point<E>) {
         for (value, pos) in izip!(chain![evals], chain![&self.in_eval_expr]) {
             claims[*pos] = PointAndEval {
@@ -341,7 +324,6 @@ impl<E: ExtensionField> Layer<E> {
     pub fn from_circuit_builder(
         cb: &CircuitBuilder<E>,
         layer_name: String,
-        n_challenges: usize,
         out_evals: OutEvalGroups,
     ) -> Layer<E> {
         let w_len = cb.cs.w_expressions.len() + cb.cs.w_table_expressions.len();
@@ -533,7 +515,6 @@ impl<E: ExtensionField> Layer<E> {
                 cb.cs.num_fixed,
                 0,
                 expressions,
-                n_challenges,
                 in_eval_expr,
                 expr_evals,
                 ((None, vec![]), 0, 0),
@@ -557,7 +538,6 @@ impl<E: ExtensionField> Layer<E> {
                 cb.cs.num_fixed,
                 0,
                 expressions,
-                n_challenges,
                 in_eval_expr,
                 expr_evals,
                 (

--- a/gkr_iop/src/gkr/layer.rs
+++ b/gkr_iop/src/gkr/layer.rs
@@ -202,7 +202,7 @@ impl<E: ExtensionField> Layer<E> {
         wit: LayerWitness<PB>,
         claims: &mut [PointAndEval<E>],
         pub_io_evals: &[E],
-        challenges: &mut Vec<E>,
+        challenges: &[E],
         transcript: &mut T,
         selector_ctxs: &[SelectorContext],
     ) -> (LayerProof<E>, Point<E>) {
@@ -249,7 +249,7 @@ impl<E: ExtensionField> Layer<E> {
         proof: LayerProof<E>,
         claims: &mut [PointAndEval<E>],
         pub_io_evals: &[E],
-        challenges: &mut Vec<E>,
+        challenges: &[E],
         transcript: &mut Trans,
         selector_ctxs: &[SelectorContext],
     ) -> Result<Point<E>, BackendError> {

--- a/gkr_iop/src/gkr/layer_constraint_system.rs
+++ b/gkr_iop/src/gkr/layer_constraint_system.rs
@@ -290,7 +290,6 @@ impl<E: ExtensionField> LayerConstraintSystem<E> {
         mut self,
         layer_name: String,
         in_expr_evals: Vec<usize>,
-        n_challenges: usize,
         ram_write_evals: impl ExactSizeIterator<Item = (SelectorType<E>, usize)>,
         ram_read_evals: impl ExactSizeIterator<Item = (SelectorType<E>, usize)>,
         lookup_evals: impl ExactSizeIterator<Item = (SelectorType<E>, usize)>,
@@ -332,15 +331,13 @@ impl<E: ExtensionField> LayerConstraintSystem<E> {
             );
         }
 
-        self.into_layer(layer_name, in_expr_evals, n_challenges)
+        self.into_layer(layer_name, in_expr_evals)
     }
 
-    /// n_challenges: num of challenges dedicated to this layer
     pub fn into_layer(
         self,
         layer_name: String,
         in_eval_expr: Vec<usize>,
-        n_challenges: usize,
     ) -> Layer<E> {
         let witin_offset = 0 as WitnessId;
         let structural_witin_offset = witin_offset + (self.num_witin as WitnessId);
@@ -419,7 +416,6 @@ impl<E: ExtensionField> LayerConstraintSystem<E> {
                 self.num_fixed,
                 0,
                 expressions,
-                n_challenges,
                 in_eval_expr,
                 expr_evals,
                 ((None, vec![]), 0, 0),
@@ -443,7 +439,6 @@ impl<E: ExtensionField> LayerConstraintSystem<E> {
                 self.num_fixed,
                 0,
                 expressions,
-                n_challenges,
                 in_eval_expr,
                 expr_evals,
                 (

--- a/gkr_iop/src/gkr/layer_constraint_system.rs
+++ b/gkr_iop/src/gkr/layer_constraint_system.rs
@@ -334,11 +334,7 @@ impl<E: ExtensionField> LayerConstraintSystem<E> {
         self.into_layer(layer_name, in_expr_evals)
     }
 
-    pub fn into_layer(
-        self,
-        layer_name: String,
-        in_eval_expr: Vec<usize>,
-    ) -> Layer<E> {
+    pub fn into_layer(self, layer_name: String, in_eval_expr: Vec<usize>) -> Layer<E> {
         let witin_offset = 0 as WitnessId;
         let structural_witin_offset = witin_offset + (self.num_witin as WitnessId);
         let fixed_offset = structural_witin_offset + (self.num_structural_witin as WitnessId);

--- a/gkr_iop/src/gkr/mock.rs
+++ b/gkr_iop/src/gkr/mock.rs
@@ -51,7 +51,7 @@ impl<E: ExtensionField> MockProver<E> {
         // TODO: check the rotation argument.
         let mut rng = thread_rng();
         evaluations.resize_with(circuit.n_evaluations, Default::default);
-        challenges.resize_with(2 + circuit.n_challenges, || E::random(&mut rng));
+        challenges.resize_with(2, || E::random(&mut rng));
         // check the input layer
         for (layer, layer_wit) in izip!(&circuit.layers, &circuit_wit.layers) {
             let num_vars = layer_wit.num_vars();

--- a/gkr_iop/src/lib.rs
+++ b/gkr_iop/src/lib.rs
@@ -49,9 +49,6 @@ pub trait ProtocolBuilder<E: ExtensionField>: Sized {
     fn n_fixed(&self) -> usize {
         todo!()
     }
-    fn n_challenges(&self) -> usize {
-        todo!()
-    }
     fn n_evaluations(&self) -> usize {
         todo!()
     }


### PR DESCRIPTION
# Description
`n_challenges` on `Layer`, `Chip`, and `GKRCircuit` was always 0 — every
layout struct initialized it to 0 and never assigned any other value.
The design intended per-layer challenge sampling, but it was never
actually used.

This PR removes the field and all its plumbing:
- `Layer.n_challenges` field and the `update_challenges` method it drove
- `n_challenges` parameter from `Layer::new`, `Layer::from_circuit_builder`, `LayerConstraintSystem::into_layer`, and `LayerConstraintSystem::into_layer_with_lookup_eval_iter`
- `Chip.n_challenges` and the corresponding `Chip::new_from_cb` parameter
- `GKRCircuit.n_challenges`
- `ProtocolBuilder::n_challenges()` trait method
- `generate_layer_challenges` in the recursion verifier (replaced by passing `challenges` directly)

No behavior change — `sample_and_append_challenge_pows(0, ...)` was a no-op, and `update_challenges` with n=0 neither sampled nor wrote anything meaningful.