### PR TITLE
ci: mark slow basefold_verifier tests as ignored

### DIFF
--- a/ceno_recursion/src/basefold_verifier/query_phase.rs
+++ b/ceno_recursion/src/basefold_verifier/query_phase.rs
@@ -942,6 +942,7 @@ pub mod tests {
     }
 
     #[test]
+    #[ignore = "slow — run via cargo test -- --include-ignored"]
     fn test_simple_batch() {
         for num_var in 5..20 {
             construct_test(vec![(num_var, 20)]);
@@ -949,6 +950,7 @@ pub mod tests {
     }
 
     #[test]
+    #[ignore = "slow — run via cargo test -- --include-ignored"]
     fn test_decreasing_batch() {
         construct_test(vec![
             (14, 20),
@@ -961,6 +963,7 @@ pub mod tests {
     }
 
     #[test]
+    #[ignore = "slow — run via cargo test -- --include-ignored"]
     fn test_random_batch() {
         construct_test(vec![(10, 20), (12, 30), (11, 10), (12, 15)]);
     }

--- a/ceno_recursion/src/basefold_verifier/verifier.rs
+++ b/ceno_recursion/src/basefold_verifier/verifier.rs
@@ -392,6 +392,7 @@ pub mod tests {
     }
 
     #[test]
+    #[ignore = "slow — run via cargo test -- --include-ignored"]
     fn test_simple_batch() {
         for num_var in 5..20 {
             construct_test(vec![vec![(num_var, 20)]]);
@@ -411,11 +412,13 @@ pub mod tests {
     }
 
     #[test]
+    #[ignore = "slow — run via cargo test -- --include-ignored"]
     fn test_random_batch() {
         construct_test(vec![vec![(10, 20), (12, 30), (11, 10), (12, 15)]]);
     }
 
     #[test]
+    #[ignore = "slow — run via cargo test -- --include-ignored"]
     fn test_e2e_fibonacci_batch() {
         construct_test(vec![
             vec![


### PR DESCRIPTION
The 6 slow basefold-verifier tests in `ceno_recursion` pin each `cargo make tests` pass at ~10 min, ~20 min across both feature-set runs. Mark them `#[ignore]` so default CI skips them; run locally with `cargo test -p ceno_recursion --lib -- --ignored --skip aggregation`.

No CI step runs them in `--ignored` mode yet — follow-up if we want merge-queue to still exercise them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)