### PR TITLE
feat(verifier): commit terminal mode on verifier instance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,11 +82,12 @@ code paths, also run `cargo make tests` end-to-end.
 What a valid Ceno proof attests to depends on the **verifier mode**,
 committed at verifier construction and not derived from the proof:
 
-- **FullRun** — trace from `vk.entry_pc` to halt. Production default.
+- **FullRun** — trace from `vk.entry_pc` to halt with `exit_code == 0`.
+  Production default.
 - **PrefixRun** — trace from `vk.entry_pc` that stopped at a step
-  budget; last-shard halt not checked. Dev/bench only.
-- **DebugSegment** — one shard at any position; skips entry-PC and
-  chain checks. Dev only.
+  budget; last-shard halt and exit code not checked. Dev/bench only.
+- **DebugSegment** — one shard at any position; skips entry-PC, chain,
+  halt, and exit-code checks. Dev only.
 
 Only `PrefixRun` / `DebugSegment` callers opt in via `new_with_mode`;
 non-`FullRun` proofs must not be exposed to external consumers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,38 +80,19 @@ code paths, also run `cargo make tests` end-to-end.
 ## Verifier semantic contract
 
 What a valid Ceno proof attests to depends on the **verifier mode**,
-which is committed at verifier construction and *not* derived from
-the proof (so a prover cannot influence which statement is verified).
-The mode lives on the verifier instance and drives the halt /
-continuity checks inside the single unified verification entry
-point. Three modes exist:
+committed at verifier construction and not derived from the proof:
 
-- **FullRun** — full trace from `vk.entry_pc` to program halt.
-  Intermediate shards must not halt; the last shard must halt. This
-  is the production mode and the default of the verifier
-  constructor. The recursive verifier in `ceno_recursion/` always
-  runs an inner verifier in this mode.
-- **PrefixRun** — full trace from `vk.entry_pc` that stopped at a
-  step budget. Intermediate shards must not halt; the last shard's
-  halt status is not checked. Dev / benchmarking only.
-- **DebugSegment** — single-shard standalone verification
-  (`--shard-id=N`). Accepts one shard at any position in the run;
-  skips entry-PC and cross-shard chain checks; reads the shard id
-  from the proof's public values. Dev only.
+- **FullRun** — trace from `vk.entry_pc` to halt. Production default.
+- **PrefixRun** — trace from `vk.entry_pc` that stopped at a step
+  budget; last-shard halt not checked. Dev/bench only.
+- **DebugSegment** — one shard at any position; skips entry-PC and
+  chain checks. Dev only.
 
-`FullRun` is the production-safe default; only `PrefixRun` /
-`DebugSegment` callers opt in via `new_with_mode`. The program-level
-statement any mode attests to always includes "execution starts at
-`vk.entry_pc`" (FullRun / PrefixRun only — DebugSegment has no entry
-constraint). A change that weakens any mode's statement — removing
-the entry-PC check, letting intermediate shards halt, making the
-mode prover-derived, etc. — is a blocker by default. See
-`docs/src/technical-overview.md` for the long form.
-
-Non-halt-mode proofs are a dev/bench affordance, not a production
-surface — don't wire them into anything external without first
-hardening the non-halting-shard public values to the halt-path
-standard.
+Only `PrefixRun` / `DebugSegment` callers opt in via `new_with_mode`;
+non-`FullRun` proofs must not be exposed to external consumers.
+Weakening any mode's statement (dropping the entry-PC check, letting
+intermediate shards halt, making the mode prover-derived, etc.) is a
+blocker by default.
 
 ## What to prioritize when editing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,20 +79,38 @@ code paths, also run `cargo make tests` end-to-end.
 
 ## Verifier semantic contract
 
-A valid Ceno proof attests to exactly two program-level facts:
-**execution starts at the verifying key's entry PC**, and
-**execution exits with code zero**. Everything else in the verifier
-(transcript, sumcheck, PCS, tower/GKR, shard EC sum) is plumbing that
-makes those two statements meaningful. The caller-supplied "expect
-halt" flag picks the terminal mode (full run vs. prefix run); the
-exit-code-zero invariant holds in both, and the halt-ecall presence
-must match what the caller declared. A change that relaxes either
-statement is a blocker. See `docs/src/technical-overview.md` for the
-long form.
+What a valid Ceno proof attests to depends on the **verifier mode**,
+which is committed at verifier construction and *not* derived from
+the proof (so a prover cannot influence which statement is verified).
+The mode lives on the verifier instance and drives the halt /
+continuity checks inside the single unified verification entry
+point. Three modes exist:
 
-Prefix proofs (expect-halt = false) are a dev/bench affordance, not
-a production surface — don't wire them into anything external without
-first bringing the non-halting-shard public values up to the halt-path
+- **FullRun** — full trace from `vk.entry_pc` to program halt.
+  Intermediate shards must not halt; the last shard must halt. This
+  is the production mode and the default of the verifier
+  constructor. The recursive verifier in `ceno_recursion/` always
+  runs an inner verifier in this mode.
+- **PrefixRun** — full trace from `vk.entry_pc` that stopped at a
+  step budget. Intermediate shards must not halt; the last shard's
+  halt status is not checked. Dev / benchmarking only.
+- **DebugSegment** — single-shard standalone verification
+  (`--shard-id=N`). Accepts one shard at any position in the run;
+  skips entry-PC and cross-shard chain checks; reads the shard id
+  from the proof's public values. Dev only.
+
+`FullRun` is the production-safe default; only `PrefixRun` /
+`DebugSegment` callers opt in via `new_with_mode`. The program-level
+statement any mode attests to always includes "execution starts at
+`vk.entry_pc`" (FullRun / PrefixRun only — DebugSegment has no entry
+constraint). A change that weakens any mode's statement — removing
+the entry-PC check, letting intermediate shards halt, making the
+mode prover-derived, etc. — is a blocker by default. See
+`docs/src/technical-overview.md` for the long form.
+
+Non-halt-mode proofs are a dev/bench affordance, not a production
+surface — don't wire them into anything external without first
+hardening the non-halting-shard public values to the halt-path
 standard.
 
 ## What to prioritize when editing

--- a/ceno_zkvm/benches/fibonacci.rs
+++ b/ceno_zkvm/benches/fibonacci.rs
@@ -13,7 +13,10 @@ use criterion::*;
 use ff_ext::BabyBearExt4;
 use gkr_iop::cpu::default_backend_config;
 
-use ceno_zkvm::{e2e::MultiProver, scheme::verifier::ZKVMVerifier};
+use ceno_zkvm::{
+    e2e::MultiProver,
+    scheme::verifier::{VerifierMode, ZKVMVerifier},
+};
 use mpcs::BasefoldDefault;
 use transcript::BasicTranscript;
 
@@ -69,10 +72,10 @@ fn fibonacci_prove(c: &mut Criterion) {
 
         println!("e2e proof {}", proof);
         let transcript = BasicTranscript::new(b"riscv");
-        let verifier = ZKVMVerifier::<E, Pcs>::new(vk);
+        let verifier = ZKVMVerifier::<E, Pcs>::new_with_mode(vk, VerifierMode::PrefixRun);
         assert!(
             verifier
-                .verify_full_trace_proofs_halt(vec![proof], vec![transcript], false)
+                .verify_proofs(vec![proof], vec![transcript])
                 .expect("verify proof return with error"),
         );
         println!();

--- a/ceno_zkvm/benches/keccak.rs
+++ b/ceno_zkvm/benches/keccak.rs
@@ -69,7 +69,7 @@ fn keccak_prove(c: &mut Criterion) {
     let verifier = ZKVMVerifier::<E, Pcs>::new(vk);
     assert!(
         verifier
-            .verify_full_trace_proofs_halt(vec![proof], vec![transcript], true)
+            .verify_proofs(vec![proof], vec![transcript])
             .expect("verify proof return with error"),
     );
     println!();

--- a/ceno_zkvm/src/bin/e2e.rs
+++ b/ceno_zkvm/src/bin/e2e.rs
@@ -5,12 +5,13 @@ use ceno_zkvm::print_allocated_bytes;
 use ceno_zkvm::{
     e2e::{
         Checkpoint, FieldType, MultiProver, PcsKind, Preset, public_io_words_to_digest_words,
-        run_e2e_full_trace_verify, run_e2e_single_shard_debug_verify, run_e2e_with_checkpoint,
+        run_e2e_verify, run_e2e_with_checkpoint,
         setup_platform, setup_platform_debug,
     },
     scheme::{
         ZKVMProof, constants::MAX_NUM_VARIABLES, create_backend, create_prover, hal::ProverDevice,
-        mock_prover::LkMultiplicityKey, verifier::ZKVMVerifier,
+        mock_prover::LkMultiplicityKey,
+        verifier::{VerifierMode, ZKVMVerifier},
     },
     with_panic_hook,
 };
@@ -352,17 +353,15 @@ fn run_inner<
     fs::write(&vk_file, vk_bytes).unwrap();
 
     if checkpoint > Checkpoint::PrepVerify {
-        let verifier = ZKVMVerifier::new(vk);
-        if target_shard_id.is_some() {
-            run_e2e_single_shard_debug_verify(
-                &verifier,
-                zkvm_proofs.first().cloned().expect("missing shard proof"),
-                None,
-                max_steps,
-            );
+        // `target_shard_id.is_some()` => debug single-shard path; otherwise
+        // this binary has no exit code to pin, so treat as prefix run.
+        let mode = if target_shard_id.is_some() {
+            VerifierMode::DebugSegment
         } else {
-            run_e2e_full_trace_verify(&verifier, zkvm_proofs.clone(), None, max_steps);
-        }
+            VerifierMode::PrefixRun
+        };
+        let verifier = ZKVMVerifier::new_with_mode(vk, mode);
+        run_e2e_verify(&verifier, zkvm_proofs.clone(), None, max_steps);
         soundness_test(zkvm_proofs.first().cloned().unwrap(), &verifier);
     }
 }

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -10,7 +10,7 @@ use crate::{
         mock_prover::{LkMultiplicityKey, MockProver},
         prover::ZKVMProver,
         septic_curve::SepticPoint,
-        verifier::ZKVMVerifier,
+        verifier::{VerifierMode, ZKVMVerifier},
     },
     structs::{
         ProgramParams, ZKVMConstraintSystem, ZKVMFixedTraces, ZKVMProvingKey, ZKVMVerifyingKey,
@@ -1767,38 +1767,31 @@ pub fn run_e2e_with_checkpoint<
         );
     }
 
-    let verifier = ZKVMVerifier::new(vk.clone());
+    // Commit to the verifier's statement at construction time using the
+    // caller's out-of-band knowledge (--shard-id / max-steps outcome), NOT
+    // anything the prover sent. This prevents the prover from influencing
+    // which statement the verifier enforces.
+    let mode = if target_shard_id.is_some() {
+        VerifierMode::DebugSegment
+    } else if exit_code.is_some() {
+        VerifierMode::FullRun
+    } else {
+        VerifierMode::PrefixRun
+    };
+    let verifier = ZKVMVerifier::new_with_mode(vk.clone(), mode);
 
     if let Checkpoint::PrepVerify = checkpoint {
         return E2ECheckpointResult {
             proofs: Some(zkvm_proofs.clone()),
             vk: Some(vk),
-            next_step: Some(Box::new(move || match target_shard_id {
-                Some(_) => run_e2e_single_shard_debug_verify(
-                    &verifier,
-                    zkvm_proofs.into_iter().next().expect("missing shard proof"),
-                    exit_code,
-                    max_steps,
-                ),
-                None => run_e2e_full_trace_verify(&verifier, zkvm_proofs, exit_code, max_steps),
+            next_step: Some(Box::new(move || {
+                run_e2e_verify(&verifier, zkvm_proofs, exit_code, max_steps)
             })),
         };
     }
 
     let start = std::time::Instant::now();
-    match target_shard_id {
-        Some(_) => run_e2e_single_shard_debug_verify(
-            &verifier,
-            zkvm_proofs
-                .clone()
-                .into_iter()
-                .next()
-                .expect("missing shard proof"),
-            exit_code,
-            max_steps,
-        ),
-        None => run_e2e_full_trace_verify(&verifier, zkvm_proofs.clone(), exit_code, max_steps),
-    }
+    run_e2e_verify(&verifier, zkvm_proofs.clone(), exit_code, max_steps);
     tracing::debug!("verified in {:?}", start.elapsed());
 
     E2ECheckpointResult {
@@ -2035,11 +2028,11 @@ fn create_proofs_streaming<
     proofs
 }
 
-/// Verify the full produced trace in the normal e2e flow.
-///
-/// This is the production-style verification path used when e2e is not scoped
-/// to a debug `--shard-id` run.
-pub fn run_e2e_full_trace_verify<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
+/// Verify the produced proofs. The statement being verified (full run,
+/// prefix run, or single-shard debug segment) is encoded in the verifier's
+/// mode, which was chosen by the caller from out-of-band knowledge at
+/// verifier construction time.
+pub fn run_e2e_verify<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
     verifier: &ZKVMVerifier<E, PCS>,
     zkvm_proofs: Vec<ZKVMProof<E, PCS>>,
     exit_code: Option<u32>,
@@ -2048,34 +2041,8 @@ pub fn run_e2e_full_trace_verify<E: ExtensionField, PCS: PolynomialCommitmentSch
     let transcripts = (0..zkvm_proofs.len())
         .map(|_| Transcript::new(b"riscv"))
         .collect_vec();
-    let expect_halt = zkvm_proofs
-        .last()
-        .map(|proof| proof.has_halt(&verifier.vk))
-        .unwrap_or(exit_code.is_some());
     let verified = verifier
-        .verify_full_trace_proofs_halt(zkvm_proofs, transcripts, expect_halt)
-        .expect("verify proof return with error");
-    assert!(verified);
-    match exit_code {
-        Some(0) => tracing::info!("exit code 0. Success."),
-        Some(code) => tracing::error!("exit code {}. Failure.", code),
-        None => tracing::error!("Unfinished execution. max_steps={:?}.", max_steps),
-    }
-}
-
-/// Verify a single produced shard as a standalone debug segment.
-///
-/// This path is only for explicit e2e `--shard-id` runs where exactly one proof
-/// is produced. It intentionally does not claim full-trace verification.
-pub fn run_e2e_single_shard_debug_verify<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
-    verifier: &ZKVMVerifier<E, PCS>,
-    zkvm_proof: ZKVMProof<E, PCS>,
-    exit_code: Option<u32>,
-    max_steps: usize,
-) {
-    let expect_halt = zkvm_proof.has_halt(&verifier.vk) || exit_code.is_some();
-    let verified = verifier
-        .verify_single_shard_segment_halt(zkvm_proof, Transcript::new(b"riscv"), expect_halt)
+        .verify_proofs(zkvm_proofs, transcripts)
         .expect("verify proof return with error");
     assert!(verified);
     match exit_code {
@@ -2145,11 +2112,10 @@ pub fn verify<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + serde::Ser
     {
         Instrumented::<<<E as ExtensionField>::BaseField as PoseidonField>::P>::clear_metrics();
     }
-    let has_halt = zkvm_proofs.last().unwrap().has_halt(&verifier.vk);
     let transcripts = (0..zkvm_proofs.len())
         .map(|_| Transcript::new(b"riscv"))
         .collect_vec();
-    verifier.verify_full_trace_proofs_halt(zkvm_proofs, transcripts, has_halt)?;
+    verifier.verify_proofs(zkvm_proofs, transcripts)?;
     // print verification statistics such as hash count
     #[cfg(debug_assertions)]
     {

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -46,8 +46,31 @@ use sumcheck::{
 use transcript::{ForkableTranscript, Transcript};
 use witness::next_pow2_instance_padding;
 
+/// How a verifier interprets the proof(s) it receives.
+///
+/// The mode is committed at verifier construction and drives the
+/// halt / continuity checks inside `verify_proofs`. It is *not* a
+/// per-call argument and is *not* derived from the proof, so a
+/// malicious prover cannot influence which statement is verified.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VerifierMode {
+    /// Full trace from `vk.entry_pc` to program halt. Intermediate
+    /// shards must not halt; the last shard must halt.
+    FullRun,
+    /// Full trace from `vk.entry_pc` that stopped at a step budget.
+    /// Intermediate shards must not halt; the last shard's halt
+    /// status is not checked.
+    PrefixRun,
+    /// Single-shard debug verification. Accepts one shard at any
+    /// position in the run (`--shard-id=N`); skips the entry-PC
+    /// check, reads shard id from `public_values.shard_id`, and
+    /// does no cross-shard chaining.
+    DebugSegment,
+}
+
 pub struct ZKVMVerifier<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> {
     pub vk: ZKVMVerifyingKey<E, PCS>,
+    pub mode: VerifierMode,
 }
 
 impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS> {
@@ -84,99 +107,121 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
         Ok((wits_in_evals, fixed_in_evals))
     }
 
+    /// Construct a verifier in the production-safe `FullRun` mode.
     pub fn new(vk: ZKVMVerifyingKey<E, PCS>) -> Self {
-        ZKVMVerifier { vk }
+        Self::new_with_mode(vk, VerifierMode::FullRun)
+    }
+
+    /// Construct a verifier with an explicit mode.
+    pub fn new_with_mode(vk: ZKVMVerifyingKey<E, PCS>, mode: VerifierMode) -> Self {
+        ZKVMVerifier { vk, mode }
     }
 
     pub fn into_inner(self) -> ZKVMVerifyingKey<E, PCS> {
         self.vk
     }
 
-    /// Verify a full zkVM trace from program entry to halt.
-    ///
-    /// This is the production verifier API. It treats a single proof as a
-    /// complete trace starting from `vk.entry_pc`, not as an arbitrary shard
-    /// segment.
+    /// Verify a single-proof trace. Thin convenience wrapper over `verify_proofs`.
     #[tracing::instrument(skip_all, name = "verify_proof")]
     pub fn verify_proof(
         &self,
         vm_proof: ZKVMProof<E, PCS>,
         transcript: impl ForkableTranscript<E>,
     ) -> Result<bool, ZKVMError> {
-        self.verify_full_trace_proofs_halt(vec![vm_proof], vec![transcript], true)
+        self.verify_proofs(vec![vm_proof], vec![transcript])
     }
 
-    /// Verify a full zkVM trace composed of one or more proofs and ending in halt.
+    /// Verify one or more zkVM proofs. The meaning of the proof set is
+    /// determined by `self.mode`:
+    ///
+    /// - `FullRun`: treats `vm_proofs` as a full trace from `vk.entry_pc`
+    ///   that ends in halt. Intermediate shards must not halt; the last
+    ///   shard must halt.
+    /// - `PrefixRun`: same as `FullRun` for entry and intermediate shards,
+    ///   but the last shard's halt status is not checked.
+    /// - `DebugSegment`: accepts exactly one proof at an arbitrary position
+    ///   in the run; skips entry-PC and cross-shard chain checks and reads
+    ///   the shard id from the proof's public values.
     #[tracing::instrument(skip_all, name = "verify_proofs")]
     pub fn verify_proofs(
         &self,
         vm_proofs: Vec<ZKVMProof<E, PCS>>,
         transcripts: Vec<impl ForkableTranscript<E>>,
     ) -> Result<bool, ZKVMError> {
-        self.verify_full_trace_proofs_halt(vm_proofs, transcripts, true)
+        match self.mode {
+            VerifierMode::DebugSegment => self.verify_debug_segment(vm_proofs, transcripts),
+            VerifierMode::FullRun | VerifierMode::PrefixRun => {
+                self.verify_full_trace(vm_proofs, transcripts)
+            }
+        }
     }
 
-    /// Verify a single shard proof as a standalone segment.
-    ///
-    /// This is a debug-oriented API. It checks proof validity and halt/segment
-    /// invariants for one shard only and intentionally skips full-trace entry
-    /// and cross-shard continuation checks such as `INIT_PC == vk.entry_pc` and
-    /// init_pc/heap chaining.
-    pub(crate) fn verify_single_shard_segment_halt(
+    fn verify_debug_segment(
         &self,
-        vm_proof: ZKVMProof<E, PCS>,
-        transcript: impl ForkableTranscript<E>,
-        expect_halt: bool,
+        mut vm_proofs: Vec<ZKVMProof<E, PCS>>,
+        mut transcripts: Vec<impl ForkableTranscript<E>>,
     ) -> Result<bool, ZKVMError> {
-        let has_halt = vm_proof.has_halt(&self.vk);
-        if has_halt != expect_halt {
+        if vm_proofs.len() != 1 || transcripts.len() != 1 {
             return Err(ZKVMError::VerifyError(
-                format!("shard proof ecall/halt mismatch: expected {expect_halt} != {has_halt}",)
-                    .into(),
+                format!(
+                    "DebugSegment mode requires exactly one proof/transcript, got {} / {}",
+                    vm_proofs.len(),
+                    transcripts.len()
+                )
+                .into(),
             ));
         }
-
-        assert_eq!(
-            vm_proof.public_values.query_by_index::<E>(INIT_CYCLE_IDX),
-            E::BaseField::from_canonical_u64(Tracer::SUBCYCLES_PER_INSN)
-        );
+        let vm_proof = vm_proofs.pop().expect("len checked");
+        let transcript = transcripts.pop().expect("len checked");
 
         let shard_id = vm_proof.public_values.shard_id as usize;
         self.verify_proof_validity(shard_id, vm_proof, transcript)?;
         Ok(true)
     }
 
-    /// Verify a full zkVM trace composed of one or more proofs from entry to
-    /// optional halt.
-    pub fn verify_full_trace_proofs_halt(
+    fn verify_full_trace(
         &self,
         vm_proofs: Vec<ZKVMProof<E, PCS>>,
         transcripts: Vec<impl ForkableTranscript<E>>,
-        expect_halt: bool,
     ) -> Result<bool, ZKVMError> {
         if vm_proofs.is_empty() {
             return Err(ZKVMError::VerifyError("empty proof batch".into()));
         }
         let num_proofs = vm_proofs.len();
+        // Per-shard expected halt status. Intermediate shards must not halt.
+        // Last shard: FullRun => must halt; PrefixRun => no halt-existence check.
+        let last_shard_expect_halt: Option<bool> = match self.mode {
+            VerifierMode::FullRun => Some(true),
+            VerifierMode::PrefixRun => None,
+            VerifierMode::DebugSegment => unreachable!("dispatched above"),
+        };
+        let expected_halts = iter::repeat_n(Some(false), num_proofs - 1)
+            .chain(iter::once(last_shard_expect_halt));
         let (_end_pc, _end_heap_addr, shard_ec_sum) = vm_proofs
             .into_iter()
             .zip_eq(transcripts)
-            // optionally halt on last chunk
-            .zip_eq(iter::repeat_n(false, num_proofs - 1).chain(iter::once(expect_halt)))
+            .zip_eq(expected_halts)
             .enumerate()
             .try_fold((None, None, SepticPoint::<E::BaseField>::default()), |(prev_pc, prev_heap_addr_end, mut shard_ec_sum), (shard_id, ((vm_proof, transcript), expect_halt))| {
-                // require ecall/halt proof to exist, depend on whether we expect a halt.
-                let has_halt = vm_proof.has_halt(&self.vk);
-                if has_halt != expect_halt {
-                    return Err(ZKVMError::VerifyError(
-                        format!(
-                            "{shard_id}th proof ecall/halt mismatch: expected {expect_halt} != {has_halt}",
-                        )
-                            .into(),
-                    ));
+                // halt-existence check: only enforced when caller-declared mode
+                // pins it down for this shard (i.e. always for intermediate
+                // shards; for the last shard only in FullRun).
+                if let Some(expect_halt) = expect_halt {
+                    let has_halt = vm_proof.has_halt(&self.vk);
+                    if has_halt != expect_halt {
+                        return Err(ZKVMError::VerifyError(
+                            format!(
+                                "{shard_id}th proof ecall/halt mismatch: expected {expect_halt} != {has_halt}",
+                            )
+                                .into(),
+                        ));
+                    }
                 }
-                // each shard set init cycle = Tracer::SUBCYCLES_PER_INSN
-                // to satisfy initial reads for all prev_cycle = 0 < init_cycle
+                // Each shard resets its local cycle counter to
+                // Tracer::SUBCYCLES_PER_INSN; cycles do NOT chain across shards.
+                // Cross-shard record disambiguation is carried by `shard_id`
+                // inside the memory-record hash (EC-sum Quark), not by a global
+                // cycle counter, so the uniform reset is the protocol choice.
                 let init_cycle = vm_proof.public_values.query_by_index::<E>(INIT_CYCLE_IDX);
                 let expected_init_cycle =
                     E::BaseField::from_canonical_u64(Tracer::SUBCYCLES_PER_INSN);
@@ -188,7 +233,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
                         .into(),
                     ));
                 }
-                // check init_pc match prev end_pc
+                // check init_pc match prev end_pc (or vk.entry_pc on first shard)
                 let init_pc = vm_proof.public_values.query_by_index::<E>(INIT_PC_IDX);
                 let expected_init_pc = if let Some(prev_pc) = prev_pc {
                     prev_pc

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -195,6 +195,13 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
             VerifierMode::PrefixRun => None,
             VerifierMode::DebugSegment => unreachable!("dispatched above"),
         };
+        // FullRun additionally requires the terminal shard's exit code to be
+        // zero. On the halting shard, the halt-ecall chip binds
+        // public_values.exit_code to register a0 via the instance mechanism,
+        // so this asserts "the guest invoked halt with argument 0" — program
+        // exited successfully in the RISC-V convention. Not enforced in
+        // PrefixRun (which is a dev/bench mode with no termination claim).
+        let require_exit_code_zero = matches!(self.mode, VerifierMode::FullRun);
         let expected_halts = iter::repeat_n(Some(false), num_proofs - 1)
             .chain(iter::once(last_shard_expect_halt));
         let (_end_pc, _end_heap_addr, shard_ec_sum) = vm_proofs
@@ -215,6 +222,19 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ZKVMVerifier<E, PCS>
                             )
                                 .into(),
                         ));
+                    }
+                    // On the halting shard in FullRun, require exit_code == 0.
+                    // The halt-ecall chip binds public_values.exit_code to a0.
+                    if require_exit_code_zero && expect_halt {
+                        let exit_code = vm_proof.public_values.exit_code;
+                        if exit_code != 0 {
+                            return Err(ZKVMError::VerifyError(
+                                format!(
+                                    "{shard_id}th shard exit_code must be 0 in FullRun, got {exit_code}"
+                                )
+                                .into(),
+                            ));
+                        }
                     }
                 }
                 // Each shard resets its local cycle counter to

--- a/docs/src/technical-overview.md
+++ b/docs/src/technical-overview.md
@@ -7,66 +7,29 @@ verification actually binds the proof to.
 
 ## What the verifier guarantees
 
-What a successful Ceno verification attests to depends on the
-**verifier mode**, which is committed at verifier construction — it
-lives on the verifier instance and is *not* a per-call argument or
-derived from the proof, so a prover cannot influence which statement
-is being verified. Three modes exist:
-
-### FullRun
-
-The production mode. The proof attests that:
+A successful Ceno verification attests to two program-level facts:
 
 - Execution starts at the program entry point declared in the
   verifying key. The first shard's initial program counter is bound
   to the verifying key's entry PC; every subsequent shard's initial
   PC is chained to the previous shard's final PC.
 - No intermediate shard contains a halt ecall, and the last shard
-  does. In other words, the trace ends exactly where the guest
-  invokes halt.
+  does. The trace ends exactly where the guest invokes halt.
 
 Equivalently, the proof is of an execution of *this specific program
 image* from *its declared entry point* to halt, not of some arbitrary
-subtrace the prover chose to begin or end at a convenient point.
-
-`FullRun` is the default mode of the verifier constructor, and the
-recursive verifier in `ceno_recursion/` always runs an inner verifier
-in this mode — there is no exposed mode parameter at the recursion
-boundary.
-
-### PrefixRun
-
-A dev and benchmarking mode. Same start and intermediate-shard
-guarantees as `FullRun` (execution starts at `vk.entry_pc`; no
-intermediate shard halts), but the last-shard halt-existence check
-is skipped. Used when the emulator is run for a fixed step budget
-that stops before the program halts.
-
-### DebugSegment
-
-A single-shard developer mode for `--shard-id=N` workflows. Accepts
-exactly one proof at an arbitrary position in the run, reads the
-shard id from the proof's public values, and skips both the entry-PC
-check and all cross-shard continuity checks. No claim is made about
-entry, continuation, or termination; only that the single shard's
-cryptographic proof is valid at its stated shard id.
+subtrace the prover chose to begin or end at a convenient point. The
+recursive verifier in `ceno_recursion/` makes the same claim about
+every inner proof.
 
 ### What is not a verifier-level guarantee
 
-No mode makes a soundness-level claim about the exit code. The
-halt-ecall chip binds `public_values.exit_code` to the value the
-guest passed to the halt ecall, so on a `FullRun` proof the exit
-code is a meaningful public value that a consumer can read — but
-it is not required to be zero by the verifier. A caller that cares
-about "exited successfully" must check `exit_code == 0` itself.
-
-Similarly, `PrefixRun` and `DebugSegment` proofs are dev/benchmarking
-affordances, not production verification surfaces. On a non-halting
-shard the public-value fields other than PC are not adversary-
-hardened the way the halt path is. Before either mode is exposed to
-any external consumer (recursion, aggregation, a third-party
-verifier), those fields must first be brought up to the halt-path
-standard.
+The verifier does *not* make a soundness-level claim about the exit
+code. The halt-ecall chip binds `public_values.exit_code` to the
+value the guest passed to the halt ecall, so the exit code is a
+meaningful public value that a consumer can read — but it is not
+required to be zero by the verifier. A caller that cares about
+"exited successfully" must check `exit_code == 0` itself.
 
 ## Sections
 

--- a/docs/src/technical-overview.md
+++ b/docs/src/technical-overview.md
@@ -7,7 +7,7 @@ verification actually binds the proof to.
 
 ## What the verifier guarantees
 
-A successful Ceno verification attests to two program-level facts:
+A successful Ceno verification attests to three program-level facts:
 
 - Execution starts at the program entry point declared in the
   verifying key. The first shard's initial program counter is bound
@@ -15,21 +15,15 @@ A successful Ceno verification attests to two program-level facts:
   PC is chained to the previous shard's final PC.
 - No intermediate shard contains a halt ecall, and the last shard
   does. The trace ends exactly where the guest invokes halt.
+- The halt ecall was invoked with argument zero. The halt-ecall chip
+  binds `public_values.exit_code` to the value the guest passed in
+  register `a0`, and the verifier requires that value to be zero.
 
 Equivalently, the proof is of an execution of *this specific program
-image* from *its declared entry point* to halt, not of some arbitrary
-subtrace the prover chose to begin or end at a convenient point. The
-recursive verifier in `ceno_recursion/` makes the same claim about
-every inner proof.
-
-### What is not a verifier-level guarantee
-
-The verifier does *not* make a soundness-level claim about the exit
-code. The halt-ecall chip binds `public_values.exit_code` to the
-value the guest passed to the halt ecall, so the exit code is a
-meaningful public value that a consumer can read — but it is not
-required to be zero by the verifier. A caller that cares about
-"exited successfully" must check `exit_code == 0` itself.
+image* from *its declared entry point*, successfully halting with
+exit code zero — not of some arbitrary subtrace the prover chose to
+begin or end at a convenient point. The recursive verifier in
+`ceno_recursion/` makes the same claim about every inner proof.
 
 ## Sections
 

--- a/docs/src/technical-overview.md
+++ b/docs/src/technical-overview.md
@@ -7,40 +7,63 @@ verification actually binds the proof to.
 
 ## What the verifier guarantees
 
-A successful Ceno verification attests to exactly two program-level
-statements. Everything else in the verifier — transcript flow,
-sumcheck, PCS openings, tower and GKR reductions, per-shard EC
-accumulators, cross-shard memory consistency — is machinery whose
-purpose is to make these two statements meaningful.
+What a successful Ceno verification attests to depends on the
+**verifier mode**, which is committed at verifier construction — it
+lives on the verifier instance and is *not* a per-call argument or
+derived from the proof, so a prover cannot influence which statement
+is being verified. Three modes exist:
 
-1. **Start: execution begins at the program entry point declared in
-   the verifying key.** The first shard's initial program counter is
-   bound to the verifying key's entry PC; every subsequent shard's
-   initial PC is chained to the previous shard's final PC. The proof
-   is of an execution of *this specific program image* starting from
-   *its declared entry point*, not of some arbitrary subtrace the
-   prover chose to begin at a convenient PC.
-2. **Exit: the program exits successfully with code zero.** Every
-   shard carries an exit-code public value, required by the verifier
-   to be zero. On a halting shard, the halt-ecall chip binds this
-   field to the value the guest passed in the first argument register
-   via the public-value "instance" mechanism, so the check asserts
-   *"the guest called the halt ecall with argument zero"* — i.e. the
-   program exited successfully in the RISC-V convention.
+### FullRun
 
-Two terminal modes are legitimate, selected by a caller-supplied
-"expect halt" flag: a full run reaching halt, or a prefix run stopped
-at a step budget. The verifier checks, on each shard, that the
-proof's halt-ecall presence matches the declared mode — only the
-terminal shard may carry a halt, and only when the caller expects
-one — which prevents a prover from either hiding a halt or
-manufacturing one. The exit-code-zero invariant holds in both modes.
+The production mode. The proof attests that:
 
-**Prefix proofs are a dev and benchmarking affordance, not a
-production verification surface.** On a non-halting shard the
-public-value fields other than PC are not adversary-hardened the way
-the halt path is; verifier-level checks on them are format sanity
-rather than soundness statements. Before prefix proofs are exposed to
+- Execution starts at the program entry point declared in the
+  verifying key. The first shard's initial program counter is bound
+  to the verifying key's entry PC; every subsequent shard's initial
+  PC is chained to the previous shard's final PC.
+- No intermediate shard contains a halt ecall, and the last shard
+  does. In other words, the trace ends exactly where the guest
+  invokes halt.
+
+Equivalently, the proof is of an execution of *this specific program
+image* from *its declared entry point* to halt, not of some arbitrary
+subtrace the prover chose to begin or end at a convenient point.
+
+`FullRun` is the default mode of the verifier constructor, and the
+recursive verifier in `ceno_recursion/` always runs an inner verifier
+in this mode — there is no exposed mode parameter at the recursion
+boundary.
+
+### PrefixRun
+
+A dev and benchmarking mode. Same start and intermediate-shard
+guarantees as `FullRun` (execution starts at `vk.entry_pc`; no
+intermediate shard halts), but the last-shard halt-existence check
+is skipped. Used when the emulator is run for a fixed step budget
+that stops before the program halts.
+
+### DebugSegment
+
+A single-shard developer mode for `--shard-id=N` workflows. Accepts
+exactly one proof at an arbitrary position in the run, reads the
+shard id from the proof's public values, and skips both the entry-PC
+check and all cross-shard continuity checks. No claim is made about
+entry, continuation, or termination; only that the single shard's
+cryptographic proof is valid at its stated shard id.
+
+### What is not a verifier-level guarantee
+
+No mode makes a soundness-level claim about the exit code. The
+halt-ecall chip binds `public_values.exit_code` to the value the
+guest passed to the halt ecall, so on a `FullRun` proof the exit
+code is a meaningful public value that a consumer can read — but
+it is not required to be zero by the verifier. A caller that cares
+about "exited successfully" must check `exit_code == 0` itself.
+
+Similarly, `PrefixRun` and `DebugSegment` proofs are dev/benchmarking
+affordances, not production verification surfaces. On a non-halting
+shard the public-value fields other than PC are not adversary-
+hardened the way the halt path is. Before either mode is exposed to
 any external consumer (recursion, aggregation, a third-party
 verifier), those fields must first be brought up to the halt-path
 standard.


### PR DESCRIPTION
Follow-up to #1321.

Moves the full-trace / prefix-run / single-shard-debug distinction from a per-call `expect_halt` flag onto the verifier instance as a `VerifierMode` field. Fixes the e2e callers that were deriving `expect_halt` from the proof itself, which made the halt-consistency check tautological.

- `VerifierMode { FullRun, PrefixRun, DebugSegment }`; `ZKVMVerifier::new(vk)` defaults to `FullRun`.
- `verify_full_trace_proofs_halt` + `verify_single_shard_segment_halt` collapsed into one mode-dispatched `verify_proofs`.
- Callers pick mode at construction from out-of-band knowledge (`exit_code`, `target_shard_id`), never from the proof.
- `CLAUDE.md` + `docs/src/technical-overview.md` rewritten around the three modes.