### PR TITLE
feat: add repo-level CLAUDE.md and shared PR review checklist

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -51,8 +51,12 @@ If there are no findings, state that explicitly and mention residual risks or te
 - Arithmetic and layout correctness (field operations, multilinear indexing, padding/boundary math, off-by-one risks).
 - Performance regressions in proving/verifying hot paths (unnecessary clones, extra allocations, accidental quadratic behavior, synchronization overhead).
 - Architecture integrity across crates (API layering, unnecessary coupling, abstraction leaks).
-- Panic and invariant handling on potentially untrusted proof/input data (`unwrap`, `expect`, indexing, assertions).
+- Panic and invariant handling on potentially untrusted proof/input data (`unwrap`, `expect`, indexing, assertions) — treat panics on proof-derived data in verifier code paths as liveness / DoS findings, not style.
 - Determinism and concurrency risks (parallel iteration order assumptions, shared mutable state).
+
+## Review checklist
+
+Work through `./.github/pr-review-checklist.md` for any PR touching prover/verifier or proof-system code. That file is the canonical, category-by-category checklist (transcript / Fiat–Shamir, sumcheck layer plumbing, PCS openings, determinism, verifier robustness, feature-gate parity, scope) and is shared with `CLAUDE.md` and human reviewers.
 
 ## Testing guidance
 

--- a/.github/pr-review-checklist.md
+++ b/.github/pr-review-checklist.md
@@ -1,0 +1,85 @@
+# Ceno PR review checklist
+
+Shared checklist for humans and AI assistants reviewing PRs in this
+repo. Referenced from `CLAUDE.md` and `.github/copilot-instructions.md`.
+
+Work through these categories for any PR that touches prover/verifier
+or proof-system code. Items are ordered by severity — soundness
+concerns first, style last.
+
+## Asymmetry to keep in mind
+
+A bug in **verifier** (or shared-protocol) code can let an invalid
+proof pass — a soundness break. A bug in **prover**-only code usually
+just fails to produce a valid proof — a liveness failure. Scrutinize
+verifier-side edits more than prover-side edits, and treat any edit to
+verifier code as the highest-scrutiny change in the repo.
+
+"Verifier code" includes the **recursive verifier** in `ceno_recursion/`.
+Recursion compresses many shard proofs into a single smaller proof by
+running a verifier inside another proof, so a bug there can silently
+pass invalid inner proofs through the compressed proof. Same scrutiny
+as the top-level verifier.
+
+**Recursion / native-verifier parity is a review category of its own.**
+Any protocol-level change to the Rust verifier (transcript absorbs,
+challenge derivation, PCS opening points, padding, domain-separation
+tags, field ops) must be mirrored in the recursion circuit, and vice
+versa. If a PR changes one side without the other → blocker. If the
+mirroring is present but the diff makes it hard to see the two sides
+correspond, ask for a before/after correspondence in the description.
+
+## Transcript and Fiat–Shamir
+
+Silent soundness bugs live here.
+
+- New `transcript.append_*` or challenge derivation — prover and
+  verifier must absorb **identical bytes in the same order**. Verify
+  both sides of the diff.
+- New absorb without a domain-separation label → **blocker**.
+- Reordering an existing absorb is a protocol change; blocker unless
+  explicitly intended and called out.
+
+## Sumcheck and GKR layer plumbing
+
+- `running_evals` claim flow is preserved across the edit.
+- Boundary and padding arithmetic holds when chip size or layer count
+  changes (powers of two, selector polynomials).
+- Hypercube variable ordering (LE vs BE) is consistent on prover and
+  verifier sides.
+
+## PCS opening points
+
+- Batched and individual openings match the points the verifier
+  reconstructs.
+- Any change to how opening points are derived is protocol-equivalent
+  to a transcript change and deserves the same scrutiny.
+
+## Determinism on transcript-sensitive paths
+
+- New parallel iteration over `HashMap`, `HashSet`, or otherwise
+  unordered input.
+- Sort-before-hash when input is not already in a canonical order.
+
+## Verifier robustness (liveness / DoS)
+
+- `unwrap`, `expect`, index operator, or `assert!` on proof-derived
+  bytes in verifier code paths → finding.
+- Bounds checks present before indexing into proof-derived arrays.
+
+## Feature-gate and build parity
+
+- Goldilocks field exercised (`cargo make tests_goldilock`).
+- CPU-only build still works after changes to `gkr_iop/src/hal.rs`,
+  layer-prover traits, `gkr_iop/src/cpu`, or `gkr_iop/src/gpu`.
+- New expensive debug assertion gated behind the `sanity-check`
+  feature rather than `debug_assertions`.
+
+## Scope
+
+- Changes to workspace primitives from `scroll-tech/gkr-backend`
+  (`sumcheck`, `transcript`, `mpcs`, `multilinear_extensions`,
+  `ff_ext`, `poseidon`, `p3`, `whir`, `witness`, `sp1-curves`) belong
+  in that repo, not this one.
+- Backwards-compat shims are not accepted; the repo is pre-production
+  and clean edits are preferred.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,134 @@
+# Ceno zkVM — repo guide
+
+Ceno is a **multivariate-polynomial (GKR-based) zkVM for RISC-V** written in
+Rust. A bug in **verifier** code can let an invalid proof pass — a
+soundness break. A bug in **prover** code usually just fails to produce
+a valid proof (a liveness failure, not a soundness one). The verifier
+is the load-bearing side; **soundness and correctness come before
+performance, and performance comes before style**. Don't block on style
+when correctness is at stake; don't trade soundness for a speedup
+without explicit justification.
+
+## Layout
+
+Main crates in this repo:
+
+- `ceno_zkvm/` — main zkVM prover and verifier. Chip circuits, shard
+  orchestration, PCS integration, end-to-end (`bin e2e`).
+- `gkr_iop/` — local GKR circuit framework: `Chip`, `Layer`, zerocheck /
+  sumcheck / linear layer provers, CPU and GPU backends. 
+- `ceno_emul/` — RISC-V emulator (produces traces for the prover).
+- `ceno_recursion/` — recursive proof aggregation stack. Compresses
+  shard proofs by running a verifier inside another proof; treat as
+  verifier code for soundness purposes. **Must stay in lockstep with
+  the native Rust verifier** — any protocol-level change on one side
+  (transcript absorbs, challenge derivation, PCS opening points,
+  padding, domain-separation tags, field ops) needs the mirrored
+  change on the other, or the recursive proof silently verifies a
+  different statement than the Rust verifier.
+- `ceno_cli/` (`cargo ceno …`), `ceno_host/`, `derive/`.
+- `ceno_rt/`, `ceno_serde/` — runtime APIs used **inside guest
+  programs** (the guest Rust code that compiles to the
+  `riscv32im-unknown-none-elf` target).
+- `guest_libs/{crypto,keccak,sha2}/` — Ceno-specific crypto libraries
+  that guest programs call; they route through accelerated precompile
+  paths where available.
+- `examples/` — ~30 example guest programs (fibonacci, keccak,
+  secp256k1, sha256, bn254, …) that exercise the zkVM end-to-end. 
+- `examples-builder/` — build harness for `examples/`.
+
+A few workspace deps used by guest programs (`ceno_crypto_primitives`,
+`ceno_syscall`) live in a separate repo `scroll-tech/ceno-patch`,
+pinned by git branch in the top-level `Cargo.toml` (same pattern as
+`gkr-backend`).
+
+Low-level proof-system primitives (`sumcheck`, `transcript`, `mpcs`,
+`multilinear_extensions`, `ff_ext`, `poseidon`, `p3`, `whir`, `witness`,
+`sp1-curves`) come from a **separate repo**, `scroll-tech/gkr-backend`,
+pinned by git tag in `Cargo.toml`. Edits to those live in that repo, not
+here — don't try to fix upstream primitives by patching in this tree.
+
+## Docs
+
+User-facing mdbook at `docs/src/`. Start with
+`docs/src/architecture-overview.md` (multi-chip architecture +
+segmentation). PIOP appendices cover grand-product, local rotation, and
+EC-sum Quark.
+
+## Toolchain and commands
+
+Pinned to `nightly-2025-11-20` (see `rust-toolchain.toml`), plus the
+`riscv32im-unknown-none-elf` target. `cargo-make` is required.
+
+CI gate (`.github/workflows/lints.yml`, `tests.yml`):
+
+```sh
+cargo fmt --all --check
+cargo check --workspace --all-targets
+cargo check --workspace --all-targets --release
+cargo make clippy                           # clippy --workspace --all-targets -- -D warnings
+cargo clippy --workspace --all-targets --release
+taplo fmt --check --diff
+cargo make tests                            # full test run, RUST_MIN_STACK=33554432
+cargo make tests_goldilock                  # same, --no-default-features --features goldilocks
+```
+
+Before declaring a change done: at minimum run `cargo make clippy` and
+the tests for the crate you touched. For anything in prover/verifier
+code paths, also run `cargo make tests` end-to-end.
+
+## What to prioritize when editing
+
+Verifier code — including the recursive verifier in `ceno_recursion/`
+— is the highest-scrutiny surface in the repo. Spend more thinking
+time per line there than anywhere else; prefer a slow, explicit edit
+over a clever one.
+
+1. **Soundness.** Transcript / challenge order, domain separation,
+   sumcheck claim flow, PCS opening points, padding and boundary
+   arithmetic, hypercube indexing. Break any of these on the verifier
+   (or shared-protocol) side and the proof system is unsound. Re-check
+   the math before any "cleanup" edit in prover/verifier code.
+2. **Determinism.** Parallel iteration order, `HashMap` key order, and
+   anything floating-point are not free. Transcript-sensitive paths
+   must be deterministic across threads and platforms.
+3. **Panics on attacker-controlled input.** `unwrap`, `expect`,
+   indexing, and `assert!` applied to untrusted proof or witness data
+   in **verifier** code paths are liveness/DoS risks (a crafted proof
+   crashes the verifier instead of being cleanly rejected), not style
+   issues.
+4. **Performance in hot paths.** Prover/verifier inner loops — avoid
+   stray `.clone()`, allocations, and accidentally quadratic patterns.
+   Note benchmark impact when editing hot loops.
+5. **Style last.**
+
+## PR review
+
+For any PR review task, follow `.github/copilot-instructions.md` for
+response shape (findings-first, `blocker` / `major` / `minor` tags,
+`path:line` locations) and `.github/pr-review-checklist.md` for the
+concrete category-by-category checklist. The priority list above is
+the filter for what counts as a finding.
+
+## Conventions and gotchas
+
+- **`goldilocks` feature** is a secondary field. Shard-RAM circuits
+  don't currently support it (see commented-out goldilocks lines in
+  `integration.yml`). Don't assume a change works on both fields
+  without running both test suites.
+- **`sanity-check` feature** (in `ceno_zkvm`) is used by integration CI
+  for extra in-prover invariant checks. Prefer gating expensive
+  debug-only assertions behind it over `debug_assertions`.
+- **GPU prover** lives behind the `gpu` feature (and `ceno_gpu` /
+  `cudarc` optional deps in `gkr_iop`). Don't break CPU-only builds
+  when touching backend-abstracted code
+  (`gkr_iop/src/hal.rs`, layer-prover traits, `gkr_iop/src/cpu`,
+  `gkr_iop/src/gpu`).
+- **No backwards-compat shims.** Repo is pre-production (README:
+  "not suitable for use in production"); clean edits beat migration
+  scaffolding.
+- **Don't skip git hooks** (`--no-verify`) or bypass `-D warnings`.
+- **`cargo make` is the source of truth** for test invocations; don't
+  substitute bare `cargo test` when a `cargo make` target exists (it
+  sets `RUST_MIN_STACK` and other env needed to avoid stack overflow
+  in prover code).


### PR DESCRIPTION
## Summary

- `CLAUDE.md`: repo guide covering crate layout, toolchain, edit priorities (soundness first, with verifier code including ceno_recursion as the highest-scrutiny surface), and gotchas.
- `.github/pr-review-checklist.md`: canonical category-by-category review checklist (transcript/Fiat–Shamir, sumcheck plumbing, PCS openings, determinism, verifier robustness, feature parity, recursion/native-verifier parity, scope).
- `.github/copilot-instructions.md`: surface the verifier-vs-prover asymmetry and point to the new shared checklist instead of duplicating it inline.