### PR TITLE
feat(sumcheck): enable frontload dependency set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "ff_ext"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
 dependencies = [
  "once_cell",
  "p3",
@@ -3243,7 +3243,7 @@ dependencies = [
 [[package]]
 name = "mpcs"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -3267,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "multilinear_extensions"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
 dependencies = [
  "either",
  "ff_ext",
@@ -4558,7 +4558,7 @@ dependencies = [
 [[package]]
 name = "p3"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
 dependencies = [
  "p3-air",
  "p3-baby-bear",
@@ -5126,7 +5126,7 @@ dependencies = [
 [[package]]
 name = "poseidon"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
 dependencies = [
  "ff_ext",
  "p3",
@@ -6083,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6208,7 +6208,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
 dependencies = [
  "either",
  "ff_ext",
@@ -6226,7 +6226,7 @@ dependencies = [
 [[package]]
 name = "sumcheck_macro"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
 dependencies = [
  "itertools 0.13.0",
  "p3",
@@ -6633,7 +6633,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
 dependencies = [
  "ff_ext",
  "itertools 0.13.0",
@@ -6927,7 +6927,7 @@ dependencies = [
 [[package]]
 name = "whir"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -7214,7 +7214,7 @@ dependencies = [
 [[package]]
 name = "witness"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
 dependencies = [
  "ff_ext",
  "multilinear_extensions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "ff_ext"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
 dependencies = [
  "once_cell",
  "p3",
@@ -3243,7 +3243,7 @@ dependencies = [
 [[package]]
 name = "mpcs"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -3267,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "multilinear_extensions"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
 dependencies = [
  "either",
  "ff_ext",
@@ -4558,7 +4558,7 @@ dependencies = [
 [[package]]
 name = "p3"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
 dependencies = [
  "p3-air",
  "p3-baby-bear",
@@ -5126,7 +5126,7 @@ dependencies = [
 [[package]]
 name = "poseidon"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
 dependencies = [
  "ff_ext",
  "p3",
@@ -6083,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6208,7 +6208,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
 dependencies = [
  "either",
  "ff_ext",
@@ -6226,7 +6226,7 @@ dependencies = [
 [[package]]
 name = "sumcheck_macro"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
 dependencies = [
  "itertools 0.13.0",
  "p3",
@@ -6633,7 +6633,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
 dependencies = [
  "ff_ext",
  "itertools 0.13.0",
@@ -6927,7 +6927,7 @@ dependencies = [
 [[package]]
 name = "whir"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -7214,7 +7214,7 @@ dependencies = [
 [[package]]
 name = "witness"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.25#f56aea652c0ba8a510bac04af9587ad500ed4a1c"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#94b8f5b922ca14c359eccbe267ec5b1e3034b09a"
 dependencies = [
  "ff_ext",
  "multilinear_extensions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "ff_ext"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.26#17e9a595be98408c4e3701519ab32ed7988d8119"
 dependencies = [
  "once_cell",
  "p3",
@@ -3243,7 +3243,7 @@ dependencies = [
 [[package]]
 name = "mpcs"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.26#17e9a595be98408c4e3701519ab32ed7988d8119"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -3267,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "multilinear_extensions"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.26#17e9a595be98408c4e3701519ab32ed7988d8119"
 dependencies = [
  "either",
  "ff_ext",
@@ -4558,7 +4558,7 @@ dependencies = [
 [[package]]
 name = "p3"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.26#17e9a595be98408c4e3701519ab32ed7988d8119"
 dependencies = [
  "p3-air",
  "p3-baby-bear",
@@ -5126,7 +5126,7 @@ dependencies = [
 [[package]]
 name = "poseidon"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.26#17e9a595be98408c4e3701519ab32ed7988d8119"
 dependencies = [
  "ff_ext",
  "p3",
@@ -6083,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.26#17e9a595be98408c4e3701519ab32ed7988d8119"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6208,7 +6208,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.26#17e9a595be98408c4e3701519ab32ed7988d8119"
 dependencies = [
  "either",
  "ff_ext",
@@ -6226,7 +6226,7 @@ dependencies = [
 [[package]]
 name = "sumcheck_macro"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.26#17e9a595be98408c4e3701519ab32ed7988d8119"
 dependencies = [
  "itertools 0.13.0",
  "p3",
@@ -6633,7 +6633,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.26#17e9a595be98408c4e3701519ab32ed7988d8119"
 dependencies = [
  "ff_ext",
  "itertools 0.13.0",
@@ -6927,7 +6927,7 @@ dependencies = [
 [[package]]
 name = "whir"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.26#17e9a595be98408c4e3701519ab32ed7988d8119"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -7214,7 +7214,7 @@ dependencies = [
 [[package]]
 name = "witness"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Ffrontload#f8847d88c4e1b076349ea588647fb72831c667ed"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.26#17e9a595be98408c4e3701519ab32ed7988d8119"
 dependencies = [
  "ff_ext",
  "multilinear_extensions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,16 +27,16 @@ version = "0.1.0"
 ceno_crypto_primitives = { git = "https://github.com/scroll-tech/ceno-patch.git", package = "ceno_crypto_primitives", branch = "main" }
 ceno_syscall = { git = "https://github.com/scroll-tech/ceno-patch.git", package = "ceno_syscall", branch = "main" }
 
-ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "ff_ext", tag = "v1.0.0-alpha.25" }
-mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "mpcs", tag = "v1.0.0-alpha.25" }
-multilinear_extensions = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "multilinear_extensions", tag = "v1.0.0-alpha.25" }
-p3 = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "p3", tag = "v1.0.0-alpha.25" }
-poseidon = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "poseidon", tag = "v1.0.0-alpha.25" }
-sp1-curves = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sp1-curves", tag = "v1.0.0-alpha.25" }
-sumcheck = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sumcheck", tag = "v1.0.0-alpha.25" }
-transcript = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "transcript", tag = "v1.0.0-alpha.25" }
-whir = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "whir", tag = "v1.0.0-alpha.25" }
-witness = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "witness", tag = "v1.0.0-alpha.25" }
+ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "ff_ext", branch = "feat/frontload" }
+mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "mpcs", branch = "feat/frontload" }
+multilinear_extensions = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "multilinear_extensions", branch = "feat/frontload" }
+p3 = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "p3", branch = "feat/frontload" }
+poseidon = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "poseidon", branch = "feat/frontload" }
+sp1-curves = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sp1-curves", branch = "feat/frontload" }
+sumcheck = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sumcheck", branch = "feat/frontload" }
+transcript = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "transcript", branch = "feat/frontload" }
+whir = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "whir", branch = "feat/frontload" }
+witness = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "witness", branch = "feat/frontload" }
 
 anyhow = { version = "1.0", default-features = false }
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,16 +27,16 @@ version = "0.1.0"
 ceno_crypto_primitives = { git = "https://github.com/scroll-tech/ceno-patch.git", package = "ceno_crypto_primitives", branch = "main" }
 ceno_syscall = { git = "https://github.com/scroll-tech/ceno-patch.git", package = "ceno_syscall", branch = "main" }
 
-ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "ff_ext", branch = "feat/frontload" }
-mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "mpcs", branch = "feat/frontload" }
-multilinear_extensions = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "multilinear_extensions", branch = "feat/frontload" }
-p3 = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "p3", branch = "feat/frontload" }
-poseidon = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "poseidon", branch = "feat/frontload" }
-sp1-curves = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sp1-curves", branch = "feat/frontload" }
-sumcheck = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sumcheck", branch = "feat/frontload" }
-transcript = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "transcript", branch = "feat/frontload" }
-whir = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "whir", branch = "feat/frontload" }
-witness = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "witness", branch = "feat/frontload" }
+ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "ff_ext", tag = "v1.0.0-alpha.26" }
+mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "mpcs", tag = "v1.0.0-alpha.26" }
+multilinear_extensions = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "multilinear_extensions", tag = "v1.0.0-alpha.26" }
+p3 = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "p3", tag = "v1.0.0-alpha.26" }
+poseidon = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "poseidon", tag = "v1.0.0-alpha.26" }
+sp1-curves = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sp1-curves", tag = "v1.0.0-alpha.26" }
+sumcheck = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sumcheck", tag = "v1.0.0-alpha.26" }
+transcript = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "transcript", tag = "v1.0.0-alpha.26" }
+whir = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "whir", tag = "v1.0.0-alpha.26" }
+witness = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "witness", tag = "v1.0.0-alpha.26" }
 
 anyhow = { version = "1.0", default-features = false }
 bincode = "1"


### PR DESCRIPTION
## Problem

Enable Ceno to consume the frontload sumcheck work from `gkr-backend` and `ceno-gpu`.

## Design Rationale

This PR only updates dependency pins. The implementation lives in:

| Area | Summary |
|------|---------|
| `gkr_iop` / `gkr-backend` | Makes frontload/prefix sumcheck the default CPU path and keeps forced suffix available for comparison. |
| `ceno-gpu` | Adds frontload support to GPU sumcheck v2 kernels, removes legacy v1 flat-buffer kernels, and keeps PCS/basefold on suffix. |

## Change Highlights

- Update `gkr-backend` branch lock from the older frontload commit to the latest frontload dependency set.
- Keep all Ceno `gkr-backend` crates on one consistent revision to avoid duplicate `sumcheck` / `transcript` types.

## Benchmark / Performance Impact

Benchmark: Reth GPU E2E, block `23817600`, `CENO_GPU_ENABLE_WITGEN=0`.
Positive percentage means faster.

| Metric | Baseline | This PR | Change |
|--------|---------:|--------:|-------:|
| E2E total | 75.400s | 75.600s | -0.3% |
| `app_prove` | 60.400s | 61.000s | -1.0% |
| `build_tower_witness_gpu` | 4.613s | 3.491s | **+24.3%** |
| `prove_main_constraints` | 24.364s | 22.622s | **+7.1%** |
| `pcs_opening` | 15.441s | 15.246s | +1.3% |
| `prove_tower_relation_gpu` | 172.341s | 176.090s | -2.2% |

| GPU Span | Baseline | This PR | Change |
|----------|---------:|--------:|-------:|
| Tower `prove_generic_sumcheck_gpu` | 161.604s | 168.859s | -4.5% |
| Main `prove_generic_sumcheck_gpu` | 22.443s | 21.244s | **+5.3%** |
| PCS `batch_commit_phase` | 6.566s | 6.453s | +1.7% |
| PCS `batch_query_phase` | 4.615s | 4.617s | -0.0% |

Raw results:

- Baseline: https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/25241194699
- This PR: https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/25419833788

## Testing

```sh
cargo install --git https://github.com/scroll-tech/ceno --branch feat/frontload --features jemalloc --features nightly-features --locked --force cargo-ceno
CENO_GPU_ENABLE_WITGEN=0 cargo run --features "jemalloc,gpu" --release --bin ceno-reth-benchmark-bin -- --mode prove-app --block-number 23817600
```

## Risks and Rollout

Main risk is cross-repo dependency skew between `ceno`, `gkr-backend`, and `ceno-gpu`. Rollback is to revert the dependency update.

## Follow-ups (optional)

Investigate tower GPU sumcheck regression while keeping PCS/basefold on suffix.

## Copilot Reviewer Directive (keep this section)

When Copilot reviews this PR, apply `.github/copilot-instructions.md` strictly.
