### PR TITLE
[follow up on #1259] gpu witnessgen flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "ff_ext"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "once_cell",
  "p3",
@@ -3243,7 +3243,7 @@ dependencies = [
 [[package]]
 name = "mpcs"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -3267,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "multilinear_extensions"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "either",
  "ff_ext",
@@ -4558,7 +4558,7 @@ dependencies = [
 [[package]]
 name = "p3"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "p3-air",
  "p3-baby-bear",
@@ -5126,7 +5126,7 @@ dependencies = [
 [[package]]
 name = "poseidon"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "ff_ext",
  "p3",
@@ -6083,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6208,7 +6208,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "either",
  "ff_ext",
@@ -6226,7 +6226,7 @@ dependencies = [
 [[package]]
 name = "sumcheck_macro"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "itertools 0.13.0",
  "p3",
@@ -6633,7 +6633,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "ff_ext",
  "itertools 0.13.0",
@@ -6927,7 +6927,7 @@ dependencies = [
 [[package]]
 name = "whir"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -7214,7 +7214,7 @@ dependencies = [
 [[package]]
 name = "witness"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.22#a140b93cf80109ef86c2327b9a940d4cace83628"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
 dependencies = [
  "ff_ext",
  "multilinear_extensions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "ff_ext"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
 dependencies = [
  "once_cell",
  "p3",
@@ -3243,7 +3243,7 @@ dependencies = [
 [[package]]
 name = "mpcs"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -3267,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "multilinear_extensions"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
 dependencies = [
  "either",
  "ff_ext",
@@ -4558,7 +4558,7 @@ dependencies = [
 [[package]]
 name = "p3"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
 dependencies = [
  "p3-air",
  "p3-baby-bear",
@@ -5126,7 +5126,7 @@ dependencies = [
 [[package]]
 name = "poseidon"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
 dependencies = [
  "ff_ext",
  "p3",
@@ -6083,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6208,7 +6208,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
 dependencies = [
  "either",
  "ff_ext",
@@ -6226,7 +6226,7 @@ dependencies = [
 [[package]]
 name = "sumcheck_macro"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
 dependencies = [
  "itertools 0.13.0",
  "p3",
@@ -6633,7 +6633,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
 dependencies = [
  "ff_ext",
  "itertools 0.13.0",
@@ -6927,7 +6927,7 @@ dependencies = [
 [[package]]
 name = "whir"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -7214,7 +7214,7 @@ dependencies = [
 [[package]]
 name = "witness"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?rev=e4ae45faa1ef716611ae634b3f879c64e49cc8f3#e4ae45faa1ef716611ae634b3f879c64e49cc8f3"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fwitness_gpu_buffer#0d96edbc454014214483a1b428e66792a84a713a"
 dependencies = [
  "ff_ext",
  "multilinear_extensions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [workspace]
 members = [
-  "ceno_cli",
-  "ceno_emul",
-  "ceno_host",
-  "ceno_serde",
-  "ceno_rt",
-  "ceno_zkvm",
-  "ceno_recursion",
-  "derive",
-  "examples-builder",
-  "examples",
-  "guest_libs/*",
+    "ceno_cli",
+    "ceno_emul",
+    "ceno_host",
+    "ceno_serde",
+    "ceno_rt",
+    "ceno_zkvm",
+    "ceno_recursion",
+    "derive",
+    "examples-builder",
+    "examples",
+    "guest_libs/*",
 ]
 resolver = "2"
 
@@ -27,16 +27,16 @@ version = "0.1.0"
 ceno_crypto_primitives = { git = "https://github.com/scroll-tech/ceno-patch.git", package = "ceno_crypto_primitives", branch = "main" }
 ceno_syscall = { git = "https://github.com/scroll-tech/ceno-patch.git", package = "ceno_syscall", branch = "main" }
 
-ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "ff_ext", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
-mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "mpcs", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
-multilinear_extensions = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "multilinear_extensions", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
-p3 = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "p3", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
-poseidon = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "poseidon", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
-sp1-curves = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sp1-curves", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
-sumcheck = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sumcheck", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
-transcript = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "transcript", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
-whir = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "whir", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
-witness = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "witness", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
+ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "ff_ext", branch = "feat/witness_gpu_buffer" }
+mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "mpcs", branch = "feat/witness_gpu_buffer" }
+multilinear_extensions = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "multilinear_extensions", branch = "feat/witness_gpu_buffer" }
+p3 = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "p3", branch = "feat/witness_gpu_buffer" }
+poseidon = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "poseidon", branch = "feat/witness_gpu_buffer" }
+sp1-curves = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sp1-curves", branch = "feat/witness_gpu_buffer" }
+sumcheck = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sumcheck", branch = "feat/witness_gpu_buffer" }
+transcript = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "transcript", branch = "feat/witness_gpu_buffer" }
+whir = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "whir", branch = "feat/witness_gpu_buffer" }
+witness = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "witness", branch = "feat/witness_gpu_buffer" }
 
 anyhow = { version = "1.0", default-features = false }
 bincode = "1"
@@ -66,11 +66,11 @@ secp = "0.4.1"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 smallvec = { version = "1.13.2", features = [
-  "const_generics",
-  "const_new",
-  "serde",
-  "union",
-  "write",
+    "const_generics",
+    "const_new",
+    "serde",
+    "union",
+    "write",
 ] }
 strum = "0.26"
 strum_macros = "0.26"
@@ -79,7 +79,7 @@ thiserror = "2"
 thread_local = "1.1"
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 tracing = { version = "0.1", features = [
-  "attributes",
+    "attributes",
 ] }
 tracing-forest = { version = "0.1.6" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,16 +27,16 @@ version = "0.1.0"
 ceno_crypto_primitives = { git = "https://github.com/scroll-tech/ceno-patch.git", package = "ceno_crypto_primitives", branch = "main" }
 ceno_syscall = { git = "https://github.com/scroll-tech/ceno-patch.git", package = "ceno_syscall", branch = "main" }
 
-ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "ff_ext", tag = "v1.0.0-alpha.22" }
-mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "mpcs", tag = "v1.0.0-alpha.22" }
-multilinear_extensions = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "multilinear_extensions", tag = "v1.0.0-alpha.22" }
-p3 = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "p3", tag = "v1.0.0-alpha.22" }
-poseidon = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "poseidon", tag = "v1.0.0-alpha.22" }
-sp1-curves = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sp1-curves", tag = "v1.0.0-alpha.22" }
-sumcheck = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sumcheck", tag = "v1.0.0-alpha.22" }
-transcript = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "transcript", tag = "v1.0.0-alpha.22" }
-whir = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "whir", tag = "v1.0.0-alpha.22" }
-witness = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "witness", tag = "v1.0.0-alpha.22" }
+ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "ff_ext", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
+mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "mpcs", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
+multilinear_extensions = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "multilinear_extensions", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
+p3 = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "p3", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
+poseidon = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "poseidon", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
+sp1-curves = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sp1-curves", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
+sumcheck = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sumcheck", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
+transcript = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "transcript", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
+whir = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "whir", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
+witness = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "witness", rev = "e4ae45faa1ef716611ae634b3f879c64e49cc8f3" }
 
 anyhow = { version = "1.0", default-features = false }
 bincode = "1"

--- a/ceno_cli/Cargo.toml
+++ b/ceno_cli/Cargo.toml
@@ -43,7 +43,7 @@ openvm-stark-sdk.workspace = true
 
 ff_ext.workspace = true
 gkr_iop = { path = "../gkr_iop" }
-mpcs.workspace = true
+mpcs = { workspace = true, features = ["whir"] }
 
 [build-dependencies]
 vergen-git2 = { version = "9.1.0", features = ["build", "cargo", "rustc", "emit_and_set"] }

--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -19,7 +19,7 @@ cudarc = { workspace = true, optional = true }
 either.workspace = true
 ff_ext.workspace = true
 gkr_iop = { path = "../gkr_iop" }
-mpcs.workspace = true
+mpcs = { workspace = true, features = ["whir"] }
 multilinear_extensions.workspace = true
 once_cell.workspace = true
 p3.workspace = true

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -73,6 +73,22 @@ fn log_gpu_mem_pool_after_shard(label: &str, shard_id: usize) {
     });
 }
 
+#[cfg(feature = "gpu")]
+fn maybe_trim_gpu_mem_pool_after_shard() {
+    use crate::scheme::scheduler::{ChipProvingMode, get_chip_proving_mode};
+
+    if get_chip_proving_mode() != ChipProvingMode::Concurrent {
+        return;
+    }
+
+    use gkr_iop::gpu::gpu_prover::*;
+    info_span!("[ceno] trim_gpu_mem_pool_after_shard").in_scope(|| {
+        let cuda_hal = get_cuda_hal().unwrap();
+        cuda_hal.inner().trim_mem_pool().unwrap();
+        cuda_hal.inner().synchronize().unwrap();
+    });
+}
+
 // default value: 16GB VRAM, each cell 4 byte, log explosion 2
 pub const DEFAULT_MAX_CELLS_PER_SHARDS: u64 = (1 << 30) * 16 / 4 / 2;
 pub const DEFAULT_MAX_CYCLE_PER_SHARDS: Cycle = 1 << 29;
@@ -2189,6 +2205,7 @@ fn create_proofs_streaming<
                             log_gpu_mem_pool_after_shard("before_release", shard_ctx.shard_id);
                             crate::instructions::gpu::cache::release_all_shard_gpu_caches();
                             log_gpu_mem_pool_after_shard("after_release", shard_ctx.shard_id);
+                            maybe_trim_gpu_mem_pool_after_shard();
                         }
                         #[cfg(feature = "gpu")]
                         if let Some(baseline) = _witgen_mem_baseline {
@@ -2250,6 +2267,7 @@ fn create_proofs_streaming<
                         log_gpu_mem_pool_after_shard("before_release", shard_ctx.shard_id);
                         crate::instructions::gpu::cache::release_all_shard_gpu_caches();
                         log_gpu_mem_pool_after_shard("after_release", shard_ctx.shard_id);
+                        maybe_trim_gpu_mem_pool_after_shard();
                     }
                     #[cfg(feature = "gpu")]
                     if let Some(baseline) = _witgen_mem_baseline {

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1328,7 +1328,14 @@ pub fn generate_witness<'a, E: ExtensionField>(
     init_mem_state: &InitMemState,
     // this is for debug purpose, which only run target shard id and skip all others
     target_shard_id: Option<usize>,
-) -> impl Iterator<Item = (ZKVMWitnesses<E>, ShardContext<'a>, PublicValues)> {
+) -> impl Iterator<
+    Item = (
+        ZKVMWitnesses<E>,
+        ShardContext<'a>,
+        PublicValues,
+        Option<u64>,
+    ),
+> {
     let mut shard_ctx_builder = std::mem::take(&mut emul_result.shard_ctx_builder);
     assert!(
         emul_result.executed_steps > 0,
@@ -1408,7 +1415,7 @@ pub fn generate_witness<'a, E: ExtensionField>(
             if let Some(target_shard_id) = target_shard_id {
                 if shard_ctx.shard_id < target_shard_id {
                     tracing::debug!("{}th shard skipped", shard_ctx.shard_id);
-                    return Some((zkvm_witness, shard_ctx, pi));
+                    return Some((zkvm_witness, shard_ctx, pi, None));
                 } else if shard_ctx.shard_id > target_shard_id {
                     tracing::debug!("{}th shard skipped", shard_ctx.shard_id);
                     return None;
@@ -1453,6 +1460,8 @@ pub fn generate_witness<'a, E: ExtensionField>(
                     None
                 }
             };
+            #[cfg(not(feature = "gpu"))]
+            let witgen_mem_baseline: Option<u64> = None;
 
             info_span!("assign_opcode_circuits").in_scope(|| {
                 system_config
@@ -1677,46 +1686,47 @@ pub fn generate_witness<'a, E: ExtensionField>(
                 crate::instructions::gpu::dispatch::invalidate_shard_meta_cache();
                 crate::instructions::gpu::dispatch::assert_caches_released_before_prove();
 
-                // Post-witgen VRAM must match the pre-witgen baseline exactly.
-                if let Some(baseline) = witgen_mem_baseline {
-                    let hal = gkr_iop::gpu::get_cuda_hal()
-                        .expect("cuda hal must be available if baseline was taken");
-                    hal.inner
-                        .synchronize()
-                        .expect("cuda synchronize before witgen post-check");
-                    let post_witgen = hal
-                        .inner
-                        .mem_pool()
-                        .get_used_size()
-                        .expect("cudaMemPoolGetAttribute UsedMemCurrent");
-                    let delta_bytes = post_witgen as i64 - baseline as i64;
-                    assert_eq!(
-                        post_witgen, baseline,
-                        "shard {} witgen leaked GPU memory: baseline={} B ({} MB), \
-                         post_witgen={} B ({} MB), delta={} B ({:.2} MB)",
-                        shard_ctx.shard_id,
-                        baseline,
-                        baseline >> 20,
-                        post_witgen,
-                        post_witgen >> 20,
-                        delta_bytes,
-                        delta_bytes as f64 / (1024.0 * 1024.0),
-                    );
-                    // println! matches the existing [MemPool] log style and
-                    // is always visible regardless of tracing filters.
-                    println!(
-                        "[witgen memcheck] shard {}: VRAM clean, \
-                         baseline = post_witgen = {} bytes ({} MB)",
-                        shard_ctx.shard_id,
-                        baseline,
-                        baseline >> 20,
-                    );
-                }
             }
 
-            Some((zkvm_witness, shard_ctx, pi))
+            Some((zkvm_witness, shard_ctx, pi, witgen_mem_baseline))
         })
     })
+}
+
+#[cfg(feature = "gpu")]
+fn assert_witgen_mem_released(shard_id: usize, baseline: u64) {
+    use gkr_iop::gpu::gpu_prover::*;
+
+    let hal = get_cuda_hal().expect("cuda hal must be available if baseline was taken");
+    hal.inner
+        .synchronize()
+        .expect("cuda synchronize before witgen post-check");
+    let post_witgen = hal
+        .inner
+        .mem_pool()
+        .get_used_size()
+        .expect("cudaMemPoolGetAttribute UsedMemCurrent");
+    let delta_bytes = post_witgen as i64 - baseline as i64;
+    assert_eq!(
+        post_witgen,
+        baseline,
+        "shard {} witgen leaked GPU memory: baseline={} B ({} MB), \
+         post_witgen={} B ({} MB), delta={} B ({:.2} MB)",
+        shard_id,
+        baseline,
+        baseline >> 20,
+        post_witgen,
+        post_witgen >> 20,
+        delta_bytes,
+        delta_bytes as f64 / (1024.0 * 1024.0),
+    );
+    println!(
+        "[witgen memcheck] shard {}: VRAM clean, \
+         baseline = post_witgen = {} bytes ({} MB)",
+        shard_id,
+        baseline,
+        baseline >> 20,
+    );
 }
 
 // Encodes useful early return points of the e2e pipeline
@@ -2140,7 +2150,7 @@ fn create_proofs_streaming<
 
                     // GPU consumer: prove each shard as it arrives
                     let mut proofs = Vec::new();
-                    while let Ok((zkvm_witness, shard_ctx, pi)) = rx.recv() {
+                    while let Ok((zkvm_witness, shard_ctx, pi, witgen_mem_baseline)) = rx.recv() {
                         if is_mock_proving {
                             MockProver::assert_satisfied_full(
                                 &shard_ctx,
@@ -2163,6 +2173,10 @@ fn create_proofs_streaming<
                             shard_ctx.shard_id,
                             start.elapsed()
                         );
+                        #[cfg(feature = "gpu")]
+                        if let Some(baseline) = witgen_mem_baseline {
+                            assert_witgen_mem_released(shard_ctx.shard_id, baseline);
+                        }
                         proofs.push(zkvm_proof);
                     }
                     proofs
@@ -2191,7 +2205,7 @@ fn create_proofs_streaming<
                 };
 
             wit_iter
-                .map(|(zkvm_witness, shard_ctx, pi)| {
+                .map(|(zkvm_witness, shard_ctx, pi, witgen_mem_baseline)| {
                     if is_mock_proving {
                         MockProver::assert_satisfied_full(
                             &shard_ctx,
@@ -2214,6 +2228,10 @@ fn create_proofs_streaming<
                         shard_ctx.shard_id,
                         start.elapsed()
                     );
+                    #[cfg(feature = "gpu")]
+                    if let Some(baseline) = witgen_mem_baseline {
+                        assert_witgen_mem_released(shard_ctx.shard_id, baseline);
+                    }
                     tracing::info!("e2e proof stat: {}", zkvm_proof);
                     zkvm_proof
                 })

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1484,9 +1484,8 @@ pub fn generate_witness<'a, E: ExtensionField>(
                 )
             }).unwrap();
 
-            // Free GPU shard_steps cache after all opcode circuits are done.
-            #[cfg(feature = "gpu")]
-            crate::instructions::gpu::cache::invalidate_shard_steps_cache();
+            // Keep shard_steps cache alive across witgen and prove for this shard.
+            // It is released at shard-end after create_proof.
 
             info_span!("assign_dummy_circuits").in_scope(|| {
                 system_config
@@ -1679,14 +1678,8 @@ pub fn generate_witness<'a, E: ExtensionField>(
                 });
             }
 
-            // Drop all per-shard GPU buffers before yielding to prove — witgen
-            // and prove must not share VRAM.
-            #[cfg(feature = "gpu")]
-            {
-                crate::instructions::gpu::dispatch::invalidate_shard_meta_cache();
-                crate::instructions::gpu::dispatch::assert_caches_released_before_prove();
-
-            }
+            // Keep per-shard GPU caches alive for prove-time reuse in this shard.
+            // They are explicitly released at shard-end after create_proof.
 
             Some((zkvm_witness, shard_ctx, pi, witgen_mem_baseline))
         })
@@ -2150,7 +2143,7 @@ fn create_proofs_streaming<
 
                     // GPU consumer: prove each shard as it arrives
                     let mut proofs = Vec::new();
-                    while let Ok((zkvm_witness, shard_ctx, pi, witgen_mem_baseline)) = rx.recv() {
+                    while let Ok((zkvm_witness, shard_ctx, pi, _witgen_mem_baseline)) = rx.recv() {
                         if is_mock_proving {
                             MockProver::assert_satisfied_full(
                                 &shard_ctx,
@@ -2174,7 +2167,11 @@ fn create_proofs_streaming<
                             start.elapsed()
                         );
                         #[cfg(feature = "gpu")]
-                        if let Some(baseline) = witgen_mem_baseline {
+                        if crate::instructions::gpu::config::is_gpu_witgen_enabled() {
+                            crate::instructions::gpu::cache::release_all_shard_gpu_caches();
+                        }
+                        #[cfg(feature = "gpu")]
+                        if let Some(baseline) = _witgen_mem_baseline {
                             assert_witgen_mem_released(shard_ctx.shard_id, baseline);
                         }
                         proofs.push(zkvm_proof);
@@ -2205,7 +2202,7 @@ fn create_proofs_streaming<
                 };
 
             wit_iter
-                .map(|(zkvm_witness, shard_ctx, pi, witgen_mem_baseline)| {
+                .map(|(zkvm_witness, shard_ctx, pi, _witgen_mem_baseline)| {
                     if is_mock_proving {
                         MockProver::assert_satisfied_full(
                             &shard_ctx,
@@ -2229,7 +2226,11 @@ fn create_proofs_streaming<
                         start.elapsed()
                     );
                     #[cfg(feature = "gpu")]
-                    if let Some(baseline) = witgen_mem_baseline {
+                    if crate::instructions::gpu::config::is_gpu_witgen_enabled() {
+                        crate::instructions::gpu::cache::release_all_shard_gpu_caches();
+                    }
+                    #[cfg(feature = "gpu")]
+                    if let Some(baseline) = _witgen_mem_baseline {
                         assert_witgen_mem_released(shard_ctx.shard_id, baseline);
                     }
                     tracing::info!("e2e proof stat: {}", zkvm_proof);

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -73,22 +73,6 @@ fn log_gpu_mem_pool_after_shard(label: &str, shard_id: usize) {
     });
 }
 
-#[cfg(feature = "gpu")]
-fn maybe_trim_gpu_mem_pool_after_shard() {
-    use crate::scheme::scheduler::{ChipProvingMode, get_chip_proving_mode};
-
-    if get_chip_proving_mode() != ChipProvingMode::Concurrent {
-        return;
-    }
-
-    use gkr_iop::gpu::gpu_prover::*;
-    info_span!("[ceno] trim_gpu_mem_pool_after_shard").in_scope(|| {
-        let cuda_hal = get_cuda_hal().unwrap();
-        cuda_hal.inner().trim_mem_pool().unwrap();
-        cuda_hal.inner().synchronize().unwrap();
-    });
-}
-
 // default value: 16GB VRAM, each cell 4 byte, log explosion 2
 pub const DEFAULT_MAX_CELLS_PER_SHARDS: u64 = (1 << 30) * 16 / 4 / 2;
 pub const DEFAULT_MAX_CYCLE_PER_SHARDS: Cycle = 1 << 29;
@@ -2205,7 +2189,6 @@ fn create_proofs_streaming<
                             log_gpu_mem_pool_after_shard("before_release", shard_ctx.shard_id);
                             crate::instructions::gpu::cache::release_all_shard_gpu_caches();
                             log_gpu_mem_pool_after_shard("after_release", shard_ctx.shard_id);
-                            maybe_trim_gpu_mem_pool_after_shard();
                         }
                         #[cfg(feature = "gpu")]
                         if let Some(baseline) = _witgen_mem_baseline {
@@ -2267,7 +2250,6 @@ fn create_proofs_streaming<
                         log_gpu_mem_pool_after_shard("before_release", shard_ctx.shard_id);
                         crate::instructions::gpu::cache::release_all_shard_gpu_caches();
                         log_gpu_mem_pool_after_shard("after_release", shard_ctx.shard_id);
-                        maybe_trim_gpu_mem_pool_after_shard();
                     }
                     #[cfg(feature = "gpu")]
                     if let Some(baseline) = _witgen_mem_baseline {

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -55,6 +55,24 @@ use tracing::info_span;
 use transcript::BasicTranscript as Transcript;
 use witness::next_pow2_instance_padding;
 
+#[cfg(feature = "gpu")]
+fn log_gpu_mem_pool_after_shard(label: &str, shard_id: usize) {
+    use gkr_iop::gpu::gpu_prover::*;
+
+    info_span!("[ceno] log_gpu_mem_pool_after_shard").in_scope(|| {
+        let cuda_hal = get_cuda_hal().unwrap();
+        let mem_pool = cuda_hal.inner().mem_pool();
+        let used_bytes = mem_pool.get_used_size().unwrap_or(0);
+        let reserved_bytes = mem_pool.get_reserved_size().unwrap_or(0);
+        tracing::info!(
+            "[gpu shard end][{label}] shard_id={} used={:.2}MB reserved={:.2}MB",
+            shard_id,
+            used_bytes as f64 / (1024.0 * 1024.0),
+            reserved_bytes as f64 / (1024.0 * 1024.0),
+        );
+    });
+}
+
 // default value: 16GB VRAM, each cell 4 byte, log explosion 2
 pub const DEFAULT_MAX_CELLS_PER_SHARDS: u64 = (1 << 30) * 16 / 4 / 2;
 pub const DEFAULT_MAX_CYCLE_PER_SHARDS: Cycle = 1 << 29;
@@ -2168,7 +2186,9 @@ fn create_proofs_streaming<
                         );
                         #[cfg(feature = "gpu")]
                         if crate::instructions::gpu::config::is_gpu_witgen_enabled() {
+                            log_gpu_mem_pool_after_shard("before_release", shard_ctx.shard_id);
                             crate::instructions::gpu::cache::release_all_shard_gpu_caches();
+                            log_gpu_mem_pool_after_shard("after_release", shard_ctx.shard_id);
                         }
                         #[cfg(feature = "gpu")]
                         if let Some(baseline) = _witgen_mem_baseline {
@@ -2227,7 +2247,9 @@ fn create_proofs_streaming<
                     );
                     #[cfg(feature = "gpu")]
                     if crate::instructions::gpu::config::is_gpu_witgen_enabled() {
+                        log_gpu_mem_pool_after_shard("before_release", shard_ctx.shard_id);
                         crate::instructions::gpu::cache::release_all_shard_gpu_caches();
+                        log_gpu_mem_pool_after_shard("after_release", shard_ctx.shard_id);
                     }
                     #[cfg(feature = "gpu")]
                     if let Some(baseline) = _witgen_mem_baseline {

--- a/ceno_zkvm/src/instructions.rs
+++ b/ceno_zkvm/src/instructions.rs
@@ -220,6 +220,18 @@ pub trait Instruction<E: ExtensionField> {
             &indices,
         )
     }
+
+    #[cfg(feature = "gpu")]
+    fn build_gpu_replay_plan(
+        _config: &Self::InstructionConfig,
+        _shard_ctx: &ShardContext,
+        _num_witin: usize,
+        _num_structural_witin: usize,
+        _shard_steps: &[StepRecord],
+        _step_indices: &[StepIndex],
+    ) -> Option<crate::structs::GpuReplayPlan<E>> {
+        None
+    }
 }
 
 pub fn full_step_indices(steps: &[StepRecord]) -> Vec<StepIndex> {
@@ -367,6 +379,30 @@ macro_rules! impl_gpu_assign {
                 shard_steps,
                 step_indices,
             )
+        }
+
+        #[cfg(feature = "gpu")]
+        fn build_gpu_replay_plan(
+            config: &Self::InstructionConfig,
+            shard_ctx: &$crate::e2e::ShardContext,
+            num_witin: usize,
+            num_structural_witin: usize,
+            shard_steps: &[ceno_emul::StepRecord],
+            step_indices: &[ceno_emul::StepIndex],
+        ) -> Option<$crate::structs::GpuReplayPlan<E>> {
+            use $crate::instructions::gpu::dispatch;
+            let gpu_kind: Option<dispatch::GpuWitgenKind> = $kind_expr;
+            gpu_kind.map(|kind| {
+                dispatch::build_gpu_replay_plan::<E, Self>(
+                    config,
+                    shard_ctx,
+                    num_witin,
+                    num_structural_witin,
+                    shard_steps,
+                    step_indices,
+                    kind,
+                )
+            })
         }
     };
 }

--- a/ceno_zkvm/src/instructions/gpu/cache.rs
+++ b/ceno_zkvm/src/instructions/gpu/cache.rs
@@ -661,6 +661,21 @@ pub(crate) fn with_cached_gpu_ctx<R>(
     })
 }
 
+/// Borrow cached shard steps and optionally shard metadata.
+///
+/// Replay-time witness restoration uses only the raw step buffer and must not
+/// rebind shard side-effect outputs, so `include_meta = false` returns `None`
+/// for shard metadata even though the resident shard session still exists.
+pub(crate) fn with_cached_gpu_ctx_opt<R>(
+    include_meta: bool,
+    f: impl FnOnce(&CudaSlice<u8>, Option<&ShardDeviceBuffers>) -> R,
+) -> R {
+    if include_meta {
+        return with_cached_gpu_ctx(|steps, meta| f(steps, Some(meta)));
+    }
+    with_cached_shard_steps(|steps| f(steps, None))
+}
+
 /// Drop the shard metadata cache. Call at end of each shard's witgen so no
 /// witgen GPU memory survives into prove.
 pub fn invalidate_shard_meta_cache() {

--- a/ceno_zkvm/src/instructions/gpu/cache.rs
+++ b/ceno_zkvm/src/instructions/gpu/cache.rs
@@ -10,10 +10,29 @@ use ceno_gpu::{
     common::witgen::types::{GpuShardRamRecord, GpuShardScalars},
 };
 use rayon::prelude::*;
-use std::cell::RefCell;
+use std::{
+    cell::RefCell,
+    sync::{Arc, Mutex, OnceLock},
+};
 use tracing::info_span;
 
 use crate::{e2e::ShardContext, error::ZKVMError};
+
+/// Compatibility session handle for shard-scoped GPU cache lifetime.
+///
+/// This is a lightweight API wrapper over the existing thread-local caches,
+/// used to make call sites move toward explicit begin/release boundaries.
+#[derive(Debug, Clone, Copy)]
+pub struct GpuShardSession {
+    shard_id: usize,
+}
+
+impl GpuShardSession {
+    #[inline]
+    pub fn shard_id(self) -> usize {
+        self.shard_id
+    }
+}
 
 /// Packed next-access entry (16 bytes, u128-aligned).
 /// Stores (cycle, addr, next_cycle) with 40-bit cycles for GPU bulk H2D upload.
@@ -73,12 +92,33 @@ impl PartialOrd for PackedNextAccessEntry {
 }
 
 /// Cached shard_steps device buffer with metadata for logging.
+#[derive(Clone)]
 struct ShardStepsCache {
     host_ptr: usize,
     byte_len: usize,
     shard_id: usize,
     n_steps: usize,
     device_buf: CudaSlice<u8>,
+}
+
+#[derive(Clone)]
+struct GlobalReplaySession {
+    shard_steps: ShardStepsCache,
+    device_bufs: ShardDeviceBuffers,
+}
+
+fn global_replay_session() -> &'static Mutex<Option<Arc<GlobalReplaySession>>> {
+    // Compatibility bridge for prove-time replay on worker threads.
+    //
+    // Witgen originally cached shard raw buffers in thread-local storage, but
+    // replay may execute on a different worker thread. This global exposes one
+    // shard's resident raw GPU session cross-thread so replay can borrow the
+    // same device allocations instead of re-uploading raw shard data.
+    //
+    // TLS and this global clone only Rust handles / pointers to the same GPU
+    // allocations; they do not intentionally create duplicate VRAM copies.
+    static GLOBAL: OnceLock<Mutex<Option<Arc<GlobalReplaySession>>>> = OnceLock::new();
+    GLOBAL.get_or_init(|| Mutex::new(None))
 }
 
 // Thread-local cache for shard_steps device buffer. Invalidated when shard changes.
@@ -101,6 +141,14 @@ pub(crate) fn upload_shard_steps_cached(
         if let Some(c) = cache.as_ref() {
             if c.host_ptr == ptr && c.byte_len == byte_len {
                 return Ok(()); // cache hit
+            }
+        }
+        if let Some(global) = global_replay_session().lock().unwrap().as_ref() {
+            let g = &global.shard_steps;
+            if g.host_ptr == ptr && g.byte_len == byte_len && g.shard_id == shard_id {
+                // Rehydrate TLS from the shard-global replay session.
+                *cache = Some(g.clone());
+                return Ok(());
             }
         }
         // Cache miss: upload
@@ -132,8 +180,12 @@ pub(crate) fn upload_shard_steps_cached(
 pub(crate) fn with_cached_shard_steps<R>(f: impl FnOnce(&CudaSlice<u8>) -> R) -> R {
     SHARD_STEPS_DEVICE.with(|cache| {
         let cache = cache.borrow();
-        let c = cache.as_ref().expect("shard_steps not uploaded");
-        f(&c.device_buf)
+        if let Some(c) = cache.as_ref() {
+            return f(&c.device_buf);
+        }
+        let global = global_replay_session().lock().unwrap();
+        let session = global.as_ref().expect("shard_steps not uploaded");
+        f(&session.shard_steps.device_buf)
     })
 }
 
@@ -153,6 +205,8 @@ pub fn invalidate_shard_steps_cache() {
         }
         *cache = None;
     });
+    // End-of-shard teardown for cross-thread replay visibility.
+    *global_replay_session().lock().unwrap() = None;
 }
 
 /// Cached shard metadata device buffers for GPU shard records.
@@ -391,6 +445,22 @@ pub(crate) fn ensure_shard_metadata_cached(
                 c.shard_id, shard_id,
             );
         }
+        if let Some(global) = global_replay_session().lock().unwrap().as_ref() {
+            if global.shard_steps.shard_id == shard_id {
+                *cache = Some(ShardMetadataCache {
+                    shard_id,
+                    // These cloned handles reuse the same underlying device
+                    // buffers/pointers; this does not allocate a second copy of
+                    // shard metadata in VRAM.
+                    device_bufs: global.device_bufs.clone(),
+                    shared_ec_buf: None,
+                    shared_ec_count: None,
+                    shared_addr_buf: None,
+                    shared_addr_count: None,
+                });
+                return Ok(());
+            }
+        }
 
         // Build sorted packed next-access entries from HashMap and H2D upload.
         let sorted = build_sorted_next_accesses(shard_ctx);
@@ -559,8 +629,12 @@ pub(crate) fn ensure_shard_metadata_cached(
 pub(crate) fn with_cached_shard_meta<R>(f: impl FnOnce(&ShardDeviceBuffers) -> R) -> R {
     SHARD_META_CACHE.with(|cache| {
         let cache = cache.borrow();
-        let c = cache.as_ref().expect("shard metadata not uploaded");
-        f(&c.device_bufs)
+        if let Some(c) = cache.as_ref() {
+            return f(&c.device_bufs);
+        }
+        let global = global_replay_session().lock().unwrap();
+        let session = global.as_ref().expect("shard metadata not uploaded");
+        f(&session.device_bufs)
     })
 }
 
@@ -571,12 +645,19 @@ pub(crate) fn with_cached_gpu_ctx<R>(
 ) -> R {
     SHARD_STEPS_DEVICE.with(|steps_cache| {
         let steps = steps_cache.borrow();
-        let s = steps.as_ref().expect("shard_steps not uploaded");
-        SHARD_META_CACHE.with(|meta_cache| {
-            let meta = meta_cache.borrow();
-            let m = meta.as_ref().expect("shard metadata not uploaded");
-            f(&s.device_buf, &m.device_bufs)
-        })
+        if let Some(s) = steps.as_ref() {
+            return SHARD_META_CACHE.with(|meta_cache| {
+                let meta = meta_cache.borrow();
+                let m = meta.as_ref().expect("shard metadata not uploaded");
+                f(&s.device_buf, &m.device_bufs)
+            });
+        }
+
+        let global = global_replay_session().lock().unwrap();
+        let session = global
+            .as_ref()
+            .expect("shard GPU replay session not uploaded");
+        f(&session.shard_steps.device_buf, &session.device_bufs)
     })
 }
 
@@ -773,4 +854,64 @@ pub fn flush_shared_ec_buffers(shard_ctx: &mut ShardContext) -> Result<(), ZKVME
 
         Ok(())
     })
+}
+
+/// Begin a shard session by ensuring both raw step records and shard metadata
+/// are ready on device.
+pub(crate) fn begin_gpu_shard_session(
+    hal: &CudaHalBB31,
+    shard_ctx: &ShardContext,
+    shard_steps: &[StepRecord],
+) -> Result<GpuShardSession, ZKVMError> {
+    upload_shard_steps_cached(hal, shard_steps, shard_ctx.shard_id)?;
+    ensure_shard_metadata_cached(hal, shard_ctx, shard_steps.len())?;
+    SHARD_STEPS_DEVICE.with(|steps_cache| {
+        SHARD_META_CACHE.with(|meta_cache| {
+            let steps = steps_cache.borrow();
+            let meta = meta_cache.borrow();
+            let steps = steps.as_ref().expect("shard_steps not uploaded");
+            let meta = meta.as_ref().expect("shard metadata not uploaded");
+            let raw_only_meta = ShardDeviceBuffers {
+                scalars: meta.device_bufs.scalars.clone(),
+                next_access_packed: meta.device_bufs.next_access_packed.clone(),
+                prev_shard_cycle_range: meta.device_bufs.prev_shard_cycle_range.clone(),
+                prev_shard_heap_range: meta.device_bufs.prev_shard_heap_range.clone(),
+                prev_shard_hint_range: meta.device_bufs.prev_shard_hint_range.clone(),
+                gpu_ec_shard_id: None,
+                shared_ec_out_ptr: 0,
+                shared_ec_count_ptr: 0,
+                shared_addr_out_ptr: 0,
+                shared_addr_count_ptr: 0,
+                shared_ec_capacity: 0,
+                shared_addr_capacity: 0,
+            };
+            // Replay needs only shard-resident raw inputs. Keep step records and
+            // immutable shard metadata alive across the shard; do not retain
+            // transient witness/device-backing here.
+            *global_replay_session().lock().unwrap() = Some(Arc::new(GlobalReplaySession {
+                shard_steps: ShardStepsCache {
+                    host_ptr: steps.host_ptr,
+                    byte_len: steps.byte_len,
+                    shard_id: steps.shard_id,
+                    n_steps: steps.n_steps,
+                    device_buf: steps.device_buf.clone(),
+                },
+                device_bufs: raw_only_meta,
+            }));
+        });
+    });
+    Ok(GpuShardSession {
+        shard_id: shard_ctx.shard_id,
+    })
+}
+
+/// Release all shard-scoped GPU caches.
+pub fn release_all_shard_gpu_caches() {
+    invalidate_shard_steps_cache();
+    invalidate_shard_meta_cache();
+}
+
+/// End a shard session and free all shard-scoped GPU caches.
+pub fn end_gpu_shard_session(_session: GpuShardSession) {
+    release_all_shard_gpu_caches();
 }

--- a/ceno_zkvm/src/instructions/gpu/cache.rs
+++ b/ceno_zkvm/src/instructions/gpu/cache.rs
@@ -18,6 +18,19 @@ use tracing::info_span;
 
 use crate::{e2e::ShardContext, error::ZKVMError};
 
+#[derive(Debug, Default, Clone, Copy)]
+pub struct GpuReplayCacheStats {
+    pub shard_steps_bytes: usize,
+    pub shard_meta_bytes: usize,
+    pub shared_side_effect_bytes: usize,
+}
+
+impl GpuReplayCacheStats {
+    pub fn total_bytes(self) -> usize {
+        self.shard_steps_bytes + self.shard_meta_bytes + self.shared_side_effect_bytes
+    }
+}
+
 /// Compatibility session handle for shard-scoped GPU cache lifetime.
 ///
 /// This is a lightweight API wrapper over the existing thread-local caches,
@@ -207,6 +220,51 @@ pub fn invalidate_shard_steps_cache() {
     });
     // End-of-shard teardown for cross-thread replay visibility.
     *global_replay_session().lock().unwrap() = None;
+}
+
+pub fn current_replay_cache_stats() -> GpuReplayCacheStats {
+    let shard_steps_bytes = SHARD_STEPS_DEVICE.with(|cache| {
+        cache
+            .borrow()
+            .as_ref()
+            .map(|c| c.device_buf.len())
+            .unwrap_or(0)
+    });
+    let (shard_meta_bytes, shared_side_effect_bytes) = SHARD_META_CACHE.with(|cache| {
+        let cache = cache.borrow();
+        let Some(c) = cache.as_ref() else {
+            return (0usize, 0usize);
+        };
+        let meta_bytes = c.device_bufs.scalars.len()
+            + c.device_bufs.next_access_packed.len()
+            + c.device_bufs.prev_shard_cycle_range.len() * std::mem::size_of::<u64>()
+            + c.device_bufs.prev_shard_heap_range.len() * std::mem::size_of::<u32>()
+            + c.device_bufs.prev_shard_hint_range.len() * std::mem::size_of::<u32>();
+        let shared_bytes = c
+            .shared_ec_buf
+            .as_ref()
+            .map(|buf| buf.len() * std::mem::size_of::<u32>())
+            .unwrap_or(0)
+            + c.shared_ec_count
+                .as_ref()
+                .map(|buf| buf.len() * std::mem::size_of::<u32>())
+                .unwrap_or(0)
+            + c.shared_addr_buf
+                .as_ref()
+                .map(|buf| buf.len() * std::mem::size_of::<u32>())
+                .unwrap_or(0)
+            + c.shared_addr_count
+                .as_ref()
+                .map(|buf| buf.len() * std::mem::size_of::<u32>())
+                .unwrap_or(0);
+        (meta_bytes, shared_bytes)
+    });
+
+    GpuReplayCacheStats {
+        shard_steps_bytes,
+        shard_meta_bytes,
+        shared_side_effect_bytes,
+    }
 }
 
 /// Cached shard metadata device buffers for GPU shard records.

--- a/ceno_zkvm/src/instructions/gpu/cache.rs
+++ b/ceno_zkvm/src/instructions/gpu/cache.rs
@@ -111,7 +111,7 @@ struct ShardStepsCache {
     byte_len: usize,
     shard_id: usize,
     n_steps: usize,
-    device_buf: CudaSlice<u8>,
+    device_buf: Arc<CudaSlice<u8>>,
 }
 
 #[derive(Clone)]
@@ -174,9 +174,9 @@ pub(crate) fn upload_shard_steps_cached(
         );
         let bytes: &[u8] =
             unsafe { std::slice::from_raw_parts(shard_steps.as_ptr() as *const u8, byte_len) };
-        let device_buf = hal.inner.htod_copy_stream(None, bytes).map_err(|e| {
+        let device_buf = Arc::new(hal.inner.htod_copy_stream(None, bytes).map_err(|e| {
             ZKVMError::InvalidWitness(format!("shard_steps H2D failed: {e}").into())
-        })?;
+        })?);
         *cache = Some(ShardStepsCache {
             host_ptr: ptr,
             byte_len,
@@ -194,11 +194,11 @@ pub(crate) fn with_cached_shard_steps<R>(f: impl FnOnce(&CudaSlice<u8>) -> R) ->
     SHARD_STEPS_DEVICE.with(|cache| {
         let cache = cache.borrow();
         if let Some(c) = cache.as_ref() {
-            return f(&c.device_buf);
+            return f(c.device_buf.as_ref());
         }
         let global = global_replay_session().lock().unwrap();
         let session = global.as_ref().expect("shard_steps not uploaded");
-        f(&session.shard_steps.device_buf)
+        f(session.shard_steps.device_buf.as_ref())
     })
 }
 
@@ -967,7 +967,7 @@ pub(crate) fn begin_gpu_shard_session(
                     byte_len: steps.byte_len,
                     shard_id: steps.shard_id,
                     n_steps: steps.n_steps,
-                    device_buf: steps.device_buf.clone(),
+                    device_buf: Arc::clone(&steps.device_buf),
                 },
                 device_bufs: raw_only_meta,
             }));

--- a/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
@@ -454,7 +454,10 @@ fn gpu_assign_keccak_inner<E: ExtensionField>(
             num_witin,
             InstancePaddingStrategy::Default,
         );
-        rmm.set_device_backing(gpu_result.witness.device_buffer, DeviceMatrixLayout::ColMajor);
+        rmm.set_device_backing(
+            gpu_result.witness.device_buffer,
+            DeviceMatrixLayout::ColMajor,
+        );
         rmm
     };
 

--- a/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
@@ -363,6 +363,7 @@ fn replay_keccak_witness_from_packed<E: ExtensionField>(
                 shard_offset,
                 fetch_base_pc,
                 fetch_num_slots,
+                true,
                 None,
                 None,
             )
@@ -537,6 +538,7 @@ fn gpu_assign_keccak_inner<E: ExtensionField>(
                     shard_ctx.current_shard_offset_cycle(),
                     fetch_base_pc,
                     fetch_num_slots,
+                    false,
                     None,
                     Some(shard_bufs),
                 )

--- a/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
@@ -355,22 +355,18 @@ fn replay_keccak_witness_from_packed<E: ExtensionField>(
 
     let col_map = info_span!("col_map").in_scope(|| extract_keccak_column_map(config, num_witin));
     let gpu_result = info_span!("gpu_kernel").in_scope(|| {
-        with_cached_shard_meta(|shard_bufs| {
-            hal.witgen
-                .witgen_keccak(
-                    &col_map,
-                    packed_instances,
-                    num_padded_rows,
-                    shard_offset,
-                    fetch_base_pc,
-                    fetch_num_slots,
-                    None,
-                    Some(shard_bufs),
-                )
-                .map_err(|e| {
-                    ZKVMError::InvalidWitness(format!("GPU witgen_keccak failed: {e}").into())
-                })
-        })
+        hal.witgen
+            .witgen_keccak(
+                &col_map,
+                packed_instances,
+                num_padded_rows,
+                shard_offset,
+                fetch_base_pc,
+                fetch_num_slots,
+                None,
+                None,
+            )
+            .map_err(|e| ZKVMError::InvalidWitness(format!("GPU witgen_keccak failed: {e}").into()))
     })?;
 
     let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()

--- a/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
@@ -16,7 +16,7 @@ use ceno_gpu::{
 use gkr_iop::utils::lk_multiplicity::Multiplicity;
 use p3::field::FieldAlgebra;
 use tracing::info_span;
-use witness::{InstancePaddingStrategy, RowMajorMatrix};
+use witness::{DeviceMatrixLayout, InstancePaddingStrategy, RowMajorMatrix};
 
 use crate::{
     e2e::ShardContext,
@@ -406,9 +406,9 @@ fn gpu_assign_keccak_inner<E: ExtensionField>(
         })?;
     }
 
-    // Step 8: Transpose GPU witness (column-major -> row-major) + D2H
-    let raw_witin = info_span!("transpose_d2h", rows = num_padded_rows, cols = num_witin)
-        .in_scope(|| {
+    // Step 8: Keep witness on device in normal mode; D2H only for debug compare.
+    let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled() {
+        info_span!("transpose_d2h", rows = num_padded_rows, cols = num_witin).in_scope(|| {
             let mut rmm_buffer = hal
                 .alloc_elems_on_device(num_padded_rows * num_witin, false, None)
                 .map_err(|e| {
@@ -438,18 +438,25 @@ fn gpu_assign_keccak_inner<E: ExtensionField>(
                 )
             };
 
-            // Construct a rotation-aware matrix and fill with GPU-transposed data.
-            // new_by_rotation allocates the correct padded size; we overwrite the real portion.
             let mut rmm = RowMajorMatrix::<E::BaseField>::new_by_rotation(
                 num_instances,
                 rotation,
                 num_witin,
                 InstancePaddingStrategy::Default,
             );
-            // Access inner p3 matrix's values via DerefMut
             std::ops::DerefMut::deref_mut(&mut rmm).values[..data.len()].copy_from_slice(&data);
             Ok::<_, ZKVMError>(rmm)
-        })?;
+        })?
+    } else {
+        let mut rmm = RowMajorMatrix::<E::BaseField>::new_by_rotation(
+            num_instances,
+            rotation,
+            num_witin,
+            InstancePaddingStrategy::Default,
+        );
+        rmm.set_device_backing(gpu_result.witness.device_buffer, DeviceMatrixLayout::ColMajor);
+        rmm
+    };
 
     // Step 9: Build structural witness on CPU with selector indices
     let raw_structural = info_span!("structural_witness").in_scope(|| {

--- a/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
@@ -28,7 +28,7 @@ use crate::{
         },
         config::{
             is_debug_compare_enabled, is_gpu_witgen_enabled, is_kind_disabled,
-            should_materialize_witness_on_gpu,
+            should_materialize_witness_on_gpu, should_materialize_witness_on_initial_assign,
         },
         dispatch::{GpuWitgenKind, compute_fetch_params, is_force_cpu_path},
         utils::{
@@ -506,6 +506,8 @@ fn gpu_assign_keccak_inner<E: ExtensionField>(
     let num_padded_instances = num_instances.next_power_of_two().max(2);
     let num_padded_rows = num_padded_instances * 32; // 2^5 = 32 rows per instance
     let rotation = KECCAK_ROUNDS_CEIL_LOG2; // = 5
+    let materialize_initial_witness = crate::instructions::gpu::config::is_debug_compare_enabled()
+        || should_materialize_witness_on_initial_assign();
 
     // Step 1: Extract column map
     let col_map = info_span!("col_map").in_scope(|| extract_keccak_column_map(config, num_witin));
@@ -615,7 +617,9 @@ fn gpu_assign_keccak_inner<E: ExtensionField>(
 
     // Step 8: Keep witness on device only when cache policy keeps device backing.
     // In debug mode or cache-none mode, do transpose + D2H.
-    let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
+    let raw_witin = if !materialize_initial_witness {
+        RowMajorMatrix::<E::BaseField>::empty()
+    } else if crate::instructions::gpu::config::is_debug_compare_enabled()
         || !should_materialize_witness_on_gpu()
     {
         info_span!("transpose_d2h", rows = num_padded_rows, cols = num_witin).in_scope(|| {

--- a/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
@@ -28,7 +28,7 @@ use crate::{
         },
         config::{
             is_debug_compare_enabled, is_gpu_witgen_enabled, is_kind_disabled,
-            should_keep_witness_device_backing,
+            should_materialize_witness_on_gpu,
         },
         dispatch::{GpuWitgenKind, compute_fetch_params, is_force_cpu_path},
         utils::{
@@ -279,6 +279,210 @@ pub fn gpu_assign_keccak_instances<E: ExtensionField>(
     })
 }
 
+#[cfg(feature = "gpu")]
+pub fn build_keccak_replay_plan<E: ExtensionField>(
+    config: &crate::instructions::riscv::ecall::keccak::EcallKeccakConfig<E>,
+    shard_ctx: &ShardContext,
+    num_witin: usize,
+    num_structural_witin: usize,
+    shard_steps: &[StepRecord],
+    step_indices: &[StepIndex],
+) -> crate::structs::GpuReplayPlan<E> {
+    let (fetch_base_pc, fetch_num_slots) = compute_fetch_params(shard_steps, step_indices);
+    let packed_instances =
+        pack_keccak_instances(shard_steps, step_indices, &shard_ctx.syscall_witnesses);
+    crate::structs::GpuReplayPlan::new(
+        shard_ctx.shard_id,
+        GpuWitgenKind::Keccak,
+        std::sync::Arc::<[StepIndex]>::from(step_indices.to_vec()),
+        num_witin,
+        num_structural_witin,
+        shard_ctx.current_shard_offset_cycle(),
+        fetch_base_pc,
+        fetch_num_slots,
+        Some(Arc::<[GpuKeccakInstance]>::from(packed_instances)),
+        config as *const crate::instructions::riscv::ecall::keccak::EcallKeccakConfig<E> as usize,
+        replay_keccak_witness_from_resident_raw::<E>,
+    )
+}
+
+#[cfg(feature = "gpu")]
+fn replay_keccak_witness_from_resident_raw<E: ExtensionField>(
+    config_ptr: usize,
+    replay: &crate::structs::GpuReplayPlan<E>,
+) -> Result<RMMCollections<E::BaseField>, ZKVMError> {
+    use gkr_iop::gpu::get_cuda_hal;
+
+    let hal = get_cuda_hal()
+        .map_err(|e| ZKVMError::InvalidWitness(format!("Failed to get CUDA HAL: {e}").into()))?;
+    let config = unsafe {
+        &*(config_ptr as *const crate::instructions::riscv::ecall::keccak::EcallKeccakConfig<E>)
+    };
+    let packed_instances = replay.keccak_instances.as_ref().ok_or_else(|| {
+        ZKVMError::InvalidWitness("keccak replay missing packed instance data".into())
+    })?;
+    let replayed = replay_keccak_witness_from_packed::<E>(
+        config,
+        replay.num_witin,
+        replay.num_structural_witin,
+        packed_instances.as_ref(),
+        replay.step_indices.len(),
+        replay.shard_offset,
+        replay.fetch_base_pc,
+        replay.fetch_num_slots,
+        &hal,
+    )?;
+    Ok(replayed.0)
+}
+
+#[cfg(feature = "gpu")]
+fn replay_keccak_witness_from_packed<E: ExtensionField>(
+    config: &crate::instructions::riscv::ecall::keccak::EcallKeccakConfig<E>,
+    num_witin: usize,
+    num_structural_witin: usize,
+    packed_instances: &[GpuKeccakInstance],
+    num_instances: usize,
+    shard_offset: u64,
+    fetch_base_pc: u32,
+    fetch_num_slots: usize,
+    hal: &CudaHalBB31,
+) -> Result<(RMMCollections<E::BaseField>, Multiplicity<u64>), ZKVMError> {
+    use crate::precompiles::KECCAK_ROUNDS_CEIL_LOG2;
+
+    let num_padded_instances = num_instances.next_power_of_two().max(2);
+    let num_padded_rows = num_padded_instances * 32;
+    let rotation = KECCAK_ROUNDS_CEIL_LOG2;
+
+    let col_map = info_span!("col_map").in_scope(|| extract_keccak_column_map(config, num_witin));
+    let gpu_result = info_span!("gpu_kernel").in_scope(|| {
+        with_cached_shard_meta(|shard_bufs| {
+            hal.witgen
+                .witgen_keccak(
+                    &col_map,
+                    packed_instances,
+                    num_padded_rows,
+                    shard_offset,
+                    fetch_base_pc,
+                    fetch_num_slots,
+                    None,
+                    Some(shard_bufs),
+                )
+                .map_err(|e| {
+                    ZKVMError::InvalidWitness(format!("GPU witgen_keccak failed: {e}").into())
+                })
+        })
+    })?;
+
+    let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
+        || !should_materialize_witness_on_gpu()
+    {
+        info_span!("transpose_d2h", rows = num_padded_rows, cols = num_witin).in_scope(|| {
+            let mut rmm_buffer = hal
+                .alloc_elems_on_device(num_padded_rows * num_witin, false, None)
+                .map_err(|e| {
+                    ZKVMError::InvalidWitness(format!("GPU alloc for transpose failed: {e}").into())
+                })?;
+            matrix_transpose::<CudaHalBB31, ff_ext::BabyBearExt4, _>(
+                &hal.inner,
+                &mut rmm_buffer,
+                &gpu_result.witness.device_buffer,
+                num_padded_rows,
+                num_witin,
+            )
+            .map_err(|e| ZKVMError::InvalidWitness(format!("GPU transpose failed: {e}").into()))?;
+
+            let gpu_data: Vec<<ff_ext::BabyBearExt4 as ExtensionField>::BaseField> =
+                rmm_buffer.to_vec().map_err(|e| {
+                    ZKVMError::InvalidWitness(format!("GPU D2H copy failed: {e}").into())
+                })?;
+
+            let data: Vec<E::BaseField> = unsafe {
+                let mut data = std::mem::ManuallyDrop::new(gpu_data);
+                Vec::from_raw_parts(
+                    data.as_mut_ptr() as *mut E::BaseField,
+                    data.len(),
+                    data.capacity(),
+                )
+            };
+
+            let mut rmm = RowMajorMatrix::<E::BaseField>::new_by_rotation(
+                num_instances,
+                rotation,
+                num_witin,
+                InstancePaddingStrategy::Default,
+            );
+            std::ops::DerefMut::deref_mut(&mut rmm).values[..data.len()].copy_from_slice(&data);
+            Ok::<_, ZKVMError>(rmm)
+        })?
+    } else {
+        let mut rmm = RowMajorMatrix::<E::BaseField>::new_by_rotation(
+            num_instances,
+            rotation,
+            num_witin,
+            InstancePaddingStrategy::Default,
+        );
+        rmm.set_device_backing(
+            gpu_result.witness.device_buffer,
+            DeviceMatrixLayout::ColMajor,
+        );
+        rmm
+    };
+
+    let raw_structural = info_span!("structural_witness").in_scope(|| {
+        let mut raw_structural = RowMajorMatrix::<E::BaseField>::new_by_rotation(
+            num_instances,
+            rotation,
+            num_structural_witin,
+            InstancePaddingStrategy::Default,
+        );
+
+        let sel_first = config
+            .layout
+            .selector_type_layout
+            .sel_first
+            .as_ref()
+            .expect("sel_first must be Some");
+        let sel_last = config
+            .layout
+            .selector_type_layout
+            .sel_last
+            .as_ref()
+            .expect("sel_last must be Some");
+
+        let sel_first_id = sel_first.selector_expr().id();
+        let sel_last_id = sel_last.selector_expr().id();
+        let sel_all_id = config
+            .layout
+            .selector_type_layout
+            .sel_all
+            .selector_expr()
+            .id();
+
+        let sel_first_indices = sel_first.sparse_indices();
+        let sel_last_indices = sel_last.sparse_indices();
+        let sel_all_indices = config.layout.selector_type_layout.sel_all.sparse_indices();
+
+        for instance_chunk in raw_structural.iter_mut().take(num_instances) {
+            for &idx in sel_first_indices {
+                instance_chunk[idx * num_structural_witin + sel_first_id] = E::BaseField::ONE;
+            }
+            for &idx in sel_last_indices {
+                instance_chunk[idx * num_structural_witin + sel_last_id] = E::BaseField::ONE;
+            }
+            for &idx in sel_all_indices {
+                instance_chunk[idx * num_structural_witin + sel_all_id] = E::BaseField::ONE;
+            }
+        }
+        raw_structural.padding_by_strategy();
+        raw_structural
+    });
+
+    Ok((
+        [raw_witin, raw_structural],
+        LkMultiplicity::default().into_finalize_result(),
+    ))
+}
+
 /// Keccak-specific GPU witness generation, separate from `gpu_assign_instances_inner` because:
 ///   1. Rotation: each instance spans 32 rows (not 1), requiring `new_by_rotation`
 ///   2. Structural witness: 3 selectors (sel_first/sel_last/sel_all) vs the standard 1
@@ -412,7 +616,7 @@ fn gpu_assign_keccak_inner<E: ExtensionField>(
     // Step 8: Keep witness on device only when cache policy keeps device backing.
     // In debug mode or cache-none mode, do transpose + D2H.
     let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
-        || !should_keep_witness_device_backing()
+        || !should_materialize_witness_on_gpu()
     {
         info_span!("transpose_d2h", rows = num_padded_rows, cols = num_witin).in_scope(|| {
             let mut rmm_buffer = hal

--- a/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
@@ -304,6 +304,9 @@ pub fn build_keccak_replay_plan<E: ExtensionField>(
         fetch_base_pc,
         fetch_num_slots,
         Some(Arc::<[GpuKeccakInstance]>::from(packed_instances)),
+        None,
+        0,
+        0,
         config as *const crate::instructions::riscv::ecall::keccak::EcallKeccakConfig<E> as usize,
         replay_keccak_witness_from_resident_raw::<E>,
     )

--- a/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
@@ -26,7 +26,10 @@ use crate::{
             ensure_shard_metadata_cached, read_shared_addr_count, read_shared_addr_range,
             with_cached_shard_meta,
         },
-        config::{is_debug_compare_enabled, is_gpu_witgen_enabled, is_kind_disabled},
+        config::{
+            is_debug_compare_enabled, is_gpu_witgen_enabled, is_kind_disabled,
+            should_keep_witness_device_backing,
+        },
         dispatch::{GpuWitgenKind, compute_fetch_params, is_force_cpu_path},
         utils::{
             d2h::{gpu_compact_ec_d2h, gpu_lk_counters_to_multiplicity},
@@ -407,7 +410,9 @@ fn gpu_assign_keccak_inner<E: ExtensionField>(
     }
 
     // Step 8: Keep witness on device in normal mode; D2H only for debug compare.
-    let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled() {
+    let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
+        || !should_keep_witness_device_backing()
+    {
         info_span!("transpose_d2h", rows = num_padded_rows, cols = num_witin).in_scope(|| {
             let mut rmm_buffer = hal
                 .alloc_elems_on_device(num_padded_rows * num_witin, false, None)

--- a/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
@@ -409,7 +409,8 @@ fn gpu_assign_keccak_inner<E: ExtensionField>(
         })?;
     }
 
-    // Step 8: Keep witness on device in normal mode; D2H only for debug compare.
+    // Step 8: Keep witness on device only when cache policy keeps device backing.
+    // In debug mode or cache-none mode, do transpose + D2H.
     let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
         || !should_keep_witness_device_backing()
     {

--- a/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
@@ -16,7 +16,9 @@ use ceno_gpu::{
 use gkr_iop::utils::lk_multiplicity::Multiplicity;
 use p3::field::FieldAlgebra;
 use tracing::info_span;
-use witness::{DeviceMatrixLayout, InstancePaddingStrategy, RowMajorMatrix};
+use witness::{
+    DeviceMatrixLayout, InstancePaddingStrategy, RowMajorMatrix, next_pow2_instance_padding,
+};
 
 use crate::{
     e2e::ShardContext,
@@ -295,6 +297,7 @@ pub fn build_keccak_replay_plan<E: ExtensionField>(
         shard_ctx.shard_id,
         GpuWitgenKind::Keccak,
         std::sync::Arc::<[StepIndex]>::from(step_indices.to_vec()),
+        next_pow2_instance_padding(step_indices.len()) * 32,
         num_witin,
         num_structural_witin,
         shard_ctx.current_shard_offset_cycle(),

--- a/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
@@ -383,7 +383,8 @@ pub(crate) fn try_gpu_assign_shard_ram<E: ExtensionField>(
             Ok(witness_buf)
         })?;
 
-    // 5. Structural witness: keep device-resident in normal mode; do transpose+D2H only for debug compare.
+    // 5. Structural witness: keep device-resident only when cache policy keeps device backing.
+    // In debug mode or cache-none mode, do transpose + D2H.
     let raw_structural_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
         || !crate::instructions::gpu::config::should_keep_witness_device_backing()
     {
@@ -443,7 +444,8 @@ pub(crate) fn try_gpu_assign_shard_ram<E: ExtensionField>(
         rmm
     };
 
-    // 6. Main witness: keep device-resident in normal mode; do transpose+D2H only for debug compare.
+    // 6. Main witness: keep device-resident only when cache policy keeps device backing.
+    // In debug mode or cache-none mode, do transpose + D2H.
     let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
         || !crate::instructions::gpu::config::should_keep_witness_device_backing()
     {
@@ -626,7 +628,8 @@ pub(crate) fn try_gpu_assign_shard_ram_from_device<E: ExtensionField>(
         },
     )?;
 
-    // Structural witness: keep device-resident in normal mode; do transpose+D2H only for debug compare.
+    // Structural witness: keep device-resident only when cache policy keeps device backing.
+    // In debug mode or cache-none mode, do transpose + D2H.
     let raw_structural_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
         || !crate::instructions::gpu::config::should_keep_witness_device_backing()
     {
@@ -686,7 +689,8 @@ pub(crate) fn try_gpu_assign_shard_ram_from_device<E: ExtensionField>(
         rmm
     };
 
-    // Witness: keep device-resident in normal mode; do transpose+D2H only for debug compare.
+    // Witness: keep device-resident only when cache policy keeps device backing.
+    // In debug mode or cache-none mode, do transpose + D2H.
     let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
         || !crate::instructions::gpu::config::should_keep_witness_device_backing()
     {

--- a/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
@@ -235,7 +235,7 @@ pub(crate) fn try_gpu_assign_shard_ram<E: ExtensionField>(
     };
     use gkr_iop::gpu::gpu_prover::get_cuda_hal;
     use p3::field::PrimeField32;
-    use witness::{InstancePaddingStrategy, next_pow2_instance_padding};
+    use witness::{DeviceMatrixLayout, InstancePaddingStrategy, next_pow2_instance_padding};
 
     type BB = <ff_ext::BabyBearExt4 as ExtensionField>::BaseField;
 
@@ -383,42 +383,14 @@ pub(crate) fn try_gpu_assign_shard_ram<E: ExtensionField>(
             Ok(witness_buf)
         })?;
 
-    // 5. GPU transpose: column-major → row-major + D2H
-    let (wit_data, struct_data) = tracing::info_span!(
-        "gpu_shard_ram_transpose_d2h",
+    // 5. Keep witness on device in normal mode; keep structural witness host-resident.
+    let struct_data = tracing::info_span!(
+        "gpu_shard_ram_structural_transpose_d2h",
         num_rows_padded,
-        num_witin,
+        num_structural_witin,
     )
     .in_scope(|| -> Result<_, ZKVMError> {
         let wit_num_rows = num_rows_padded;
-        let wit_num_cols = num_witin;
-        let mut rmm_buf = hal
-            .witgen
-            .alloc_elems_on_device(wit_num_rows * wit_num_cols, false, None)
-            .map_err(|e| {
-                ZKVMError::InvalidWitness(format!("GPU alloc for transpose failed: {e}").into())
-            })?;
-        matrix_transpose::<CudaHalBB31, ff_ext::BabyBearExt4, _>(
-            &hal.inner,
-            &mut rmm_buf,
-            &witness_buf,
-            wit_num_rows,
-            wit_num_cols,
-        )
-        .map_err(|e| ZKVMError::InvalidWitness(format!("GPU transpose failed: {e}").into()))?;
-
-        let gpu_wit_data: Vec<BB> = rmm_buf
-            .to_vec()
-            .map_err(|e| ZKVMError::InvalidWitness(format!("GPU D2H wit failed: {e}").into()))?;
-        let wit_data: Vec<E::BaseField> = unsafe {
-            let mut data = std::mem::ManuallyDrop::new(gpu_wit_data);
-            Vec::from_raw_parts(
-                data.as_mut_ptr() as *mut E::BaseField,
-                data.len(),
-                data.capacity(),
-            )
-        };
-
         let struct_num_cols = num_structural_witin;
         let mut struct_rmm_buf = hal
             .witgen
@@ -442,7 +414,7 @@ pub(crate) fn try_gpu_assign_shard_ram<E: ExtensionField>(
         let gpu_struct_data: Vec<BB> = struct_rmm_buf
             .to_vec()
             .map_err(|e| ZKVMError::InvalidWitness(format!("GPU D2H struct failed: {e}").into()))?;
-        let struct_data: Vec<E::BaseField> = unsafe {
+        let out: Vec<E::BaseField> = unsafe {
             let mut data = std::mem::ManuallyDrop::new(gpu_struct_data);
             Vec::from_raw_parts(
                 data.as_mut_ptr() as *mut E::BaseField,
@@ -451,14 +423,58 @@ pub(crate) fn try_gpu_assign_shard_ram<E: ExtensionField>(
             )
         };
 
-        Ok((wit_data, struct_data))
+        Ok(out)
     })?;
 
-    let raw_witin = witness::RowMajorMatrix::new_by_values(
-        wit_data,
-        num_witin,
-        InstancePaddingStrategy::Default,
-    );
+    let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled() {
+        tracing::info_span!("gpu_shard_ram_witness_transpose_d2h", num_rows_padded, num_witin)
+            .in_scope(|| -> Result<_, ZKVMError> {
+                let mut rmm_buf = hal
+                    .witgen
+                    .alloc_elems_on_device(num_rows_padded * num_witin, false, None)
+                    .map_err(|e| {
+                        ZKVMError::InvalidWitness(
+                            format!("GPU alloc for witness transpose failed: {e}").into(),
+                        )
+                    })?;
+                matrix_transpose::<CudaHalBB31, ff_ext::BabyBearExt4, _>(
+                    &hal.inner,
+                    &mut rmm_buf,
+                    &witness_buf,
+                    num_rows_padded,
+                    num_witin,
+                )
+                .map_err(|e| {
+                    ZKVMError::InvalidWitness(format!("GPU witness transpose failed: {e}").into())
+                })?;
+
+                let gpu_wit_data: Vec<BB> = rmm_buf.to_vec().map_err(|e| {
+                    ZKVMError::InvalidWitness(format!("GPU D2H witness failed: {e}").into())
+                })?;
+                let wit_data: Vec<E::BaseField> = unsafe {
+                    let mut data = std::mem::ManuallyDrop::new(gpu_wit_data);
+                    Vec::from_raw_parts(
+                        data.as_mut_ptr() as *mut E::BaseField,
+                        data.len(),
+                        data.capacity(),
+                    )
+                };
+                Ok(witness::RowMajorMatrix::new_by_values(
+                    wit_data,
+                    num_witin,
+                    InstancePaddingStrategy::Default,
+                ))
+            })?
+    } else {
+        let mut rmm = witness::RowMajorMatrix::new(
+            num_rows_padded,
+            num_witin,
+            InstancePaddingStrategy::Default,
+        );
+        rmm.set_device_backing(witness_buf, DeviceMatrixLayout::ColMajor);
+        rmm
+    };
+
     let raw_structural_witin = witness::RowMajorMatrix::new_by_values(
         struct_data,
         num_structural_witin,
@@ -498,7 +514,7 @@ pub(crate) fn try_gpu_assign_shard_ram_from_device<E: ExtensionField>(
 ) -> Result<Option<crate::tables::RMMCollections<E::BaseField>>, ZKVMError> {
     use ceno_gpu::{Buffer, CudaHal, bb31::CudaHalBB31, common::transpose::matrix_transpose};
     use gkr_iop::gpu::gpu_prover::get_cuda_hal;
-    use witness::{InstancePaddingStrategy, next_pow2_instance_padding};
+    use witness::{DeviceMatrixLayout, InstancePaddingStrategy, next_pow2_instance_padding};
 
     type BB = <ff_ext::BabyBearExt4 as ExtensionField>::BaseField;
 
@@ -592,42 +608,14 @@ pub(crate) fn try_gpu_assign_shard_ram_from_device<E: ExtensionField>(
         },
     )?;
 
-    // GPU transpose + D2H
-    let (wit_data, struct_data) = tracing::info_span!(
-        "gpu_shard_ram_transpose_d2h_from_device",
+    // Keep witness on device in normal mode; keep structural witness host-resident.
+    let struct_data = tracing::info_span!(
+        "gpu_shard_ram_structural_transpose_d2h_from_device",
         num_rows_padded,
-        num_witin,
+        num_structural_witin,
     )
     .in_scope(|| -> Result<_, ZKVMError> {
         let wit_num_rows = num_rows_padded;
-        let wit_num_cols = num_witin;
-        let mut rmm_buf = hal
-            .witgen
-            .alloc_elems_on_device(wit_num_rows * wit_num_cols, false, None)
-            .map_err(|e| {
-                ZKVMError::InvalidWitness(format!("GPU alloc for transpose failed: {e}").into())
-            })?;
-        matrix_transpose::<CudaHalBB31, ff_ext::BabyBearExt4, _>(
-            &hal.inner,
-            &mut rmm_buf,
-            &witness_buf,
-            wit_num_rows,
-            wit_num_cols,
-        )
-        .map_err(|e| ZKVMError::InvalidWitness(format!("GPU transpose failed: {e}").into()))?;
-
-        let gpu_wit_data: Vec<BB> = rmm_buf
-            .to_vec()
-            .map_err(|e| ZKVMError::InvalidWitness(format!("GPU D2H wit failed: {e}").into()))?;
-        let wit_data: Vec<E::BaseField> = unsafe {
-            let mut data = std::mem::ManuallyDrop::new(gpu_wit_data);
-            Vec::from_raw_parts(
-                data.as_mut_ptr() as *mut E::BaseField,
-                data.len(),
-                data.capacity(),
-            )
-        };
-
         let struct_num_cols = num_structural_witin;
         let mut struct_rmm_buf = hal
             .witgen
@@ -651,7 +639,7 @@ pub(crate) fn try_gpu_assign_shard_ram_from_device<E: ExtensionField>(
         let gpu_struct_data: Vec<BB> = struct_rmm_buf
             .to_vec()
             .map_err(|e| ZKVMError::InvalidWitness(format!("GPU D2H struct failed: {e}").into()))?;
-        let struct_data: Vec<E::BaseField> = unsafe {
+        let out: Vec<E::BaseField> = unsafe {
             let mut data = std::mem::ManuallyDrop::new(gpu_struct_data);
             Vec::from_raw_parts(
                 data.as_mut_ptr() as *mut E::BaseField,
@@ -660,14 +648,62 @@ pub(crate) fn try_gpu_assign_shard_ram_from_device<E: ExtensionField>(
             )
         };
 
-        Ok((wit_data, struct_data))
+        Ok(out)
     })?;
 
-    let raw_witin = witness::RowMajorMatrix::new_by_values(
-        wit_data,
-        num_witin,
-        InstancePaddingStrategy::Default,
-    );
+    let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled() {
+        tracing::info_span!(
+            "gpu_shard_ram_witness_transpose_d2h_from_device",
+            num_rows_padded,
+            num_witin,
+        )
+        .in_scope(|| -> Result<_, ZKVMError> {
+            let mut rmm_buf = hal
+                .witgen
+                .alloc_elems_on_device(num_rows_padded * num_witin, false, None)
+                .map_err(|e| {
+                    ZKVMError::InvalidWitness(
+                        format!("GPU alloc for witness transpose failed: {e}").into(),
+                    )
+                })?;
+            matrix_transpose::<CudaHalBB31, ff_ext::BabyBearExt4, _>(
+                &hal.inner,
+                &mut rmm_buf,
+                &witness_buf,
+                num_rows_padded,
+                num_witin,
+            )
+            .map_err(|e| {
+                ZKVMError::InvalidWitness(format!("GPU witness transpose failed: {e}").into())
+            })?;
+
+            let gpu_wit_data: Vec<BB> = rmm_buf.to_vec().map_err(|e| {
+                ZKVMError::InvalidWitness(format!("GPU D2H witness failed: {e}").into())
+            })?;
+            let wit_data: Vec<E::BaseField> = unsafe {
+                let mut data = std::mem::ManuallyDrop::new(gpu_wit_data);
+                Vec::from_raw_parts(
+                    data.as_mut_ptr() as *mut E::BaseField,
+                    data.len(),
+                    data.capacity(),
+                )
+            };
+            Ok(witness::RowMajorMatrix::new_by_values(
+                wit_data,
+                num_witin,
+                InstancePaddingStrategy::Default,
+            ))
+        })?
+    } else {
+        let mut rmm = witness::RowMajorMatrix::new(
+            num_rows_padded,
+            num_witin,
+            InstancePaddingStrategy::Default,
+        );
+        rmm.set_device_backing(witness_buf, DeviceMatrixLayout::ColMajor);
+        rmm
+    };
+
     let raw_structural_witin = witness::RowMajorMatrix::new_by_values(
         struct_data,
         num_structural_witin,

--- a/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
@@ -1,14 +1,64 @@
 use ceno_emul::WordAddr;
-use ceno_gpu::common::witgen::types::ShardRamColumnMap;
+use ceno_gpu::common::{buffer::BufferImpl, witgen::types::ShardRamColumnMap};
 use ff_ext::ExtensionField;
 use gkr_iop::RAMType;
 use rustc_hash::FxHashSet;
+use std::sync::Arc;
 
 use crate::{
     e2e::ShardContext,
     error::ZKVMError,
-    tables::{MemFinalRecord, ShardRamConfig, ShardRamRecord},
+    tables::{MemFinalRecord, ShardRamCircuit, ShardRamConfig, ShardRamRecord},
 };
+
+#[cfg(feature = "gpu")]
+pub fn build_shard_ram_replay_plan<E: ExtensionField>(
+    shard_id: usize,
+    config: &ShardRamConfig<E>,
+    num_witin: usize,
+    num_structural_witin: usize,
+    device_records: Arc<BufferImpl<'static, u32>>,
+    num_records: usize,
+    num_local_writes: usize,
+) -> crate::structs::GpuReplayPlan<E> {
+    crate::structs::GpuReplayPlan::new(
+        shard_id,
+        crate::instructions::gpu::dispatch::GpuWitgenKind::ShardRam,
+        Arc::<[ceno_emul::StepIndex]>::from(Vec::<ceno_emul::StepIndex>::new()),
+        witness::next_pow2_instance_padding(num_records) * 2,
+        num_witin,
+        num_structural_witin,
+        0,
+        0,
+        0,
+        None,
+        Some(device_records),
+        num_records,
+        num_local_writes,
+        config as *const ShardRamConfig<E> as usize,
+        replay_shard_ram_witness_from_device::<E>,
+    )
+}
+
+#[cfg(feature = "gpu")]
+fn replay_shard_ram_witness_from_device<E: ExtensionField>(
+    config_ptr: usize,
+    replay: &crate::structs::GpuReplayPlan<E>,
+) -> Result<crate::tables::RMMCollections<E::BaseField>, ZKVMError> {
+    let config = unsafe { &*(config_ptr as *const ShardRamConfig<E>) };
+    let device_records = replay.shard_ram_records.as_ref().ok_or_else(|| {
+        ZKVMError::InvalidWitness("ShardRam replay missing device records".into())
+    })?;
+    ShardRamCircuit::<E>::try_gpu_assign_instances_from_device(
+        config,
+        replay.num_witin,
+        replay.num_structural_witin,
+        device_records.as_ref(),
+        replay.shard_ram_num_records,
+        replay.shard_ram_num_local_writes,
+    )?
+    .ok_or_else(|| ZKVMError::InvalidWitness("ShardRam replay returned None".into()))
+}
 
 /// Filter and construct a cross-shard ShardRamRecord without EC computation.
 /// EC is computed in batch on device by the GPU pipeline.
@@ -982,12 +1032,8 @@ pub(crate) fn try_gpu_assign_shared_circuit<E: ExtensionField>(
 
                 let chunk_byte_start = records_offset * record_u32s * 4;
                 let chunk_byte_end = (records_offset + chunk_size) * record_u32s * 4;
-                let chunk_view = partitioned_buf.as_slice_range(chunk_byte_start..chunk_byte_end);
-                let chunk_buf: ceno_gpu::common::buffer::BufferImpl<'static, u32> = unsafe {
-                    std::mem::transmute(ceno_gpu::common::buffer::BufferImpl::<u32>::new_from_view(
-                        chunk_view,
-                    ))
-                };
+                let chunk_buf: ceno_gpu::common::buffer::BufferImpl<'static, u32> =
+                    partitioned_buf.owned_subrange(chunk_byte_start..chunk_byte_end);
 
                 let witness = ShardRamCircuit::<E>::try_gpu_assign_instances_from_device(
                     config,
@@ -1003,11 +1049,26 @@ pub(crate) fn try_gpu_assign_shared_circuit<E: ExtensionField>(
                 })?;
 
                 let num_reads = chunk_size - chunk_writes;
-                inputs.push(ChipInput::new(
+                let mut input = ChipInput::new(
                     ShardRamCircuit::<E>::name(),
                     witness,
                     [chunk_writes, num_reads],
-                ));
+                );
+                if crate::instructions::gpu::config::is_gpu_witgen_enabled()
+                    && !crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit()
+                    && num_witin > 0
+                {
+                    input.gpu_replay_plan = Some(build_shard_ram_replay_plan(
+                        shard_ctx.shard_id,
+                        config,
+                        num_witin,
+                        num_structural_witin,
+                        Arc::new(chunk_buf),
+                        chunk_size,
+                        chunk_writes,
+                    ));
+                }
+                inputs.push(input);
 
                 records_offset += chunk_size;
             }

--- a/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
@@ -383,88 +383,108 @@ pub(crate) fn try_gpu_assign_shard_ram<E: ExtensionField>(
             Ok(witness_buf)
         })?;
 
-    // 5. Keep witness on device in normal mode; keep structural witness host-resident.
-    let struct_data = tracing::info_span!(
-        "gpu_shard_ram_structural_transpose_d2h",
-        num_rows_padded,
-        num_structural_witin,
-    )
-    .in_scope(|| -> Result<_, ZKVMError> {
-        let wit_num_rows = num_rows_padded;
-        let struct_num_cols = num_structural_witin;
-        let mut struct_rmm_buf = hal
-            .witgen
-            .alloc_elems_on_device(wit_num_rows * struct_num_cols, false, None)
-            .map_err(|e| {
-                ZKVMError::InvalidWitness(
-                    format!("GPU alloc for struct transpose failed: {e}").into(),
-                )
-            })?;
-        matrix_transpose::<CudaHalBB31, ff_ext::BabyBearExt4, _>(
-            &hal.inner,
-            &mut struct_rmm_buf,
-            &gpu_structural.device_buffer,
-            wit_num_rows,
-            struct_num_cols,
+    // 5. Structural witness: keep device-resident in normal mode; do transpose+D2H only for debug compare.
+    let raw_structural_witin = if crate::instructions::gpu::config::is_debug_compare_enabled() {
+        let struct_data = tracing::info_span!(
+            "gpu_shard_ram_structural_transpose_d2h",
+            num_rows_padded,
+            num_structural_witin,
         )
-        .map_err(|e| {
-            ZKVMError::InvalidWitness(format!("GPU struct transpose failed: {e}").into())
-        })?;
-
-        let gpu_struct_data: Vec<BB> = struct_rmm_buf
-            .to_vec()
-            .map_err(|e| ZKVMError::InvalidWitness(format!("GPU D2H struct failed: {e}").into()))?;
-        let out: Vec<E::BaseField> = unsafe {
-            let mut data = std::mem::ManuallyDrop::new(gpu_struct_data);
-            Vec::from_raw_parts(
-                data.as_mut_ptr() as *mut E::BaseField,
-                data.len(),
-                data.capacity(),
-            )
-        };
-
-        Ok(out)
-    })?;
-
-    let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled() {
-        tracing::info_span!("gpu_shard_ram_witness_transpose_d2h", num_rows_padded, num_witin)
-            .in_scope(|| -> Result<_, ZKVMError> {
-                let mut rmm_buf = hal
-                    .witgen
-                    .alloc_elems_on_device(num_rows_padded * num_witin, false, None)
-                    .map_err(|e| {
-                        ZKVMError::InvalidWitness(
-                            format!("GPU alloc for witness transpose failed: {e}").into(),
-                        )
-                    })?;
-                matrix_transpose::<CudaHalBB31, ff_ext::BabyBearExt4, _>(
-                    &hal.inner,
-                    &mut rmm_buf,
-                    &witness_buf,
-                    num_rows_padded,
-                    num_witin,
-                )
+        .in_scope(|| -> Result<_, ZKVMError> {
+            let wit_num_rows = num_rows_padded;
+            let struct_num_cols = num_structural_witin;
+            let mut struct_rmm_buf = hal
+                .witgen
+                .alloc_elems_on_device(wit_num_rows * struct_num_cols, false, None)
                 .map_err(|e| {
-                    ZKVMError::InvalidWitness(format!("GPU witness transpose failed: {e}").into())
-                })?;
-
-                let gpu_wit_data: Vec<BB> = rmm_buf.to_vec().map_err(|e| {
-                    ZKVMError::InvalidWitness(format!("GPU D2H witness failed: {e}").into())
-                })?;
-                let wit_data: Vec<E::BaseField> = unsafe {
-                    let mut data = std::mem::ManuallyDrop::new(gpu_wit_data);
-                    Vec::from_raw_parts(
-                        data.as_mut_ptr() as *mut E::BaseField,
-                        data.len(),
-                        data.capacity(),
+                    ZKVMError::InvalidWitness(
+                        format!("GPU alloc for struct transpose failed: {e}").into(),
                     )
-                };
-                Ok(witness::RowMajorMatrix::new_by_values(
-                    wit_data,
-                    num_witin,
-                    InstancePaddingStrategy::Default,
-                ))
-            })?
+                })?;
+            matrix_transpose::<CudaHalBB31, ff_ext::BabyBearExt4, _>(
+                &hal.inner,
+                &mut struct_rmm_buf,
+                &gpu_structural.device_buffer,
+                wit_num_rows,
+                struct_num_cols,
+            )
+            .map_err(|e| {
+                ZKVMError::InvalidWitness(format!("GPU struct transpose failed: {e}").into())
+            })?;
+
+            let gpu_struct_data: Vec<BB> = struct_rmm_buf.to_vec().map_err(|e| {
+                ZKVMError::InvalidWitness(format!("GPU D2H struct failed: {e}").into())
+            })?;
+            let out: Vec<E::BaseField> = unsafe {
+                let mut data = std::mem::ManuallyDrop::new(gpu_struct_data);
+                Vec::from_raw_parts(
+                    data.as_mut_ptr() as *mut E::BaseField,
+                    data.len(),
+                    data.capacity(),
+                )
+            };
+
+            Ok(out)
+        })?;
+        witness::RowMajorMatrix::new_by_values(
+            struct_data,
+            num_structural_witin,
+            InstancePaddingStrategy::Default,
+        )
+    } else {
+        let mut rmm = witness::RowMajorMatrix::new(
+            num_rows_padded,
+            num_structural_witin,
+            InstancePaddingStrategy::Default,
+        );
+        rmm.set_device_backing(gpu_structural.device_buffer, DeviceMatrixLayout::ColMajor);
+        rmm
+    };
+
+    // 6. Main witness: keep device-resident in normal mode; do transpose+D2H only for debug compare.
+    let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled() {
+        tracing::info_span!(
+            "gpu_shard_ram_witness_transpose_d2h",
+            num_rows_padded,
+            num_witin
+        )
+        .in_scope(|| -> Result<_, ZKVMError> {
+            let mut rmm_buf = hal
+                .witgen
+                .alloc_elems_on_device(num_rows_padded * num_witin, false, None)
+                .map_err(|e| {
+                    ZKVMError::InvalidWitness(
+                        format!("GPU alloc for witness transpose failed: {e}").into(),
+                    )
+                })?;
+            matrix_transpose::<CudaHalBB31, ff_ext::BabyBearExt4, _>(
+                &hal.inner,
+                &mut rmm_buf,
+                &witness_buf,
+                num_rows_padded,
+                num_witin,
+            )
+            .map_err(|e| {
+                ZKVMError::InvalidWitness(format!("GPU witness transpose failed: {e}").into())
+            })?;
+
+            let gpu_wit_data: Vec<BB> = rmm_buf.to_vec().map_err(|e| {
+                ZKVMError::InvalidWitness(format!("GPU D2H witness failed: {e}").into())
+            })?;
+            let wit_data: Vec<E::BaseField> = unsafe {
+                let mut data = std::mem::ManuallyDrop::new(gpu_wit_data);
+                Vec::from_raw_parts(
+                    data.as_mut_ptr() as *mut E::BaseField,
+                    data.len(),
+                    data.capacity(),
+                )
+            };
+            Ok(witness::RowMajorMatrix::new_by_values(
+                wit_data,
+                num_witin,
+                InstancePaddingStrategy::Default,
+            ))
+        })?
     } else {
         let mut rmm = witness::RowMajorMatrix::new(
             num_rows_padded,
@@ -474,12 +494,6 @@ pub(crate) fn try_gpu_assign_shard_ram<E: ExtensionField>(
         rmm.set_device_backing(witness_buf, DeviceMatrixLayout::ColMajor);
         rmm
     };
-
-    let raw_structural_witin = witness::RowMajorMatrix::new_by_values(
-        struct_data,
-        num_structural_witin,
-        InstancePaddingStrategy::Default,
-    );
 
     tracing::info!(
         "GPU shard_ram assign_instances done: {} records, {} padded rows",
@@ -608,49 +622,65 @@ pub(crate) fn try_gpu_assign_shard_ram_from_device<E: ExtensionField>(
         },
     )?;
 
-    // Keep witness on device in normal mode; keep structural witness host-resident.
-    let struct_data = tracing::info_span!(
-        "gpu_shard_ram_structural_transpose_d2h_from_device",
-        num_rows_padded,
-        num_structural_witin,
-    )
-    .in_scope(|| -> Result<_, ZKVMError> {
-        let wit_num_rows = num_rows_padded;
-        let struct_num_cols = num_structural_witin;
-        let mut struct_rmm_buf = hal
-            .witgen
-            .alloc_elems_on_device(wit_num_rows * struct_num_cols, false, None)
-            .map_err(|e| {
-                ZKVMError::InvalidWitness(
-                    format!("GPU alloc for struct transpose failed: {e}").into(),
-                )
-            })?;
-        matrix_transpose::<CudaHalBB31, ff_ext::BabyBearExt4, _>(
-            &hal.inner,
-            &mut struct_rmm_buf,
-            &gpu_structural.device_buffer,
-            wit_num_rows,
-            struct_num_cols,
+    // Structural witness: keep device-resident in normal mode; do transpose+D2H only for debug compare.
+    let raw_structural_witin = if crate::instructions::gpu::config::is_debug_compare_enabled() {
+        let struct_data = tracing::info_span!(
+            "gpu_shard_ram_structural_transpose_d2h_from_device",
+            num_rows_padded,
+            num_structural_witin,
         )
-        .map_err(|e| {
-            ZKVMError::InvalidWitness(format!("GPU struct transpose failed: {e}").into())
-        })?;
-
-        let gpu_struct_data: Vec<BB> = struct_rmm_buf
-            .to_vec()
-            .map_err(|e| ZKVMError::InvalidWitness(format!("GPU D2H struct failed: {e}").into()))?;
-        let out: Vec<E::BaseField> = unsafe {
-            let mut data = std::mem::ManuallyDrop::new(gpu_struct_data);
-            Vec::from_raw_parts(
-                data.as_mut_ptr() as *mut E::BaseField,
-                data.len(),
-                data.capacity(),
+        .in_scope(|| -> Result<_, ZKVMError> {
+            let wit_num_rows = num_rows_padded;
+            let struct_num_cols = num_structural_witin;
+            let mut struct_rmm_buf = hal
+                .witgen
+                .alloc_elems_on_device(wit_num_rows * struct_num_cols, false, None)
+                .map_err(|e| {
+                    ZKVMError::InvalidWitness(
+                        format!("GPU alloc for struct transpose failed: {e}").into(),
+                    )
+                })?;
+            matrix_transpose::<CudaHalBB31, ff_ext::BabyBearExt4, _>(
+                &hal.inner,
+                &mut struct_rmm_buf,
+                &gpu_structural.device_buffer,
+                wit_num_rows,
+                struct_num_cols,
             )
-        };
+            .map_err(|e| {
+                ZKVMError::InvalidWitness(format!("GPU struct transpose failed: {e}").into())
+            })?;
 
-        Ok(out)
-    })?;
+            let gpu_struct_data: Vec<BB> = struct_rmm_buf.to_vec().map_err(|e| {
+                ZKVMError::InvalidWitness(format!("GPU D2H struct failed: {e}").into())
+            })?;
+            let out: Vec<E::BaseField> = unsafe {
+                let mut data = std::mem::ManuallyDrop::new(gpu_struct_data);
+                Vec::from_raw_parts(
+                    data.as_mut_ptr() as *mut E::BaseField,
+                    data.len(),
+                    data.capacity(),
+                )
+            };
 
+            Ok(out)
+        })?;
+        witness::RowMajorMatrix::new_by_values(
+            struct_data,
+            num_structural_witin,
+            InstancePaddingStrategy::Default,
+        )
+    } else {
+        let mut rmm = witness::RowMajorMatrix::new(
+            num_rows_padded,
+            num_structural_witin,
+            InstancePaddingStrategy::Default,
+        );
+        rmm.set_device_backing(gpu_structural.device_buffer, DeviceMatrixLayout::ColMajor);
+        rmm
+    };
+
+    // Witness: keep device-resident in normal mode; do transpose+D2H only for debug compare.
     let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled() {
         tracing::info_span!(
             "gpu_shard_ram_witness_transpose_d2h_from_device",
@@ -703,12 +733,6 @@ pub(crate) fn try_gpu_assign_shard_ram_from_device<E: ExtensionField>(
         rmm.set_device_backing(witness_buf, DeviceMatrixLayout::ColMajor);
         rmm
     };
-
-    let raw_structural_witin = witness::RowMajorMatrix::new_by_values(
-        struct_data,
-        num_structural_witin,
-        InstancePaddingStrategy::Default,
-    );
 
     tracing::info!(
         "GPU shard_ram assign_instances (from_device) done: {} records, {} padded rows",

--- a/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
@@ -384,7 +384,9 @@ pub(crate) fn try_gpu_assign_shard_ram<E: ExtensionField>(
         })?;
 
     // 5. Structural witness: keep device-resident in normal mode; do transpose+D2H only for debug compare.
-    let raw_structural_witin = if crate::instructions::gpu::config::is_debug_compare_enabled() {
+    let raw_structural_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
+        || !crate::instructions::gpu::config::should_keep_witness_device_backing()
+    {
         let struct_data = tracing::info_span!(
             "gpu_shard_ram_structural_transpose_d2h",
             num_rows_padded,
@@ -442,7 +444,9 @@ pub(crate) fn try_gpu_assign_shard_ram<E: ExtensionField>(
     };
 
     // 6. Main witness: keep device-resident in normal mode; do transpose+D2H only for debug compare.
-    let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled() {
+    let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
+        || !crate::instructions::gpu::config::should_keep_witness_device_backing()
+    {
         tracing::info_span!(
             "gpu_shard_ram_witness_transpose_d2h",
             num_rows_padded,
@@ -623,7 +627,9 @@ pub(crate) fn try_gpu_assign_shard_ram_from_device<E: ExtensionField>(
     )?;
 
     // Structural witness: keep device-resident in normal mode; do transpose+D2H only for debug compare.
-    let raw_structural_witin = if crate::instructions::gpu::config::is_debug_compare_enabled() {
+    let raw_structural_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
+        || !crate::instructions::gpu::config::should_keep_witness_device_backing()
+    {
         let struct_data = tracing::info_span!(
             "gpu_shard_ram_structural_transpose_d2h_from_device",
             num_rows_padded,
@@ -681,7 +687,9 @@ pub(crate) fn try_gpu_assign_shard_ram_from_device<E: ExtensionField>(
     };
 
     // Witness: keep device-resident in normal mode; do transpose+D2H only for debug compare.
-    let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled() {
+    let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
+        || !crate::instructions::gpu::config::should_keep_witness_device_backing()
+    {
         tracing::info_span!(
             "gpu_shard_ram_witness_transpose_d2h_from_device",
             num_rows_padded,

--- a/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
@@ -386,7 +386,7 @@ pub(crate) fn try_gpu_assign_shard_ram<E: ExtensionField>(
     // 5. Structural witness: keep device-resident only when cache policy keeps device backing.
     // In debug mode or cache-none mode, do transpose + D2H.
     let raw_structural_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
-        || !crate::instructions::gpu::config::should_keep_witness_device_backing()
+        || !crate::instructions::gpu::config::should_materialize_witness_on_gpu()
     {
         let struct_data = tracing::info_span!(
             "gpu_shard_ram_structural_transpose_d2h",
@@ -447,7 +447,7 @@ pub(crate) fn try_gpu_assign_shard_ram<E: ExtensionField>(
     // 6. Main witness: keep device-resident only when cache policy keeps device backing.
     // In debug mode or cache-none mode, do transpose + D2H.
     let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
-        || !crate::instructions::gpu::config::should_keep_witness_device_backing()
+        || !crate::instructions::gpu::config::should_materialize_witness_on_gpu()
     {
         tracing::info_span!(
             "gpu_shard_ram_witness_transpose_d2h",
@@ -573,7 +573,7 @@ pub(crate) fn try_gpu_assign_shard_ram_from_device<E: ExtensionField>(
             )
             .map_err(|e| {
                 ZKVMError::InvalidWitness(
-                    format!("GPU shard_ram per-row (from_device) kernel failed: {e}").into(),
+                    format!("GPU shard_ram per-row (from_device) kernel failed: {e:?}").into(),
                 )
             })
     })?;
@@ -631,7 +631,7 @@ pub(crate) fn try_gpu_assign_shard_ram_from_device<E: ExtensionField>(
     // Structural witness: keep device-resident only when cache policy keeps device backing.
     // In debug mode or cache-none mode, do transpose + D2H.
     let raw_structural_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
-        || !crate::instructions::gpu::config::should_keep_witness_device_backing()
+        || !crate::instructions::gpu::config::should_materialize_witness_on_gpu()
     {
         let struct_data = tracing::info_span!(
             "gpu_shard_ram_structural_transpose_d2h_from_device",
@@ -692,7 +692,7 @@ pub(crate) fn try_gpu_assign_shard_ram_from_device<E: ExtensionField>(
     // Witness: keep device-resident only when cache policy keeps device backing.
     // In debug mode or cache-none mode, do transpose + D2H.
     let raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
-        || !crate::instructions::gpu::config::should_keep_witness_device_backing()
+        || !crate::instructions::gpu::config::should_materialize_witness_on_gpu()
     {
         tracing::info_span!(
             "gpu_shard_ram_witness_transpose_d2h_from_device",

--- a/ceno_zkvm/src/instructions/gpu/config.rs
+++ b/ceno_zkvm/src/instructions/gpu/config.rs
@@ -33,6 +33,7 @@ pub(crate) fn kind_tag(kind: GpuWitgenKind) -> &'static str {
         GpuWitgenKind::Mul(_) => "mul",
         GpuWitgenKind::Div(_) => "div",
         GpuWitgenKind::Keccak => "keccak",
+        GpuWitgenKind::ShardRam => "shard_ram",
     }
 }
 

--- a/ceno_zkvm/src/instructions/gpu/config.rs
+++ b/ceno_zkvm/src/instructions/gpu/config.rs
@@ -85,6 +85,16 @@ pub(crate) fn should_materialize_witness_on_gpu() -> bool {
     is_gpu_witgen_enabled()
 }
 
+/// Whether the initial opcode-assignment pass should eagerly materialize the
+/// witness RMM/device backing.
+///
+/// In cache-none + GPU-witgen mode we keep only replay metadata plus the
+/// shard-resident raw GPU state, and all witness materialization is deferred to
+/// commit / chip proof / opening replay.
+pub(crate) fn should_materialize_witness_on_initial_assign() -> bool {
+    should_materialize_witness_on_gpu() && should_retain_witness_device_backing_after_commit()
+}
+
 /// Whether replayable witness device backing should remain resident after commit.
 ///
 /// Policy:

--- a/ceno_zkvm/src/instructions/gpu/config.rs
+++ b/ceno_zkvm/src/instructions/gpu/config.rs
@@ -6,6 +6,7 @@
 /// - `CENO_GPU_DISABLE_WITGEN_KINDS=add,sub,keccak,...` — per-kind disable (comma-separated tags)
 /// - `CENO_GPU_DEBUG_COMPARE_WITGEN` — enable GPU vs CPU comparison for all chips (witness, LK, shard, EC)
 use super::dispatch::GpuWitgenKind;
+use ceno_gpu::common::{CacheLevel, get_gpu_cache_level};
 
 pub(crate) fn kind_tag(kind: GpuWitgenKind) -> &'static str {
     match kind {
@@ -74,17 +75,25 @@ pub(crate) fn is_gpu_witgen_enabled() -> bool {
     })
 }
 
-/// Device-backed witness matrices are only beneficial when GPU cache keeps trace/codeword
-/// artifacts for reuse. In cache-none mode, prefer D2H host materialization to avoid
-/// retaining large device-backed RMMs beyond commit.
-pub(crate) fn should_keep_witness_device_backing() -> bool {
-    if !is_gpu_witgen_enabled() {
-        return false;
-    }
-    !matches!(
-        gkr_iop::gpu::gpu_prover::get_gpu_cache_level(),
-        gkr_iop::gpu::gpu_prover::CacheLevel::None
-    )
+/// Whether initial witness assignment should materialize a GPU-backed trace RMM.
+///
+/// This is independent from the later retention policy:
+/// - with GPU witgen off, witness is materialized in CPU form as before
+/// - with GPU witgen on, witness is first produced as device-backed so commit
+///   can consume the col-major GPU trace directly without a D2H/H2D round-trip
+pub(crate) fn should_materialize_witness_on_gpu() -> bool {
+    is_gpu_witgen_enabled()
+}
+
+/// Whether replayable witness device backing should remain resident after commit.
+///
+/// Policy:
+/// - `GPU_WITGEN=0`: no special retention
+/// - `GPU_WITGEN=1` and `CACHE_LEVEL > 0`: keep device backing resident
+/// - `GPU_WITGEN=1` and `CACHE_LEVEL = 0`: clear after commit and regenerate on
+///   demand from shard-resident raw data during chip proof / PCS open
+pub(crate) fn should_retain_witness_device_backing_after_commit() -> bool {
+    is_gpu_witgen_enabled() && !matches!(get_gpu_cache_level(), CacheLevel::None)
 }
 
 /// Set `CENO_GPU_DEBUG_COMPARE_WITGEN=1` to enable GPU vs CPU comparison; default disabled.

--- a/ceno_zkvm/src/instructions/gpu/config.rs
+++ b/ceno_zkvm/src/instructions/gpu/config.rs
@@ -74,6 +74,19 @@ pub(crate) fn is_gpu_witgen_enabled() -> bool {
     })
 }
 
+/// Device-backed witness matrices are only beneficial when GPU cache keeps trace/codeword
+/// artifacts for reuse. In cache-none mode, prefer D2H host materialization to avoid
+/// retaining large device-backed RMMs beyond commit.
+pub(crate) fn should_keep_witness_device_backing() -> bool {
+    if !is_gpu_witgen_enabled() {
+        return false;
+    }
+    !matches!(
+        gkr_iop::gpu::gpu_prover::get_gpu_cache_level(),
+        gkr_iop::gpu::gpu_prover::CacheLevel::None
+    )
+}
+
 /// Set `CENO_GPU_DEBUG_COMPARE_WITGEN=1` to enable GPU vs CPU comparison; default disabled.
 pub(crate) fn is_debug_compare_enabled() -> bool {
     use std::sync::OnceLock;

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -364,7 +364,12 @@ fn gpu_assign_instances_inner<E: ExtensionField, I: Instruction<E>>(
             )
         })?
     } else {
-        gpu_witness_to_rmm::<E>(gpu_witness, total_instances, num_witin, I::padding_strategy())
+        gpu_witness_to_rmm::<E>(
+            gpu_witness,
+            total_instances,
+            num_witin,
+            I::padding_strategy(),
+        )
     };
     raw_witin.padding_by_strategy();
     debug_compare_witness::<E, I>(

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -21,7 +21,10 @@ use tracing::info_span;
 use witness::{InstancePaddingStrategy, RowMajorMatrix};
 
 use super::{
-    config::{is_gpu_witgen_enabled, is_kind_disabled, should_materialize_witness_on_gpu},
+    config::{
+        is_gpu_witgen_enabled, is_kind_disabled, should_materialize_witness_on_gpu,
+        should_materialize_witness_on_initial_assign,
+    },
     utils::debug_compare::{
         debug_compare_final_lk, debug_compare_shard_ec, debug_compare_shardram,
         debug_compare_witness,
@@ -215,6 +218,8 @@ fn gpu_assign_instances_inner<E: ExtensionField, I: Instruction<E>>(
 ) -> Result<(RMMCollections<E::BaseField>, Multiplicity<u64>), ZKVMError> {
     let num_structural_witin = num_structural_witin.max(1);
     let total_instances = step_indices.len();
+    let materialize_initial_witness = crate::instructions::gpu::config::is_debug_compare_enabled()
+        || should_materialize_witness_on_initial_assign();
 
     // Step 1: GPU fills witness matrix (+ LK counters + shard records for merged kinds)
     let (gpu_witness, gpu_lk_counters, gpu_ram_slots, gpu_compact_ec, gpu_compact_addr) =
@@ -391,7 +396,9 @@ fn gpu_assign_instances_inner<E: ExtensionField, I: Instruction<E>>(
 
     // Step 4: Keep witness on device only when cache policy keeps device backing.
     // In debug mode or cache-none mode, do transpose + D2H to build host-backed RMM.
-    let mut raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
+    let mut raw_witin = if !materialize_initial_witness {
+        RowMajorMatrix::<E::BaseField>::empty()
+    } else if crate::instructions::gpu::config::is_debug_compare_enabled()
         || !should_materialize_witness_on_gpu()
     {
         info_span!("transpose_d2h", rows = total_instances, cols = num_witin).in_scope(|| {
@@ -411,17 +418,19 @@ fn gpu_assign_instances_inner<E: ExtensionField, I: Instruction<E>>(
             I::padding_strategy(),
         )
     };
-    raw_witin.padding_by_strategy();
-    debug_compare_witness::<E, I>(
-        config,
-        shard_ctx,
-        num_witin,
-        num_structural_witin,
-        shard_steps,
-        step_indices,
-        kind,
-        &raw_witin,
-    )?;
+    if materialize_initial_witness {
+        raw_witin.padding_by_strategy();
+        debug_compare_witness::<E, I>(
+            config,
+            shard_ctx,
+            num_witin,
+            num_structural_witin,
+            shard_steps,
+            step_indices,
+            kind,
+            &raw_witin,
+        )?;
+    }
 
     Ok(([raw_witin, raw_structural], lk_multiplicity))
 }

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -64,6 +64,7 @@ pub enum GpuWitgenKind {
     Div(u32), // 0=DIV, 1=DIVU, 2=REM, 3=REMU
     Lw,
     Keccak,
+    ShardRam,
 }
 
 // Re-exports from device_cache module for external callers (e2e.rs, structs.rs).
@@ -202,6 +203,9 @@ pub(crate) fn build_gpu_replay_plan<E: ExtensionField, I: Instruction<E>>(
         fetch_base_pc,
         fetch_num_slots,
         None,
+        None,
+        0,
+        0,
         config as *const I::InstructionConfig as usize,
         replay_gpu_witness_from_resident_raw::<E, I>,
     )
@@ -287,7 +291,7 @@ fn gpu_assign_instances_inner<E: ExtensionField, I: Instruction<E>>(
     //
     // Keccak never enters this function (it has `gpu_assign_keccak_inner`).
     // Guard defensively in case the enum value is ever passed here by mistake.
-    let is_standard_kind = !matches!(kind, GpuWitgenKind::Keccak);
+    let is_standard_kind = !matches!(kind, GpuWitgenKind::Keccak | GpuWitgenKind::ShardRam);
 
     let lk_multiplicity = if gpu_lk_counters.is_some() && is_standard_kind {
         let lk_multiplicity = info_span!("gpu_lk_d2h")
@@ -1366,6 +1370,9 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
         }
         GpuWitgenKind::Keccak => {
             unreachable!("keccak uses gpu_assign_keccak_instances, not try_gpu_assign_instances")
+        }
+        GpuWitgenKind::ShardRam => {
+            unreachable!("shard ram uses its own replay path, not try_gpu_assign_instances")
         }
     }
 }

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -21,7 +21,7 @@ use tracing::info_span;
 use witness::{InstancePaddingStrategy, RowMajorMatrix};
 
 use super::{
-    config::{is_gpu_witgen_enabled, is_kind_disabled, should_keep_witness_device_backing},
+    config::{is_gpu_witgen_enabled, is_kind_disabled, should_materialize_witness_on_gpu},
     utils::debug_compare::{
         debug_compare_final_lk, debug_compare_shard_ec, debug_compare_shardram,
         debug_compare_witness,
@@ -31,6 +31,7 @@ use crate::{
     e2e::ShardContext,
     error::ZKVMError,
     instructions::{Instruction, cpu_collect_lk_and_shardram, cpu_collect_shardram},
+    structs::GpuReplayPlan,
     tables::RMMCollections,
     witness::LkMultiplicity,
 };
@@ -69,9 +70,8 @@ pub use super::cache::{
 };
 use super::{
     cache::{
-        ensure_shard_metadata_cached, read_shared_addr_count, read_shared_addr_range,
-        upload_shard_steps_cached, with_cached_gpu_ctx, with_cached_shard_meta,
-        with_cached_shard_steps,
+        begin_gpu_shard_session, read_shared_addr_count, read_shared_addr_range,
+        with_cached_gpu_ctx, with_cached_shard_meta,
     },
     utils::d2h::{
         CompactEcBuf, LkResult, RamBuf, WitResult, gpu_collect_shard_records, gpu_compact_ec_d2h,
@@ -169,6 +169,40 @@ pub(crate) fn try_gpu_assign_instances<E: ExtensionField, I: Instruction<E>>(
     })
 }
 
+#[cfg(feature = "gpu")]
+pub(crate) fn build_gpu_replay_plan<E: ExtensionField, I: Instruction<E>>(
+    config: &I::InstructionConfig,
+    shard_ctx: &ShardContext,
+    num_witin: usize,
+    num_structural_witin: usize,
+    shard_steps: &[StepRecord],
+    step_indices: &[StepIndex],
+    kind: GpuWitgenKind,
+) -> GpuReplayPlan<E> {
+    // Replay plans are intentionally split into:
+    // - shared shard state: referenced by pointer / cached separately in the
+    //   shard GPU session (`shard_ctx`, `shard_steps`, resident raw buffers)
+    // - per-chip state: owned here (`step_indices`, kind, shape metadata)
+    //
+    // This keeps per-chip replay metadata small while allowing many chips in
+    // the same shard to reconstruct witness on demand from one resident raw
+    // shard session.
+    let (fetch_base_pc, fetch_num_slots) = compute_fetch_params(shard_steps, step_indices);
+    GpuReplayPlan::new(
+        shard_ctx.shard_id,
+        kind,
+        std::sync::Arc::<[StepIndex]>::from(step_indices.to_vec()),
+        num_witin,
+        num_structural_witin,
+        shard_ctx.current_shard_offset_cycle(),
+        fetch_base_pc,
+        fetch_num_slots,
+        None,
+        config as *const I::InstructionConfig as usize,
+        replay_gpu_witness_from_resident_raw::<E, I>,
+    )
+}
+
 fn gpu_assign_instances_inner<E: ExtensionField, I: Instruction<E>>(
     config: &I::InstructionConfig,
     shard_ctx: &mut ShardContext,
@@ -185,14 +219,17 @@ fn gpu_assign_instances_inner<E: ExtensionField, I: Instruction<E>>(
     // Step 1: GPU fills witness matrix (+ LK counters + shard records for merged kinds)
     let (gpu_witness, gpu_lk_counters, gpu_ram_slots, gpu_compact_ec, gpu_compact_addr) =
         info_span!("gpu_kernel").in_scope(|| {
+            let fetch_params = compute_fetch_params(shard_steps, step_indices);
             gpu_fill_witness::<E, I>(
                 hal,
                 config,
-                shard_ctx,
+                Some(shard_ctx),
                 num_witin,
-                shard_steps,
+                Some(shard_steps),
                 step_indices,
                 kind,
+                shard_ctx.current_shard_offset_cycle(),
+                fetch_params,
             )
         })?;
 
@@ -355,7 +392,7 @@ fn gpu_assign_instances_inner<E: ExtensionField, I: Instruction<E>>(
     // Step 4: Keep witness on device only when cache policy keeps device backing.
     // In debug mode or cache-none mode, do transpose + D2H to build host-backed RMM.
     let mut raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
-        || !should_keep_witness_device_backing()
+        || !should_materialize_witness_on_gpu()
     {
         info_span!("transpose_d2h", rows = total_instances, cols = num_witin).in_scope(|| {
             gpu_witness_to_rmm_d2h::<E>(
@@ -416,11 +453,13 @@ pub(crate) fn compute_fetch_params(
 fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
     hal: &CudaHalBB31,
     config: &I::InstructionConfig,
-    shard_ctx: &ShardContext,
+    shard_ctx: Option<&ShardContext>,
     num_witin: usize,
-    shard_steps: &[StepRecord],
+    shard_steps: Option<&[StepRecord]>,
     step_indices: &[StepIndex],
     kind: GpuWitgenKind,
+    shard_offset: u64,
+    fetch_params: (u32, usize),
 ) -> Result<
     (
         WitResult,
@@ -431,15 +470,15 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
     ),
     ZKVMError,
 > {
-    // Upload shard_steps to GPU once (cached across ADD/LW calls within same shard).
-    let shard_id = shard_ctx.shard_id;
-    info_span!("upload_shard_steps")
-        .in_scope(|| upload_shard_steps_cached(hal, shard_steps, shard_id))?;
+    if let (Some(shard_ctx), Some(shard_steps)) = (shard_ctx, shard_steps) {
+        // Ensure shard-scoped GPU raw data is ready for this kernel dispatch.
+        let _session = info_span!("begin_shard_session")
+            .in_scope(|| begin_gpu_shard_session(hal, shard_ctx, shard_steps))?;
+    }
 
     // Convert step_indices from usize to u32 for GPU.
     let indices_u32: Vec<u32> = info_span!("indices_u32", n = step_indices.len())
         .in_scope(|| step_indices.iter().map(|&i| i as u32).collect());
-    let shard_offset = shard_ctx.current_shard_offset_cycle();
 
     // Helper to split GpuWitgenFullResult into (witness, Some(lk_counters), ram_slots, compact_ec, compact_addr)
     macro_rules! split_full {
@@ -456,11 +495,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
     }
 
     // Compute fetch params for all GPU kinds (LK counters are merged into all kernels)
-    let (fetch_base_pc, fetch_num_slots) = compute_fetch_params(shard_steps, step_indices);
-
-    // Ensure shard metadata is cached for GPU shard records (shared across all kernel kinds)
-    info_span!("ensure_shard_meta")
-        .in_scope(|| ensure_shard_metadata_cached(hal, shard_ctx, shard_steps.len()))?;
+    let (fetch_base_pc, fetch_num_slots) = fetch_params;
 
     match kind {
         GpuWitgenKind::Add => {
@@ -486,7 +521,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                             )
                             .map_err(|e| {
                                 ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_add failed: {e}").into(),
+                                    format!("GPU witgen_add failed: {e:?}").into(),
                                 )
                             })
                     )
@@ -516,7 +551,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                             )
                             .map_err(|e| {
                                 ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_sub failed: {e}").into(),
+                                    format!("GPU witgen_sub failed: {e:?}").into(),
                                 )
                             })
                     )
@@ -548,7 +583,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                             )
                             .map_err(|e| {
                                 ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_logic_r failed: {e}").into(),
+                                    format!("GPU witgen_logic_r failed: {e:?}").into(),
                                 )
                             })
                     )
@@ -581,7 +616,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                             )
                             .map_err(|e| {
                                 ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_logic_i failed: {e}").into(),
+                                    format!("GPU witgen_logic_i failed: {e:?}").into(),
                                 )
                             })
                     )
@@ -612,7 +647,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                             )
                             .map_err(|e| {
                                 ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_addi failed: {e}").into(),
+                                    format!("GPU witgen_addi failed: {e:?}").into(),
                                 )
                             })
                     )
@@ -1191,4 +1226,52 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
             unreachable!("keccak uses gpu_assign_keccak_instances, not try_gpu_assign_instances")
         }
     }
+}
+
+#[cfg(feature = "gpu")]
+fn replay_gpu_witness_from_resident_raw<E: ExtensionField, I: Instruction<E>>(
+    config_ptr: usize,
+    replay: &GpuReplayPlan<E>,
+) -> Result<RMMCollections<E::BaseField>, ZKVMError> {
+    use gkr_iop::gpu::get_cuda_hal;
+
+    let hal = get_cuda_hal()
+        .map_err(|e| ZKVMError::InvalidWitness(format!("Failed to get CUDA HAL: {e}").into()))?;
+    let config = unsafe { &*(config_ptr as *const I::InstructionConfig) };
+    // Replay is not recursive through `assign_opcode_circuit` / the trait-level
+    // `assign_instances`. It reconstructs only the transient witness/device
+    // backing from the shard-resident raw GPU session and this chip's replay
+    // metadata, without touching shard_ctx or re-running LK/shardram collection.
+    let total_instances = replay.step_indices.len();
+    let (gpu_witness, _, _, _, _) = gpu_fill_witness::<E, I>(
+        &hal,
+        config,
+        None,
+        replay.num_witin,
+        None,
+        replay.step_indices.as_ref(),
+        replay.kind,
+        replay.shard_offset,
+        (replay.fetch_base_pc, replay.fetch_num_slots),
+    )?;
+
+    let mut raw_structural = RowMajorMatrix::<E::BaseField>::new(
+        total_instances,
+        replay.num_structural_witin.max(1),
+        I::padding_strategy(),
+    );
+    for row in raw_structural.iter_mut() {
+        *row.last_mut().unwrap() = E::BaseField::ONE;
+    }
+    raw_structural.padding_by_strategy();
+
+    let mut raw_witin = gpu_witness_to_rmm::<E>(
+        gpu_witness,
+        total_instances,
+        replay.num_witin,
+        I::padding_strategy(),
+    );
+    raw_witin.padding_by_strategy();
+
+    Ok([raw_witin, raw_structural])
 }

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -352,7 +352,8 @@ fn gpu_assign_instances_inner<E: ExtensionField, I: Instruction<E>>(
     }
     raw_structural.padding_by_strategy();
 
-    // Step 4: Keep witness on device in normal mode; D2H only for debug comparison.
+    // Step 4: Keep witness on device only when cache policy keeps device backing.
+    // In debug mode or cache-none mode, do transpose + D2H to build host-backed RMM.
     let mut raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
         || !should_keep_witness_device_backing()
     {

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -74,7 +74,7 @@ pub use super::cache::{
 use super::{
     cache::{
         begin_gpu_shard_session, read_shared_addr_count, read_shared_addr_range,
-        with_cached_gpu_ctx, with_cached_shard_meta,
+        with_cached_gpu_ctx_opt, with_cached_shard_meta,
     },
     utils::d2h::{
         CompactEcBuf, LkResult, RamBuf, WitResult, gpu_collect_shard_records, gpu_compact_ec_d2h,
@@ -204,6 +204,45 @@ pub(crate) fn build_gpu_replay_plan<E: ExtensionField, I: Instruction<E>>(
         config as *const I::InstructionConfig as usize,
         replay_gpu_witness_from_resident_raw::<E, I>,
     )
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum GpuFillMode {
+    /// Initial opcode-assignment pass.
+    ///
+    /// This mode has full shard context available and is allowed to bind shard
+    /// side-effect buffers so kernels can produce LK / shardram / shared-circuit
+    /// outputs in addition to witness data.
+    AssignWithSideEffects,
+    /// Replay-time witness restoration.
+    ///
+    /// This mode intentionally has no live `ShardContext` / host `shard_steps`.
+    /// Witness is reconstructed only from resident raw GPU shard data plus the
+    /// replay descriptor. Replay must not bind shard side-effect buffers or
+    /// mutate shard-side accumulators again.
+    ReplayWitnessOnly,
+}
+
+impl GpuFillMode {
+    fn from_optional_ctx(
+        shard_ctx: Option<&ShardContext>,
+        shard_steps: Option<&[StepRecord]>,
+    ) -> Self {
+        match (shard_ctx, shard_steps) {
+            (Some(_), Some(_)) => Self::AssignWithSideEffects,
+            (None, None) => Self::ReplayWitnessOnly,
+            (Some(_), None) | (None, Some(_)) => {
+                panic!(
+                    "gpu_fill_witness requires shard_ctx and shard_steps to be both present \
+                     (initial assign) or both absent (replay)"
+                );
+            }
+        }
+    }
+
+    fn binds_shard_side_effects(self) -> bool {
+        matches!(self, Self::AssignWithSideEffects)
+    }
 }
 
 fn gpu_assign_instances_inner<E: ExtensionField, I: Instruction<E>>(
@@ -479,6 +518,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
     ),
     ZKVMError,
 > {
+    let fill_mode = GpuFillMode::from_optional_ctx(shard_ctx, shard_steps);
     if let (Some(shard_ctx), Some(shard_steps)) = (shard_ctx, shard_steps) {
         // Ensure shard-scoped GPU raw data is ready for this kernel dispatch.
         let _session = info_span!("begin_shard_session")
@@ -515,26 +555,29 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
             let col_map = info_span!("col_map")
                 .in_scope(|| super::chips::add::extract_add_column_map(arith_config, num_witin));
             info_span!("hal_witgen_add").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_add(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_add failed: {e:?}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_add(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_add failed: {e:?}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
         GpuWitgenKind::Sub => {
@@ -545,26 +588,29 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
             let col_map = info_span!("col_map")
                 .in_scope(|| super::chips::sub::extract_sub_column_map(arith_config, num_witin));
             info_span!("hal_witgen_sub").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_sub(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_sub failed: {e:?}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_sub(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_sub failed: {e:?}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
         GpuWitgenKind::LogicR(logic_kind) => {
@@ -576,27 +622,30 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                 super::chips::logic_r::extract_logic_r_column_map(logic_config, num_witin)
             });
             info_span!("hal_witgen_logic_r").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_logic_r(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                logic_kind,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_logic_r failed: {e:?}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_logic_r(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    logic_kind,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_logic_r failed: {e:?}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
 
@@ -609,27 +658,30 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                 super::chips::logic_i::extract_logic_i_column_map(logic_config, num_witin)
             });
             info_span!("hal_witgen_logic_i").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_logic_i(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                logic_kind,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_logic_i failed: {e:?}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_logic_i(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    logic_kind,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_logic_i failed: {e:?}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
 
@@ -641,26 +693,29 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
             let col_map = info_span!("col_map")
                 .in_scope(|| super::chips::addi::extract_addi_column_map(addi_config, num_witin));
             info_span!("hal_witgen_addi").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_addi(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_addi failed: {e:?}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_addi(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_addi failed: {e:?}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
 
@@ -672,26 +727,29 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
             let col_map = info_span!("col_map")
                 .in_scope(|| super::chips::lui::extract_lui_column_map(lui_config, num_witin));
             info_span!("hal_witgen_lui").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_lui(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_lui failed: {e}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_lui(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_lui failed: {e}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
 
@@ -704,26 +762,29 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                 super::chips::auipc::extract_auipc_column_map(auipc_config, num_witin)
             });
             info_span!("hal_witgen_auipc").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_auipc(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_auipc failed: {e}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_auipc(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_auipc failed: {e}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
 
@@ -735,26 +796,29 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
             let col_map = info_span!("col_map")
                 .in_scope(|| super::chips::jal::extract_jal_column_map(jal_config, num_witin));
             info_span!("hal_witgen_jal").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_jal(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_jal failed: {e}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_jal(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_jal failed: {e}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
 
@@ -769,27 +833,30 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                 super::chips::shift_r::extract_shift_r_column_map(shift_config, num_witin)
             });
             info_span!("hal_witgen_shift_r").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_shift_r(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                shift_kind,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_shift_r failed: {e}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_shift_r(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    shift_kind,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_shift_r failed: {e}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
 
@@ -804,27 +871,30 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                 super::chips::shift_i::extract_shift_i_column_map(shift_config, num_witin)
             });
             info_span!("hal_witgen_shift_i").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_shift_i(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                shift_kind,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_shift_i failed: {e}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_shift_i(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    shift_kind,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_shift_i failed: {e}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
 
@@ -836,27 +906,30 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
             let col_map = info_span!("col_map")
                 .in_scope(|| super::chips::slt::extract_slt_column_map(slt_config, num_witin));
             info_span!("hal_witgen_slt").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_slt(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                is_signed,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_slt failed: {e}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_slt(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    is_signed,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_slt failed: {e}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
 
@@ -868,27 +941,30 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
             let col_map = info_span!("col_map")
                 .in_scope(|| super::chips::slti::extract_slti_column_map(slti_config, num_witin));
             info_span!("hal_witgen_slti").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_slti(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                is_signed,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_slti failed: {e}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_slti(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    is_signed,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_slti failed: {e}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
 
@@ -903,27 +979,30 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                 super::chips::branch_eq::extract_branch_eq_column_map(branch_config, num_witin)
             });
             info_span!("hal_witgen_branch_eq").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_branch_eq(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                is_beq,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_branch_eq failed: {e}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_branch_eq(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    is_beq,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_branch_eq failed: {e}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
 
@@ -938,27 +1017,30 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                 super::chips::branch_cmp::extract_branch_cmp_column_map(branch_config, num_witin)
             });
             info_span!("hal_witgen_branch_cmp").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_branch_cmp(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                is_signed,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_branch_cmp failed: {e}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_branch_cmp(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    is_signed,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_branch_cmp failed: {e}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
 
@@ -970,26 +1052,29 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
             let col_map = info_span!("col_map")
                 .in_scope(|| super::chips::jalr::extract_jalr_column_map(jalr_config, num_witin));
             info_span!("hal_witgen_jalr").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_jalr(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_jalr failed: {e}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_jalr(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_jalr failed: {e}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
 
@@ -1002,27 +1087,30 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
             let col_map = info_span!("col_map")
                 .in_scope(|| super::chips::sw::extract_sw_column_map(sw_config, num_witin));
             info_span!("hal_witgen_sw").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_sw(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                mem_max_bits,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_sw failed: {e}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_sw(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    mem_max_bits,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_sw failed: {e}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
 
@@ -1035,27 +1123,30 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
             let col_map = info_span!("col_map")
                 .in_scope(|| super::chips::sh::extract_sh_column_map(sh_config, num_witin));
             info_span!("hal_witgen_sh").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_sh(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                mem_max_bits,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_sh failed: {e}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_sh(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    mem_max_bits,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_sh failed: {e}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
 
@@ -1068,27 +1159,30 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
             let col_map = info_span!("col_map")
                 .in_scope(|| super::chips::sb::extract_sb_column_map(sb_config, num_witin));
             info_span!("hal_witgen_sb").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_sb(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                mem_max_bits,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_sb failed: {e}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_sb(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    mem_max_bits,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_sb failed: {e}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
 
@@ -1105,29 +1199,32 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
             });
             let mem_max_bits = load_config.memory_addr.max_bits as u32;
             info_span!("hal_witgen_load_sub").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_load_sub(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                load_width,
-                                is_signed,
-                                mem_max_bits,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_load_sub failed: {e}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_load_sub(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    load_width,
+                                    is_signed,
+                                    mem_max_bits,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_load_sub failed: {e}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
 
@@ -1139,27 +1236,30 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
             let col_map = info_span!("col_map")
                 .in_scope(|| super::chips::mul::extract_mul_column_map(mul_config, num_witin));
             info_span!("hal_witgen_mul").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_mul(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                mul_kind,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_mul failed: {e}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_mul(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    mul_kind,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_mul failed: {e}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
 
@@ -1171,27 +1271,30 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
             let col_map = info_span!("col_map")
                 .in_scope(|| super::chips::div::extract_div_column_map(div_config, num_witin));
             info_span!("hal_witgen_div").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_div(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                div_kind,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_div failed: {e}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_div(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    div_kind,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_div failed: {e}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
         GpuWitgenKind::Lw => {
@@ -1208,27 +1311,30 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
             let col_map = info_span!("col_map")
                 .in_scope(|| super::chips::lw::extract_lw_column_map(load_config, num_witin));
             info_span!("hal_witgen_lw").in_scope(|| {
-                with_cached_gpu_ctx(|gpu_records, shard_bufs| {
-                    split_full!(
-                        hal.witgen
-                            .witgen_lw(
-                                &col_map,
-                                gpu_records,
-                                &indices_u32,
-                                shard_offset,
-                                mem_max_bits,
-                                fetch_base_pc,
-                                fetch_num_slots,
-                                None,
-                                Some(shard_bufs),
-                            )
-                            .map_err(|e| {
-                                ZKVMError::InvalidWitness(
-                                    format!("GPU witgen_lw failed: {e}").into(),
+                with_cached_gpu_ctx_opt(
+                    fill_mode.binds_shard_side_effects(),
+                    |gpu_records, shard_bufs| {
+                        split_full!(
+                            hal.witgen
+                                .witgen_lw(
+                                    &col_map,
+                                    gpu_records,
+                                    &indices_u32,
+                                    shard_offset,
+                                    mem_max_bits,
+                                    fetch_base_pc,
+                                    fetch_num_slots,
+                                    None,
+                                    shard_bufs,
                                 )
-                            })
-                    )
-                })
+                                .map_err(|e| {
+                                    ZKVMError::InvalidWitness(
+                                        format!("GPU witgen_lw failed: {e}").into(),
+                                    )
+                                })
+                        )
+                    },
+                )
             })
         }
         GpuWitgenKind::Keccak => {

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -18,7 +18,7 @@ use gkr_iop::utils::lk_multiplicity::Multiplicity;
 use p3::field::FieldAlgebra;
 use std::cell::Cell;
 use tracing::info_span;
-use witness::{InstancePaddingStrategy, RowMajorMatrix};
+use witness::{InstancePaddingStrategy, RowMajorMatrix, next_pow2_instance_padding};
 
 use super::{
     config::{
@@ -195,6 +195,7 @@ pub(crate) fn build_gpu_replay_plan<E: ExtensionField, I: Instruction<E>>(
         shard_ctx.shard_id,
         kind,
         std::sync::Arc::<[StepIndex]>::from(step_indices.to_vec()),
+        next_pow2_instance_padding(step_indices.len()),
         num_witin,
         num_structural_witin,
         shard_ctx.current_shard_offset_cycle(),

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -243,6 +243,10 @@ impl GpuFillMode {
     fn binds_shard_side_effects(self) -> bool {
         matches!(self, Self::AssignWithSideEffects)
     }
+
+    fn is_replay_witness_only(self) -> bool {
+        matches!(self, Self::ReplayWitnessOnly)
+    }
 }
 
 fn gpu_assign_instances_inner<E: ExtensionField, I: Instruction<E>>(
@@ -567,6 +571,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     shard_offset,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -600,6 +605,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     shard_offset,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -635,6 +641,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     logic_kind,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -671,6 +678,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     logic_kind,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -705,6 +713,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     shard_offset,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -739,6 +748,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     shard_offset,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -774,6 +784,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     shard_offset,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -808,6 +819,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     shard_offset,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -846,6 +858,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     shift_kind,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -884,6 +897,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     shift_kind,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -919,6 +933,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     is_signed,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -954,6 +969,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     is_signed,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -992,6 +1008,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     is_beq,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -1030,6 +1047,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     is_signed,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -1064,6 +1082,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     shard_offset,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -1100,6 +1119,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     mem_max_bits,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -1136,6 +1156,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     mem_max_bits,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -1172,6 +1193,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     mem_max_bits,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -1214,6 +1236,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     mem_max_bits,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -1249,6 +1272,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     mul_kind,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -1284,6 +1308,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     div_kind,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )
@@ -1324,6 +1349,7 @@ fn gpu_fill_witness<E: ExtensionField, I: Instruction<E>>(
                                     mem_max_bits,
                                     fetch_base_pc,
                                     fetch_num_slots,
+                                    fill_mode.is_replay_witness_only(),
                                     None,
                                     shard_bufs,
                                 )

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -21,7 +21,7 @@ use tracing::info_span;
 use witness::{InstancePaddingStrategy, RowMajorMatrix};
 
 use super::{
-    config::{is_gpu_witgen_enabled, is_kind_disabled},
+    config::{is_gpu_witgen_enabled, is_kind_disabled, should_keep_witness_device_backing},
     utils::debug_compare::{
         debug_compare_final_lk, debug_compare_shard_ec, debug_compare_shardram,
         debug_compare_witness,
@@ -353,7 +353,9 @@ fn gpu_assign_instances_inner<E: ExtensionField, I: Instruction<E>>(
     raw_structural.padding_by_strategy();
 
     // Step 4: Keep witness on device in normal mode; D2H only for debug comparison.
-    let mut raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled() {
+    let mut raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled()
+        || !should_keep_witness_device_backing()
+    {
         info_span!("transpose_d2h", rows = total_instances, cols = num_witin).in_scope(|| {
             gpu_witness_to_rmm_d2h::<E>(
                 hal,

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -75,7 +75,7 @@ use super::{
     },
     utils::d2h::{
         CompactEcBuf, LkResult, RamBuf, WitResult, gpu_collect_shard_records, gpu_compact_ec_d2h,
-        gpu_lk_counters_to_multiplicity, gpu_witness_to_rmm,
+        gpu_lk_counters_to_multiplicity, gpu_witness_to_rmm, gpu_witness_to_rmm_d2h,
     },
 };
 
@@ -352,17 +352,20 @@ fn gpu_assign_instances_inner<E: ExtensionField, I: Instruction<E>>(
     }
     raw_structural.padding_by_strategy();
 
-    // Step 4: Transpose (column-major → row-major) on GPU, then D2H copy to RowMajorMatrix
-    let mut raw_witin = info_span!("transpose_d2h", rows = total_instances, cols = num_witin)
-        .in_scope(|| {
-            gpu_witness_to_rmm::<E>(
+    // Step 4: Keep witness on device in normal mode; D2H only for debug comparison.
+    let mut raw_witin = if crate::instructions::gpu::config::is_debug_compare_enabled() {
+        info_span!("transpose_d2h", rows = total_instances, cols = num_witin).in_scope(|| {
+            gpu_witness_to_rmm_d2h::<E>(
                 hal,
                 gpu_witness,
                 total_instances,
                 num_witin,
                 I::padding_strategy(),
             )
-        })?;
+        })?
+    } else {
+        gpu_witness_to_rmm::<E>(gpu_witness, total_instances, num_witin, I::padding_strategy())
+    };
     raw_witin.padding_by_strategy();
     debug_compare_witness::<E, I>(
         config,

--- a/ceno_zkvm/src/instructions/gpu/utils/d2h.rs
+++ b/ceno_zkvm/src/instructions/gpu/utils/d2h.rs
@@ -220,16 +220,27 @@ pub(crate) fn gpu_witness_to_rmm_d2h<E: ExtensionField>(
     gpu_result: ceno_gpu::common::witgen::types::GpuWitnessResult<
         ceno_gpu::common::BufferImpl<'static, <ff_ext::BabyBearExt4 as ExtensionField>::BaseField>,
     >,
-    num_rows: usize,
+    logical_num_rows: usize,
     num_cols: usize,
     padding: InstancePaddingStrategy,
 ) -> Result<RowMajorMatrix<E::BaseField>, ZKVMError> {
+    // Kernel output may be power-of-two padded; always use the actual produced row count.
+    let produced_rows = gpu_result.num_rows;
+    if produced_rows < logical_num_rows {
+        return Err(ZKVMError::InvalidWitness(
+            format!(
+                "GPU witness rows ({produced_rows}) smaller than logical rows ({logical_num_rows})"
+            )
+            .into(),
+        ));
+    }
+
     // Transpose from column-major to row-major on GPU.
     // Column-major (num_rows x num_cols) is stored as num_cols groups of num_rows elements,
     // which is equivalent to a (num_cols x num_rows) row-major matrix.
     // Transposing with cols=num_rows, rows=num_cols produces (num_rows x num_cols) row-major.
     let mut rmm_buffer = hal
-        .alloc_elems_on_device(num_rows * num_cols, false, None)
+        .alloc_elems_on_device(produced_rows * num_cols, false, None)
         .map_err(|e| {
             ZKVMError::InvalidWitness(format!("GPU alloc for transpose failed: {e}").into())
         })?;
@@ -237,7 +248,7 @@ pub(crate) fn gpu_witness_to_rmm_d2h<E: ExtensionField>(
         &hal.inner,
         &mut rmm_buffer,
         &gpu_result.device_buffer,
-        num_rows,
+        produced_rows,
         num_cols,
     )
     .map_err(|e| ZKVMError::InvalidWitness(format!("GPU transpose failed: {e}").into()))?;

--- a/ceno_zkvm/src/instructions/gpu/utils/d2h.rs
+++ b/ceno_zkvm/src/instructions/gpu/utils/d2h.rs
@@ -21,7 +21,7 @@ use gkr_iop::{RAMType, tables::LookupTable, utils::lk_multiplicity::Multiplicity
 use p3::field::FieldAlgebra;
 use rustc_hash::FxHashMap;
 use tracing::info_span;
-use witness::{InstancePaddingStrategy, RowMajorMatrix};
+use witness::{DeviceMatrixLayout, InstancePaddingStrategy, RowMajorMatrix};
 
 use crate::{
     e2e::{RAMRecord, ShardContext},
@@ -215,7 +215,7 @@ pub(crate) fn gpu_lk_counters_to_multiplicity(
 ///
 /// GPU witgen kernels output column-major layout for better memory coalescing.
 /// This function transposes to row-major on GPU before copying to host.
-pub(crate) fn gpu_witness_to_rmm<E: ExtensionField>(
+pub(crate) fn gpu_witness_to_rmm_d2h<E: ExtensionField>(
     hal: &CudaHalBB31,
     gpu_result: ceno_gpu::common::witgen::types::GpuWitnessResult<
         ceno_gpu::common::BufferImpl<'static, <ff_ext::BabyBearExt4 as ExtensionField>::BaseField>,
@@ -260,3 +260,22 @@ pub(crate) fn gpu_witness_to_rmm<E: ExtensionField>(
         data, num_cols, padding,
     ))
 }
+
+/// Build a host RowMajorMatrix placeholder while keeping source witness on device.
+///
+/// This avoids the GPU->CPU copy in normal GPU mode. Downstream GPU commit
+/// reads from device backing directly.
+pub(crate) fn gpu_witness_to_rmm<E: ExtensionField>(
+    gpu_result: ceno_gpu::common::witgen::types::GpuWitnessResult<
+        ceno_gpu::common::BufferImpl<'static, <ff_ext::BabyBearExt4 as ExtensionField>::BaseField>,
+    >,
+    num_rows: usize,
+    num_cols: usize,
+    padding: InstancePaddingStrategy,
+) -> RowMajorMatrix<E::BaseField> {
+    let mut rmm = RowMajorMatrix::<E::BaseField>::new(num_rows, num_cols, padding);
+    // Keep the original col-major witness buffer as the source of truth for GPU commit.
+    rmm.set_device_backing(gpu_result.device_buffer, DeviceMatrixLayout::ColMajor);
+    rmm
+}
+

--- a/ceno_zkvm/src/instructions/gpu/utils/d2h.rs
+++ b/ceno_zkvm/src/instructions/gpu/utils/d2h.rs
@@ -278,4 +278,3 @@ pub(crate) fn gpu_witness_to_rmm<E: ExtensionField>(
     rmm.set_device_backing(gpu_result.device_buffer, DeviceMatrixLayout::ColMajor);
     rmm
 }
-

--- a/ceno_zkvm/src/instructions/gpu/utils/d2h.rs
+++ b/ceno_zkvm/src/instructions/gpu/utils/d2h.rs
@@ -258,7 +258,7 @@ pub(crate) fn gpu_witness_to_rmm_d2h<E: ExtensionField>(
         .map_err(|e| ZKVMError::InvalidWitness(format!("GPU D2H copy failed: {e}").into()))?;
 
     // Safety: BabyBear is the only supported GPU field, and E::BaseField must match
-    let data: Vec<E::BaseField> = unsafe {
+    let mut data: Vec<E::BaseField> = unsafe {
         let mut data = std::mem::ManuallyDrop::new(gpu_data);
         Vec::from_raw_parts(
             data.as_mut_ptr() as *mut E::BaseField,
@@ -266,6 +266,26 @@ pub(crate) fn gpu_witness_to_rmm_d2h<E: ExtensionField>(
             data.capacity(),
         )
     };
+
+    // Keep logical instance count consistent with CPU/structural witnesses.
+    // GPU kernels may emit power-of-two padded rows; here we drop extra padded rows
+    // and let RowMajorMatrix apply normal padding policy afterward.
+    let logical_elems = logical_num_rows
+        .checked_mul(num_cols)
+        .ok_or_else(|| ZKVMError::InvalidWitness("logical witness shape overflow".into()))?;
+    if data.len() < logical_elems {
+        return Err(ZKVMError::InvalidWitness(
+            format!(
+                "GPU D2H witness has too few elements: got {}, need {} (rows={}, cols={})",
+                data.len(),
+                logical_elems,
+                logical_num_rows,
+                num_cols
+            )
+            .into(),
+        ));
+    }
+    data.truncate(logical_elems);
 
     Ok(RowMajorMatrix::<E::BaseField>::new_by_values(
         data, num_cols, padding,

--- a/ceno_zkvm/src/instructions/riscv/ecall/keccak.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/keccak.rs
@@ -333,4 +333,25 @@ impl<E: ExtensionField> Instruction<E> for KeccakInstruction<E> {
             lk_multiplicity.into_finalize_result(),
         ))
     }
+
+    #[cfg(feature = "gpu")]
+    fn build_gpu_replay_plan(
+        config: &Self::InstructionConfig,
+        shard_ctx: &ShardContext,
+        num_witin: usize,
+        num_structural_witin: usize,
+        shard_steps: &[StepRecord],
+        step_indices: &[StepIndex],
+    ) -> Option<crate::structs::GpuReplayPlan<E>> {
+        Some(
+            crate::instructions::gpu::chips::keccak::build_keccak_replay_plan(
+                config,
+                shard_ctx,
+                num_witin,
+                num_structural_witin,
+                shard_steps,
+                step_indices,
+            ),
+        )
+    }
 }

--- a/ceno_zkvm/src/scheme/gpu/memory.rs
+++ b/ceno_zkvm/src/scheme/gpu/memory.rs
@@ -37,7 +37,7 @@ pub fn init_gpu_mem_tracker<'a>(
     }
 }
 
-const ESTIMATION_TOLERANCE_BYTES: usize = 1024 * 1024; // max estimation error: 1 MB
+const ESTIMATION_TOLERANCE_BYTES: usize = 2 * 1024 * 1024; // max under-estimation error: 2 MB
 const ESTIMATION_SAFETY_MARGIN_BYTES: usize = 10 * 1024 * 1024; // reserved headroom / allowed over-estimate margin: 10 MB
 
 /// Validate that the estimated GPU memory matches actual usage within tolerance.

--- a/ceno_zkvm/src/scheme/gpu/memory.rs
+++ b/ceno_zkvm/src/scheme/gpu/memory.rs
@@ -106,7 +106,12 @@ pub fn estimate_chip_proof_memory<E: ExtensionField, PCS: PolynomialCommitmentSc
     let n = num_var_with_rotation.saturating_sub(1);
     let ecc_quark_temporary_bytes = estimate_ecc_quark_bytes_from_num_vars(n);
 
-    // Part 4: build/prove tower (temporary usage)
+    // Part 4: build/prove tower (scheduler-facing live peak)
+    //
+    // `tower_prove_bytes` already includes the TowerInput buffers that remain
+    // live while `create_proof` runs, so the top-level model must combine the
+    // build and prove phases as overlapping live sets, not treat prove as only
+    // "new allocations inside create_proof".
     let (tower_build_bytes, tower_prove_bytes) = estimate_tower_stage_bytes(composed_cs, input);
     let tower_temporary_bytes = tower_build_bytes + tower_prove_bytes;
 

--- a/ceno_zkvm/src/scheme/gpu/memory.rs
+++ b/ceno_zkvm/src/scheme/gpu/memory.rs
@@ -1,9 +1,10 @@
 use crate::{
+    instructions::gpu::dispatch::GpuWitgenKind,
     scheme::{
         constants::{NUM_FANIN, SEPTIC_EXTENSION_DEGREE},
         hal::ProofInput,
     },
-    structs::ComposedConstrainSystem,
+    structs::{ComposedConstrainSystem, GpuReplayPlan},
 };
 use ceno_gpu::{
     estimate_build_tower_memory, estimate_prove_tower_memory, estimate_sumcheck_memory,
@@ -215,6 +216,51 @@ pub fn estimate_replay_materialization_bytes(
     let base_elem_size = std::mem::size_of::<BB31Base>();
     let mle_len = 1usize << num_vars;
     (num_witin + num_structural_witin) * mle_len * base_elem_size
+}
+
+pub fn estimate_replay_materialization_bytes_for_plan<E: ExtensionField>(
+    replay_plan: &GpuReplayPlan<E>,
+    _num_vars: usize,
+) -> usize {
+    let elem_size = std::mem::size_of::<BB31Base>();
+    let witness_bytes = replay_plan.trace_height * replay_plan.num_witin * elem_size;
+    let structural_bytes = match replay_plan.kind {
+        // Standard opcode replay rebuilds structural witness on CPU and only
+        // uploads it later in `transport_structural_witness_to_gpu`, so the
+        // replay scope itself should not charge structural GPU bytes.
+        GpuWitgenKind::Keccak | GpuWitgenKind::ShardRam => {
+            replay_plan.trace_height * replay_plan.num_structural_witin * elem_size
+        }
+        _ => 0,
+    };
+    let base_bytes = witness_bytes + structural_bytes;
+    let standard_indices_temp_bytes = match replay_plan.kind {
+        GpuWitgenKind::Keccak | GpuWitgenKind::ShardRam => 0,
+        _ => replay_plan.step_indices.len() * std::mem::size_of::<u32>(),
+    };
+    let keccak_instances_temp_bytes = match replay_plan.kind {
+        GpuWitgenKind::Keccak => replay_plan
+            .keccak_instances
+            .as_ref()
+            .map(|instances| {
+                instances.len()
+                    * std::mem::size_of::<ceno_gpu::common::witgen::types::GpuKeccakInstance>()
+            })
+            .unwrap_or(0),
+        _ => 0,
+    };
+
+    match replay_plan.kind {
+        GpuWitgenKind::ShardRam => {
+            let n = replay_plan.shard_ram_num_records.next_power_of_two();
+            // ShardRam replay constructs an EC tree on GPU from the device records.
+            // Peak temp occurs at the first layer when cur_x/cur_y and next_x/next_y
+            // coexist. Each point coordinate stores 7 BabyBear limbs.
+            let ec_tree_temp_bytes = (2 * n * 7 * elem_size) + (2 * (n / 2) * 7 * elem_size);
+            base_bytes + ec_tree_temp_bytes
+        }
+        _ => base_bytes + standard_indices_temp_bytes + keccak_instances_temp_bytes,
+    }
 }
 
 pub(crate) fn estimate_trace_bytes<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(

--- a/ceno_zkvm/src/scheme/gpu/memory.rs
+++ b/ceno_zkvm/src/scheme/gpu/memory.rs
@@ -122,7 +122,9 @@ pub fn estimate_chip_proof_memory<E: ExtensionField, PCS: PolynomialCommitmentSc
         // so the peak is the max of those stage-local lifetimes.
         let tower_build_stage_bytes =
             trace_est.trace_resident_bytes + main_witness_bytes + tower_build_bytes;
-        let tower_prove_stage_bytes = tower_prove_bytes;
+        // TowerInput stays resident through create_proof, so tower prove overlaps
+        // the built tower buffers with the proof-time working set.
+        let tower_prove_stage_bytes = tower_build_bytes + tower_prove_bytes;
         let ecc_stage_bytes = trace_est.trace_resident_bytes + ecc_quark_temporary_bytes;
         let main_stage_bytes = trace_est.trace_resident_bytes + main_constraints_temporary_bytes;
         let replay_stage_bytes = trace_est.trace_resident_bytes + trace_est.trace_temporary_bytes;

--- a/ceno_zkvm/src/scheme/gpu/memory.rs
+++ b/ceno_zkvm/src/scheme/gpu/memory.rs
@@ -113,7 +113,7 @@ pub fn estimate_chip_proof_memory<E: ExtensionField, PCS: PolynomialCommitmentSc
     // build and prove phases as overlapping live sets, not treat prove as only
     // "new allocations inside create_proof".
     let (tower_build_bytes, tower_prove_bytes) = estimate_tower_stage_bytes(composed_cs, input);
-    let tower_temporary_bytes = tower_build_bytes + tower_prove_bytes;
+    let tower_temporary_bytes = tower_build_bytes.max(tower_prove_bytes);
 
     // Part 5: main constraints (temporary usage)
     let main_constraints_temporary_bytes = estimate_main_constraints_bytes(composed_cs, input);
@@ -129,9 +129,11 @@ pub fn estimate_chip_proof_memory<E: ExtensionField, PCS: PolynomialCommitmentSc
         // so the peak is the max of those stage-local lifetimes.
         let tower_build_stage_bytes =
             trace_est.trace_resident_bytes + main_witness_bytes + tower_build_bytes;
-        // TowerInput stays resident through create_proof, so tower prove overlaps
-        // the built tower buffers with the proof-time working set.
-        let tower_prove_stage_bytes = tower_build_bytes + tower_prove_bytes;
+        // `tower_prove_bytes` is already an inclusive live-peak for create_proof:
+        // it counts the TowerInput buffers that remain live plus the proof-time
+        // scratch allocated inside create_proof. Do not add tower_build_bytes
+        // again here or the TowerInput backing gets double-counted.
+        let tower_prove_stage_bytes = tower_prove_bytes;
         let ecc_stage_bytes = trace_est.trace_resident_bytes + ecc_quark_temporary_bytes;
         let main_stage_bytes = trace_est.trace_resident_bytes + main_constraints_temporary_bytes;
         let replay_stage_bytes = trace_est.trace_resident_bytes + trace_est.trace_temporary_bytes;

--- a/ceno_zkvm/src/scheme/gpu/memory.rs
+++ b/ceno_zkvm/src/scheme/gpu/memory.rs
@@ -18,6 +18,8 @@ use gkr_iop::gpu::{
 use mpcs::PolynomialCommitmentScheme;
 use std::sync::OnceLock;
 
+#[cfg(feature = "gpu")]
+use crate::instructions::gpu::config::should_materialize_witness_on_gpu;
 use crate::scheme::scheduler::{ChipProvingMode, get_chip_proving_mode};
 
 pub fn init_gpu_mem_tracker<'a>(
@@ -325,6 +327,14 @@ pub(crate) fn estimate_tower_bytes<E: ExtensionField, PCS: PolynomialCommitmentS
 /// Returns `(0, 0)` when trace is cached (`CacheLevel::Trace` or `CacheLevel::Full`),
 /// When cache is disabled (`CacheLevel::None`, the default), estimates actual allocation costs.
 pub(crate) fn estimate_trace_extraction_bytes(num_witin: usize, num_vars: usize) -> (usize, usize) {
+    if should_materialize_witness_on_gpu() {
+        // GPU witgen keeps witness traces device-backed in col-major form.
+        // `get_trace` then builds view-based polynomials directly from the
+        // resident device buffer, so there is no per-task extraction buffer or
+        // additional resident witness allocation to account for here.
+        return (0, 0);
+    }
+
     if matches!(get_gpu_cache_level(), CacheLevel::None) {
         // Default cache level is None
         let base_elem_size = std::mem::size_of::<BB31Base>();

--- a/ceno_zkvm/src/scheme/gpu/memory.rs
+++ b/ceno_zkvm/src/scheme/gpu/memory.rs
@@ -38,7 +38,7 @@ pub fn init_gpu_mem_tracker<'a>(
 }
 
 const ESTIMATION_TOLERANCE_BYTES: usize = 1024 * 1024; // max estimation error: 1 MB
-const ESTIMATION_SAFETY_MARGIN_BYTES: usize = 5 * 1024 * 1024; // reserved headroom: 5 MB, 1MB for each sub-stage
+const ESTIMATION_SAFETY_MARGIN_BYTES: usize = 10 * 1024 * 1024; // reserved headroom / allowed over-estimate margin: 10 MB
 
 /// Validate that the estimated GPU memory matches actual usage within tolerance.
 /// - Under-estimate (actual > estimated): diff must be <= `ESTIMATION_TOLERANCE_BYTES`

--- a/ceno_zkvm/src/scheme/gpu/memory.rs
+++ b/ceno_zkvm/src/scheme/gpu/memory.rs
@@ -19,7 +19,9 @@ use mpcs::PolynomialCommitmentScheme;
 use std::sync::OnceLock;
 
 #[cfg(feature = "gpu")]
-use crate::instructions::gpu::config::should_materialize_witness_on_gpu;
+use crate::instructions::gpu::config::{
+    should_materialize_witness_on_gpu, should_retain_witness_device_backing_after_commit,
+};
 use crate::scheme::scheduler::{ChipProvingMode, get_chip_proving_mode};
 
 pub fn init_gpu_mem_tracker<'a>(
@@ -327,19 +329,28 @@ pub(crate) fn estimate_tower_bytes<E: ExtensionField, PCS: PolynomialCommitmentS
 /// Returns `(0, 0)` when trace is cached (`CacheLevel::Trace` or `CacheLevel::Full`),
 /// When cache is disabled (`CacheLevel::None`, the default), estimates actual allocation costs.
 pub(crate) fn estimate_trace_extraction_bytes(num_witin: usize, num_vars: usize) -> (usize, usize) {
+    let base_elem_size = std::mem::size_of::<BB31Base>();
+    let mle_len = 1usize << num_vars;
+    let poly_bytes = num_witin * mle_len * base_elem_size;
+
     if should_materialize_witness_on_gpu() {
-        // GPU witgen keeps witness traces device-backed in col-major form.
-        // `get_trace` then builds view-based polynomials directly from the
-        // resident device buffer, so there is no per-task extraction buffer or
-        // additional resident witness allocation to account for here.
-        return (0, 0);
+        if should_retain_witness_device_backing_after_commit() {
+            // Eager GPU cache path: committed traces stay resident and
+            // extraction builds view-based polynomials directly from the
+            // already-live device buffer.
+            return (0, 0);
+        }
+
+        // Cache-none replay path: the task regenerates one witness/device
+        // backing on demand and keeps that col-major buffer resident for the
+        // duration of the chip proof. There is no separate extraction temp
+        // buffer, but the replayed witness itself must be accounted for as
+        // resident task memory.
+        return (poly_bytes, 0);
     }
 
     if matches!(get_gpu_cache_level(), CacheLevel::None) {
         // Default cache level is None
-        let base_elem_size = std::mem::size_of::<BB31Base>();
-        let mle_len = 1usize << num_vars;
-        let poly_bytes = num_witin * mle_len * base_elem_size;
         // get_trace allocates poly copies (resident) + temp_buffer (2x, freed after)
         (poly_bytes, 2 * poly_bytes)
     } else {

--- a/ceno_zkvm/src/scheme/gpu/memory.rs
+++ b/ceno_zkvm/src/scheme/gpu/memory.rs
@@ -112,9 +112,10 @@ pub fn estimate_chip_proof_memory<E: ExtensionField, PCS: PolynomialCommitmentSc
     // Part 5: main constraints (temporary usage)
     let main_constraints_temporary_bytes = estimate_main_constraints_bytes(composed_cs, input);
 
-    let keccak_stage_split = witness_replayable && circuit_name == "Ecall_Keccak";
-    let (resident_bytes, stage_peak_usage_bytes, total_usage_bytes) = if keccak_stage_split {
-        // Keccak replay is materialized twice:
+    let replay_stage_split =
+        witness_replayable && matches!(circuit_name, "Ecall_Keccak" | "ShardRamCircuit");
+    let (resident_bytes, stage_peak_usage_bytes, total_usage_bytes) = if replay_stage_split {
+        // Replayable large-memory chips are materialized twice:
         // - once for build_main_witness + build_tower_witness
         // - once again for main constraints
         // The replayed trace/device backing is explicitly released before the
@@ -159,12 +160,12 @@ pub fn estimate_chip_proof_memory<E: ExtensionField, PCS: PolynomialCommitmentSc
     tracing::info!(
         "[mem estimate][{}] resident: trace={:.2}MB, main_witness={:.2}MB",
         circuit_name,
-        to_mb(if keccak_stage_split {
+        to_mb(if replay_stage_split {
             0
         } else {
             trace_est.trace_resident_bytes
         }),
-        to_mb(if keccak_stage_split {
+        to_mb(if replay_stage_split {
             0
         } else {
             main_witness_bytes

--- a/ceno_zkvm/src/scheme/gpu/memory.rs
+++ b/ceno_zkvm/src/scheme/gpu/memory.rs
@@ -106,14 +106,15 @@ pub fn estimate_chip_proof_memory<E: ExtensionField, PCS: PolynomialCommitmentSc
     let n = num_var_with_rotation.saturating_sub(1);
     let ecc_quark_temporary_bytes = estimate_ecc_quark_bytes_from_num_vars(n);
 
-    // Part 4: build/prove tower (scheduler-facing live peak)
+    // Part 4: build/prove tower
     //
-    // `tower_prove_bytes` already includes the TowerInput buffers that remain
-    // live while `create_proof` runs, so the top-level model must combine the
-    // build and prove phases as overlapping live sets, not treat prove as only
-    // "new allocations inside create_proof".
-    let (tower_build_bytes, tower_prove_bytes) = estimate_tower_stage_bytes(composed_cs, input);
-    let tower_temporary_bytes = tower_build_bytes.max(tower_prove_bytes);
+    // `tower_prove_local_bytes` is only the new allocation occupancy inside
+    // `create_proof`, while `tower_input_live_bytes` tracks the already-built
+    // TowerInput buffers that remain live during that stage.
+    let (tower_build_bytes, tower_prove_local_bytes, tower_input_live_bytes) =
+        estimate_tower_stage_components(composed_cs, input);
+    let tower_prove_peak_bytes = tower_input_live_bytes + tower_prove_local_bytes;
+    let tower_temporary_bytes = tower_build_bytes.max(tower_prove_peak_bytes);
 
     // Part 5: main constraints (temporary usage)
     let main_constraints_temporary_bytes = estimate_main_constraints_bytes(composed_cs, input);
@@ -129,11 +130,10 @@ pub fn estimate_chip_proof_memory<E: ExtensionField, PCS: PolynomialCommitmentSc
         // so the peak is the max of those stage-local lifetimes.
         let tower_build_stage_bytes =
             trace_est.trace_resident_bytes + main_witness_bytes + tower_build_bytes;
-        // `tower_prove_bytes` is already an inclusive live-peak for create_proof:
-        // it counts the TowerInput buffers that remain live plus the proof-time
-        // scratch allocated inside create_proof. Do not add tower_build_bytes
-        // again here or the TowerInput backing gets double-counted.
-        let tower_prove_stage_bytes = tower_prove_bytes;
+        // During tower prove, the replayed witness/device backing has already
+        // been cleared, but the built TowerInput buffers remain live and
+        // overlap with the fresh create_proof allocations.
+        let tower_prove_stage_bytes = tower_prove_peak_bytes;
         let ecc_stage_bytes = trace_est.trace_resident_bytes + ecc_quark_temporary_bytes;
         let main_stage_bytes = trace_est.trace_resident_bytes + main_constraints_temporary_bytes;
         let replay_stage_bytes = trace_est.trace_resident_bytes + trace_est.trace_temporary_bytes;
@@ -186,7 +186,7 @@ pub fn estimate_chip_proof_memory<E: ExtensionField, PCS: PolynomialCommitmentSc
         to_mb(trace_est.trace_temporary_bytes),
         to_mb(ecc_quark_temporary_bytes),
         to_mb(tower_build_bytes),
-        to_mb(tower_prove_bytes),
+        to_mb(tower_prove_peak_bytes),
         to_mb(main_constraints_temporary_bytes),
     );
     // Total peak = resident + max(stage temporaries)
@@ -389,12 +389,10 @@ pub(crate) fn estimate_main_constraints_bytes<
     eqs_bytes + sumcheck_bytes
 }
 
-/// Estimate temporary GPU memory for the tower proving stage (build + prove).
-/// Used by prove_tower_relation to validate against actual mem_tracker measurements.
-pub(crate) fn estimate_tower_stage_bytes<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
+fn estimate_tower_stage_components<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
     composed_cs: &ComposedConstrainSystem<E>,
     input: &ProofInput<'_, GpuBackend<E, PCS>>,
-) -> (usize, usize) {
+) -> (usize, usize, usize) {
     let cs = &composed_cs.zkvm_v1_css;
     let num_prod_towers = composed_cs.num_reads() + composed_cs.num_writes();
     let num_logup_towers = if composed_cs.is_with_lk_table() {
@@ -426,15 +424,30 @@ pub(crate) fn estimate_tower_stage_bytes<E: ExtensionField, PCS: PolynomialCommi
         elem_size,
     );
 
-    (build_est.total_bytes, prove_est.total_bytes)
+    let tower_input_live_bytes =
+        prove_est.prod_tower_buffer_bytes + prove_est.logup_tower_buffer_bytes;
+    let prove_local_bytes = prove_est.total_bytes.saturating_sub(tower_input_live_bytes);
+
+    (build_est.total_bytes, prove_local_bytes, tower_input_live_bytes)
+}
+
+/// Estimate temporary GPU memory for the tower proving stage (build + prove).
+/// Used by prove_tower_relation to validate against actual mem_tracker measurements.
+pub(crate) fn estimate_tower_stage_bytes<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
+    composed_cs: &ComposedConstrainSystem<E>,
+    input: &ProofInput<'_, GpuBackend<E, PCS>>,
+) -> (usize, usize) {
+    let (build_bytes, prove_local_bytes, _) = estimate_tower_stage_components(composed_cs, input);
+    (build_bytes, prove_local_bytes)
 }
 
 pub(crate) fn estimate_tower_bytes<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
     composed_cs: &ComposedConstrainSystem<E>,
     input: &ProofInput<'_, GpuBackend<E, PCS>>,
 ) -> usize {
-    let (build_bytes, prove_bytes) = estimate_tower_stage_bytes(composed_cs, input);
-    build_bytes + prove_bytes
+    let (build_bytes, prove_local_bytes, tower_input_live_bytes) =
+        estimate_tower_stage_components(composed_cs, input);
+    build_bytes.max(tower_input_live_bytes + prove_local_bytes)
 }
 
 /// Estimate GPU memory for trace extraction (get_trace).

--- a/ceno_zkvm/src/scheme/gpu/memory.rs
+++ b/ceno_zkvm/src/scheme/gpu/memory.rs
@@ -105,40 +105,77 @@ pub fn estimate_chip_proof_memory<E: ExtensionField, PCS: PolynomialCommitmentSc
     let n = num_var_with_rotation.saturating_sub(1);
     let ecc_quark_temporary_bytes = estimate_ecc_quark_bytes_from_num_vars(n);
 
-    // Part 4: build & prove tower (temporary usage)
-    let tower_temporary_bytes = estimate_tower_bytes(composed_cs, input);
+    // Part 4: build/prove tower (temporary usage)
+    let (tower_build_bytes, tower_prove_bytes) = estimate_tower_stage_bytes(composed_cs, input);
+    let tower_temporary_bytes = tower_build_bytes + tower_prove_bytes;
 
     // Part 5: main constraints (temporary usage)
     let main_constraints_temporary_bytes = estimate_main_constraints_bytes(composed_cs, input);
 
-    // Peak is max across all stages (extraction, tower, ecc, main).
-    // Each stage's temporary memory is on top of the resident usage (records + deferred_resident).
-    let stage_peak_usage_bytes = trace_est
-        .trace_temporary_bytes
-        .max(tower_temporary_bytes)
-        .max(ecc_quark_temporary_bytes)
-        .max(main_constraints_temporary_bytes);
-
-    let total_usage_bytes = trace_est.trace_resident_bytes
-        + main_witness_bytes
-        + stage_peak_usage_bytes
-        + ESTIMATION_SAFETY_MARGIN_BYTES;
+    let keccak_stage_split = witness_replayable && circuit_name == "Ecall_Keccak";
+    let (resident_bytes, stage_peak_usage_bytes, total_usage_bytes) = if keccak_stage_split {
+        // Keccak replay is materialized twice:
+        // - once for build_main_witness + build_tower_witness
+        // - once again for main constraints
+        // The replayed trace/device backing is explicitly released before the
+        // standalone tower prove and again before the main-constraints stage,
+        // so the peak is the max of those stage-local lifetimes.
+        let tower_build_stage_bytes =
+            trace_est.trace_resident_bytes + main_witness_bytes + tower_build_bytes;
+        let tower_prove_stage_bytes = tower_prove_bytes;
+        let ecc_stage_bytes = trace_est.trace_resident_bytes + ecc_quark_temporary_bytes;
+        let main_stage_bytes = trace_est.trace_resident_bytes + main_constraints_temporary_bytes;
+        let replay_stage_bytes = trace_est.trace_resident_bytes + trace_est.trace_temporary_bytes;
+        let stage_peak = tower_build_stage_bytes
+            .max(tower_prove_stage_bytes)
+            .max(ecc_stage_bytes)
+            .max(main_stage_bytes)
+            .max(replay_stage_bytes);
+        (
+            0usize,
+            stage_peak,
+            stage_peak + ESTIMATION_SAFETY_MARGIN_BYTES,
+        )
+    } else {
+        // Peak is max across all stages (extraction, tower, ecc, main).
+        // Each stage's temporary memory is on top of the resident usage (records + deferred_resident).
+        let stage_peak = trace_est
+            .trace_temporary_bytes
+            .max(tower_temporary_bytes)
+            .max(ecc_quark_temporary_bytes)
+            .max(main_constraints_temporary_bytes);
+        let resident = trace_est.trace_resident_bytes + main_witness_bytes;
+        (
+            resident,
+            stage_peak,
+            resident + stage_peak + ESTIMATION_SAFETY_MARGIN_BYTES,
+        )
+    };
 
     let to_mb = |bytes: usize| bytes as f64 / (1024.0 * 1024.0);
     // Resident memory (always occupied during chip proof)
     tracing::info!(
         "[mem estimate][{}] resident: trace={:.2}MB, main_witness={:.2}MB",
         circuit_name,
-        to_mb(trace_est.trace_resident_bytes),
-        to_mb(main_witness_bytes),
+        to_mb(if keccak_stage_split {
+            0
+        } else {
+            trace_est.trace_resident_bytes
+        }),
+        to_mb(if keccak_stage_split {
+            0
+        } else {
+            main_witness_bytes
+        }),
     );
     // Temporary memory per stage (only one active at a time, peak = max)
     tracing::info!(
-        "[mem estimate][{}] temporary: extract_trace={:.2}MB, ecc_quark={:.2}MB, prove_tower={:.2}MB,  prove_main={:.2}MB",
+        "[mem estimate][{}] temporary: extract_trace={:.2}MB, ecc_quark={:.2}MB, build_tower={:.2}MB, prove_tower={:.2}MB, prove_main={:.2}MB",
         circuit_name,
         to_mb(trace_est.trace_temporary_bytes),
         to_mb(ecc_quark_temporary_bytes),
-        to_mb(tower_temporary_bytes),
+        to_mb(tower_build_bytes),
+        to_mb(tower_prove_bytes),
         to_mb(main_constraints_temporary_bytes),
     );
     // Total peak = resident + max(stage temporaries)
@@ -146,7 +183,7 @@ pub fn estimate_chip_proof_memory<E: ExtensionField, PCS: PolynomialCommitmentSc
         "[mem estimate][{}] total_usage={:.2}MB (resident={:.2}MB + temporary={:.2}MB)",
         circuit_name,
         to_mb(total_usage_bytes),
-        to_mb(trace_est.trace_resident_bytes + main_witness_bytes),
+        to_mb(resident_bytes),
         to_mb(stage_peak_usage_bytes),
     );
 
@@ -298,10 +335,10 @@ pub(crate) fn estimate_main_constraints_bytes<
 
 /// Estimate temporary GPU memory for the tower proving stage (build + prove).
 /// Used by prove_tower_relation to validate against actual mem_tracker measurements.
-pub(crate) fn estimate_tower_bytes<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
+pub(crate) fn estimate_tower_stage_bytes<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
     composed_cs: &ComposedConstrainSystem<E>,
     input: &ProofInput<'_, GpuBackend<E, PCS>>,
-) -> usize {
+) -> (usize, usize) {
     let cs = &composed_cs.zkvm_v1_css;
     let num_prod_towers = composed_cs.num_reads() + composed_cs.num_writes();
     let num_logup_towers = if composed_cs.is_with_lk_table() {
@@ -333,7 +370,15 @@ pub(crate) fn estimate_tower_bytes<E: ExtensionField, PCS: PolynomialCommitmentS
         elem_size,
     );
 
-    build_est.total_bytes + prove_est.total_bytes
+    (build_est.total_bytes, prove_est.total_bytes)
+}
+
+pub(crate) fn estimate_tower_bytes<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
+    composed_cs: &ComposedConstrainSystem<E>,
+    input: &ProofInput<'_, GpuBackend<E, PCS>>,
+) -> usize {
+    let (build_bytes, prove_bytes) = estimate_tower_stage_bytes(composed_cs, input);
+    build_bytes + prove_bytes
 }
 
 /// Estimate GPU memory for trace extraction (get_trace).

--- a/ceno_zkvm/src/scheme/gpu/memory.rs
+++ b/ceno_zkvm/src/scheme/gpu/memory.rs
@@ -90,12 +90,13 @@ pub fn estimate_chip_proof_memory<E: ExtensionField, PCS: PolynomialCommitmentSc
     composed_cs: &ComposedConstrainSystem<E>,
     input: &ProofInput<'_, GpuBackend<E, PCS>>,
     circuit_name: &str,
+    witness_replayable: bool,
 ) -> u64 {
     let num_var_with_rotation =
         input.log2_num_instances() + composed_cs.rotation_vars().unwrap_or(0);
 
     // Part 1: trace (base usage: witness & structural mles)
-    let trace_est = estimate_trace_bytes(composed_cs, input);
+    let trace_est = estimate_trace_bytes(composed_cs, input, witness_replayable);
 
     // Part 2: main witness (base usage)
     let main_witness_bytes = estimate_main_witness_bytes(composed_cs, num_var_with_rotation);
@@ -166,9 +167,20 @@ pub(crate) fn estimate_structural_mle_bytes(num_structural_witin: usize, num_var
     num_structural_witin * mle_len * base_elem_size
 }
 
+pub fn estimate_replay_materialization_bytes(
+    num_witin: usize,
+    num_structural_witin: usize,
+    num_vars: usize,
+) -> usize {
+    let base_elem_size = std::mem::size_of::<BB31Base>();
+    let mle_len = 1usize << num_vars;
+    (num_witin + num_structural_witin) * mle_len * base_elem_size
+}
+
 pub(crate) fn estimate_trace_bytes<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
     composed_cs: &ComposedConstrainSystem<E>,
     input: &ProofInput<'_, GpuBackend<E, PCS>>,
+    witness_replayable: bool,
 ) -> TraceEstimate {
     let cs = &composed_cs.zkvm_v1_css;
     let num_var_with_rotation =
@@ -176,8 +188,11 @@ pub(crate) fn estimate_trace_bytes<E: ExtensionField, PCS: PolynomialCommitmentS
 
     let structural_mle_bytes =
         estimate_structural_mle_bytes(cs.num_structural_witin as usize, num_var_with_rotation);
-    let (witness_mle_bytes, trace_temporary_bytes) =
-        estimate_trace_extraction_bytes(cs.num_witin as usize, num_var_with_rotation);
+    let (witness_mle_bytes, trace_temporary_bytes) = estimate_trace_extraction_bytes(
+        cs.num_witin as usize,
+        num_var_with_rotation,
+        witness_replayable,
+    );
 
     TraceEstimate {
         trace_resident_bytes: witness_mle_bytes + structural_mle_bytes,
@@ -328,7 +343,11 @@ pub(crate) fn estimate_tower_bytes<E: ExtensionField, PCS: PolynomialCommitmentS
 ///
 /// Returns `(0, 0)` when trace is cached (`CacheLevel::Trace` or `CacheLevel::Full`),
 /// When cache is disabled (`CacheLevel::None`, the default), estimates actual allocation costs.
-pub(crate) fn estimate_trace_extraction_bytes(num_witin: usize, num_vars: usize) -> (usize, usize) {
+pub(crate) fn estimate_trace_extraction_bytes(
+    num_witin: usize,
+    num_vars: usize,
+    witness_replayable: bool,
+) -> (usize, usize) {
     let base_elem_size = std::mem::size_of::<BB31Base>();
     let mle_len = 1usize << num_vars;
     let poly_bytes = num_witin * mle_len * base_elem_size;
@@ -341,12 +360,19 @@ pub(crate) fn estimate_trace_extraction_bytes(num_witin: usize, num_vars: usize)
             return (0, 0);
         }
 
-        // Cache-none replay path: the task regenerates one witness/device
-        // backing on demand and keeps that col-major buffer resident for the
-        // duration of the chip proof. There is no separate extraction temp
-        // buffer, but the replayed witness itself must be accounted for as
-        // resident task memory.
-        return (poly_bytes, 0);
+        if witness_replayable {
+            // Cache-none replay path: the task regenerates one witness/device
+            // backing on demand and keeps that col-major buffer resident for the
+            // duration of the chip proof. There is no separate extraction temp
+            // buffer, but the replayed witness itself must be accounted for as
+            // resident task memory.
+            return (poly_bytes, 0);
+        }
+
+        // GPU witgen alone does not imply replayability. Non-replayable traces
+        // still go through basefold::get_trace in cache-none mode, which
+        // allocates the extracted witness plus a temporary 2x transpose buffer.
+        return (poly_bytes, 2 * poly_bytes);
     }
 
     if matches!(get_gpu_cache_level(), CacheLevel::None) {

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -4,6 +4,7 @@ use super::hal::{
 };
 use crate::{
     error::ZKVMError,
+    instructions::gpu::cache::current_replay_cache_stats,
     scheme::{
         cpu::TowerRelationOutput,
         hal::{DeviceProvingKey, MainSumcheckEvals, ProofInput, TowerProverSpec},
@@ -78,6 +79,140 @@ pub struct GpuTowerProver;
 pub enum DeferredGpuTrace<E: ExtensionField> {
     Eager(witness::RowMajorMatrix<E::BaseField>),
     Replay(crate::structs::GpuReplayPlan<E>),
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct PcsResidentStats {
+    digest_tree_bytes: usize,
+    codeword_leaves_bytes: usize,
+    trace_gpu_bytes: usize,
+    rmms_device_bytes: usize,
+    rmms_device_count: usize,
+    total_rmms: usize,
+}
+
+fn pcs_resident_stats(
+    pcs_data_basefold: &BasefoldCommitmentWithWitnessGpu<
+        BB31Base,
+        BufferImpl<BB31Base>,
+        GpuDigestLayer,
+        GpuMatrix<'static>,
+        GpuPolynomial<'static>,
+    >,
+) -> PcsResidentStats {
+    let digest_tree_bytes =
+        pcs_data_basefold.codeword.digest_buf.len() * std::mem::size_of::<BB31Base>();
+    let codeword_leaves_bytes = pcs_data_basefold
+        .codeword
+        .leaves
+        .as_ref()
+        .map(|leaves| {
+            leaves
+                .iter()
+                .map(|leaf| leaf.values().len() * std::mem::size_of::<BB31Base>())
+                .sum::<usize>()
+        })
+        .unwrap_or(0);
+    let trace_gpu_bytes = pcs_data_basefold
+        .trace
+        .as_ref()
+        .map(|traces| {
+            traces
+                .iter()
+                .flatten()
+                .map(|poly| poly.evaluations().len() * std::mem::size_of::<BB31Base>())
+                .sum::<usize>()
+        })
+        .unwrap_or(0);
+    let (rmms_device_bytes, rmms_device_count, total_rmms) = pcs_data_basefold
+        .rmms
+        .as_ref()
+        .map(|rmms| {
+            (
+                rmms.iter()
+                    .filter(|rmm| rmm.has_device_backing())
+                    .map(|rmm| rmm.height() * rmm.width() * std::mem::size_of::<BB31Base>())
+                    .sum::<usize>(),
+                rmms.iter().filter(|rmm| rmm.has_device_backing()).count(),
+                rmms.len(),
+            )
+        })
+        .unwrap_or((0, 0, 0));
+    PcsResidentStats {
+        digest_tree_bytes,
+        codeword_leaves_bytes,
+        trace_gpu_bytes,
+        rmms_device_bytes,
+        rmms_device_count,
+        total_rmms,
+    }
+}
+
+pub fn log_gpu_proof_baseline<E, PCS>(
+    label: &str,
+    witness_data: &<GpuBackend<E, PCS> as ProverBackend>::PcsData,
+    fixed_mles: &[Arc<gkr_iop::gpu::MultilinearExtensionGpu<'static, E>>],
+) where
+    E: ExtensionField,
+    PCS: PolynomialCommitmentScheme<E>,
+{
+    assert_eq!(
+        std::any::TypeId::of::<E::BaseField>(),
+        std::any::TypeId::of::<BB31Base>(),
+        "GPU baseline logging only supports BabyBear base field",
+    );
+    let cuda_hal = get_cuda_hal().expect("cuda hal must exist for gpu baseline logging");
+    let pool = cuda_hal.inner.mem_pool();
+    let used_bytes = pool.get_used_size().unwrap_or(0);
+    let reserved_bytes = pool.get_reserved_size().unwrap_or(0);
+
+    let pcs_data_basefold: &BasefoldCommitmentWithWitnessGpu<
+        BB31Base,
+        BufferImpl<BB31Base>,
+        GpuDigestLayer,
+        GpuMatrix<'static>,
+        GpuPolynomial<'static>,
+    > = unsafe { std::mem::transmute(witness_data) };
+
+    let pcs = pcs_resident_stats(pcs_data_basefold);
+    let fixed_mle_bytes = fixed_mles
+        .iter()
+        .map(|mle| match &mle.mle {
+            gkr_iop::gpu::gpu_prover::GpuFieldType::Base(poly) => {
+                poly.evaluations().len() * std::mem::size_of::<BB31Base>()
+            }
+            gkr_iop::gpu::gpu_prover::GpuFieldType::Ext(poly) => {
+                poly.evaluations().len() * std::mem::size_of::<BB31Ext>()
+            }
+            gkr_iop::gpu::gpu_prover::GpuFieldType::Unreachable => 0,
+        })
+        .sum::<usize>();
+    let replay_cache = current_replay_cache_stats();
+    let accounted_bytes = replay_cache.total_bytes()
+        + pcs.digest_tree_bytes
+        + pcs.codeword_leaves_bytes
+        + pcs.trace_gpu_bytes
+        + pcs.rmms_device_bytes
+        + fixed_mle_bytes;
+    let unaccounted_bytes = (used_bytes as usize).saturating_sub(accounted_bytes);
+    let mb = |bytes: usize| bytes as f64 / (1024.0 * 1024.0);
+    tracing::info!(
+        "[gpu baseline][{label}] pool: used={:.2}MB reserved={:.2}MB | replay: steps={:.2}MB meta={:.2}MB shared={:.2}MB total={:.2}MB | pcs: digest_tree={:.2}MB leaves={:.2}MB trace_gpu={:.2}MB rmms_device={:.2}MB ({}/{}) | fixed_mles={:.2}MB | unaccounted={:.2}MB",
+        mb(used_bytes as usize),
+        mb(reserved_bytes as usize),
+        mb(replay_cache.shard_steps_bytes),
+        mb(replay_cache.shard_meta_bytes),
+        mb(replay_cache.shared_side_effect_bytes),
+        mb(replay_cache.total_bytes()),
+        mb(pcs.digest_tree_bytes),
+        mb(pcs.codeword_leaves_bytes),
+        mb(pcs.trace_gpu_bytes),
+        mb(pcs.rmms_device_bytes),
+        pcs.rmms_device_count,
+        pcs.total_rmms,
+        mb(fixed_mle_bytes),
+        mb(unaccounted_bytes),
+    );
 }
 
 use crate::{
@@ -1042,9 +1177,31 @@ pub fn clear_replayable_trace_device_backing<E, PCS>(
         return;
     };
 
+    let before_device_count = rmms.iter().filter(|rmm| rmm.has_device_backing()).count();
+    let before_device_bytes = rmms
+        .iter()
+        .filter(|rmm| rmm.has_device_backing())
+        .map(|rmm| rmm.height() * rmm.width() * std::mem::size_of::<BB31Base>())
+        .sum::<usize>();
+
     for (trace_idx, _) in replayable_traces {
         rmms[*trace_idx].clear_device_backing();
     }
+
+    let after_device_count = rmms.iter().filter(|rmm| rmm.has_device_backing()).count();
+    let after_device_bytes = rmms
+        .iter()
+        .filter(|rmm| rmm.has_device_backing())
+        .map(|rmm| rmm.height() * rmm.width() * std::mem::size_of::<BB31Base>())
+        .sum::<usize>();
+    tracing::info!(
+        "[gpu] cleared replayable PCS RMM device backing: replayable_traces={}, rmms_device_before={:.2}MB ({}) -> after={:.2}MB ({})",
+        replayable_traces.len(),
+        before_device_bytes as f64 / (1024.0 * 1024.0),
+        before_device_count,
+        after_device_bytes as f64 / (1024.0 * 1024.0),
+        after_device_count,
+    );
 }
 
 pub fn restore_replayable_trace_device_backing<E, PCS>(

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -783,14 +783,54 @@ where
     E: ExtensionField,
 {
     let cuda_hal = get_cuda_hal().unwrap();
-    let structural_mles = structural_rmm.to_mles();
-
     let gpu_mem_tracker = init_gpu_mem_tracker(&cuda_hal, "transport_structural_witness_to_gpu");
 
-    let result = structural_mles
-        .iter()
-        .map(|mle| Arc::new(MultilinearExtensionGpu::from_ceno(&cuda_hal, mle)))
-        .collect();
+    let result = if structural_rmm.device_backing_layout() == Some(DeviceMatrixLayout::ColMajor) {
+        assert_eq!(
+            std::any::TypeId::of::<E::BaseField>(),
+            std::any::TypeId::of::<BB31Base>(),
+            "GPU structural fast path only supports BabyBear base field"
+        );
+        let device_buffer = structural_rmm
+            .device_backing_ref::<BufferImpl<'static, BB31Base>>()
+            .unwrap_or_else(|| panic!("col-major structural device backing type mismatch"));
+        let rows = structural_rmm.height();
+        let cols = structural_rmm.width();
+        let poly_len_bytes = rows * std::mem::size_of::<BB31Base>();
+        let total_bytes = cols * poly_len_bytes;
+        assert_eq!(
+            device_buffer.len() * std::mem::size_of::<BB31Base>(),
+            total_bytes,
+            "structural col-major buffer size mismatch"
+        );
+        let num_vars_in_poly = rows.trailing_zeros() as usize;
+        assert_eq!(rows, 1usize << num_vars_in_poly);
+
+        (0..cols)
+            .map(|col_idx| {
+                let src_byte_offset = col_idx * poly_len_bytes;
+                let view =
+                    device_buffer.as_slice_range(src_byte_offset..src_byte_offset + poly_len_bytes);
+                let view_buf = BufferImpl::new_from_view(view);
+                let view_poly = GpuPolynomial::new(view_buf, num_vars_in_poly);
+                let view_poly_static: GpuPolynomial<'static> =
+                    unsafe { std::mem::transmute(view_poly) };
+                let mle_static = MultilinearExtensionGpu::from_ceno_gpu_base(view_poly_static);
+                Arc::new(unsafe {
+                    std::mem::transmute::<
+                        MultilinearExtensionGpu<'static, E>,
+                        MultilinearExtensionGpu<'a, E>,
+                    >(mle_static)
+                })
+            })
+            .collect()
+    } else {
+        let structural_mles = structural_rmm.to_mles();
+        structural_mles
+            .iter()
+            .map(|mle| Arc::new(MultilinearExtensionGpu::from_ceno(&cuda_hal, mle)))
+            .collect()
+    };
 
     let estimated_bytes = estimate_structural_mle_bytes(num_structural_witin, num_vars);
     check_gpu_mem_estimation(gpu_mem_tracker, estimated_bytes);

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -10,7 +10,10 @@ use crate::{
     },
     structs::{ComposedConstrainSystem, PointAndEval, TowerProofs},
 };
-use ceno_gpu::bb31::{CudaHalBB31, GpuPolynomial};
+use ceno_gpu::{
+    Buffer, CudaHal,
+    bb31::{CudaHalBB31, GpuPolynomial},
+};
 use either::Either;
 use ff_ext::ExtensionField;
 use gkr_iop::{
@@ -47,6 +50,7 @@ use sumcheck::{
 use transcript::{BasicTranscript, Transcript};
 use witness::next_pow2_instance_padding;
 
+use ceno_gpu::common::transpose::matrix_transpose;
 use tracing::info_span;
 use witness::DeviceMatrixLayout;
 
@@ -569,6 +573,55 @@ pub fn prove_ec_sum_quark_impl<'a, E: ExtensionField, PCS: PolynomialCommitmentS
     })
 }
 
+fn normalize_traces_to_device_col_major<E: ExtensionField>(
+    cuda_hal: &Arc<CudaHalBB31>,
+    vec_traces: &mut [witness::RowMajorMatrix<E::BaseField>],
+) {
+    let mut already_col_major = 0usize;
+    let mut cpu_upload_and_transpose = 0usize;
+    let device_retranspose_todo = 0usize;
+
+    for (idx, trace) in vec_traces.iter_mut().enumerate() {
+        if trace.has_device_backing() {
+            if trace.device_backing_layout() != Some(DeviceMatrixLayout::ColMajor) {
+                panic!("TODO: GPU trace at index {idx} is device-backed but not col-major");
+            }
+            already_col_major += 1;
+            continue;
+        }
+
+        let rows = trace.height();
+        let cols = trace.width();
+        let host_vals_bb31: &[BB31Base] = unsafe { std::mem::transmute(trace.values()) };
+
+        let row_major_buf = cuda_hal
+            .alloc_elems_from_host(host_vals_bb31, None)
+            .unwrap_or_else(|e| panic!("failed to upload cpu trace {idx} to gpu: {e}"));
+        let mut col_major_buf = cuda_hal
+            .alloc_elems_on_device(rows * cols, false, None)
+            .unwrap_or_else(|e| panic!("failed to alloc col-major buffer for trace {idx}: {e}"));
+        matrix_transpose::<CudaHalBB31, ff_ext::BabyBearExt4, _>(
+            &cuda_hal.inner,
+            &mut col_major_buf,
+            &row_major_buf,
+            rows,
+            cols,
+        )
+        .unwrap_or_else(|e| panic!("failed to transpose trace {idx} to col-major: {e}"));
+
+        trace.set_device_backing(col_major_buf, DeviceMatrixLayout::ColMajor);
+        cpu_upload_and_transpose += 1;
+    }
+
+    tracing::debug!(
+        total_traces = vec_traces.len(),
+        already_col_major,
+        cpu_upload_and_transpose,
+        device_retranspose_todo,
+        "normalized gpu trace backing to device col-major"
+    );
+}
+
 impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> TraceCommitter<GpuBackend<E, PCS>>
     for GpuProver<GpuBackend<E, PCS>>
 {
@@ -601,19 +654,26 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> TraceCommitter<GpuBa
         let is_pcs_match = std::mem::size_of::<mpcs::BasefoldCommitmentWithWitness<BB31Ext>>()
             == std::mem::size_of::<PCS::CommitmentWithWitness>();
         let (mles, pcs_data, commit) = if is_pcs_match {
-            let vec_traces: Vec<witness::RowMajorMatrix<E::BaseField>> =
+            let mut vec_traces: Vec<witness::RowMajorMatrix<E::BaseField>> =
                 traces.into_values().collect();
 
-            for (idx, trace) in vec_traces.iter().enumerate() {
-                assert!(
-                    trace.has_device_backing(),
-                    "GPU mode requires device-backed witness trace at index {idx}"
-                );
-                assert_eq!(
-                    trace.device_backing_layout(),
-                    Some(DeviceMatrixLayout::ColMajor),
-                    "GPU mode requires col-major device-backed witness trace at index {idx}"
-                );
+            if crate::instructions::gpu::config::is_gpu_witgen_enabled() {
+                let span = entered_span!("[gpu] normalize_trace_backing", profiling_2 = true);
+                let cuda_hal = get_cuda_hal().unwrap();
+                normalize_traces_to_device_col_major::<E>(&cuda_hal, &mut vec_traces);
+                drop(cuda_hal);
+                for (idx, trace) in vec_traces.iter().enumerate() {
+                    assert!(
+                        trace.has_device_backing(),
+                        "GPU mode requires device-backed witness trace at index {idx}"
+                    );
+                    assert_eq!(
+                        trace.device_backing_layout(),
+                        Some(DeviceMatrixLayout::ColMajor),
+                        "GPU mode requires col-major device-backed witness trace at index {idx}"
+                    );
+                }
+                exit_span!(span);
             }
 
             let span = entered_span!("[gpu] hal init", profiling_2 = true);

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -63,8 +63,8 @@ mod memory;
 mod util;
 pub(crate) use memory::{
     check_gpu_mem_estimation, estimate_chip_proof_memory, estimate_main_witness_bytes,
-    estimate_replay_materialization_bytes, estimate_tower_bytes, estimate_tower_stage_bytes,
-    init_gpu_mem_tracker,
+    estimate_replay_materialization_bytes_for_plan, estimate_tower_bytes,
+    estimate_tower_stage_bytes, init_gpu_mem_tracker,
 };
 use memory::{
     estimate_ecc_quark_bytes_from_num_vars, estimate_main_constraints_bytes,
@@ -1367,7 +1367,12 @@ where
             .collect()
     };
 
-    let estimated_bytes = estimate_structural_mle_bytes(num_structural_witin, num_vars);
+    let estimated_bytes =
+        if structural_rmm.device_backing_layout() == Some(DeviceMatrixLayout::ColMajor) {
+            0
+        } else {
+            estimate_structural_mle_bytes(num_structural_witin, num_vars)
+        };
     check_gpu_mem_estimation(gpu_mem_tracker, estimated_bytes);
 
     result
@@ -1960,11 +1965,8 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>
             let gpu_mem_tracker = init_gpu_mem_tracker(&cuda_hal, "replay_gpu_witness_from_raw");
             let num_vars =
                 task.input.log2_num_instances() + task.pk.get_cs().rotation_vars().unwrap_or(0);
-            let estimated_replay_bytes = estimate_replay_materialization_bytes(
-                task.pk.get_cs().zkvm_v1_css.num_witin as usize,
-                task.pk.get_cs().zkvm_v1_css.num_structural_witin as usize,
-                num_vars,
-            );
+            let estimated_replay_bytes =
+                estimate_replay_materialization_bytes_for_plan(replay_plan, num_vars);
             tracing::info!(
                 "[gpu] replaying witness from raw: circuit={}, estimated={:.2}MB",
                 task.circuit_name,

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -148,6 +148,38 @@ fn pcs_resident_stats(
     }
 }
 
+pub fn log_gpu_pcs_baseline<E, PCS>(
+    label: &str,
+    pcs_data: &<GpuBackend<E, PCS> as ProverBackend>::PcsData,
+) where
+    E: ExtensionField,
+    PCS: PolynomialCommitmentScheme<E>,
+{
+    assert_eq!(
+        std::any::TypeId::of::<E::BaseField>(),
+        std::any::TypeId::of::<BB31Base>(),
+        "GPU PCS baseline logging only supports BabyBear base field",
+    );
+    let pcs_data_basefold: &BasefoldCommitmentWithWitnessGpu<
+        BB31Base,
+        BufferImpl<BB31Base>,
+        GpuDigestLayer,
+        GpuMatrix<'static>,
+        GpuPolynomial<'static>,
+    > = unsafe { std::mem::transmute(pcs_data) };
+    let pcs = pcs_resident_stats(pcs_data_basefold);
+    let mb = |bytes: usize| bytes as f64 / (1024.0 * 1024.0);
+    tracing::info!(
+        "[gpu pcs baseline][{label}] digest_tree={:.2}MB leaves={:.2}MB trace_gpu={:.2}MB rmms_device={:.2}MB ({}/{})",
+        mb(pcs.digest_tree_bytes),
+        mb(pcs.codeword_leaves_bytes),
+        mb(pcs.trace_gpu_bytes),
+        mb(pcs.rmms_device_bytes),
+        pcs.rmms_device_count,
+        pcs.total_rmms,
+    );
+}
+
 pub fn log_gpu_proof_baseline<E, PCS>(
     label: &str,
     witness_data: &<GpuBackend<E, PCS> as ProverBackend>::PcsData,

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -657,7 +657,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> TraceCommitter<GpuBa
             let mut vec_traces: Vec<witness::RowMajorMatrix<E::BaseField>> =
                 traces.into_values().collect();
 
-            if crate::instructions::gpu::config::should_keep_witness_device_backing() {
+            if crate::instructions::gpu::config::should_materialize_witness_on_gpu() {
                 let span = entered_span!("[gpu] normalize_trace_backing", profiling_2 = true);
                 let cuda_hal = get_cuda_hal().unwrap();
                 normalize_traces_to_device_col_major::<E>(&cuda_hal, &mut vec_traces);
@@ -830,6 +830,109 @@ where
     mles
 }
 
+pub fn extract_witness_mles_for_trace_rmm<'a, E>(
+    witness_rmm: witness::RowMajorMatrix<<E as ExtensionField>::BaseField>,
+) -> Vec<Arc<MultilinearExtensionGpu<'a, E>>>
+where
+    E: ExtensionField,
+{
+    assert_eq!(
+        witness_rmm.device_backing_layout(),
+        Some(DeviceMatrixLayout::ColMajor),
+        "replayed witness RMM must keep col-major device backing",
+    );
+    assert_eq!(
+        std::any::TypeId::of::<E::BaseField>(),
+        std::any::TypeId::of::<BB31Base>(),
+        "GPU replay only supports BabyBear base field",
+    );
+
+    let device_buffer = witness_rmm
+        .device_backing_ref::<BufferImpl<'static, BB31Base>>()
+        .unwrap_or_else(|| panic!("col-major replay witness device backing type mismatch"));
+    let rows = witness_rmm.height();
+    let cols = witness_rmm.width();
+    let poly_len_bytes = rows * std::mem::size_of::<BB31Base>();
+
+    (0..cols)
+        .map(|col_idx| {
+            let src_byte_offset = col_idx * poly_len_bytes;
+            // Keep an owned handle to the parent GPU allocation instead of a
+            // borrowed CudaView. The resulting MLE outlives this helper.
+            let view_buf =
+                device_buffer.owned_subrange(src_byte_offset..src_byte_offset + poly_len_bytes);
+            let view_poly = GpuPolynomial::new(view_buf, rows.trailing_zeros() as usize);
+            let view_poly_static: GpuPolynomial<'static> =
+                unsafe { std::mem::transmute(view_poly) };
+            let mle_static = MultilinearExtensionGpu::from_ceno_gpu_base(view_poly_static);
+            Arc::new(unsafe {
+                std::mem::transmute::<
+                    MultilinearExtensionGpu<'static, E>,
+                    MultilinearExtensionGpu<'a, E>,
+                >(mle_static)
+            })
+        })
+        .collect()
+}
+
+pub fn clear_replayable_trace_device_backing<E, PCS>(
+    pcs_data: &mut <GpuBackend<E, PCS> as ProverBackend>::PcsData,
+    replayable_traces: &[(usize, crate::structs::GpuReplayPlan<E>)],
+) where
+    E: ExtensionField,
+    PCS: PolynomialCommitmentScheme<E>,
+{
+    let pcs_data_basefold: &mut BasefoldCommitmentWithWitnessGpu<
+        BB31Base,
+        BufferImpl<BB31Base>,
+        GpuDigestLayer,
+        GpuMatrix<'static>,
+        GpuPolynomial<'static>,
+    > = unsafe { std::mem::transmute(pcs_data) };
+
+    let Some(rmms) = pcs_data_basefold.rmms.as_mut() else {
+        return;
+    };
+
+    for (trace_idx, _) in replayable_traces {
+        rmms[*trace_idx].clear_device_backing();
+    }
+}
+
+pub fn restore_replayable_trace_device_backing<E, PCS>(
+    pcs_data: &mut <GpuBackend<E, PCS> as ProverBackend>::PcsData,
+    replayable_traces: &[(usize, crate::structs::GpuReplayPlan<E>)],
+) -> Result<(), ZKVMError>
+where
+    E: ExtensionField,
+    PCS: PolynomialCommitmentScheme<E>,
+{
+    assert_eq!(
+        std::any::TypeId::of::<E::BaseField>(),
+        std::any::TypeId::of::<BB31Base>(),
+        "GPU replay restore only supports BabyBear base field",
+    );
+    let pcs_data_basefold: &mut BasefoldCommitmentWithWitnessGpu<
+        BB31Base,
+        BufferImpl<BB31Base>,
+        GpuDigestLayer,
+        GpuMatrix<'static>,
+        GpuPolynomial<'static>,
+    > = unsafe { std::mem::transmute(pcs_data) };
+
+    let Some(rmms) = pcs_data_basefold.rmms.as_mut() else {
+        return Ok(());
+    };
+
+    for (trace_idx, replay_plan) in replayable_traces {
+        let [witness_rmm, _] = replay_plan.replay()?;
+        let witness_rmm_bb31: witness::RowMajorMatrix<BB31Base> =
+            unsafe { std::mem::transmute(witness_rmm) };
+        rmms[*trace_idx] = witness_rmm_bb31;
+    }
+    Ok(())
+}
+
 /// Transport a CPU-side structural witness RowMajorMatrix to GPU MLEs.
 /// Standalone version that doesn't require `&self` on GpuProver, enabling
 /// just-in-time GPU upload inside parallel task closures.
@@ -870,9 +973,10 @@ where
         (0..cols)
             .map(|col_idx| {
                 let src_byte_offset = col_idx * poly_len_bytes;
-                let view =
-                    device_buffer.as_slice_range(src_byte_offset..src_byte_offset + poly_len_bytes);
-                let view_buf = BufferImpl::new_from_view(view);
+                // Structural MLEs also escape this helper; use an owned-range
+                // buffer handle rather than a borrowed view into `structural_rmm`.
+                let view_buf =
+                    device_buffer.owned_subrange(src_byte_offset..src_byte_offset + poly_len_bytes);
                 let view_poly = GpuPolynomial::new(view_buf, num_vars_in_poly);
                 let view_poly_static: GpuPolynomial<'static> =
                     unsafe { std::mem::transmute(view_poly) };
@@ -1439,8 +1543,9 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> DeviceTransporter<Gp
             .map(|gpu_poly| {
                 let evals = gpu_poly.evaluations();
                 let byte_len = evals.len() * std::mem::size_of::<BB31Base>();
-                let view = evals.as_slice_range(0..byte_len);
-                let view_buf = BufferImpl::new_from_view(view);
+                // Fixed-trace MLEs live for the whole proving key lifetime on
+                // the GPU side, so they must not borrow a temporary CudaView.
+                let view_buf = evals.owned_subrange(0..byte_len);
                 let view_poly = GpuPolynomial::new(view_buf, gpu_poly.num_vars());
                 let view_poly_static: GpuPolynomial<'static> =
                     unsafe { std::mem::transmute(view_poly) };
@@ -1480,6 +1585,23 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>
         task: &mut crate::scheme::scheduler::ChipTask<'_, GpuBackend<E, PCS>>,
         pcs_data: &<GpuBackend<E, PCS> as gkr_iop::hal::ProverBackend>::PcsData,
     ) {
+        if let Some(replay_plan) = task.gpu_replay_plan.as_ref() {
+            let [witness_rmm, structural_rmm] =
+                replay_plan.replay().expect("GPU raw replay failed");
+            task.input.witness = info_span!("[ceno] replay_gpu_witness_from_raw")
+                .in_scope(|| extract_witness_mles_for_trace_rmm::<E>(witness_rmm));
+            task.input.structural_witness = info_span!("[ceno] transport_structural_witness")
+                .in_scope(|| {
+                    transport_structural_witness_to_gpu::<E>(
+                        structural_rmm,
+                        task.pk.get_cs().zkvm_v1_css.num_structural_witin as usize,
+                        task.input.log2_num_instances()
+                            + task.pk.get_cs().rotation_vars().unwrap_or(0),
+                    )
+                });
+            return;
+        }
+
         let num_vars =
             task.input.log2_num_instances() + task.pk.get_cs().rotation_vars().unwrap_or(0);
 

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -14,6 +14,7 @@ use crate::{
 use ceno_gpu::{
     Buffer, CudaHal,
     bb31::{CudaHalBB31, GpuPolynomial},
+    get_cuda_mem_info,
 };
 use either::Either;
 use ff_ext::ExtensionField;
@@ -199,6 +200,8 @@ pub fn log_gpu_proof_baseline<E, PCS>(
     let pool = cuda_hal.inner.mem_pool();
     let used_bytes = pool.get_used_size().unwrap_or(0);
     let reserved_bytes = pool.get_reserved_size().unwrap_or(0);
+    let (cuda_free_bytes, cuda_total_bytes) = get_cuda_mem_info().unwrap_or((0usize, 0usize));
+    let cuda_used_bytes = cuda_total_bytes.saturating_sub(cuda_free_bytes);
 
     let pcs_data_basefold: &BasefoldCommitmentWithWitnessGpu<
         BB31Base,
@@ -230,6 +233,16 @@ pub fn log_gpu_proof_baseline<E, PCS>(
         + fixed_mle_bytes;
     let unaccounted_bytes = (used_bytes as usize).saturating_sub(accounted_bytes);
     let mb = |bytes: usize| bytes as f64 / (1024.0 * 1024.0);
+    tracing::info!(
+        "[gpu device][{label}] cuda_used={:.2}MB cuda_free={:.2}MB cuda_total={:.2}MB | pool_used={:.2}MB pool_reserved={:.2}MB pool_booked={:.2}MB pool_max={:.2}MB",
+        mb(cuda_used_bytes),
+        mb(cuda_free_bytes),
+        mb(cuda_total_bytes),
+        mb(used_bytes as usize),
+        mb(reserved_bytes as usize),
+        mb(pool.get_booked_total() as usize),
+        mb(pool.get_max_size() as usize),
+    );
     tracing::info!(
         "[gpu baseline][{label}] pool: used={:.2}MB reserved={:.2}MB | replay: steps={:.2}MB meta={:.2}MB shared={:.2}MB total={:.2}MB | pcs: digest_tree={:.2}MB leaves={:.2}MB trace_gpu={:.2}MB rmms_device={:.2}MB ({}/{}) | fixed_mles={:.2}MB | unaccounted={:.2}MB",
         mb(used_bytes as usize),

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -268,6 +268,22 @@ pub fn prove_main_constraints_impl<
     let Some(gkr_circuit) = gkr_circuit else {
         panic!("empty gkr circuit")
     };
+    let estimated_main_constraints_bytes =
+        estimate_main_constraints_bytes::<E, PCS>(composed_cs, input);
+    if let Ok(cuda_hal) = get_cuda_hal() {
+        let mem_pool = cuda_hal.inner.mem_pool();
+        let used_bytes = mem_pool.get_used_size().unwrap_or(0);
+        let reserved_bytes = mem_pool.get_reserved_size().unwrap_or(0);
+        tracing::info!(
+            "[gpu] entering prove_main_constraints: estimated={:.2}MB, used={:.2}MB, reserved={:.2}MB, witness={}, fixed={}, structural={}",
+            estimated_main_constraints_bytes as f64 / (1024.0 * 1024.0),
+            used_bytes as f64 / (1024.0 * 1024.0),
+            reserved_bytes as f64 / (1024.0 * 1024.0),
+            input.witness.len(),
+            input.fixed.len(),
+            input.structural_witness.len(),
+        );
+    }
     let selector_ctxs = if cs.ec_final_sum.is_empty() {
         // it's not global chip
         vec![

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -47,6 +47,7 @@ use transcript::{BasicTranscript, Transcript};
 use witness::next_pow2_instance_padding;
 
 use tracing::info_span;
+use witness::DeviceMatrixLayout;
 
 #[cfg(feature = "gpu")]
 use gkr_iop::gpu::gpu_prover::*;
@@ -601,6 +602,18 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> TraceCommitter<GpuBa
         let (mles, pcs_data, commit) = if is_pcs_match {
             let vec_traces: Vec<witness::RowMajorMatrix<E::BaseField>> =
                 traces.into_values().collect();
+
+            for (idx, trace) in vec_traces.iter().enumerate() {
+                assert!(
+                    trace.has_device_backing(),
+                    "GPU mode requires device-backed witness trace at index {idx}"
+                );
+                assert_eq!(
+                    trace.device_backing_layout(),
+                    Some(DeviceMatrixLayout::ColMajor),
+                    "GPU mode requires col-major device-backed witness trace at index {idx}"
+                );
+            }
 
             let span = entered_span!("[gpu] hal init", profiling_2 = true);
             let cuda_hal = get_cuda_hal().unwrap();

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -29,6 +29,7 @@ use multilinear_extensions::{
     util::ceil_log2,
     virtual_poly::{build_eq_x_r_vec, eq_eval},
 };
+use p3::matrix::Matrix;
 use rayon::iter::{
     IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator,
     IntoParallelRefMutIterator, ParallelIterator,

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -74,6 +74,12 @@ use util::{
 
 pub struct GpuTowerProver;
 
+#[derive(Clone)]
+pub enum DeferredGpuTrace<E: ExtensionField> {
+    Eager(witness::RowMajorMatrix<E::BaseField>),
+    Replay(crate::structs::GpuReplayPlan<E>),
+}
+
 use crate::{
     scheme::{
         constants::{NUM_FANIN, SEPTIC_EXTENSION_DEGREE},
@@ -622,6 +628,104 @@ fn normalize_traces_to_device_col_major<E: ExtensionField>(
     );
 }
 
+pub fn commit_traces_deferred_cache_none<E, PCS>(
+    prover: &GpuProver<GpuBackend<E, PCS>>,
+    traces: BTreeMap<usize, DeferredGpuTrace<E>>,
+) -> (
+    Vec<MultilinearExtensionGpu<'static, E>>,
+    <GpuBackend<E, PCS> as ProverBackend>::PcsData,
+    PCS::Commitment,
+)
+where
+    E: ExtensionField,
+    PCS: PolynomialCommitmentScheme<E>,
+{
+    if std::any::TypeId::of::<E::BaseField>() != std::any::TypeId::of::<BB31Base>() {
+        panic!("GPU backend only supports BabyBear base field");
+    }
+
+    let ordered_sources = traces.into_values().collect_vec();
+    let max_poly_size_log2 = ordered_sources
+        .iter()
+        .map(|source| match source {
+            DeferredGpuTrace::Eager(rmm) => {
+                ceil_log2(next_pow2_instance_padding(rmm.num_instances()))
+            }
+            DeferredGpuTrace::Replay(plan) => {
+                ceil_log2(next_pow2_instance_padding(plan.step_indices.len()))
+            }
+        })
+        .max()
+        .unwrap();
+    if max_poly_size_log2 > prover.backend.max_poly_size_log2 {
+        panic!(
+            "max_poly_size_log2 {} > max_poly_size_log2 backend {}",
+            max_poly_size_log2, prover.backend.max_poly_size_log2
+        );
+    }
+
+    let is_pcs_match = std::mem::size_of::<mpcs::BasefoldCommitmentWithWitness<BB31Ext>>()
+        == std::mem::size_of::<PCS::CommitmentWithWitness>();
+    if !is_pcs_match {
+        panic!("GPU commitment data is not compatible with the PCS");
+    }
+
+    let cuda_hal = get_cuda_hal().unwrap();
+    cuda_hal
+        .inner
+        .synchronize()
+        .expect("cuda synchronize before deferred batch_commit mem snapshot");
+    let mem_pool = cuda_hal.inner.mem_pool();
+    let used_bytes = mem_pool
+        .get_used_size()
+        .expect("cudaMemPoolGetAttribute UsedMemCurrent before deferred batch_commit");
+    let reserved_bytes = mem_pool.get_reserved_size().unwrap_or(0);
+    tracing::info!(
+        "[gpu] entering deferred batch_commit: traces={}, used={:.2}MB, reserved={:.2}MB",
+        ordered_sources.len(),
+        used_bytes as f64 / (1024.0 * 1024.0),
+        reserved_bytes as f64 / (1024.0 * 1024.0),
+    );
+
+    let specs = ordered_sources
+        .iter()
+        .map(|source| match source {
+            DeferredGpuTrace::Eager(rmm) => ceno_gpu::common::poseidon2::DeferredRmmSpec {
+                height: next_pow2_instance_padding(rmm.num_instances()),
+                persist_actual: true,
+            },
+            DeferredGpuTrace::Replay(plan) => ceno_gpu::common::poseidon2::DeferredRmmSpec {
+                height: next_pow2_instance_padding(plan.step_indices.len()),
+                persist_actual: false,
+            },
+        })
+        .collect_vec();
+    let mut ordered_sources = ordered_sources.into_iter().map(Some).collect_vec();
+    let pcs_data = cuda_hal
+        .basefold
+        .batch_commit_cache_none_deferred(&cuda_hal, specs, |trace_idx| {
+            let source = ordered_sources[trace_idx]
+                .take()
+                .expect("deferred commit source reused");
+            let witness_rmm: witness::RowMajorMatrix<E::BaseField> = match source {
+                DeferredGpuTrace::Eager(rmm) => rmm,
+                DeferredGpuTrace::Replay(plan) => plan
+                    .replay()
+                    .map(|[witness_rmm, _]| witness_rmm)
+                    .map_err(|e| ceno_gpu::HalError::InvalidInput(format!("{e:?}")))?,
+            };
+            Ok(unsafe { std::mem::transmute(witness_rmm) })
+        })
+        .unwrap();
+
+    let basefold_commit = cuda_hal.basefold.get_pure_commitment(&pcs_data);
+    let commit: PCS::Commitment = unsafe { std::mem::transmute_copy(&basefold_commit) };
+    let pcs_data_generic: <GpuBackend<E, PCS> as ProverBackend>::PcsData =
+        unsafe { std::mem::transmute_copy(&pcs_data) };
+    std::mem::forget(pcs_data);
+    (vec![], pcs_data_generic, commit)
+}
+
 impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> TraceCommitter<GpuBackend<E, PCS>>
     for GpuProver<GpuBackend<E, PCS>>
 {
@@ -684,6 +788,21 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> TraceCommitter<GpuBa
                 unsafe { std::mem::transmute(vec_traces) };
 
             let span = entered_span!("[gpu] batch_commit", profiling_2 = true);
+            cuda_hal
+                .inner
+                .synchronize()
+                .expect("cuda synchronize before batch_commit mem snapshot");
+            let mem_pool = cuda_hal.inner.mem_pool();
+            let used_bytes = mem_pool
+                .get_used_size()
+                .expect("cudaMemPoolGetAttribute UsedMemCurrent before batch_commit");
+            let reserved_bytes = mem_pool.get_reserved_size().unwrap_or(0);
+            tracing::info!(
+                "[gpu] entering batch_commit: traces={}, used={:.2}MB, reserved={:.2}MB",
+                traces_gl64.len(),
+                used_bytes as f64 / (1024.0 * 1024.0),
+                reserved_bytes as f64 / (1024.0 * 1024.0),
+            );
             let pcs_data = cuda_hal
                 .basefold
                 .batch_commit(&cuda_hal, traces_gl64)

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -275,6 +275,28 @@ pub fn log_gpu_pool_usage(label: &str) {
     );
 }
 
+pub fn log_gpu_device_state(label: &str) {
+    let cuda_hal = get_cuda_hal().expect("cuda hal must exist for gpu device logging");
+    let pool = cuda_hal.inner.mem_pool();
+    let used_bytes = pool.get_used_size().unwrap_or(0);
+    let reserved_bytes = pool.get_reserved_size().unwrap_or(0);
+    let booked_bytes = pool.get_booked_total();
+    let max_bytes = pool.get_max_size();
+    let (cuda_free_bytes, cuda_total_bytes) = get_cuda_mem_info().unwrap_or((0usize, 0usize));
+    let cuda_used_bytes = cuda_total_bytes.saturating_sub(cuda_free_bytes);
+    let mb = |bytes: usize| bytes as f64 / (1024.0 * 1024.0);
+    tracing::info!(
+        "[gpu device][{label}] cuda_used={:.2}MB cuda_free={:.2}MB cuda_total={:.2}MB | pool_used={:.2}MB pool_reserved={:.2}MB pool_booked={:.2}MB pool_max={:.2}MB",
+        mb(cuda_used_bytes),
+        mb(cuda_free_bytes),
+        mb(cuda_total_bytes),
+        mb(used_bytes as usize),
+        mb(reserved_bytes as usize),
+        mb(booked_bytes as usize),
+        mb(max_bytes as usize),
+    );
+}
+
 use crate::{
     scheme::{
         constants::{NUM_FANIN, SEPTIC_EXTENSION_DEGREE},

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -60,17 +60,19 @@ use gkr_iop::gpu::gpu_prover::*;
 
 mod memory;
 mod util;
-pub use memory::{
+pub(crate) use memory::{
     check_gpu_mem_estimation, estimate_chip_proof_memory, estimate_main_witness_bytes,
-    estimate_replay_materialization_bytes, init_gpu_mem_tracker,
+    estimate_replay_materialization_bytes, estimate_tower_bytes, estimate_tower_stage_bytes,
+    init_gpu_mem_tracker,
 };
 use memory::{
     estimate_ecc_quark_bytes_from_num_vars, estimate_main_constraints_bytes,
-    estimate_structural_mle_bytes, estimate_tower_bytes, estimate_trace_extraction_bytes,
+    estimate_structural_mle_bytes, estimate_trace_extraction_bytes,
 };
+pub(crate) use util::expect_basic_transcript;
 use util::{
-    WitnessRegistry, batch_mles_take_half, expect_basic_transcript, hal_to_backend_error,
-    mle_filter_even_odd_batch, mle_host_to_gpu, read_septic_value_from_gpu, symbolic_from_mle,
+    WitnessRegistry, batch_mles_take_half, hal_to_backend_error, mle_filter_even_odd_batch,
+    mle_host_to_gpu, read_septic_value_from_gpu, symbolic_from_mle,
 };
 
 pub struct GpuTowerProver;
@@ -247,6 +249,19 @@ pub fn log_gpu_proof_baseline<E, PCS>(
     );
 }
 
+pub fn log_gpu_pool_usage(label: &str) {
+    let cuda_hal = get_cuda_hal().expect("cuda hal must exist for gpu pool logging");
+    let pool = cuda_hal.inner.mem_pool();
+    let used_bytes = pool.get_used_size().unwrap_or(0);
+    let reserved_bytes = pool.get_reserved_size().unwrap_or(0);
+    let mb = |bytes: usize| bytes as f64 / (1024.0 * 1024.0);
+    tracing::info!(
+        "[gpu pool][{label}] used={:.2}MB reserved={:.2}MB",
+        mb(used_bytes as usize),
+        mb(reserved_bytes as usize),
+    );
+}
+
 use crate::{
     scheme::{
         constants::{NUM_FANIN, SEPTIC_EXTENSION_DEGREE},
@@ -346,7 +361,7 @@ pub fn prove_tower_relation_impl<E: ExtensionField, PCS: PolynomialCommitmentSch
 
 // Extract out_evals from GPU-built tower witnesses
 #[allow(clippy::type_complexity)]
-fn extract_out_evals_from_gpu_towers<E: ff_ext::ExtensionField>(
+pub(crate) fn extract_out_evals_from_gpu_towers<E: ff_ext::ExtensionField>(
     prod_gpu: &[ceno_gpu::GpuProverSpec], // GPU-built product towers
     logup_gpu: &[ceno_gpu::GpuProverSpec], // GPU-built logup towers
     r_set_len: usize,
@@ -1346,7 +1361,7 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-fn build_tower_witness_gpu<'buf, E: ExtensionField>(
+pub(crate) fn build_tower_witness_gpu<'buf, E: ExtensionField>(
     composed_cs: &ComposedConstrainSystem<E>,
     input: &ProofInput<'_, GpuBackend<E, impl PolynomialCommitmentScheme<E>>>,
     records: &[ArcMultilinearExtensionGpu<'_, E>],

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -657,7 +657,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> TraceCommitter<GpuBa
             let mut vec_traces: Vec<witness::RowMajorMatrix<E::BaseField>> =
                 traces.into_values().collect();
 
-            if crate::instructions::gpu::config::is_gpu_witgen_enabled() {
+            if crate::instructions::gpu::config::should_keep_witness_device_backing() {
                 let span = entered_span!("[gpu] normalize_trace_backing", profiling_2 = true);
                 let cuda_hal = get_cuda_hal().unwrap();
                 normalize_traces_to_device_col_major::<E>(&cuda_hal, &mut vec_traces);

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -664,12 +664,8 @@ where
     let max_poly_size_log2 = ordered_sources
         .iter()
         .map(|source| match source {
-            DeferredGpuTrace::Eager(rmm) => {
-                ceil_log2(next_pow2_instance_padding(rmm.num_instances()))
-            }
-            DeferredGpuTrace::Replay(plan) => {
-                ceil_log2(next_pow2_instance_padding(plan.step_indices.len()))
-            }
+            DeferredGpuTrace::Eager(rmm) => ceil_log2(rmm.height()),
+            DeferredGpuTrace::Replay(plan) => ceil_log2(plan.trace_height),
         })
         .max()
         .unwrap();
@@ -707,11 +703,11 @@ where
         .iter()
         .map(|source| match source {
             DeferredGpuTrace::Eager(rmm) => ceno_gpu::common::poseidon2::DeferredRmmSpec {
-                height: next_pow2_instance_padding(rmm.num_instances()),
+                height: rmm.height(),
                 persist_actual: true,
             },
             DeferredGpuTrace::Replay(plan) => ceno_gpu::common::poseidon2::DeferredRmmSpec {
-                height: next_pow2_instance_padding(plan.step_indices.len()),
+                height: plan.trace_height,
                 persist_actual: false,
             },
         })
@@ -727,7 +723,14 @@ where
                 DeferredGpuTrace::Eager(rmm) => rmm,
                 DeferredGpuTrace::Replay(plan) => plan
                     .replay()
-                    .map(|[witness_rmm, _]| witness_rmm)
+                    .map(|[witness_rmm, _]| {
+                        assert_eq!(
+                            witness_rmm.height(),
+                            plan.trace_height,
+                            "replayed trace height changed between plan build and deferred commit",
+                        );
+                        witness_rmm
+                    })
                     .map_err(|e| ceno_gpu::HalError::InvalidInput(format!("{e:?}")))?,
             };
             Ok(unsafe { std::mem::transmute(witness_rmm) })
@@ -1071,6 +1074,11 @@ where
 
     for (trace_idx, replay_plan) in replayable_traces {
         let [witness_rmm, _] = replay_plan.replay()?;
+        assert_eq!(
+            witness_rmm.height(),
+            replay_plan.trace_height,
+            "replayed trace height changed before PCS opening restore",
+        );
         let witness_rmm_bb31: witness::RowMajorMatrix<BB31Base> =
             unsafe { std::mem::transmute(witness_rmm) };
         rmms[*trace_idx] = witness_rmm_bb31;

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -61,7 +61,7 @@ mod memory;
 mod util;
 pub use memory::{
     check_gpu_mem_estimation, estimate_chip_proof_memory, estimate_main_witness_bytes,
-    init_gpu_mem_tracker,
+    estimate_replay_materialization_bytes, init_gpu_mem_tracker,
 };
 use memory::{
     estimate_ecc_quark_bytes_from_num_vars, estimate_main_constraints_bytes,
@@ -895,7 +895,8 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> TraceCommitter<GpuBa
                     0
                 };
 
-                let (resident, temporary) = estimate_trace_extraction_bytes(num_witin, num_vars);
+                let (resident, temporary) =
+                    estimate_trace_extraction_bytes(num_witin, num_vars, true);
                 check_gpu_mem_estimation(gpu_mem_tracker, resident + temporary);
 
                 trace_idx += 1;
@@ -945,7 +946,7 @@ where
         .get_trace(&cuda_hal, pcs_data_basefold, trace_idx, stream.as_ref())
         .unwrap_or_else(|err| panic!("Failed to extract trace {trace_idx}: {err}"));
 
-    let (resident, temporary) = estimate_trace_extraction_bytes(expected_num, num_vars);
+    let (resident, temporary) = estimate_trace_extraction_bytes(expected_num, num_vars, false);
     check_gpu_mem_estimation(gpu_mem_tracker, resident + temporary);
 
     let mles: Vec<Arc<MultilinearExtensionGpu<'a, E>>> = poly_group
@@ -971,6 +972,9 @@ pub fn extract_witness_mles_for_trace_rmm<'a, E>(
 where
     E: ExtensionField,
 {
+    let cuda_hal = get_cuda_hal().unwrap();
+    let gpu_mem_tracker = init_gpu_mem_tracker(&cuda_hal, "extract_witness_mles_for_trace_rmm");
+
     assert_eq!(
         witness_rmm.device_backing_layout(),
         Some(DeviceMatrixLayout::ColMajor),
@@ -988,6 +992,12 @@ where
     let rows = witness_rmm.height();
     let cols = witness_rmm.width();
     let poly_len_bytes = rows * std::mem::size_of::<BB31Base>();
+
+    // This helper only wraps already-materialized col-major device backing in
+    // owned subrange handles. The replay() call that produced `witness_rmm`
+    // paid the actual witness-buffer allocation cost; converting those columns
+    // into MLE handles does not allocate more VRAM here.
+    check_gpu_mem_estimation(gpu_mem_tracker, 0);
 
     (0..cols)
         .map(|col_idx| {
@@ -1721,8 +1731,23 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>
         pcs_data: &<GpuBackend<E, PCS> as gkr_iop::hal::ProverBackend>::PcsData,
     ) {
         if let Some(replay_plan) = task.gpu_replay_plan.as_ref() {
+            let cuda_hal = get_cuda_hal().unwrap();
+            let gpu_mem_tracker = init_gpu_mem_tracker(&cuda_hal, "replay_gpu_witness_from_raw");
+            let num_vars =
+                task.input.log2_num_instances() + task.pk.get_cs().rotation_vars().unwrap_or(0);
+            let estimated_replay_bytes = estimate_replay_materialization_bytes(
+                task.pk.get_cs().zkvm_v1_css.num_witin as usize,
+                task.pk.get_cs().zkvm_v1_css.num_structural_witin as usize,
+                num_vars,
+            );
+            tracing::info!(
+                "[gpu] replaying witness from raw: circuit={}, estimated={:.2}MB",
+                task.circuit_name,
+                estimated_replay_bytes as f64 / (1024.0 * 1024.0),
+            );
             let [witness_rmm, structural_rmm] =
                 replay_plan.replay().expect("GPU raw replay failed");
+            check_gpu_mem_estimation(gpu_mem_tracker, estimated_replay_bytes);
             task.input.witness = info_span!("[ceno] replay_gpu_witness_from_raw")
                 .in_scope(|| extract_witness_mles_for_trace_rmm::<E>(witness_rmm));
             task.input.structural_witness = info_span!("[ceno] transport_structural_witness")

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -209,14 +209,23 @@ impl<
             let mut wits_rmms = BTreeMap::new();
 
             let mut structural_rmms = Vec::with_capacity(name_and_instances.len());
+            #[cfg(feature = "gpu")]
+            let mut gpu_replay_plans = Vec::with_capacity(name_and_instances.len());
             // commit to opcode circuits first and then commit to table circuits, sorted by name
             for (i, chip_input) in witnesses.into_iter_sorted().enumerate() {
-                let [witness_rmm, structural_witness_rmm] = chip_input.witness_rmms;
+                let crate::structs::ChipInput {
+                    witness_rmms,
+                    gpu_replay_plan,
+                    ..
+                } = chip_input;
+                let [witness_rmm, structural_witness_rmm] = witness_rmms;
 
                 if witness_rmm.num_instances() > 0 {
                     wits_rmms.insert(i, witness_rmm);
                 }
                 structural_rmms.push(structural_witness_rmm);
+                #[cfg(feature = "gpu")]
+                gpu_replay_plans.push(gpu_replay_plan);
             }
 
             tracing::debug!(
@@ -247,7 +256,7 @@ impl<
             };
 
             // commit to witness traces in batch
-            let (witness_mles, witness_data, witin_commit) = info_span!("[ceno] commit_traces")
+            let (witness_mles, mut witness_data, witin_commit) = info_span!("[ceno] commit_traces")
                 .in_scope(|| self.device.commit_traces(wits_rmms));
             PCS::write_commitment(&witin_commit, &mut transcript).map_err(ZKVMError::PCSError)?;
             exit_span!(commit_to_traces_span);
@@ -270,6 +279,8 @@ impl<
                 shard_ctx,
                 name_and_instances,
                 structural_rmms,
+                #[cfg(feature = "gpu")]
+                gpu_replay_plans,
                 witness_mles,
                 &witness_data,
                 fixed_mles,
@@ -277,6 +288,30 @@ impl<
                 &pi,
                 &circuit_trace_indices,
             );
+            #[cfg(feature = "gpu")]
+            let replayable_traces: Vec<(usize, crate::structs::GpuReplayPlan<E>)> = tasks
+                .iter()
+                .filter_map(|task| {
+                    task.gpu_replay_plan
+                        .as_ref()
+                        .and_then(|plan| plan.trace_idx.map(|trace_idx| (trace_idx, plan.clone())))
+                })
+                .collect();
+            #[cfg(feature = "gpu")]
+            if crate::instructions::gpu::config::is_gpu_witgen_enabled()
+                && !crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit()
+            {
+                if std::any::TypeId::of::<PB>()
+                    == std::any::TypeId::of::<gkr_iop::gpu::GpuBackend<E, PCS>>()
+                {
+                    let gpu_witness_data: &mut <gkr_iop::gpu::GpuBackend<E, PCS> as ProverBackend>::PcsData =
+                        unsafe { std::mem::transmute(&mut witness_data) };
+                    crate::scheme::gpu::clear_replayable_trace_device_backing::<E, PCS>(
+                        gpu_witness_data,
+                        &replayable_traces,
+                    );
+                }
+            }
             exit_span!(build_tasks_span);
 
             // Phase 2: Execute chip proof tasks
@@ -301,7 +336,23 @@ impl<
             // batch opening pcs
             // generate static info from prover key for expected num variable
             let pcs_opening = entered_span!("pcs_opening", profiling_1 = true);
+            #[cfg(feature = "gpu")]
+            if crate::instructions::gpu::config::is_gpu_witgen_enabled()
+                && !crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit()
+                && std::any::TypeId::of::<PB>()
+                    == std::any::TypeId::of::<gkr_iop::gpu::GpuBackend<E, PCS>>()
+            {
+                let gpu_witness_data: &mut <gkr_iop::gpu::GpuBackend<E, PCS> as ProverBackend>::PcsData =
+                    unsafe { std::mem::transmute(&mut witness_data) };
+                crate::scheme::gpu::restore_replayable_trace_device_backing::<E, PCS>(
+                    gpu_witness_data,
+                    &replayable_traces,
+                )?;
+            }
             let mpcs_opening_proof = info_span!("[ceno] pcs_opening").in_scope(|| {
+                #[cfg(feature = "gpu")]
+                {
+                }
                 self.device.open(
                     witness_data,
                     self.get_device_proving_key(shard_ctx)
@@ -370,6 +421,7 @@ impl<
                             &task.challenges,
                             gpu_wd.0,
                             task.witness_trace_idx,
+                            task.gpu_replay_plan.clone(),
                             task.num_witin,
                             task.structural_rmm,
                         )?;
@@ -522,6 +574,7 @@ impl<
         shard_ctx: &ShardContext,
         name_and_instances: Vec<(String, [usize; 2])>,
         structural_rmms: Vec<witness::RowMajorMatrix<E::BaseField>>,
+        #[cfg(feature = "gpu")] gpu_replay_plans: Vec<Option<crate::structs::GpuReplayPlan<E>>>,
         #[allow(unused_mut)] mut witness_mles: Vec<PB::MultilinearPoly<'data>>,
         witness_data: &PB::PcsData,
         mut fixed_mles: Vec<Arc<PB::MultilinearPoly<'data>>>,
@@ -653,6 +706,11 @@ impl<
             } else {
                 None
             };
+            #[cfg(feature = "gpu")]
+            let gpu_replay_plan = gpu_replay_plans[this_idx].clone().map(|mut plan| {
+                plan.trace_idx = witness_trace_idx;
+                plan
+            });
 
             tasks.push(ChipTask {
                 task_id,
@@ -664,6 +722,8 @@ impl<
                 has_witness_or_fixed: cs.num_witin() > 0 || cs.num_fixed() > 0,
                 challenges,
                 witness_trace_idx,
+                #[cfg(feature = "gpu")]
+                gpu_replay_plan,
                 num_witin: cs.num_witin(),
                 structural_rmm: task_structural_rmm,
             });
@@ -727,6 +787,7 @@ pub fn create_chip_proof_gpu_impl<'a, E, PCS>(
     // Deferred extraction params:
     pcs_data: &<gkr_iop::gpu::GpuBackend<E, PCS> as gkr_iop::hal::ProverBackend>::PcsData,
     witness_trace_idx: Option<usize>,
+    #[cfg(feature = "gpu")] gpu_replay_plan: Option<crate::structs::GpuReplayPlan<E>>,
     num_witin: usize,
     structural_rmm: Option<witness::RowMajorMatrix<<E as ExtensionField>::BaseField>>,
 ) -> Result<CreateTableProof<E>, ZKVMError>
@@ -748,6 +809,31 @@ where
     let _thread_stream_guard = gkr_iop::gpu::bind_thread_stream(_stream.clone());
 
     // Deferred witness extraction: extract from committed pcs_data just-in-time
+    #[cfg(feature = "gpu")]
+    if let Some(replay_plan) = gpu_replay_plan.as_ref() {
+        let [witness_rmm, structural_rmm_from_replay] = replay_plan.replay()?;
+        input.witness = info_span!("[ceno] replay_gpu_witness_from_raw")
+            .in_scope(|| crate::scheme::gpu::extract_witness_mles_for_trace_rmm::<E>(witness_rmm));
+        if structural_rmm.is_none() {
+            input.structural_witness =
+                info_span!("[ceno] transport_structural_witness").in_scope(|| {
+                    transport_structural_witness_to_gpu::<E>(
+                        structural_rmm_from_replay,
+                        circuit_pk.get_cs().zkvm_v1_css.num_structural_witin as usize,
+                        input.log2_num_instances()
+                            + circuit_pk.get_cs().rotation_vars().unwrap_or(0),
+                    )
+                });
+        }
+    } else if let Some(trace_idx) = witness_trace_idx {
+        let num_vars =
+            input.log2_num_instances() + circuit_pk.get_cs().rotation_vars().unwrap_or(0);
+        input.witness = info_span!("[ceno] extract_witness_mles").in_scope(|| {
+            extract_witness_mles_for_trace::<E, PCS>(pcs_data, trace_idx, num_witin, num_vars)
+        });
+    }
+
+    #[cfg(not(feature = "gpu"))]
     if let Some(trace_idx) = witness_trace_idx {
         let num_vars =
             input.log2_num_instances() + circuit_pk.get_cs().rotation_vars().unwrap_or(0);

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -946,10 +946,18 @@ where
     E: ExtensionField,
     PCS: PolynomialCommitmentScheme<E> + 'static,
 {
-    use crate::scheme::gpu::{
-        check_gpu_mem_estimation, estimate_replay_materialization_bytes,
-        extract_witness_mles_for_trace, prove_ec_sum_quark_impl, prove_main_constraints_impl,
-        prove_tower_relation_impl, transport_structural_witness_to_gpu,
+    use crate::{
+        instructions::gpu::dispatch::GpuWitgenKind,
+        scheme::{
+            constants::NUM_FANIN,
+            gpu::{
+                build_tower_witness_gpu, check_gpu_mem_estimation,
+                estimate_replay_materialization_bytes, estimate_tower_stage_bytes,
+                extract_out_evals_from_gpu_towers, extract_witness_mles_for_trace,
+                log_gpu_pool_usage, prove_ec_sum_quark_impl, prove_main_constraints_impl,
+                prove_tower_relation_impl, transport_structural_witness_to_gpu,
+            },
+        },
     };
     use gkr_iop::gpu::{GpuBackend, get_cuda_hal};
 
@@ -959,46 +967,71 @@ where
         .get_pool_stream()
         .expect("should acquire stream");
     let _thread_stream_guard = gkr_iop::gpu::bind_thread_stream(_stream.clone());
+    let keccak_stage_split = gpu_replay_plan
+        .as_ref()
+        .is_some_and(|plan| matches!(plan.kind, GpuWitgenKind::Keccak));
+    let structural_from_replay = structural_rmm.is_none();
 
     // Deferred witness extraction: extract from committed pcs_data just-in-time
     #[cfg(feature = "gpu")]
-    if let Some(replay_plan) = gpu_replay_plan.as_ref() {
-        let gpu_mem_tracker =
-            crate::scheme::gpu::init_gpu_mem_tracker(&cuda_hal, "replay_gpu_witness_from_raw");
-        let num_vars =
-            input.log2_num_instances() + circuit_pk.get_cs().rotation_vars().unwrap_or(0);
-        let estimated_replay_bytes = estimate_replay_materialization_bytes(
-            circuit_pk.get_cs().zkvm_v1_css.num_witin as usize,
-            circuit_pk.get_cs().zkvm_v1_css.num_structural_witin as usize,
-            num_vars,
-        );
-        let estimated_replay_mb = estimated_replay_bytes as f64 / (1024.0 * 1024.0);
-        tracing::info!(
-            "[gpu] replaying witness from raw: circuit={}, estimated={:.2}MB",
-            name,
-            estimated_replay_mb,
-        );
-        let [witness_rmm, structural_rmm_from_replay] = replay_plan.replay()?;
-        check_gpu_mem_estimation(gpu_mem_tracker, estimated_replay_bytes);
-        input.witness = info_span!("[ceno] replay_gpu_witness_from_raw")
-            .in_scope(|| crate::scheme::gpu::extract_witness_mles_for_trace_rmm::<E>(witness_rmm));
-        if structural_rmm.is_none() {
-            input.structural_witness =
-                info_span!("[ceno] transport_structural_witness").in_scope(|| {
-                    transport_structural_witness_to_gpu::<E>(
-                        structural_rmm_from_replay,
-                        circuit_pk.get_cs().zkvm_v1_css.num_structural_witin as usize,
-                        input.log2_num_instances()
-                            + circuit_pk.get_cs().rotation_vars().unwrap_or(0),
-                    )
-                });
+    let materialize_replay_input =
+        |input: &mut ProofInput<'a, GpuBackend<E, PCS>>| -> Result<(), ZKVMError> {
+            let Some(replay_plan) = gpu_replay_plan.as_ref() else {
+                return Ok(());
+            };
+            let gpu_mem_tracker =
+                crate::scheme::gpu::init_gpu_mem_tracker(&cuda_hal, "replay_gpu_witness_from_raw");
+            let num_vars =
+                input.log2_num_instances() + circuit_pk.get_cs().rotation_vars().unwrap_or(0);
+            let estimated_replay_bytes = estimate_replay_materialization_bytes(
+                circuit_pk.get_cs().zkvm_v1_css.num_witin as usize,
+                circuit_pk.get_cs().zkvm_v1_css.num_structural_witin as usize,
+                num_vars,
+            );
+            let estimated_replay_mb = estimated_replay_bytes as f64 / (1024.0 * 1024.0);
+            tracing::info!(
+                "[gpu] replaying witness from raw: circuit={}, estimated={:.2}MB",
+                name,
+                estimated_replay_mb,
+            );
+            log_gpu_pool_usage(&format!("{name}:before_replay"));
+            let [witness_rmm, structural_rmm_from_replay] = replay_plan.replay()?;
+            check_gpu_mem_estimation(gpu_mem_tracker, estimated_replay_bytes);
+            input.witness = info_span!("[ceno] replay_gpu_witness_from_raw").in_scope(|| {
+                crate::scheme::gpu::extract_witness_mles_for_trace_rmm::<E>(witness_rmm)
+            });
+            if structural_from_replay {
+                input.structural_witness = info_span!("[ceno] transport_structural_witness")
+                    .in_scope(|| {
+                        transport_structural_witness_to_gpu::<E>(
+                            structural_rmm_from_replay,
+                            circuit_pk.get_cs().zkvm_v1_css.num_structural_witin as usize,
+                            input.log2_num_instances()
+                                + circuit_pk.get_cs().rotation_vars().unwrap_or(0),
+                        )
+                    });
+            }
+            log_gpu_pool_usage(&format!("{name}:after_replay"));
+            Ok(())
+        };
+
+    #[cfg(feature = "gpu")]
+    let clear_materialized_input = |input: &mut ProofInput<'a, GpuBackend<E, PCS>>| {
+        input.witness = vec![];
+        input.structural_witness = vec![];
+    };
+
+    #[cfg(feature = "gpu")]
+    if !keccak_stage_split {
+        if gpu_replay_plan.is_some() {
+            materialize_replay_input(&mut input)?;
+        } else if let Some(trace_idx) = witness_trace_idx {
+            let num_vars =
+                input.log2_num_instances() + circuit_pk.get_cs().rotation_vars().unwrap_or(0);
+            input.witness = info_span!("[ceno] extract_witness_mles").in_scope(|| {
+                extract_witness_mles_for_trace::<E, PCS>(pcs_data, trace_idx, num_witin, num_vars)
+            });
         }
-    } else if let Some(trace_idx) = witness_trace_idx {
-        let num_vars =
-            input.log2_num_instances() + circuit_pk.get_cs().rotation_vars().unwrap_or(0);
-        input.witness = info_span!("[ceno] extract_witness_mles").in_scope(|| {
-            extract_witness_mles_for_trace::<E, PCS>(pcs_data, trace_idx, num_witin, num_vars)
-        });
     }
 
     #[cfg(not(feature = "gpu"))]
@@ -1015,16 +1048,175 @@ where
     let num_var_with_rotation = log2_num_instances + cs.rotation_vars().unwrap_or(0);
 
     // Deferred structural witness transport: CPU -> GPU just-in-time
-    if let Some(rmm) = structural_rmm {
-        let num_structural_witin = cs.zkvm_v1_css.num_structural_witin as usize;
-        input.structural_witness =
-            info_span!("[ceno] transport_structural_witness").in_scope(|| {
-                transport_structural_witness_to_gpu::<E>(
-                    rmm,
-                    num_structural_witin,
-                    num_var_with_rotation,
+    if !keccak_stage_split {
+        if let Some(rmm) = structural_rmm {
+            let num_structural_witin = cs.zkvm_v1_css.num_structural_witin as usize;
+            input.structural_witness =
+                info_span!("[ceno] transport_structural_witness").in_scope(|| {
+                    transport_structural_witness_to_gpu::<E>(
+                        rmm,
+                        num_structural_witin,
+                        num_var_with_rotation,
+                    )
+                });
+        }
+    }
+
+    if keccak_stage_split {
+        materialize_replay_input(&mut input)?;
+        let cs = circuit_pk.get_cs();
+
+        let ecc_proof = if !cs.zkvm_v1_css.ec_final_sum.is_empty() {
+            let span = entered_span!("run_ecc_final_sum", profiling_2 = true);
+            let ec_point_exprs = &cs.zkvm_v1_css.ec_point_exprs;
+            assert_eq!(ec_point_exprs.len(), SEPTIC_EXTENSION_DEGREE * 2);
+            let mut xs_ys = ec_point_exprs
+                .iter()
+                .map(|expr| match expr {
+                    Expression::WitIn(id) => input.witness[*id as usize].clone(),
+                    _ => unreachable!("ec point's expression must be WitIn"),
+                })
+                .collect_vec();
+            let ys = xs_ys.split_off(SEPTIC_EXTENSION_DEGREE);
+            let xs = xs_ys;
+            let slopes = cs
+                .zkvm_v1_css
+                .ec_slope_exprs
+                .iter()
+                .map(|expr| match expr {
+                    Expression::WitIn(id) => input.witness[*id as usize].clone(),
+                    _ => unreachable!("slope's expression must be WitIn"),
+                })
+                .collect_vec();
+            let ecc_proof = Some(info_span!("[ceno] prove_ec_sum_quark").in_scope(|| {
+                prove_ec_sum_quark_impl::<E, PCS>(input.num_instances(), xs, ys, slopes, transcript)
+            })?);
+            exit_span!(span);
+            ecc_proof
+        } else {
+            None
+        };
+
+        let records = info_span!("[ceno] build_main_witness").in_scope(|| {
+            build_main_witness::<
+                E,
+                PCS,
+                GpuBackend<E, PCS>,
+                gkr_iop::gpu::GpuProver<GpuBackend<E, PCS>>,
+            >(cs, &input, challenges)
+        });
+        log_gpu_pool_usage(&format!("{name}:after_build_main_witness"));
+
+        let span = entered_span!("prove_tower_relation", profiling_2 = true);
+        let r_set_len =
+            cs.zkvm_v1_css.r_expressions.len() + cs.zkvm_v1_css.r_table_expressions.len();
+        let (tower_build_estimated_bytes, tower_prove_estimated_bytes) =
+            estimate_tower_stage_bytes::<E, PCS>(cs, &input);
+        tracing::info!(
+            "[gpu tower][{}] estimated: build_tower={:.2}MB, prove_tower={:.2}MB",
+            name,
+            tower_build_estimated_bytes as f64 / (1024.0 * 1024.0),
+            tower_prove_estimated_bytes as f64 / (1024.0 * 1024.0),
+        );
+        let tower_build_mem_tracker =
+            crate::scheme::gpu::init_gpu_mem_tracker(&cuda_hal, "build_tower_witness_gpu");
+        let mut big_buffers = Vec::new();
+        let mut ones_buffer = Vec::new();
+        let mut view_last_layers = Vec::new();
+        log_gpu_pool_usage(&format!("{name}:before_build_tower_witness"));
+        let (prod_gpu, logup_gpu, lk_out_evals, w_out_evals, r_out_evals) =
+            info_span!("[ceno] build_tower_witness_gpu").in_scope(|| {
+                let (prod_gpu, logup_gpu) = build_tower_witness_gpu(
+                    cs,
+                    &input,
+                    &records,
+                    challenges,
+                    &cuda_hal,
+                    &mut big_buffers,
+                    &mut ones_buffer,
+                    &mut view_last_layers,
                 )
+                .map_err(|e| {
+                    ZKVMError::InvalidWitness(format!("build_tower_witness_gpu failed: {e}").into())
+                })?;
+                let (r_out_evals, w_out_evals, lk_out_evals) =
+                    extract_out_evals_from_gpu_towers(&prod_gpu, &logup_gpu, r_set_len);
+                Ok::<_, ZKVMError>((prod_gpu, logup_gpu, lk_out_evals, w_out_evals, r_out_evals))
+            })?;
+        check_gpu_mem_estimation(tower_build_mem_tracker, tower_build_estimated_bytes);
+        log_gpu_pool_usage(&format!("{name}:after_build_tower_witness"));
+
+        for eval in r_out_evals
+            .iter()
+            .chain(w_out_evals.iter())
+            .chain(lk_out_evals.iter())
+            .flatten()
+        {
+            transcript.append_field_element_ext(eval);
+        }
+
+        clear_materialized_input(&mut input);
+
+        let basic_tr = crate::scheme::gpu::expect_basic_transcript(transcript);
+        let tower_input = ceno_gpu::TowerInput {
+            prod_specs: prod_gpu,
+            logup_specs: logup_gpu,
+        };
+        let tower_prove_mem_tracker =
+            crate::scheme::gpu::init_gpu_mem_tracker(&cuda_hal, "prove_tower_relation_gpu");
+        log_gpu_pool_usage(&format!("{name}:before_prove_tower"));
+        let (rt_tower_gl, tower_proof_gpu) = info_span!("[ceno] prove_tower_relation_gpu")
+            .in_scope(|| {
+                cuda_hal
+                    .tower
+                    .create_proof(
+                        &cuda_hal,
+                        &tower_input,
+                        NUM_FANIN,
+                        basic_tr,
+                        gkr_iop::gpu::get_thread_stream().as_ref(),
+                    )
+                    .expect("gpu tower create_proof failed")
             });
+        log_gpu_pool_usage(&format!("{name}:after_prove_tower"));
+        let rt_tower: Point<E> = unsafe { std::mem::transmute(rt_tower_gl) };
+        let tower_proof: TowerProofs<E> = unsafe { std::mem::transmute(tower_proof_gpu) };
+        check_gpu_mem_estimation(tower_prove_mem_tracker, tower_prove_estimated_bytes);
+        drop(records);
+        exit_span!(span);
+
+        assert_eq!(rt_tower.len(), num_var_with_rotation);
+
+        materialize_replay_input(&mut input)?;
+        let span = entered_span!("prove_main_constraints", profiling_2 = true);
+        let (input_opening_point, evals, main_sumcheck_proofs, gkr_iop_proof) =
+            info_span!("[ceno] prove_main_constraints").in_scope(|| {
+                prove_main_constraints_impl::<E, PCS>(rt_tower, &input, cs, challenges, transcript)
+            })?;
+        let MainSumcheckEvals {
+            wits_in_evals,
+            fixed_in_evals,
+        } = evals;
+        clear_materialized_input(&mut input);
+        exit_span!(span);
+
+        return Ok((
+            ZKVMChipProof {
+                r_out_evals,
+                w_out_evals,
+                lk_out_evals,
+                main_sumcheck_proofs,
+                gkr_iop_proof,
+                tower_proof,
+                ecc_proof,
+                num_instances: input.num_instances,
+            },
+            MainSumcheckEvals {
+                wits_in_evals,
+                fixed_in_evals,
+            },
+            input_opening_point,
+        ));
     }
 
     // run ecc quark prover using _impl function

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -1049,9 +1049,9 @@ where
         .get_pool_stream()
         .expect("should acquire stream");
     let _thread_stream_guard = gkr_iop::gpu::bind_thread_stream(_stream.clone());
-    let keccak_stage_split = gpu_replay_plan
+    let replay_stage_split = gpu_replay_plan
         .as_ref()
-        .is_some_and(|plan| matches!(plan.kind, GpuWitgenKind::Keccak));
+        .is_some_and(|plan| matches!(plan.kind, GpuWitgenKind::Keccak | GpuWitgenKind::ShardRam));
     let structural_from_replay = structural_rmm.is_none();
 
     // Deferred witness extraction: extract from committed pcs_data just-in-time
@@ -1104,7 +1104,7 @@ where
     };
 
     #[cfg(feature = "gpu")]
-    if !keccak_stage_split {
+    if !replay_stage_split {
         if gpu_replay_plan.is_some() {
             materialize_replay_input(&mut input)?;
         } else if let Some(trace_idx) = witness_trace_idx {
@@ -1130,7 +1130,7 @@ where
     let num_var_with_rotation = log2_num_instances + cs.rotation_vars().unwrap_or(0);
 
     // Deferred structural witness transport: CPU -> GPU just-in-time
-    if !keccak_stage_split {
+    if !replay_stage_split {
         if let Some(rmm) = structural_rmm {
             let num_structural_witin = cs.zkvm_v1_css.num_structural_witin as usize;
             input.structural_witness =
@@ -1144,7 +1144,7 @@ where
         }
     }
 
-    if keccak_stage_split {
+    if replay_stage_split {
         materialize_replay_input(&mut input)?;
         let cs = circuit_pk.get_cs();
 

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -1034,7 +1034,7 @@ where
             constants::NUM_FANIN,
             gpu::{
                 build_tower_witness_gpu, check_gpu_mem_estimation,
-                estimate_replay_materialization_bytes, estimate_tower_stage_bytes,
+                estimate_replay_materialization_bytes_for_plan, estimate_tower_stage_bytes,
                 extract_out_evals_from_gpu_towers, extract_witness_mles_for_trace,
                 log_gpu_pool_usage, prove_ec_sum_quark_impl, prove_main_constraints_impl,
                 prove_tower_relation_impl, transport_structural_witness_to_gpu,
@@ -1065,11 +1065,8 @@ where
                 crate::scheme::gpu::init_gpu_mem_tracker(&cuda_hal, "replay_gpu_witness_from_raw");
             let num_vars =
                 input.log2_num_instances() + circuit_pk.get_cs().rotation_vars().unwrap_or(0);
-            let estimated_replay_bytes = estimate_replay_materialization_bytes(
-                circuit_pk.get_cs().zkvm_v1_css.num_witin as usize,
-                circuit_pk.get_cs().zkvm_v1_css.num_structural_witin as usize,
-                num_vars,
-            );
+            let estimated_replay_bytes =
+                estimate_replay_materialization_bytes_for_plan(replay_plan, num_vars);
             let estimated_replay_mb = estimated_replay_bytes as f64 / (1024.0 * 1024.0);
             tracing::info!(
                 "[gpu] replaying witness from raw: circuit={}, estimated={:.2}MB",

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -1,3 +1,4 @@
+use ceno_gpu::Buffer;
 use ff_ext::ExtensionField;
 use gkr_iop::{
     cpu::{CpuBackend, CpuProver},
@@ -373,6 +374,35 @@ impl<
             if std::any::TypeId::of::<PB>()
                 == std::any::TypeId::of::<gkr_iop::gpu::GpuBackend<E, PCS>>()
             {
+                if let Some(active_dpk) = self.get_device_proving_key(shard_ctx) {
+                    let active_fixed_pcs: &<gkr_iop::gpu::GpuBackend<E, PCS> as ProverBackend>::PcsData =
+                        unsafe { std::mem::transmute(active_dpk.pcs_data.as_ref()) };
+                    crate::scheme::gpu::log_gpu_pcs_baseline::<E, PCS>(
+                        if shard_ctx.is_first_shard() {
+                            "fixed_active_first"
+                        } else {
+                            "fixed_active_non_first"
+                        },
+                        active_fixed_pcs,
+                    );
+                }
+                let inactive_dpk = if shard_ctx.is_first_shard() {
+                    self.device_non_first_shard_pk.as_ref()
+                } else {
+                    self.device_first_shard_pk.as_ref()
+                };
+                if let Some(inactive_dpk) = inactive_dpk {
+                    let inactive_fixed_pcs: &<gkr_iop::gpu::GpuBackend<E, PCS> as ProverBackend>::PcsData =
+                        unsafe { std::mem::transmute(inactive_dpk.pcs_data.as_ref()) };
+                    crate::scheme::gpu::log_gpu_pcs_baseline::<E, PCS>(
+                        if shard_ctx.is_first_shard() {
+                            "fixed_inactive_non_first"
+                        } else {
+                            "fixed_inactive_first"
+                        },
+                        inactive_fixed_pcs,
+                    );
+                }
                 let gpu_witness_data: &<gkr_iop::gpu::GpuBackend<E, PCS> as ProverBackend>::PcsData =
                     unsafe { std::mem::transmute(&witness_data) };
                 let gpu_fixed_mles: &[std::sync::Arc<gkr_iop::gpu::MultilinearExtensionGpu<'static, E>>] =
@@ -390,10 +420,28 @@ impl<
                     .count();
                 let task_structural_device_mb =
                     task_structural_device_bytes as f64 / (1024.0 * 1024.0);
+                let task_shard_ram_replay_raw_bytes = tasks
+                    .iter()
+                    .filter_map(|task| task.gpu_replay_plan.as_ref())
+                    .filter_map(|plan| plan.shard_ram_records.as_ref())
+                    .map(|buf| buf.len() * std::mem::size_of::<u32>())
+                    .sum::<usize>();
+                let task_shard_ram_replay_raw_count = tasks
+                    .iter()
+                    .filter_map(|task| task.gpu_replay_plan.as_ref())
+                    .filter(|plan| plan.shard_ram_records.is_some())
+                    .count();
+                let task_shard_ram_replay_raw_mb =
+                    task_shard_ram_replay_raw_bytes as f64 / (1024.0 * 1024.0);
                 tracing::info!(
                     "[gpu baseline][before_scheduler] task_structural_device={:.2}MB ({})",
                     task_structural_device_mb,
                     task_structural_device_count,
+                );
+                tracing::info!(
+                    "[gpu baseline][before_scheduler] task_shard_ram_replay_raw={:.2}MB ({})",
+                    task_shard_ram_replay_raw_mb,
+                    task_shard_ram_replay_raw_count,
                 );
                 crate::scheme::gpu::log_gpu_proof_baseline::<E, PCS>(
                     "before_scheduler",

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -207,6 +207,8 @@ impl<
 
             let commit_to_traces_span = entered_span!("batch commit to traces", profiling_1 = true);
             let mut wits_rmms = BTreeMap::new();
+            #[cfg(feature = "gpu")]
+            let mut deferred_gpu_traces = BTreeMap::new();
 
             let mut structural_rmms = Vec::with_capacity(name_and_instances.len());
             #[cfg(feature = "gpu")]
@@ -220,6 +222,24 @@ impl<
                 } = chip_input;
                 let [witness_rmm, structural_witness_rmm] = witness_rmms;
 
+                #[cfg(feature = "gpu")]
+                let use_deferred_gpu_commit = crate::instructions::gpu::config::is_gpu_witgen_enabled()
+                    && !crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit();
+
+                #[cfg(feature = "gpu")]
+                if use_deferred_gpu_commit {
+                    if let Some(plan) = gpu_replay_plan.clone() {
+                        deferred_gpu_traces
+                            .insert(i, crate::scheme::gpu::DeferredGpuTrace::Replay(plan));
+                    } else if witness_rmm.num_instances() > 0 {
+                        deferred_gpu_traces
+                            .insert(i, crate::scheme::gpu::DeferredGpuTrace::Eager(witness_rmm));
+                    }
+                } else if witness_rmm.num_instances() > 0 {
+                    wits_rmms.insert(i, witness_rmm);
+                }
+
+                #[cfg(not(feature = "gpu"))]
                 if witness_rmm.num_instances() > 0 {
                     wits_rmms.insert(i, witness_rmm);
                 }
@@ -244,7 +264,17 @@ impl<
                 let mut next_trace = 0usize;
                 (0..name_and_instances.len())
                     .map(|i| {
-                        if wits_rmms.contains_key(&i) {
+                        #[cfg(feature = "gpu")]
+                        let has_trace = if crate::instructions::gpu::config::is_gpu_witgen_enabled()
+                            && !crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit()
+                        {
+                            deferred_gpu_traces.contains_key(&i)
+                        } else {
+                            wits_rmms.contains_key(&i)
+                        };
+                        #[cfg(not(feature = "gpu"))]
+                        let has_trace = wits_rmms.contains_key(&i);
+                        if has_trace {
                             let idx = next_trace;
                             next_trace += 1;
                             Some(idx)
@@ -255,9 +285,36 @@ impl<
                     .collect()
             };
 
+            #[cfg(feature = "gpu")]
+            let use_deferred_gpu_commit = crate::instructions::gpu::config::is_gpu_witgen_enabled()
+                && !crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit()
+                && std::any::TypeId::of::<PB>()
+                    == std::any::TypeId::of::<gkr_iop::gpu::GpuBackend<E, PCS>>();
+            #[cfg(not(feature = "gpu"))]
+            let use_deferred_gpu_commit = false;
+
             // commit to witness traces in batch
-            let (witness_mles, mut witness_data, witin_commit) = info_span!("[ceno] commit_traces")
-                .in_scope(|| self.device.commit_traces(wits_rmms));
+            let (witness_mles, mut witness_data, witin_commit): (
+                Vec<PB::MultilinearPoly<'_>>,
+                PB::PcsData,
+                PCS::Commitment,
+            ) = if use_deferred_gpu_commit {
+                info_span!("[ceno] commit_traces").in_scope(|| {
+                    let gpu_device: &gkr_iop::gpu::GpuProver<gkr_iop::gpu::GpuBackend<E, PCS>> =
+                        unsafe { std::mem::transmute(&self.device) };
+                    let (gpu_witness_mles, gpu_witness_data, witin_commit) =
+                        crate::scheme::gpu::commit_traces_deferred_cache_none::<E, PCS>(
+                            gpu_device,
+                            deferred_gpu_traces,
+                        );
+                    let witness_mles = unsafe { std::mem::transmute(gpu_witness_mles) };
+                    let witness_data = unsafe { std::mem::transmute_copy(&gpu_witness_data) };
+                    std::mem::forget(gpu_witness_data);
+                    (witness_mles, witness_data, witin_commit)
+                })
+            } else {
+                info_span!("[ceno] commit_traces").in_scope(|| self.device.commit_traces(wits_rmms))
+            };
             PCS::write_commitment(&witin_commit, &mut transcript).map_err(ZKVMError::PCSError)?;
             exit_span!(commit_to_traces_span);
 

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -481,6 +481,11 @@ impl<
                 && std::any::TypeId::of::<PB>()
                     == std::any::TypeId::of::<gkr_iop::gpu::GpuBackend<E, PCS>>()
             {
+                let cuda_hal = gkr_iop::gpu::get_cuda_hal().expect("Failed to get CUDA HAL");
+                cuda_hal
+                    .inner
+                    .synchronize()
+                    .expect("cuda synchronize before pcs_opening");
                 let gpu_witness_data: &mut <gkr_iop::gpu::GpuBackend<E, PCS> as ProverBackend>::PcsData =
                     unsafe { std::mem::transmute(&mut witness_data) };
                 crate::scheme::gpu::restore_replayable_trace_device_backing::<E, PCS>(
@@ -1281,6 +1286,10 @@ where
         let tower_proof: TowerProofs<E> = unsafe { std::mem::transmute(tower_proof_gpu) };
         check_gpu_mem_estimation(tower_prove_mem_tracker, tower_prove_estimated_bytes);
         drop(records);
+        drop(tower_input);
+        drop(big_buffers);
+        drop(ones_buffer);
+        drop(view_last_layers);
         exit_span!(span);
 
         assert_eq!(rt_tower.len(), num_var_with_rotation);

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -16,7 +16,7 @@ use either::Either;
 use itertools::Itertools;
 use mpcs::{Point, PolynomialCommitmentScheme};
 use multilinear_extensions::{Expression, Instance};
-use p3::field::FieldAlgebra;
+use p3::{field::FieldAlgebra, matrix::Matrix};
 use std::iter::Iterator;
 use sumcheck::{
     macros::{entered_span, exit_span},
@@ -377,6 +377,24 @@ impl<
                     unsafe { std::mem::transmute(&witness_data) };
                 let gpu_fixed_mles: &[std::sync::Arc<gkr_iop::gpu::MultilinearExtensionGpu<'static, E>>] =
                     unsafe { std::mem::transmute(fixed_mles_preload.as_slice()) };
+                let task_structural_device_bytes = tasks
+                    .iter()
+                    .filter_map(|task| task.structural_rmm.as_ref())
+                    .filter(|rmm| rmm.has_device_backing())
+                    .map(|rmm| rmm.height() * rmm.width() * std::mem::size_of::<E::BaseField>())
+                    .sum::<usize>();
+                let task_structural_device_count = tasks
+                    .iter()
+                    .filter_map(|task| task.structural_rmm.as_ref())
+                    .filter(|rmm| rmm.has_device_backing())
+                    .count();
+                let task_structural_device_mb =
+                    task_structural_device_bytes as f64 / (1024.0 * 1024.0);
+                tracing::info!(
+                    "[gpu baseline][before_scheduler] task_structural_device={:.2}MB ({})",
+                    task_structural_device_mb,
+                    task_structural_device_count,
+                );
                 crate::scheme::gpu::log_gpu_proof_baseline::<E, PCS>(
                     "before_scheduler",
                     gpu_witness_data,
@@ -698,7 +716,16 @@ impl<
             #[cfg(feature = "gpu")]
             let (witness_mle, structural_witness, task_structural_rmm) = {
                 let _ = &structural_rmm; // suppress unused warning on structural_rmm binding
-                (vec![], vec![], Some(structural_rmm))
+                let keep_structural_rmm = gpu_replay_plans[this_idx].is_none();
+                (
+                    vec![],
+                    vec![],
+                    if keep_structural_rmm {
+                        Some(structural_rmm)
+                    } else {
+                        None
+                    },
+                )
             };
 
             // CPU path: eagerly extract witness and structural witness

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -752,7 +752,12 @@ impl<
                 );
                 let gpu_input: &ProofInput<'_, gkr_iop::gpu::GpuBackend<E, PCS>> =
                     unsafe { std::mem::transmute(&input) };
-                estimate_chip_proof_memory::<E, PCS>(cs, gpu_input, &circuit_name)
+                estimate_chip_proof_memory::<E, PCS>(
+                    cs,
+                    gpu_input,
+                    &circuit_name,
+                    gpu_replay_plans[this_idx].is_some(),
+                )
             };
             #[cfg(not(feature = "gpu"))]
             let estimated_memory = 0u64; // CPU path doesn't need memory tracking
@@ -853,6 +858,7 @@ where
     PCS: PolynomialCommitmentScheme<E> + 'static,
 {
     use crate::scheme::gpu::{
+        check_gpu_mem_estimation, estimate_replay_materialization_bytes,
         extract_witness_mles_for_trace, prove_ec_sum_quark_impl, prove_main_constraints_impl,
         prove_tower_relation_impl, transport_structural_witness_to_gpu,
     };
@@ -868,7 +874,23 @@ where
     // Deferred witness extraction: extract from committed pcs_data just-in-time
     #[cfg(feature = "gpu")]
     if let Some(replay_plan) = gpu_replay_plan.as_ref() {
+        let gpu_mem_tracker =
+            crate::scheme::gpu::init_gpu_mem_tracker(&cuda_hal, "replay_gpu_witness_from_raw");
+        let num_vars =
+            input.log2_num_instances() + circuit_pk.get_cs().rotation_vars().unwrap_or(0);
+        let estimated_replay_bytes = estimate_replay_materialization_bytes(
+            circuit_pk.get_cs().zkvm_v1_css.num_witin as usize,
+            circuit_pk.get_cs().zkvm_v1_css.num_structural_witin as usize,
+            num_vars,
+        );
+        let estimated_replay_mb = estimated_replay_bytes as f64 / (1024.0 * 1024.0);
+        tracing::info!(
+            "[gpu] replaying witness from raw: circuit={}, estimated={:.2}MB",
+            name,
+            estimated_replay_mb,
+        );
         let [witness_rmm, structural_rmm_from_replay] = replay_plan.replay()?;
+        check_gpu_mem_estimation(gpu_mem_tracker, estimated_replay_bytes);
         input.witness = info_span!("[ceno] replay_gpu_witness_from_raw")
             .in_scope(|| crate::scheme::gpu::extract_witness_mles_for_trace_rmm::<E>(witness_rmm));
         if structural_rmm.is_none() {

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -8,6 +8,8 @@ use std::{collections::BTreeMap, marker::PhantomData, sync::Arc};
 
 #[cfg(feature = "gpu")]
 use crate::scheme::gpu::estimate_chip_proof_memory;
+#[cfg(feature = "gpu")]
+use crate::scheme::scheduler::get_chip_proving_mode;
 use crate::scheme::{
     constants::SEPTIC_EXTENSION_DEGREE,
     hal::MainSumcheckEvals,
@@ -933,6 +935,22 @@ impl<
             #[cfg(not(feature = "gpu"))]
             let estimated_memory = 0u64; // CPU path doesn't need memory tracking
 
+            #[cfg(feature = "gpu")]
+            let booked_memory = {
+                let margin = if matches!(circuit_name.as_str(), "Ecall_Keccak" | "ShardRamCircuit")
+                    && matches!(
+                        get_chip_proving_mode(),
+                        crate::scheme::scheduler::ChipProvingMode::Concurrent
+                    ) {
+                    crate::scheme::scheduler::large_gpu_task_booking_margin_bytes()
+                } else {
+                    0
+                };
+                estimated_memory.saturating_add(margin)
+            };
+            #[cfg(not(feature = "gpu"))]
+            let booked_memory = estimated_memory;
+
             // Look up trace index for deferred extraction (GPU uses this; CPU ignores it)
             let witness_trace_idx = if cs.num_witin() > 0 {
                 circuit_trace_indices[this_idx]
@@ -952,6 +970,7 @@ impl<
                 pk,
                 input,
                 estimated_memory_bytes: estimated_memory,
+                booked_memory_bytes: booked_memory,
                 has_witness_or_fixed: cs.num_witin() > 0 || cs.num_fixed() > 0,
                 challenges,
                 witness_trace_idx,

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -319,7 +319,7 @@ impl<
             exit_span!(commit_to_traces_span);
 
             // Use pre-loaded fixed_mles (extracted before in_scope to avoid lifetime issues)
-            let fixed_mles = fixed_mles_preload;
+            let fixed_mles = fixed_mles_preload.clone();
 
             // squeeze two challenges from transcript
             let challenges = [
@@ -368,6 +368,20 @@ impl<
                         &replayable_traces,
                     );
                 }
+            }
+            #[cfg(feature = "gpu")]
+            if std::any::TypeId::of::<PB>()
+                == std::any::TypeId::of::<gkr_iop::gpu::GpuBackend<E, PCS>>()
+            {
+                let gpu_witness_data: &<gkr_iop::gpu::GpuBackend<E, PCS> as ProverBackend>::PcsData =
+                    unsafe { std::mem::transmute(&witness_data) };
+                let gpu_fixed_mles: &[std::sync::Arc<gkr_iop::gpu::MultilinearExtensionGpu<'static, E>>] =
+                    unsafe { std::mem::transmute(fixed_mles_preload.as_slice()) };
+                crate::scheme::gpu::log_gpu_proof_baseline::<E, PCS>(
+                    "before_scheduler",
+                    gpu_witness_data,
+                    gpu_fixed_mles,
+                );
             }
             exit_span!(build_tasks_span);
 

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -1060,7 +1060,8 @@ where
                 build_tower_witness_gpu, check_gpu_mem_estimation,
                 estimate_replay_materialization_bytes_for_plan, estimate_tower_stage_bytes,
                 extract_out_evals_from_gpu_towers, extract_witness_mles_for_trace,
-                log_gpu_pool_usage, prove_ec_sum_quark_impl, prove_main_constraints_impl,
+                log_gpu_device_state, log_gpu_pool_usage, prove_ec_sum_quark_impl,
+                prove_main_constraints_impl,
                 prove_tower_relation_impl, transport_structural_witness_to_gpu,
             },
         },
@@ -1097,6 +1098,7 @@ where
                 name,
                 estimated_replay_mb,
             );
+            log_gpu_device_state(&format!("{name}:before_replay"));
             log_gpu_pool_usage(&format!("{name}:before_replay"));
             let [witness_rmm, structural_rmm_from_replay] = replay_plan.replay()?;
             check_gpu_mem_estimation(gpu_mem_tracker, estimated_replay_bytes);
@@ -1114,6 +1116,7 @@ where
                         )
                     });
             }
+            log_gpu_device_state(&format!("{name}:after_replay"));
             log_gpu_pool_usage(&format!("{name}:after_replay"));
             Ok(())
         };
@@ -1208,6 +1211,7 @@ where
                 gkr_iop::gpu::GpuProver<GpuBackend<E, PCS>>,
             >(cs, &input, challenges)
         });
+        log_gpu_device_state(&format!("{name}:after_build_main_witness"));
         log_gpu_pool_usage(&format!("{name}:after_build_main_witness"));
 
         let span = entered_span!("prove_tower_relation", profiling_2 = true);
@@ -1226,6 +1230,7 @@ where
         let mut big_buffers = Vec::new();
         let mut ones_buffer = Vec::new();
         let mut view_last_layers = Vec::new();
+        log_gpu_device_state(&format!("{name}:before_build_tower_witness"));
         log_gpu_pool_usage(&format!("{name}:before_build_tower_witness"));
         let (prod_gpu, logup_gpu, lk_out_evals, w_out_evals, r_out_evals) =
             info_span!("[ceno] build_tower_witness_gpu").in_scope(|| {
@@ -1247,6 +1252,7 @@ where
                 Ok::<_, ZKVMError>((prod_gpu, logup_gpu, lk_out_evals, w_out_evals, r_out_evals))
             })?;
         check_gpu_mem_estimation(tower_build_mem_tracker, tower_build_estimated_bytes);
+        log_gpu_device_state(&format!("{name}:after_build_tower_witness"));
         log_gpu_pool_usage(&format!("{name}:after_build_tower_witness"));
 
         for eval in r_out_evals
@@ -1267,6 +1273,7 @@ where
         };
         let tower_prove_mem_tracker =
             crate::scheme::gpu::init_gpu_mem_tracker(&cuda_hal, "prove_tower_relation_gpu");
+        log_gpu_device_state(&format!("{name}:before_prove_tower"));
         log_gpu_pool_usage(&format!("{name}:before_prove_tower"));
         let (rt_tower_gl, tower_proof_gpu) = info_span!("[ceno] prove_tower_relation_gpu")
             .in_scope(|| {
@@ -1281,6 +1288,7 @@ where
                     )
                     .expect("gpu tower create_proof failed")
             });
+        log_gpu_device_state(&format!("{name}:after_prove_tower"));
         log_gpu_pool_usage(&format!("{name}:after_prove_tower"));
         let rt_tower: Point<E> = unsafe { std::mem::transmute(rt_tower_gl) };
         let tower_proof: TowerProofs<E> = unsafe { std::mem::transmute(tower_proof_gpu) };
@@ -1290,11 +1298,13 @@ where
         drop(big_buffers);
         drop(ones_buffer);
         drop(view_last_layers);
+        log_gpu_device_state(&format!("{name}:after_drop_tower"));
         exit_span!(span);
 
         assert_eq!(rt_tower.len(), num_var_with_rotation);
 
         materialize_replay_input(&mut input)?;
+        log_gpu_device_state(&format!("{name}:before_main_constraints"));
         let span = entered_span!("prove_main_constraints", profiling_2 = true);
         let (input_opening_point, evals, main_sumcheck_proofs, gkr_iop_proof) =
             info_span!("[ceno] prove_main_constraints").in_scope(|| {
@@ -1305,6 +1315,7 @@ where
             fixed_in_evals,
         } = evals;
         clear_materialized_input(&mut input);
+        log_gpu_device_state(&format!("{name}:after_main_constraints"));
         exit_span!(span);
 
         return Ok((

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -523,29 +523,17 @@ impl<
 
         #[cfg(feature = "gpu")]
         {
-            if ChipScheduler::is_concurrent_mode() {
-                // GPU concurrent: standalone function path (no &self needed for Send+Sync)
-                // Verify at runtime that PB is indeed GpuBackend<E, PCS> before transmuting.
-                assert_eq!(
-                    std::any::TypeId::of::<PB>(),
-                    std::any::TypeId::of::<gkr_iop::gpu::GpuBackend<E, PCS>>(),
-                    "Concurrent GPU path requires PB = GpuBackend<E, PCS>"
-                );
-                // SAFETY: TypeId check above guarantees PB = GpuBackend<E, PCS>, so PcsData types match.
+            if std::any::TypeId::of::<PB>()
+                == std::any::TypeId::of::<gkr_iop::gpu::GpuBackend<E, PCS>>()
+            {
                 let gpu_witness_data: &<gkr_iop::gpu::GpuBackend<E, PCS> as gkr_iop::hal::ProverBackend>::PcsData =
                     unsafe { std::mem::transmute(witness_data) };
 
-                // SAFETY: pcs_data is only read (via get_trace) during concurrent execution.
-                use crate::scheme::utils::SyncRef;
-                let gpu_wd = SyncRef(gpu_witness_data);
-
-                return scheduler.execute(tasks, transcript, |task, transcript| {
-                    // Append circuit_idx to per-task forked transcript (matching verifier)
+                let exec_gpu_task = |task: ChipTask<'data, PB>, transcript: &mut T| {
                     transcript.append_field_element(&E::BaseField::from_canonical_u64(
                         task.circuit_idx as u64,
                     ));
 
-                    // SAFETY: TypeId check above (before closure) guarantees PB = GpuBackend<E, PCS>.
                     let gpu_input: ProofInput<'static, gkr_iop::gpu::GpuBackend<E, PCS>> =
                         unsafe { std::mem::transmute(task.input) };
 
@@ -556,7 +544,7 @@ impl<
                             gpu_input,
                             transcript,
                             &task.challenges,
-                            gpu_wd.0,
+                            gpu_witness_data,
                             task.witness_trace_idx,
                             task.gpu_replay_plan.clone(),
                             task.num_witin,
@@ -571,7 +559,19 @@ impl<
                         input_opening_point,
                         has_witness_or_fixed: task.has_witness_or_fixed,
                     })
-                });
+                };
+
+                if ChipScheduler::is_concurrent_mode() {
+                    // SAFETY: pcs_data is only read (via get_trace) during concurrent execution.
+                    use crate::scheme::utils::SyncRef;
+                    let gpu_wd = SyncRef(gpu_witness_data);
+                    return scheduler.execute(tasks, transcript, |task, transcript| {
+                        let _ = gpu_wd;
+                        exec_gpu_task(task, transcript)
+                    });
+                } else {
+                    return scheduler.execute_sequentially(tasks, transcript, exec_gpu_task);
+                }
             }
         }
 
@@ -582,8 +582,30 @@ impl<
             transcript
                 .append_field_element(&E::BaseField::from_canonical_u64(task.circuit_idx as u64));
 
+            #[cfg(feature = "gpu")]
+            let log_keccak_pool = task.gpu_replay_plan.as_ref().is_some_and(|plan| {
+                matches!(
+                    plan.kind,
+                    crate::instructions::gpu::dispatch::GpuWitgenKind::Keccak
+                )
+            });
+
             // Prepare: deferred extraction for GPU, no-op for CPU
+            #[cfg(feature = "gpu")]
+            if log_keccak_pool {
+                crate::scheme::gpu::log_gpu_pool_usage(&format!(
+                    "{}:before_replay",
+                    task.circuit_name
+                ));
+            }
             self.device.prepare_chip_input(&mut task, witness_data);
+            #[cfg(feature = "gpu")]
+            if log_keccak_pool {
+                crate::scheme::gpu::log_gpu_pool_usage(&format!(
+                    "{}:after_replay",
+                    task.circuit_name
+                ));
+            }
 
             let (proof, opening_evals, input_opening_point) =
                 self.create_chip_proof(&task, transcript)?;
@@ -654,15 +676,51 @@ impl<
         // build main witness
         let records = info_span!("[ceno] build_main_witness")
             .in_scope(|| build_main_witness::<E, PCS, PB, PD>(cs, input, challenges));
+        #[cfg(feature = "gpu")]
+        if task.gpu_replay_plan.as_ref().is_some_and(|plan| {
+            matches!(
+                plan.kind,
+                crate::instructions::gpu::dispatch::GpuWitgenKind::Keccak
+            )
+        }) {
+            crate::scheme::gpu::log_gpu_pool_usage(&format!(
+                "{}:after_build_main_witness",
+                task.circuit_name
+            ));
+        }
 
         let span = entered_span!("prove_tower_relation", profiling_2 = true);
         // prove the product and logup sum relation between layers in tower
         // (internally calls build_tower_witness)
+        #[cfg(feature = "gpu")]
+        if task.gpu_replay_plan.as_ref().is_some_and(|plan| {
+            matches!(
+                plan.kind,
+                crate::instructions::gpu::dispatch::GpuWitgenKind::Keccak
+            )
+        }) {
+            crate::scheme::gpu::log_gpu_pool_usage(&format!(
+                "{}:before_prove_tower",
+                task.circuit_name
+            ));
+        }
         let (rt_tower, tower_proof, lk_out_evals, w_out_evals, r_out_evals) =
             info_span!("[ceno] prove_tower_relation").in_scope(|| {
                 self.device
                     .prove_tower_relation(cs, input, &records, challenges, transcript)
             });
+        #[cfg(feature = "gpu")]
+        if task.gpu_replay_plan.as_ref().is_some_and(|plan| {
+            matches!(
+                plan.kind,
+                crate::instructions::gpu::dispatch::GpuWitgenKind::Keccak
+            )
+        }) {
+            crate::scheme::gpu::log_gpu_pool_usage(&format!(
+                "{}:after_prove_tower",
+                task.circuit_name
+            ));
+        }
         exit_span!(span);
 
         assert_eq!(
@@ -673,11 +731,35 @@ impl<
         // 1. prove the main constraints among witness polynomials
         // 2. prove the relation between last layer in the tower and read/write/logup records
         let span = entered_span!("prove_main_constraints", profiling_2 = true);
+        #[cfg(feature = "gpu")]
+        if task.gpu_replay_plan.as_ref().is_some_and(|plan| {
+            matches!(
+                plan.kind,
+                crate::instructions::gpu::dispatch::GpuWitgenKind::Keccak
+            )
+        }) {
+            crate::scheme::gpu::log_gpu_pool_usage(&format!(
+                "{}:before_prove_main",
+                task.circuit_name
+            ));
+        }
         let (input_opening_point, evals, main_sumcheck_proofs, gkr_iop_proof) =
             info_span!("[ceno] prove_main_constraints").in_scope(|| {
                 self.device
                     .prove_main_constraints(rt_tower, input, cs, challenges, transcript)
             })?;
+        #[cfg(feature = "gpu")]
+        if task.gpu_replay_plan.as_ref().is_some_and(|plan| {
+            matches!(
+                plan.kind,
+                crate::instructions::gpu::dispatch::GpuWitgenKind::Keccak
+            )
+        }) {
+            crate::scheme::gpu::log_gpu_pool_usage(&format!(
+                "{}:after_prove_main",
+                task.circuit_name
+            ));
+        }
         let MainSumcheckEvals {
             wits_in_evals,
             fixed_in_evals,

--- a/ceno_zkvm/src/scheme/scheduler.rs
+++ b/ceno_zkvm/src/scheme/scheduler.rs
@@ -325,6 +325,11 @@ impl ChipScheduler {
                 mem_pool.get_booked_total() as f64 / (1024.0 * 1024.0),
                 *tasks_inflight
             );
+            crate::scheme::gpu::log_gpu_device_state(&format!(
+                "task_done{}:{}",
+                label.replace(' ', ""),
+                msg.task_id
+            ));
             samples.push((msg.task_id, msg.forked_sample));
             match msg.result {
                 Ok(r) => {
@@ -368,6 +373,10 @@ impl ChipScheduler {
                             circuit_name,
                             memory as f64 / (1024.0 * 1024.0)
                         );
+                        crate::scheme::gpu::log_gpu_device_state(&format!(
+                            "task_start:{}:{}",
+                            task_id, circuit_name
+                        ));
 
                         // Catch panics so a single worker crash doesn't deadlock
                         // the scheduler (which would block forever on done_rx.recv()
@@ -457,6 +466,10 @@ impl ChipScheduler {
                         booked_mem as f64 / (1024.0 * 1024.0),
                         mem_pool.get_booked_total() as f64 / (1024.0 * 1024.0)
                     );
+                    crate::scheme::gpu::log_gpu_device_state(&format!(
+                        "launch:{}:{}",
+                        task.task_id, task.circuit_name
+                    ));
                     tasks_inflight += 1;
                     if task_tx.send(task).is_err() {
                         mem_pool.unbook_capacity(booked_mem);
@@ -509,6 +522,7 @@ impl ChipScheduler {
                     mem_pool.get_booked_total() as f64 / (1024.0 * 1024.0),
                     tasks_inflight
                 );
+                crate::scheme::gpu::log_gpu_device_state("pool_full_wait");
 
                 // Second call site blocks instead of busy-waiting when the pool is full; this
                 // waits for the next completion to free memory before trying to launch again.

--- a/ceno_zkvm/src/scheme/scheduler.rs
+++ b/ceno_zkvm/src/scheme/scheduler.rs
@@ -521,6 +521,8 @@ impl ChipScheduler {
             Ok(())
         });
 
+        let scope_result = scope_result;
+        mem_pool.reset_booking();
         scope_result?;
 
         // 6. Sort by task_id to restore original order

--- a/ceno_zkvm/src/scheme/scheduler.rs
+++ b/ceno_zkvm/src/scheme/scheduler.rs
@@ -346,10 +346,11 @@ impl ChipScheduler {
                         };
                         let memory = task.estimated_memory_bytes;
                         let task_id = task.task_id;
+                        let circuit_name = task.circuit_name.clone();
                         tracing::info!(
                             "[scheduler] worker starting task {} ({}), estimated={:.2}MB",
                             task_id,
-                            task.circuit_name,
+                            circuit_name,
                             memory as f64 / (1024.0 * 1024.0)
                         );
 
@@ -378,11 +379,15 @@ impl ChipScheduler {
                             Ok((r, s)) => (r, s),
                             Err(panic_info) => {
                                 let msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
-                                    format!("Worker panicked on task {task_id}: {s}")
+                                    format!(
+                                        "Worker panicked on task {task_id} ({circuit_name}): {s}"
+                                    )
                                 } else if let Some(s) = panic_info.downcast_ref::<String>() {
-                                    format!("Worker panicked on task {task_id}: {s}")
+                                    format!(
+                                        "Worker panicked on task {task_id} ({circuit_name}): {s}"
+                                    )
                                 } else {
-                                    format!("Worker panicked on task {task_id}")
+                                    format!("Worker panicked on task {task_id} ({circuit_name})")
                                 };
                                 tracing::error!("{}", msg);
                                 (
@@ -430,7 +435,8 @@ impl ChipScheduler {
                     let task = pending.remove(vec_idx);
                     let booked_mem = task.estimated_memory_bytes;
                     tracing::info!(
-                        "[scheduler] Launching circuit={}, estimated_mem={:.2}MB, pool_booked={:.2}MB",
+                        "[scheduler] Launching task_id={}, circuit={}, estimated_mem={:.2}MB, pool_booked={:.2}MB",
+                        task.task_id,
                         task.circuit_name,
                         booked_mem as f64 / (1024.0 * 1024.0),
                         mem_pool.get_booked_total() as f64 / (1024.0 * 1024.0)

--- a/ceno_zkvm/src/scheme/scheduler.rs
+++ b/ceno_zkvm/src/scheme/scheduler.rs
@@ -10,6 +10,8 @@
 //! This approach eliminates long-tail latency by prioritizing large tasks and
 //! maximizes GPU utilization through backfilling with smaller tasks.
 
+#[cfg(feature = "gpu")]
+use crate::structs::GpuReplayPlan;
 use crate::{
     error::ZKVMError,
     scheme::{
@@ -66,6 +68,9 @@ pub struct ChipTask<'a, PB: ProverBackend> {
     pub challenges: [PB::E; 2],
     /// Deferred witness extraction: trace index in pcs_data (None if num_witin == 0)
     pub witness_trace_idx: Option<usize>,
+    /// Replay witness directly from shard-resident raw GPU data when available.
+    #[cfg(feature = "gpu")]
+    pub gpu_replay_plan: Option<GpuReplayPlan<PB::E>>,
     /// Expected number of witness polynomials for this circuit
     pub num_witin: usize,
     /// CPU-side structural witness RowMajorMatrix, transported to GPU on-demand

--- a/ceno_zkvm/src/scheme/scheduler.rs
+++ b/ceno_zkvm/src/scheme/scheduler.rs
@@ -346,6 +346,12 @@ impl ChipScheduler {
                         };
                         let memory = task.estimated_memory_bytes;
                         let task_id = task.task_id;
+                        tracing::info!(
+                            "[scheduler] worker starting task {} ({}), estimated={:.2}MB",
+                            task_id,
+                            task.circuit_name,
+                            memory as f64 / (1024.0 * 1024.0)
+                        );
 
                         // Catch panics so a single worker crash doesn't deadlock
                         // the scheduler (which would block forever on done_rx.recv()

--- a/ceno_zkvm/src/scheme/scheduler.rs
+++ b/ceno_zkvm/src/scheme/scheduler.rs
@@ -27,6 +27,8 @@ use p3::field::FieldAlgebra;
 use std::sync::OnceLock;
 use transcript::Transcript;
 static CHIP_PROVING_MODE: OnceLock<ChipProvingMode> = OnceLock::new();
+#[cfg(feature = "gpu")]
+static LARGE_GPU_TASK_BOOKING_MARGIN_MB: OnceLock<u64> = OnceLock::new();
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ChipProvingMode {
@@ -41,6 +43,16 @@ pub fn get_chip_proving_mode() -> ChipProvingMode {
             _ => ChipProvingMode::Concurrent,
         }
     })
+}
+
+#[cfg(feature = "gpu")]
+pub fn large_gpu_task_booking_margin_bytes() -> u64 {
+    *LARGE_GPU_TASK_BOOKING_MARGIN_MB.get_or_init(|| {
+        std::env::var("CENO_GPU_LARGE_TASK_BOOKING_MARGIN_MB")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(1024)
+    }) << 20
 }
 
 #[cfg(feature = "gpu")]
@@ -62,6 +74,8 @@ pub struct ChipTask<'a, PB: ProverBackend> {
     pub input: ProofInput<'static, PB>,
     /// Estimated GPU memory requirement in bytes
     pub estimated_memory_bytes: u64,
+    /// Scheduler-only booked GPU memory in bytes (may include extra concurrency margin)
+    pub booked_memory_bytes: u64,
     /// Whether this circuit has witness or fixed polynomials
     pub has_witness_or_fixed: bool,
     /// Challenges for this proof
@@ -345,6 +359,7 @@ impl ChipScheduler {
                             }
                         };
                         let memory = task.estimated_memory_bytes;
+                        let booked_memory = task.booked_memory_bytes;
                         let task_id = task.task_id;
                         let circuit_name = task.circuit_name.clone();
                         tracing::info!(
@@ -401,7 +416,7 @@ impl ChipScheduler {
 
                         let _ = tx.send(CompletionMessage {
                             result,
-                            memory_reserved: memory,
+                            memory_reserved: booked_memory,
                             task_id,
                             forked_sample,
                         });
@@ -428,16 +443,17 @@ impl ChipScheduler {
                 if tasks_inflight < stream_pool_size
                     && let Some(vec_idx) = pending.iter().position(|task| {
                         mem_pool
-                            .try_book_capacity(task.estimated_memory_bytes)
+                            .try_book_capacity(task.booked_memory_bytes)
                             .is_some()
                     })
                 {
                     let task = pending.remove(vec_idx);
-                    let booked_mem = task.estimated_memory_bytes;
+                    let booked_mem = task.booked_memory_bytes;
                     tracing::info!(
-                        "[scheduler] Launching task_id={}, circuit={}, estimated_mem={:.2}MB, pool_booked={:.2}MB",
+                        "[scheduler] Launching task_id={}, circuit={}, estimated_mem={:.2}MB, booked_mem={:.2}MB, pool_booked={:.2}MB",
                         task.task_id,
                         task.circuit_name,
+                        task.estimated_memory_bytes as f64 / (1024.0 * 1024.0),
                         booked_mem as f64 / (1024.0 * 1024.0),
                         mem_pool.get_booked_total() as f64 / (1024.0 * 1024.0)
                     );
@@ -473,11 +489,12 @@ impl ChipScheduler {
                     );
                     for (i, task) in pending.iter().enumerate() {
                         tracing::error!(
-                            "  task[{}]: id={}, circuit={}, estimated_mem={:.2}MB",
+                            "  task[{}]: id={}, circuit={}, estimated_mem={:.2}MB, booked_mem={:.2}MB",
                             i,
                             task.task_id,
                             task.circuit_name,
                             task.estimated_memory_bytes as f64 / (1024.0 * 1024.0),
+                            task.booked_memory_bytes as f64 / (1024.0 * 1024.0),
                         );
                     }
                     return Err(ZKVMError::BackendError(BackendError::CircuitError(

--- a/ceno_zkvm/src/scheme/tests.rs
+++ b/ceno_zkvm/src/scheme/tests.rs
@@ -258,6 +258,8 @@ fn test_rw_lk_expression_combination() {
             has_witness_or_fixed: true,
             challenges: prover_challenges,
             witness_trace_idx: None,
+            #[cfg(feature = "gpu")]
+            gpu_replay_plan: None,
             num_witin: 0,
             structural_rmm: None,
         };

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -330,6 +330,10 @@ pub struct GpuReplayPlan<E: ExtensionField> {
     // small shape/config metadata. Shared shard state stays resident in the
     // shard-global GPU caches and is rehydrated on worker threads on demand.
     pub step_indices: Arc<[StepIndex]>,
+    // Actual committed/opened witness row height after per-chip padding. This
+    // is not always equal to `step_indices.len()`: rotation-heavy chips like
+    // Keccak expand each logical instance into multiple witness rows.
+    pub trace_height: usize,
     pub num_witin: usize,
     pub num_structural_witin: usize,
     pub shard_offset: u64,
@@ -353,6 +357,7 @@ impl<E: ExtensionField> GpuReplayPlan<E> {
         shard_id: usize,
         kind: crate::instructions::gpu::dispatch::GpuWitgenKind,
         step_indices: Arc<[StepIndex]>,
+        trace_height: usize,
         num_witin: usize,
         num_structural_witin: usize,
         shard_offset: u64,
@@ -367,6 +372,7 @@ impl<E: ExtensionField> GpuReplayPlan<E> {
             trace_idx: None,
             kind,
             step_indices,
+            trace_height,
             num_witin,
             num_structural_witin,
             shard_offset,

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -10,6 +10,8 @@ use crate::{
     },
 };
 use ceno_emul::{Addr, CENO_PLATFORM, Platform, RegIdx, StepIndex, StepRecord, WordAddr};
+#[cfg(feature = "gpu")]
+use ceno_gpu::common::witgen::types::GpuKeccakInstance;
 use ff_ext::{ExtensionField, PoseidonField};
 use gkr_iop::{gkr::GKRCircuit, tables::LookupTable, utils::lk_multiplicity::Multiplicity};
 use itertools::Itertools;
@@ -312,6 +314,73 @@ pub struct ChipInput<E: ExtensionField> {
     pub name: String,
     pub witness_rmms: RMMCollections<E::BaseField>,
     pub num_instances: [usize; 2],
+    // Built after the initial chip witness assignment succeeds. It is not used
+    // by assign_opcode_circuit itself; later prove/open stages use it to
+    // regenerate transient witness buffers from shard-resident raw data.
+    pub gpu_replay_plan: Option<GpuReplayPlan<E>>,
+}
+
+#[cfg(feature = "gpu")]
+#[derive(Clone)]
+pub struct GpuReplayPlan<E: ExtensionField> {
+    pub shard_id: usize,
+    pub trace_idx: Option<usize>,
+    pub kind: crate::instructions::gpu::dispatch::GpuWitgenKind,
+    // Per-chip payload: each replay plan owns only its step-index slice plus
+    // small shape/config metadata. Shared shard state stays resident in the
+    // shard-global GPU caches and is rehydrated on worker threads on demand.
+    pub step_indices: Arc<[StepIndex]>,
+    pub num_witin: usize,
+    pub num_structural_witin: usize,
+    pub shard_offset: u64,
+    pub fetch_base_pc: u32,
+    pub fetch_num_slots: usize,
+    // Keccak replay needs a compact packed-input slice because its kernel does
+    // not consume plain step indices directly. Standard opcode chips leave this
+    // empty and rebuild from resident StepRecord + shard metadata on device.
+    pub keccak_instances: Option<Arc<[GpuKeccakInstance]>>,
+    config_ptr: usize,
+    replay_fn: fn(usize, &GpuReplayPlan<E>) -> Result<RMMCollections<E::BaseField>, ZKVMError>,
+}
+
+#[cfg(not(feature = "gpu"))]
+#[derive(Clone)]
+pub struct GpuReplayPlan<E: ExtensionField>(std::marker::PhantomData<E>);
+
+#[cfg(feature = "gpu")]
+impl<E: ExtensionField> GpuReplayPlan<E> {
+    pub fn new(
+        shard_id: usize,
+        kind: crate::instructions::gpu::dispatch::GpuWitgenKind,
+        step_indices: Arc<[StepIndex]>,
+        num_witin: usize,
+        num_structural_witin: usize,
+        shard_offset: u64,
+        fetch_base_pc: u32,
+        fetch_num_slots: usize,
+        keccak_instances: Option<Arc<[GpuKeccakInstance]>>,
+        config_ptr: usize,
+        replay_fn: fn(usize, &GpuReplayPlan<E>) -> Result<RMMCollections<E::BaseField>, ZKVMError>,
+    ) -> Self {
+        Self {
+            shard_id,
+            trace_idx: None,
+            kind,
+            step_indices,
+            num_witin,
+            num_structural_witin,
+            shard_offset,
+            fetch_base_pc,
+            fetch_num_slots,
+            keccak_instances,
+            config_ptr,
+            replay_fn,
+        }
+    }
+
+    pub fn replay(&self) -> Result<RMMCollections<E::BaseField>, ZKVMError> {
+        (self.replay_fn)(self.config_ptr, self)
+    }
 }
 
 impl<E: ExtensionField> ChipInput<E> {
@@ -324,6 +393,7 @@ impl<E: ExtensionField> ChipInput<E> {
             name,
             witness_rmms,
             num_instances,
+            gpu_replay_plan: None,
         }
     }
 
@@ -391,7 +461,26 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
             structural_instances
         };
         let num_instances = [num_instances, 0];
-        let input = ChipInput::new(OC::name(), witness, num_instances);
+        let mut input = ChipInput::new(OC::name(), witness, num_instances);
+        #[cfg(feature = "gpu")]
+        if crate::instructions::gpu::config::is_gpu_witgen_enabled()
+            && !crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit(
+            )
+            && input.witness_rmms[0].has_device_backing()
+        {
+            // The initial witness assignment already happened above. Building
+            // the replay plan here only records how to reconstruct this chip's
+            // witness later from shard-resident raw data; it is not used during
+            // this first assign pass.
+            input.gpu_replay_plan = OC::build_gpu_replay_plan(
+                config,
+                shard_ctx,
+                cs.zkvm_v1_css.num_witin as usize,
+                cs.zkvm_v1_css.num_structural_witin as usize,
+                shard_steps,
+                indices,
+            );
+        }
         assert!(self.witnesses.insert(OC::name(), vec![input]).is_none());
         assert!(
             self.lk_mlts

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -463,7 +463,8 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
         let num_instances = [num_instances, 0];
         let mut input = ChipInput::new(OC::name(), witness, num_instances);
         #[cfg(feature = "gpu")]
-        if crate::instructions::gpu::config::is_gpu_witgen_enabled()
+        if cs.zkvm_v1_css.num_witin > 0
+            && crate::instructions::gpu::config::is_gpu_witgen_enabled()
             && !crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit(
             )
             && (input.witness_rmms[0].has_device_backing()

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -11,6 +11,8 @@ use crate::{
 };
 use ceno_emul::{Addr, CENO_PLATFORM, Platform, RegIdx, StepIndex, StepRecord, WordAddr};
 #[cfg(feature = "gpu")]
+use ceno_gpu::common::buffer::BufferImpl;
+#[cfg(feature = "gpu")]
 use ceno_gpu::common::witgen::types::GpuKeccakInstance;
 use ff_ext::{ExtensionField, PoseidonField};
 use gkr_iop::{gkr::GKRCircuit, tables::LookupTable, utils::lk_multiplicity::Multiplicity};
@@ -343,6 +345,12 @@ pub struct GpuReplayPlan<E: ExtensionField> {
     // not consume plain step indices directly. Standard opcode chips leave this
     // empty and rebuild from resident StepRecord + shard metadata on device.
     pub keccak_instances: Option<Arc<[GpuKeccakInstance]>>,
+    // Shared-circuit replay keeps a compact owned view of the per-chunk
+    // `GpuShardRamRecord` buffer so ShardRam witness can be rebuilt on demand
+    // without keeping its eager witness/device backing resident.
+    pub shard_ram_records: Option<Arc<BufferImpl<'static, u32>>>,
+    pub shard_ram_num_records: usize,
+    pub shard_ram_num_local_writes: usize,
     config_ptr: usize,
     replay_fn: fn(usize, &GpuReplayPlan<E>) -> Result<RMMCollections<E::BaseField>, ZKVMError>,
 }
@@ -364,6 +372,9 @@ impl<E: ExtensionField> GpuReplayPlan<E> {
         fetch_base_pc: u32,
         fetch_num_slots: usize,
         keccak_instances: Option<Arc<[GpuKeccakInstance]>>,
+        shard_ram_records: Option<Arc<BufferImpl<'static, u32>>>,
+        shard_ram_num_records: usize,
+        shard_ram_num_local_writes: usize,
         config_ptr: usize,
         replay_fn: fn(usize, &GpuReplayPlan<E>) -> Result<RMMCollections<E::BaseField>, ZKVMError>,
     ) -> Self {
@@ -379,6 +390,9 @@ impl<E: ExtensionField> GpuReplayPlan<E> {
             fetch_base_pc,
             fetch_num_slots,
             keccak_instances,
+            shard_ram_records,
+            shard_ram_num_records,
+            shard_ram_num_local_writes,
             config_ptr,
             replay_fn,
         }

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -466,7 +466,10 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
         if crate::instructions::gpu::config::is_gpu_witgen_enabled()
             && !crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit(
             )
-            && input.witness_rmms[0].has_device_backing()
+            && (input.witness_rmms[0].has_device_backing()
+                || (num_instances[0] > 0
+                    && input.witness_rmms[0].num_instances() == 0
+                    && crate::instructions::gpu::config::should_materialize_witness_on_gpu()))
         {
             // The initial witness assignment already happened above. Building
             // the replay plan here only records how to reconstruct this chip's
@@ -479,6 +482,12 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
                 cs.zkvm_v1_css.num_structural_witin as usize,
                 shard_steps,
                 indices,
+            );
+            assert_eq!(
+                input.witness_rmms[0].num_instances(),
+                0,
+                "{}: cache-none GPU replay path must not keep an eager witness RMM after initial assign",
+                OC::name()
             );
         }
         assert!(self.witnesses.insert(OC::name(), vec![input]).is_none());

--- a/ceno_zkvm/src/tables/shard_ram.rs
+++ b/ceno_zkvm/src/tables/shard_ram.rs
@@ -896,6 +896,8 @@ mod tests {
             has_witness_or_fixed: true,
             challenges,
             witness_trace_idx: None,
+            #[cfg(feature = "gpu")]
+            gpu_replay_plan: None,
             num_witin: 0,
             structural_rmm: None,
         };


### PR DESCRIPTION
### summary of data life cycle during entire proving
  - During opcode assignment
      - shard raw GPU state is uploaded / kept resident:
          - StepRecord
          - shard metadata
          - shared shard buffers as needed
      - GPU still runs assignment-time kernels for side effects:
          - LK multiplicity
          - shardram / shared-circuit accumulation
      - witness trace is not kept as an eager RMM anymore
      - per-chip replay plan is recorded
  - During commit_traces
      - no full witness set is resident up front
      - for each trace, deferred commit does:
          - regenerate that chip’s witness/device backing from resident raw shard GPU state
          - commit that one trace
          - drop that transient witness before moving to the next trace
      - after commit finishes, only raw shard GPU state remains resident
  - During per-chip proof
      - before a chip task proves, replay regenerates that chip’s witness/device backing from raw shard GPU state
      - chip proof uses it
      - task-local witness is dropped after that chip finishes
      - raw shard GPU state stays resident across all chip proofs
  - During PCS opening
      - replay regenerates the needed witness/device backing again from raw shard GPU state
      - opening uses it
      - transient witness is dropped afterward
  - At shard end
      - shard raw GPU state is released
      - replay/session metadata is invalidated

  So the intended steady-state invariant is:

  - persistent across shard proof:
      - raw shard GPU state only
  - transient on demand:
      - witness/device backing per trace / per chip / per opening step

  Two nuances:

  - Initial assign still runs GPU kernels because side effects are needed then, but it no longer keeps eager witness RMMs in cache-none mode.
  - The remaining OOM is now later in chip proving, not in commit, which is consistent with this lifecycle shift.



