### PR TITLE
support single-shard e2e verification

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -122,6 +122,11 @@ jobs:
           RUSTFLAGS: "-C opt-level=3"
         run: cargo run --release --package ceno_zkvm --bin e2e -- --platform=ceno --max-cycle-per-shard=1600 examples/target/riscv32im-ceno-zkvm-elf/release/examples/keccak_syscall
 
+      - name: Run multi-shards keccak_syscall single shard-id (release)
+        env:
+          RUSTFLAGS: "-C opt-level=3"
+        run: cargo run --release --package ceno_zkvm --bin e2e -- --platform=ceno --max-cycle-per-shard=1600 --shard-id=1 examples/target/riscv32im-ceno-zkvm-elf/release/examples/keccak_syscall
+
       - name: Run secp256k1_add_syscall (release)
         env:
           RUSTFLAGS: "-C opt-level=3"

--- a/ceno_recursion/src/bin/e2e_aggregate.rs
+++ b/ceno_recursion/src/bin/e2e_aggregate.rs
@@ -106,6 +106,10 @@ struct Args {
     // max cycle per shard
     #[arg(long, default_value = "536870912")] // 536870912 = 2^29
     max_cycle_per_shard: u64,
+
+    /// Restrict proving to a single shard id for debugging.
+    #[arg(long)]
+    shard_id: Option<u64>,
 }
 
 fn main() {
@@ -221,6 +225,7 @@ fn main() {
 
     let max_steps = args.max_steps.unwrap_or(usize::MAX);
     let public_io_digest = public_io_words_to_digest_words(&public_io);
+    let target_shard_id = args.shard_id.map(|v| v as usize);
     let multi_prover = MultiProver::new(
         args.prover_id as usize,
         args.num_provers as usize,
@@ -240,7 +245,7 @@ fn main() {
             public_io_digest,
             max_steps,
             Checkpoint::Complete,
-            None,
+            target_shard_id,
         );
 
     let zkvm_proofs = result

--- a/ceno_zkvm/benches/fibonacci.rs
+++ b/ceno_zkvm/benches/fibonacci.rs
@@ -72,7 +72,7 @@ fn fibonacci_prove(c: &mut Criterion) {
         let verifier = ZKVMVerifier::<E, Pcs>::new(vk);
         assert!(
             verifier
-                .verify_full_trace_proof_halt(proof, transcript, false)
+                .verify_full_trace_proofs_halt(vec![proof], vec![transcript], false)
                 .expect("verify proof return with error"),
         );
         println!();

--- a/ceno_zkvm/benches/fibonacci.rs
+++ b/ceno_zkvm/benches/fibonacci.rs
@@ -72,7 +72,7 @@ fn fibonacci_prove(c: &mut Criterion) {
         let verifier = ZKVMVerifier::<E, Pcs>::new(vk);
         assert!(
             verifier
-                .verify_proof_halt(proof, transcript, false)
+                .verify_full_trace_proof_halt(proof, transcript, false)
                 .expect("verify proof return with error"),
         );
         println!();

--- a/ceno_zkvm/benches/keccak.rs
+++ b/ceno_zkvm/benches/keccak.rs
@@ -69,7 +69,7 @@ fn keccak_prove(c: &mut Criterion) {
     let verifier = ZKVMVerifier::<E, Pcs>::new(vk);
     assert!(
         verifier
-            .verify_proof_halt(proof, transcript, true)
+            .verify_full_trace_proof_halt(proof, transcript, true)
             .expect("verify proof return with error"),
     );
     println!();

--- a/ceno_zkvm/benches/keccak.rs
+++ b/ceno_zkvm/benches/keccak.rs
@@ -69,7 +69,7 @@ fn keccak_prove(c: &mut Criterion) {
     let verifier = ZKVMVerifier::<E, Pcs>::new(vk);
     assert!(
         verifier
-            .verify_full_trace_proof_halt(proof, transcript, true)
+            .verify_full_trace_proofs_halt(vec![proof], vec![transcript], true)
             .expect("verify proof return with error"),
     );
     println!();

--- a/ceno_zkvm/src/bin/e2e.rs
+++ b/ceno_zkvm/src/bin/e2e.rs
@@ -5,7 +5,8 @@ use ceno_zkvm::print_allocated_bytes;
 use ceno_zkvm::{
     e2e::{
         Checkpoint, FieldType, MultiProver, PcsKind, Preset, public_io_words_to_digest_words,
-        run_e2e_with_checkpoint, setup_platform, setup_platform_debug, verify,
+        run_e2e_full_trace_verify, run_e2e_single_shard_debug_verify, run_e2e_with_checkpoint,
+        setup_platform, setup_platform_debug,
     },
     scheme::{
         ZKVMProof, constants::MAX_NUM_VARIABLES, create_backend, create_prover, hal::ProverDevice,
@@ -350,10 +351,18 @@ fn run_inner<
     let vk_bytes = bincode::serialize(&vk).unwrap();
     fs::write(&vk_file, vk_bytes).unwrap();
 
-    if checkpoint > Checkpoint::PrepVerify && (target_shard_id.is_none() || zkvm_proofs.len() == 1)
-    {
+    if checkpoint > Checkpoint::PrepVerify {
         let verifier = ZKVMVerifier::new(vk);
-        verify(zkvm_proofs.clone(), &verifier).expect("Verification failed");
+        if target_shard_id.is_some() {
+            run_e2e_single_shard_debug_verify(
+                &verifier,
+                zkvm_proofs.first().cloned().expect("missing shard proof"),
+                None,
+                max_steps,
+            );
+        } else {
+            run_e2e_full_trace_verify(&verifier, zkvm_proofs.clone(), None, max_steps);
+        }
         soundness_test(zkvm_proofs.first().cloned().unwrap(), &verifier);
     }
 }

--- a/ceno_zkvm/src/bin/e2e.rs
+++ b/ceno_zkvm/src/bin/e2e.rs
@@ -350,7 +350,8 @@ fn run_inner<
     let vk_bytes = bincode::serialize(&vk).unwrap();
     fs::write(&vk_file, vk_bytes).unwrap();
 
-    if checkpoint > Checkpoint::PrepVerify && target_shard_id.is_none() {
+    if checkpoint > Checkpoint::PrepVerify && (target_shard_id.is_none() || zkvm_proofs.len() == 1)
+    {
         let verifier = ZKVMVerifier::new(vk);
         verify(zkvm_proofs.clone(), &verifier).expect("Verification failed");
         soundness_test(zkvm_proofs.first().cloned().unwrap(), &verifier);

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1759,8 +1759,10 @@ pub fn run_e2e_with_checkpoint<
         &init_full_mem,
     );
 
-    if target_shard_id.is_some() {
-        // skip verify as the proof are in-completed
+    let can_verify_target_shard = target_shard_id.is_none() || zkvm_proofs.len() == 1;
+    if !can_verify_target_shard {
+        // Partial multi-shard subsets still skip verification because the
+        // continuation chain between omitted shards is unavailable.
         return E2ECheckpointResult {
             proofs: Some(zkvm_proofs),
             vk: Some(vk),
@@ -1775,13 +1777,25 @@ pub fn run_e2e_with_checkpoint<
             proofs: Some(zkvm_proofs.clone()),
             vk: Some(vk),
             next_step: Some(Box::new(move || {
-                run_e2e_verify(&verifier, zkvm_proofs, exit_code, max_steps)
+                run_e2e_verify(
+                    &verifier,
+                    zkvm_proofs,
+                    exit_code,
+                    max_steps,
+                    target_shard_id,
+                )
             })),
         };
     }
 
     let start = std::time::Instant::now();
-    run_e2e_verify(&verifier, zkvm_proofs.clone(), exit_code, max_steps);
+    run_e2e_verify(
+        &verifier,
+        zkvm_proofs.clone(),
+        exit_code,
+        max_steps,
+        target_shard_id,
+    );
     tracing::debug!("verified in {:?}", start.elapsed());
 
     E2ECheckpointResult {
@@ -2023,15 +2037,29 @@ pub fn run_e2e_verify<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
     zkvm_proofs: Vec<ZKVMProof<E, PCS>>,
     exit_code: Option<u32>,
     max_steps: usize,
+    target_shard_id: Option<usize>,
 ) {
     let transcripts = (0..zkvm_proofs.len())
         .map(|_| Transcript::new(b"riscv"))
         .collect_vec();
-    assert!(
+    let expect_halt = zkvm_proofs
+        .last()
+        .map(|proof| proof.has_halt(&verifier.vk))
+        .unwrap_or(exit_code.is_some());
+    let verified = if target_shard_id.is_some() && zkvm_proofs.len() == 1 {
         verifier
-            .verify_proofs_halt(zkvm_proofs, transcripts, exit_code.is_some())
-            .expect("verify proof return with error"),
-    );
+            .verify_shard_proof_halt(
+                zkvm_proofs.into_iter().next().unwrap(),
+                transcripts.into_iter().next().unwrap(),
+                expect_halt,
+            )
+            .expect("verify proof return with error")
+    } else {
+        verifier
+            .verify_proofs_halt(zkvm_proofs, transcripts, expect_halt)
+            .expect("verify proof return with error")
+    };
+    assert!(verified);
     match exit_code {
         Some(0) => tracing::info!("exit code 0. Success."),
         Some(code) => tracing::error!("exit code {}. Failure.", code),
@@ -2099,11 +2127,19 @@ pub fn verify<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + serde::Ser
     {
         Instrumented::<<<E as ExtensionField>::BaseField as PoseidonField>::P>::clear_metrics();
     }
-    let transcripts = (0..zkvm_proofs.len())
-        .map(|_| Transcript::new(b"riscv"))
-        .collect_vec();
     let has_halt = zkvm_proofs.last().unwrap().has_halt(&verifier.vk);
-    verifier.verify_proofs_halt(zkvm_proofs, transcripts, has_halt)?;
+    if zkvm_proofs.len() == 1 {
+        verifier.verify_shard_proof_halt(
+            zkvm_proofs.into_iter().next().unwrap(),
+            Transcript::new(b"riscv"),
+            has_halt,
+        )?;
+    } else {
+        let transcripts = (0..zkvm_proofs.len())
+            .map(|_| Transcript::new(b"riscv"))
+            .collect_vec();
+        verifier.verify_proofs_halt(zkvm_proofs, transcripts, has_halt)?;
+    }
     // print verification statistics such as hash count
     #[cfg(debug_assertions)]
     {

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1759,15 +1759,12 @@ pub fn run_e2e_with_checkpoint<
         &init_full_mem,
     );
 
-    let can_verify_target_shard = target_shard_id.is_none() || zkvm_proofs.len() == 1;
-    if !can_verify_target_shard {
-        // Partial multi-shard subsets still skip verification because the
-        // continuation chain between omitted shards is unavailable.
-        return E2ECheckpointResult {
-            proofs: Some(zkvm_proofs),
-            vk: Some(vk),
-            next_step: None,
-        };
+    if let Some(target_shard_id) = target_shard_id {
+        assert_eq!(
+            zkvm_proofs.len(),
+            1,
+            "debug --shard-id={target_shard_id} must produce exactly one proof",
+        );
     }
 
     let verifier = ZKVMVerifier::new(vk.clone());
@@ -1776,26 +1773,32 @@ pub fn run_e2e_with_checkpoint<
         return E2ECheckpointResult {
             proofs: Some(zkvm_proofs.clone()),
             vk: Some(vk),
-            next_step: Some(Box::new(move || {
-                run_e2e_verify(
+            next_step: Some(Box::new(move || match target_shard_id {
+                Some(_) => run_e2e_single_shard_debug_verify(
                     &verifier,
-                    zkvm_proofs,
+                    zkvm_proofs.into_iter().next().expect("missing shard proof"),
                     exit_code,
                     max_steps,
-                    target_shard_id,
-                )
+                ),
+                None => run_e2e_full_trace_verify(&verifier, zkvm_proofs, exit_code, max_steps),
             })),
         };
     }
 
     let start = std::time::Instant::now();
-    run_e2e_verify(
-        &verifier,
-        zkvm_proofs.clone(),
-        exit_code,
-        max_steps,
-        target_shard_id,
-    );
+    match target_shard_id {
+        Some(_) => run_e2e_single_shard_debug_verify(
+            &verifier,
+            zkvm_proofs
+                .clone()
+                .into_iter()
+                .next()
+                .expect("missing shard proof"),
+            exit_code,
+            max_steps,
+        ),
+        None => run_e2e_full_trace_verify(&verifier, zkvm_proofs.clone(), exit_code, max_steps),
+    }
     tracing::debug!("verified in {:?}", start.elapsed());
 
     E2ECheckpointResult {
@@ -2032,12 +2035,15 @@ fn create_proofs_streaming<
     proofs
 }
 
-pub fn run_e2e_verify<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
+/// Verify the full produced trace in the normal e2e flow.
+///
+/// This is the production-style verification path used when e2e is not scoped
+/// to a debug `--shard-id` run.
+pub fn run_e2e_full_trace_verify<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
     verifier: &ZKVMVerifier<E, PCS>,
     zkvm_proofs: Vec<ZKVMProof<E, PCS>>,
     exit_code: Option<u32>,
     max_steps: usize,
-    target_shard_id: Option<usize>,
 ) {
     let transcripts = (0..zkvm_proofs.len())
         .map(|_| Transcript::new(b"riscv"))
@@ -2046,19 +2052,31 @@ pub fn run_e2e_verify<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
         .last()
         .map(|proof| proof.has_halt(&verifier.vk))
         .unwrap_or(exit_code.is_some());
-    let verified = if target_shard_id.is_some() && zkvm_proofs.len() == 1 {
-        verifier
-            .verify_shard_proof_halt(
-                zkvm_proofs.into_iter().next().unwrap(),
-                transcripts.into_iter().next().unwrap(),
-                expect_halt,
-            )
-            .expect("verify proof return with error")
-    } else {
-        verifier
-            .verify_proofs_halt(zkvm_proofs, transcripts, expect_halt)
-            .expect("verify proof return with error")
-    };
+    let verified = verifier
+        .verify_full_trace_proofs_halt(zkvm_proofs, transcripts, expect_halt)
+        .expect("verify proof return with error");
+    assert!(verified);
+    match exit_code {
+        Some(0) => tracing::info!("exit code 0. Success."),
+        Some(code) => tracing::error!("exit code {}. Failure.", code),
+        None => tracing::error!("Unfinished execution. max_steps={:?}.", max_steps),
+    }
+}
+
+/// Verify a single produced shard as a standalone debug segment.
+///
+/// This path is only for explicit e2e `--shard-id` runs where exactly one proof
+/// is produced. It intentionally does not claim full-trace verification.
+pub fn run_e2e_single_shard_debug_verify<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
+    verifier: &ZKVMVerifier<E, PCS>,
+    zkvm_proof: ZKVMProof<E, PCS>,
+    exit_code: Option<u32>,
+    max_steps: usize,
+) {
+    let expect_halt = zkvm_proof.has_halt(&verifier.vk) || exit_code.is_some();
+    let verified = verifier
+        .verify_single_shard_segment_halt(zkvm_proof, Transcript::new(b"riscv"), expect_halt)
+        .expect("verify proof return with error");
     assert!(verified);
     match exit_code {
         Some(0) => tracing::info!("exit code 0. Success."),
@@ -2129,7 +2147,7 @@ pub fn verify<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + serde::Ser
     }
     let has_halt = zkvm_proofs.last().unwrap().has_halt(&verifier.vk);
     if zkvm_proofs.len() == 1 {
-        verifier.verify_shard_proof_halt(
+        verifier.verify_full_trace_proof_halt(
             zkvm_proofs.into_iter().next().unwrap(),
             Transcript::new(b"riscv"),
             has_halt,
@@ -2138,7 +2156,7 @@ pub fn verify<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + serde::Ser
         let transcripts = (0..zkvm_proofs.len())
             .map(|_| Transcript::new(b"riscv"))
             .collect_vec();
-        verifier.verify_proofs_halt(zkvm_proofs, transcripts, has_halt)?;
+        verifier.verify_full_trace_proofs_halt(zkvm_proofs, transcripts, has_halt)?;
     }
     // print verification statistics such as hash count
     #[cfg(debug_assertions)]

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -2146,18 +2146,10 @@ pub fn verify<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + serde::Ser
         Instrumented::<<<E as ExtensionField>::BaseField as PoseidonField>::P>::clear_metrics();
     }
     let has_halt = zkvm_proofs.last().unwrap().has_halt(&verifier.vk);
-    if zkvm_proofs.len() == 1 {
-        verifier.verify_full_trace_proof_halt(
-            zkvm_proofs.into_iter().next().unwrap(),
-            Transcript::new(b"riscv"),
-            has_halt,
-        )?;
-    } else {
-        let transcripts = (0..zkvm_proofs.len())
-            .map(|_| Transcript::new(b"riscv"))
-            .collect_vec();
-        verifier.verify_full_trace_proofs_halt(zkvm_proofs, transcripts, has_halt)?;
-    }
+    let transcripts = (0..zkvm_proofs.len())
+        .map(|_| Transcript::new(b"riscv"))
+        .collect_vec();
+    verifier.verify_full_trace_proofs_halt(zkvm_proofs, transcripts, has_halt)?;
     // print verification statistics such as hash count
     #[cfg(debug_assertions)]
     {

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -121,6 +121,35 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         self.verify_proofs_halt(vec![vm_proof], vec![transcript], expect_halt)
     }
 
+    /// Verify a single shard proof as a standalone segment.
+    ///
+    /// Unlike `verify_proof_halt`, this checks proof validity and halt/segment
+    /// invariants for one shard only and intentionally skips cross-shard
+    /// continuation checks such as init_pc/heap chaining.
+    pub fn verify_shard_proof_halt(
+        &self,
+        vm_proof: ZKVMProof<E, PCS>,
+        transcript: impl ForkableTranscript<E>,
+        expect_halt: bool,
+    ) -> Result<bool, ZKVMError> {
+        let has_halt = vm_proof.has_halt(&self.vk);
+        if has_halt != expect_halt {
+            return Err(ZKVMError::VerifyError(
+                format!("shard proof ecall/halt mismatch: expected {expect_halt} != {has_halt}",)
+                    .into(),
+            ));
+        }
+
+        assert_eq!(
+            vm_proof.public_values.query_by_index::<E>(INIT_CYCLE_IDX),
+            E::BaseField::from_canonical_u64(Tracer::SUBCYCLES_PER_INSN)
+        );
+
+        let shard_id = vm_proof.public_values.shard_id as usize;
+        self.verify_proof_validity(shard_id, vm_proof, transcript)?;
+        Ok(true)
+    }
+
     /// Verify a trace from start to optional halt.
     pub fn verify_proofs_halt(
         &self,
@@ -237,8 +266,15 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
             }
         }
 
-        // check shard id
-        assert_eq!(vm_proof.public_values.shard_id, shard_id as u32);
+        if vm_proof.public_values.shard_id != shard_id as u32 {
+            return Err(ZKVMError::VerifyError(
+                format!(
+                    "proof shard_id mismatch: expected {} != {}",
+                    shard_id, vm_proof.public_values.shard_id
+                )
+                .into(),
+            ));
+        }
 
         // write fixed commitment to transcript
         // TODO check soundness if there is no fixed_commit but got fixed proof?

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -103,7 +103,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         vm_proof: ZKVMProof<E, PCS>,
         transcript: impl ForkableTranscript<E>,
     ) -> Result<bool, ZKVMError> {
-        self.verify_full_trace_proof_halt(vm_proof, transcript, true)
+        self.verify_full_trace_proofs_halt(vec![vm_proof], vec![transcript], true)
     }
 
     /// Verify a full zkVM trace composed of one or more proofs and ending in halt.
@@ -114,19 +114,6 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         transcripts: Vec<impl ForkableTranscript<E>>,
     ) -> Result<bool, ZKVMError> {
         self.verify_full_trace_proofs_halt(vm_proofs, transcripts, true)
-    }
-
-    /// Verify a full zkVM trace from program entry to optional halt.
-    ///
-    /// This enforces first-shard entry semantics and, for multi-shard traces,
-    /// cross-shard continuation semantics.
-    pub fn verify_full_trace_proof_halt(
-        &self,
-        vm_proof: ZKVMProof<E, PCS>,
-        transcript: impl ForkableTranscript<E>,
-        expect_halt: bool,
-    ) -> Result<bool, ZKVMError> {
-        self.verify_full_trace_proofs_halt(vec![vm_proof], vec![transcript], expect_halt)
     }
 
     /// Verify a single shard proof as a standalone segment.

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -122,7 +122,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
     /// invariants for one shard only and intentionally skips full-trace entry
     /// and cross-shard continuation checks such as `INIT_PC == vk.entry_pc` and
     /// init_pc/heap chaining.
-    pub fn verify_single_shard_segment_halt(
+    pub(crate) fn verify_single_shard_segment_halt(
         &self,
         vm_proof: ZKVMProof<E, PCS>,
         transcript: impl ForkableTranscript<E>,

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -92,41 +92,50 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         self.vk
     }
 
-    /// Verify a trace from start to halt.
+    /// Verify a full zkVM trace from program entry to halt.
+    ///
+    /// This is the production verifier API. It treats a single proof as a
+    /// complete trace starting from `vk.entry_pc`, not as an arbitrary shard
+    /// segment.
     #[tracing::instrument(skip_all, name = "verify_proof")]
     pub fn verify_proof(
         &self,
         vm_proof: ZKVMProof<E, PCS>,
         transcript: impl ForkableTranscript<E>,
     ) -> Result<bool, ZKVMError> {
-        self.verify_proof_halt(vm_proof, transcript, true)
+        self.verify_full_trace_proof_halt(vm_proof, transcript, true)
     }
 
+    /// Verify a full zkVM trace composed of one or more proofs and ending in halt.
     #[tracing::instrument(skip_all, name = "verify_proofs")]
     pub fn verify_proofs(
         &self,
         vm_proofs: Vec<ZKVMProof<E, PCS>>,
         transcripts: Vec<impl ForkableTranscript<E>>,
     ) -> Result<bool, ZKVMError> {
-        self.verify_proofs_halt(vm_proofs, transcripts, true)
+        self.verify_full_trace_proofs_halt(vm_proofs, transcripts, true)
     }
 
-    /// Verify a trace from start to optional halt.
-    pub fn verify_proof_halt(
+    /// Verify a full zkVM trace from program entry to optional halt.
+    ///
+    /// This enforces first-shard entry semantics and, for multi-shard traces,
+    /// cross-shard continuation semantics.
+    pub fn verify_full_trace_proof_halt(
         &self,
         vm_proof: ZKVMProof<E, PCS>,
         transcript: impl ForkableTranscript<E>,
         expect_halt: bool,
     ) -> Result<bool, ZKVMError> {
-        self.verify_proofs_halt(vec![vm_proof], vec![transcript], expect_halt)
+        self.verify_full_trace_proofs_halt(vec![vm_proof], vec![transcript], expect_halt)
     }
 
     /// Verify a single shard proof as a standalone segment.
     ///
-    /// Unlike `verify_proof_halt`, this checks proof validity and halt/segment
-    /// invariants for one shard only and intentionally skips cross-shard
-    /// continuation checks such as init_pc/heap chaining.
-    pub fn verify_shard_proof_halt(
+    /// This is a debug-oriented API. It checks proof validity and halt/segment
+    /// invariants for one shard only and intentionally skips full-trace entry
+    /// and cross-shard continuation checks such as `INIT_PC == vk.entry_pc` and
+    /// init_pc/heap chaining.
+    pub fn verify_single_shard_segment_halt(
         &self,
         vm_proof: ZKVMProof<E, PCS>,
         transcript: impl ForkableTranscript<E>,
@@ -150,8 +159,9 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         Ok(true)
     }
 
-    /// Verify a trace from start to optional halt.
-    pub fn verify_proofs_halt(
+    /// Verify a full zkVM trace composed of one or more proofs from entry to
+    /// optional halt.
+    pub fn verify_full_trace_proofs_halt(
         &self,
         vm_proofs: Vec<ZKVMProof<E, PCS>>,
         transcripts: Vec<impl ForkableTranscript<E>>,


### PR DESCRIPTION
## Problem

`e2e` skipped verification whenever `--shard-id` was set, even when only a single shard proof was produced. That blocked valid single-shard debugging and validation flows.

## Design Rationale

Treat single-shard verification as proof-soundness verification, not full continuation-chain verification. Verify the shard proof itself and halt invariants, but keep cross-shard continuation checks only for multi-shard proof sets.

## Change Highlights

- `ceno_zkvm`: add standalone single-shard verifier path and route single-proof `--shard-id` e2e runs through it
- `ceno_zkvm`: keep partial multi-shard subsets on the existing skip-verify behavior
- `ceno_recursion`: add `--shard-id` plumbing to `e2e_aggregate` so single-shard aggregation can be exercised directly

## Benchmark / Performance Impact

No intended performance change. This PR changes verification gating/semantics for the single-shard debug path only.
## Testing

```sh
cargo check -p ceno_zkvm -p ceno_recursion --bins --release
cargo run --config net.git-fetch-with-cli=true --release --package ceno_zkvm --bin e2e -- --platform=ceno --max-cycle-per-shard=1600 --shard-id=0 examples/target/riscv32im-ceno-zkvm-elf/release/examples/keccak_syscall
RUST_MIN_STACK=33554432 cargo run --release --package ceno_recursion --bin e2e_aggregate -- --platform=ceno --max-cycle-per-shard=1600 --shard-id=0 examples/target/riscv32im-ceno-zkvm-elf/release/examples/keccak_syscall
```

## Risks and Rollout

Main risk is semantic confusion between standalone shard verification and full multi-shard continuation verification. This PR keeps those paths separate: single-shard verifies proof validity only, while multi-shard still owns continuation checks.

## Follow-ups (optional)

None.

## Copilot Reviewer Directive (keep this section)

When Copilot reviews this PR, apply `.github/copilot-instructions.md` strictly.