### PR TITLE
Integrate Jagged PCS into CPU prover flow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,7 +33,7 @@ jobs:
       (github.event.action == 'ready_for_review' || needs.skip_check.outputs.should_skip != 'true')
 
     name: Integration testing
-    timeout-minutes: 30
+    timeout-minutes: 40
     runs-on: [ self-hosted, Linux, X64 ]
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,9 +1601,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
+name = "cuda-config"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee74643f7430213a1a78320f88649de309b20b80818325575e393f848f79f5d"
+dependencies = [
+ "glob",
+]
+
+[[package]]
+name = "cuda-runtime-sys"
+version = "0.3.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d070b301187fee3c611e75a425cf12247b7c75c09729dbdef95cb9cb64e8c39"
+dependencies = [
+ "cuda-config",
+]
+
+[[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno-gpu-mock.git?branch=main#fe8f7923b7d3a3823c27949fab0aab8e31011aa9"
+dependencies = [
+ "anyhow",
+ "cuda-runtime-sys",
+ "cudarc",
+ "downcast-rs",
+ "either",
+ "ff_ext",
+ "itertools 0.13.0",
+ "mpcs",
+ "multilinear_extensions",
+ "p3",
+ "rand 0.8.5",
+ "rayon",
+ "sha2",
+ "sppark",
+ "sppark_plug",
+ "sumcheck",
+ "thiserror 1.0.69",
+ "tracing",
+ "transcript",
+ "witness",
+]
 
 [[package]]
 name = "cudarc"
@@ -2237,7 +2276,6 @@ dependencies = [
 [[package]]
 name = "ff_ext"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fceno-bench#82f8ed72a77aa36a28248bee1a21e9ec6bbdb93d"
 dependencies = [
  "once_cell",
  "p3",
@@ -2669,6 +2707,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -3104,6 +3151,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
@@ -3243,7 +3296,6 @@ dependencies = [
 [[package]]
 name = "mpcs"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fceno-bench#82f8ed72a77aa36a28248bee1a21e9ec6bbdb93d"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -3254,7 +3306,6 @@ dependencies = [
  "p3",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "rayon",
  "serde",
  "sumcheck",
  "tracing",
@@ -3267,7 +3318,6 @@ dependencies = [
 [[package]]
 name = "multilinear_extensions"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fceno-bench#82f8ed72a77aa36a28248bee1a21e9ec6bbdb93d"
 dependencies = [
  "either",
  "ff_ext",
@@ -4558,7 +4608,6 @@ dependencies = [
 [[package]]
 name = "p3"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fceno-bench#82f8ed72a77aa36a28248bee1a21e9ec6bbdb93d"
 dependencies = [
  "p3-air",
  "p3-baby-bear",
@@ -5126,7 +5175,6 @@ dependencies = [
 [[package]]
 name = "poseidon"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fceno-bench#82f8ed72a77aa36a28248bee1a21e9ec6bbdb93d"
 dependencies = [
  "ff_ext",
  "p3",
@@ -5726,6 +5774,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
@@ -5733,7 +5794,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -6083,7 +6144,6 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fceno-bench#82f8ed72a77aa36a28248bee1a21e9ec6bbdb93d"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6116,6 +6176,25 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sppark"
+version = "0.1.11"
+dependencies = [
+ "cc",
+ "which",
+]
+
+[[package]]
+name = "sppark_plug"
+version = "0.1.0"
+dependencies = [
+ "cc",
+ "ff_ext",
+ "itertools 0.13.0",
+ "p3",
+ "sppark",
 ]
 
 [[package]]
@@ -6208,7 +6287,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fceno-bench#82f8ed72a77aa36a28248bee1a21e9ec6bbdb93d"
 dependencies = [
  "either",
  "ff_ext",
@@ -6226,7 +6304,6 @@ dependencies = [
 [[package]]
 name = "sumcheck_macro"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fceno-bench#82f8ed72a77aa36a28248bee1a21e9ec6bbdb93d"
 dependencies = [
  "itertools 0.13.0",
  "p3",
@@ -6307,7 +6384,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -6633,7 +6710,6 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fceno-bench#82f8ed72a77aa36a28248bee1a21e9ec6bbdb93d"
 dependencies = [
  "ff_ext",
  "itertools 0.13.0",
@@ -6925,9 +7001,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "whir"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fceno-bench#82f8ed72a77aa36a28248bee1a21e9ec6bbdb93d"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -7053,6 +7140,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.4",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -7214,7 +7310,6 @@ dependencies = [
 [[package]]
 name = "witness"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fceno-bench#82f8ed72a77aa36a28248bee1a21e9ec6bbdb93d"
 dependencies = [
  "ff_ext",
  "multilinear_extensions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,48 +1601,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
-name = "cuda-config"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee74643f7430213a1a78320f88649de309b20b80818325575e393f848f79f5d"
-dependencies = [
- "glob",
-]
-
-[[package]]
-name = "cuda-runtime-sys"
-version = "0.3.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d070b301187fee3c611e75a425cf12247b7c75c09729dbdef95cb9cb64e8c39"
-dependencies = [
- "cuda-config",
-]
-
-[[package]]
 name = "cuda_hal"
 version = "0.1.0"
-dependencies = [
- "anyhow",
- "cuda-runtime-sys",
- "cudarc",
- "downcast-rs",
- "either",
- "ff_ext",
- "itertools 0.13.0",
- "mpcs",
- "multilinear_extensions",
- "p3",
- "rand 0.8.5",
- "rayon",
- "sha2",
- "sppark",
- "sppark_plug",
- "sumcheck",
- "thiserror 1.0.69",
- "tracing",
- "transcript",
- "witness",
-]
+source = "git+https://github.com/scroll-tech/ceno-gpu-mock.git?branch=main#fe8f7923b7d3a3823c27949fab0aab8e31011aa9"
 
 [[package]]
 name = "cudarc"
@@ -2276,6 +2237,7 @@ dependencies = [
 [[package]]
 name = "ff_ext"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
 dependencies = [
  "once_cell",
  "p3",
@@ -2707,15 +2669,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -3151,12 +3104,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
@@ -3296,6 +3243,7 @@ dependencies = [
 [[package]]
 name = "mpcs"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -3318,6 +3266,7 @@ dependencies = [
 [[package]]
 name = "multilinear_extensions"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
 dependencies = [
  "either",
  "ff_ext",
@@ -4608,6 +4557,7 @@ dependencies = [
 [[package]]
 name = "p3"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
 dependencies = [
  "p3-air",
  "p3-baby-bear",
@@ -5175,6 +5125,7 @@ dependencies = [
 [[package]]
 name = "poseidon"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
 dependencies = [
  "ff_ext",
  "p3",
@@ -5774,19 +5725,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
@@ -5794,7 +5732,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
 
@@ -6144,6 +6082,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6176,25 +6115,6 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
-]
-
-[[package]]
-name = "sppark"
-version = "0.1.11"
-dependencies = [
- "cc",
- "which",
-]
-
-[[package]]
-name = "sppark_plug"
-version = "0.1.0"
-dependencies = [
- "cc",
- "ff_ext",
- "itertools 0.13.0",
- "p3",
- "sppark",
 ]
 
 [[package]]
@@ -6287,6 +6207,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
 dependencies = [
  "either",
  "ff_ext",
@@ -6304,6 +6225,7 @@ dependencies = [
 [[package]]
 name = "sumcheck_macro"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
 dependencies = [
  "itertools 0.13.0",
  "p3",
@@ -6384,7 +6306,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.7",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -6710,6 +6632,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
 dependencies = [
  "ff_ext",
  "itertools 0.13.0",
@@ -7001,20 +6924,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "whir"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -7140,15 +7052,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.4",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]
@@ -7310,6 +7213,7 @@ dependencies = [
 [[package]]
 name = "witness"
 version = "0.1.0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
 dependencies = [
  "ff_ext",
  "multilinear_extensions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "ff_ext"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#a1ec1fa19a58deb00f00cf999f243c7b602a7204"
 dependencies = [
  "once_cell",
  "p3",
@@ -3243,7 +3243,7 @@ dependencies = [
 [[package]]
 name = "mpcs"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#a1ec1fa19a58deb00f00cf999f243c7b602a7204"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -3266,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "multilinear_extensions"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#a1ec1fa19a58deb00f00cf999f243c7b602a7204"
 dependencies = [
  "either",
  "ff_ext",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "p3"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#a1ec1fa19a58deb00f00cf999f243c7b602a7204"
 dependencies = [
  "p3-air",
  "p3-baby-bear",
@@ -5125,7 +5125,7 @@ dependencies = [
 [[package]]
 name = "poseidon"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#a1ec1fa19a58deb00f00cf999f243c7b602a7204"
 dependencies = [
  "ff_ext",
  "p3",
@@ -6082,7 +6082,7 @@ dependencies = [
 [[package]]
 name = "sp1-curves"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#a1ec1fa19a58deb00f00cf999f243c7b602a7204"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6207,7 +6207,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#a1ec1fa19a58deb00f00cf999f243c7b602a7204"
 dependencies = [
  "either",
  "ff_ext",
@@ -6225,7 +6225,7 @@ dependencies = [
 [[package]]
 name = "sumcheck_macro"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#a1ec1fa19a58deb00f00cf999f243c7b602a7204"
 dependencies = [
  "itertools 0.13.0",
  "p3",
@@ -6632,7 +6632,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#a1ec1fa19a58deb00f00cf999f243c7b602a7204"
 dependencies = [
  "ff_ext",
  "itertools 0.13.0",
@@ -6926,7 +6926,7 @@ dependencies = [
 [[package]]
 name = "whir"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#a1ec1fa19a58deb00f00cf999f243c7b602a7204"
 dependencies = [
  "bincode 1.3.3",
  "clap",
@@ -7213,7 +7213,7 @@ dependencies = [
 [[package]]
 name = "witness"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#b633b57791538ab7becaef0b882685c17d5e76c0"
+source = "git+https://github.com/scroll-tech/gkr-backend.git?branch=feat%2Fjagged_pcs#a1ec1fa19a58deb00f00cf999f243c7b602a7204"
 dependencies = [
  "ff_ext",
  "multilinear_extensions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,16 +27,16 @@ version = "0.1.0"
 ceno_crypto_primitives = { git = "https://github.com/scroll-tech/ceno-patch.git", package = "ceno_crypto_primitives", branch = "main" }
 ceno_syscall = { git = "https://github.com/scroll-tech/ceno-patch.git", package = "ceno_syscall", branch = "main" }
 
-ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "ff_ext", branch = "feat/ceno-bench" }
-mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "mpcs", branch = "feat/ceno-bench" }
-multilinear_extensions = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "multilinear_extensions", branch = "feat/ceno-bench" }
-p3 = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "p3", branch = "feat/ceno-bench" }
-poseidon = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "poseidon", branch = "feat/ceno-bench" }
-sp1-curves = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sp1-curves", branch = "feat/ceno-bench" }
-sumcheck = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sumcheck", branch = "feat/ceno-bench" }
-transcript = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "transcript", branch = "feat/ceno-bench" }
-whir = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "whir", branch = "feat/ceno-bench" }
-witness = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "witness", branch = "feat/ceno-bench" }
+ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "ff_ext", branch = "feat/jagged_pcs_impl" }
+mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "mpcs", branch = "feat/jagged_pcs_impl" }
+multilinear_extensions = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "multilinear_extensions", branch = "feat/jagged_pcs_impl" }
+p3 = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "p3", branch = "feat/jagged_pcs_impl" }
+poseidon = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "poseidon", branch = "feat/jagged_pcs_impl" }
+sp1-curves = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sp1-curves", branch = "feat/jagged_pcs_impl" }
+sumcheck = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sumcheck", branch = "feat/jagged_pcs_impl" }
+transcript = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "transcript", branch = "feat/jagged_pcs_impl" }
+whir = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "whir", branch = "feat/jagged_pcs_impl" }
+witness = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "witness", branch = "feat/jagged_pcs_impl" }
 
 anyhow = { version = "1.0", default-features = false }
 bincode = "1"
@@ -127,20 +127,20 @@ lto = "thin"
 #ceno_crypto_primitives = { path = "../ceno-patch/crypto-primitives", package = "ceno_crypto_primitives" }
 #ceno_syscall = { path = "../ceno-patch/syscall", package = "ceno_syscall" }
 
-#[patch."https://github.com/scroll-tech/ceno-gpu-mock.git"]
-#ceno_gpu = { path = "../ceno-gpu/cuda_hal", package = "cuda_hal", default-features = false, features = ["bb31"] }
+[patch."https://github.com/scroll-tech/ceno-gpu-mock.git"]
+ceno_gpu = { path = "../ceno-gpu/cuda_hal", package = "cuda_hal", default-features = false, features = ["bb31"] }
 #
-#[patch."https://github.com/scroll-tech/gkr-backend"]
-#ff_ext = { path = "../gkr-backend/crates/ff_ext", package = "ff_ext" }
-#mpcs = { path = "../gkr-backend/crates/mpcs", package = "mpcs" }
-#multilinear_extensions = { path = "../gkr-backend/crates/multilinear_extensions", package = "multilinear_extensions" }
-#p3 = { path = "../gkr-backend/crates/p3", package = "p3" }
-#poseidon = { path = "../gkr-backend/crates/poseidon", package = "poseidon" }
-#sp1-curves = { path = "../gkr-backend/crates/curves", package = "sp1-curves" }
-#sumcheck = { path = "../gkr-backend/crates/sumcheck", package = "sumcheck" }
-#transcript = { path = "../gkr-backend/crates/transcript", package = "transcript" }
-#whir = { path = "../gkr-backend/crates/whir", package = "whir" }
-#witness = { path = "../gkr-backend/crates/witness", package = "witness" }
+[patch."https://github.com/scroll-tech/gkr-backend"]
+ff_ext = { path = "../gkr-backend/crates/ff_ext", package = "ff_ext" }
+mpcs = { path = "../gkr-backend/crates/mpcs", package = "mpcs" }
+multilinear_extensions = { path = "../gkr-backend/crates/multilinear_extensions", package = "multilinear_extensions" }
+p3 = { path = "../gkr-backend/crates/p3", package = "p3" }
+poseidon = { path = "../gkr-backend/crates/poseidon", package = "poseidon" }
+sp1-curves = { path = "../gkr-backend/crates/curves", package = "sp1-curves" }
+sumcheck = { path = "../gkr-backend/crates/sumcheck", package = "sumcheck" }
+transcript = { path = "../gkr-backend/crates/transcript", package = "transcript" }
+whir = { path = "../gkr-backend/crates/whir", package = "whir" }
+witness = { path = "../gkr-backend/crates/witness", package = "witness" }
 
 # [patch."https://github.com/scroll-tech/openvm.git"]
 # openvm = { path = "../openvm-scroll-tech/crates/toolchain/openvm", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,16 +27,16 @@ version = "0.1.0"
 ceno_crypto_primitives = { git = "https://github.com/scroll-tech/ceno-patch.git", package = "ceno_crypto_primitives", branch = "main" }
 ceno_syscall = { git = "https://github.com/scroll-tech/ceno-patch.git", package = "ceno_syscall", branch = "main" }
 
-ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "ff_ext", branch = "feat/jagged_pcs_impl" }
-mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "mpcs", branch = "feat/jagged_pcs_impl" }
-multilinear_extensions = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "multilinear_extensions", branch = "feat/jagged_pcs_impl" }
-p3 = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "p3", branch = "feat/jagged_pcs_impl" }
-poseidon = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "poseidon", branch = "feat/jagged_pcs_impl" }
-sp1-curves = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sp1-curves", branch = "feat/jagged_pcs_impl" }
-sumcheck = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sumcheck", branch = "feat/jagged_pcs_impl" }
-transcript = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "transcript", branch = "feat/jagged_pcs_impl" }
-whir = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "whir", branch = "feat/jagged_pcs_impl" }
-witness = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "witness", branch = "feat/jagged_pcs_impl" }
+ff_ext = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "ff_ext", branch = "feat/jagged_pcs" }
+mpcs = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "mpcs", branch = "feat/jagged_pcs" }
+multilinear_extensions = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "multilinear_extensions", branch = "feat/jagged_pcs" }
+p3 = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "p3", branch = "feat/jagged_pcs" }
+poseidon = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "poseidon", branch = "feat/jagged_pcs" }
+sp1-curves = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sp1-curves", branch = "feat/jagged_pcs" }
+sumcheck = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "sumcheck", branch = "feat/jagged_pcs" }
+transcript = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "transcript", branch = "feat/jagged_pcs" }
+whir = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "whir", branch = "feat/jagged_pcs" }
+witness = { git = "https://github.com/scroll-tech/gkr-backend.git", package = "witness", branch = "feat/jagged_pcs" }
 
 anyhow = { version = "1.0", default-features = false }
 bincode = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,20 +127,20 @@ lto = "thin"
 #ceno_crypto_primitives = { path = "../ceno-patch/crypto-primitives", package = "ceno_crypto_primitives" }
 #ceno_syscall = { path = "../ceno-patch/syscall", package = "ceno_syscall" }
 
-[patch."https://github.com/scroll-tech/ceno-gpu-mock.git"]
-ceno_gpu = { path = "../ceno-gpu/cuda_hal", package = "cuda_hal", default-features = false, features = ["bb31"] }
+#[patch."https://github.com/scroll-tech/ceno-gpu-mock.git"]
+#ceno_gpu = { path = "../ceno-gpu/cuda_hal", package = "cuda_hal", default-features = false, features = ["bb31"] }
 #
-[patch."https://github.com/scroll-tech/gkr-backend"]
-ff_ext = { path = "../gkr-backend/crates/ff_ext", package = "ff_ext" }
-mpcs = { path = "../gkr-backend/crates/mpcs", package = "mpcs" }
-multilinear_extensions = { path = "../gkr-backend/crates/multilinear_extensions", package = "multilinear_extensions" }
-p3 = { path = "../gkr-backend/crates/p3", package = "p3" }
-poseidon = { path = "../gkr-backend/crates/poseidon", package = "poseidon" }
-sp1-curves = { path = "../gkr-backend/crates/curves", package = "sp1-curves" }
-sumcheck = { path = "../gkr-backend/crates/sumcheck", package = "sumcheck" }
-transcript = { path = "../gkr-backend/crates/transcript", package = "transcript" }
-whir = { path = "../gkr-backend/crates/whir", package = "whir" }
-witness = { path = "../gkr-backend/crates/witness", package = "witness" }
+#[patch."https://github.com/scroll-tech/gkr-backend"]
+#ff_ext = { path = "../gkr-backend/crates/ff_ext", package = "ff_ext" }
+#mpcs = { path = "../gkr-backend/crates/mpcs", package = "mpcs" }
+#multilinear_extensions = { path = "../gkr-backend/crates/multilinear_extensions", package = "multilinear_extensions" }
+#p3 = { path = "../gkr-backend/crates/p3", package = "p3" }
+#poseidon = { path = "../gkr-backend/crates/poseidon", package = "poseidon" }
+#sp1-curves = { path = "../gkr-backend/crates/curves", package = "sp1-curves" }
+#sumcheck = { path = "../gkr-backend/crates/sumcheck", package = "sumcheck" }
+#transcript = { path = "../gkr-backend/crates/transcript", package = "transcript" }
+#whir = { path = "../gkr-backend/crates/whir", package = "whir" }
+#witness = { path = "../gkr-backend/crates/witness", package = "witness" }
 
 # [patch."https://github.com/scroll-tech/openvm.git"]
 # openvm = { path = "../openvm-scroll-tech/crates/toolchain/openvm", default-features = false }

--- a/ceno_cli/src/commands/common_args/ceno.rs
+++ b/ceno_cli/src/commands/common_args/ceno.rs
@@ -14,7 +14,8 @@ use clap::Args;
 use ff_ext::{BabyBearExt4, ExtensionField, GoldilocksExt2};
 
 use mpcs::{
-    Basefold, BasefoldRSParams, PolynomialCommitmentScheme, SecurityLevel, Whir, WhirDefaultSpec,
+    Basefold, BasefoldRSParams, Jagged, PolynomialCommitmentScheme, SecurityLevel, Whir,
+    WhirDefaultSpec,
 };
 use serde::Serialize;
 use std::{
@@ -206,6 +207,16 @@ impl CenoOptions {
     ) -> anyhow::Result<()> {
         self.try_setup_logger();
         match (self.pcs, self.field) {
+            (PcsKind::Jagged, FieldType::Goldilocks) => keygen_inner::<
+                GoldilocksExt2,
+                Jagged<Basefold<GoldilocksExt2, BasefoldRSParams>>,
+                P,
+            >(self, compilation_options, elf_path),
+            (PcsKind::Jagged, FieldType::BabyBear) => keygen_inner::<
+                BabyBearExt4,
+                Jagged<Basefold<BabyBearExt4, BasefoldRSParams>>,
+                P,
+            >(self, compilation_options, elf_path),
             (PcsKind::Basefold, FieldType::Goldilocks) => {
                 keygen_inner::<GoldilocksExt2, Basefold<GoldilocksExt2, BasefoldRSParams>, P>(
                     self,
@@ -245,6 +256,20 @@ impl CenoOptions {
     ) -> anyhow::Result<()> {
         self.try_setup_logger();
         match (self.pcs, self.field) {
+            (PcsKind::Jagged, FieldType::Goldilocks) => {
+                run_elf_inner::<
+                    GoldilocksExt2,
+                    Jagged<Basefold<GoldilocksExt2, BasefoldRSParams>>,
+                    P,
+                >(self, compilation_options, elf_path, Checkpoint::PrepWitnessGen)?;
+            }
+            (PcsKind::Jagged, FieldType::BabyBear) => {
+                run_elf_inner::<
+                    BabyBearExt4,
+                    Jagged<Basefold<BabyBearExt4, BasefoldRSParams>>,
+                    P,
+                >(self, compilation_options, elf_path, Checkpoint::PrepWitnessGen)?;
+            }
             (PcsKind::Basefold, FieldType::Goldilocks) => {
                 run_elf_inner::<GoldilocksExt2, Basefold<GoldilocksExt2, BasefoldRSParams>, P>(
                     self,
@@ -289,6 +314,16 @@ impl CenoOptions {
     ) -> anyhow::Result<()> {
         self.try_setup_logger();
         match (self.pcs, self.field) {
+            (PcsKind::Jagged, FieldType::Goldilocks) => prove_inner::<
+                GoldilocksExt2,
+                Jagged<Basefold<GoldilocksExt2, BasefoldRSParams>>,
+                P,
+            >(self, compilation_options, elf_path, Checkpoint::Complete),
+            (PcsKind::Jagged, FieldType::BabyBear) => prove_inner::<
+                BabyBearExt4,
+                Jagged<Basefold<BabyBearExt4, BasefoldRSParams>>,
+                P,
+            >(self, compilation_options, elf_path, Checkpoint::Complete),
             (PcsKind::Basefold, FieldType::Goldilocks) => {
                 prove_inner::<GoldilocksExt2, Basefold<GoldilocksExt2, BasefoldRSParams>, P>(
                     self,

--- a/ceno_cli/src/commands/common_args/ceno.rs
+++ b/ceno_cli/src/commands/common_args/ceno.rs
@@ -207,16 +207,20 @@ impl CenoOptions {
     ) -> anyhow::Result<()> {
         self.try_setup_logger();
         match (self.pcs, self.field) {
-            (PcsKind::Jagged, FieldType::Goldilocks) => keygen_inner::<
-                GoldilocksExt2,
-                Jagged<Basefold<GoldilocksExt2, BasefoldRSParams>>,
-                P,
-            >(self, compilation_options, elf_path),
-            (PcsKind::Jagged, FieldType::BabyBear) => keygen_inner::<
-                BabyBearExt4,
-                Jagged<Basefold<BabyBearExt4, BasefoldRSParams>>,
-                P,
-            >(self, compilation_options, elf_path),
+            (PcsKind::Jagged, FieldType::Goldilocks) => {
+                keygen_inner::<GoldilocksExt2, Jagged<Basefold<GoldilocksExt2, BasefoldRSParams>>, P>(
+                    self,
+                    compilation_options,
+                    elf_path,
+                )
+            }
+            (PcsKind::Jagged, FieldType::BabyBear) => {
+                keygen_inner::<BabyBearExt4, Jagged<Basefold<BabyBearExt4, BasefoldRSParams>>, P>(
+                    self,
+                    compilation_options,
+                    elf_path,
+                )
+            }
             (PcsKind::Basefold, FieldType::Goldilocks) => {
                 keygen_inner::<GoldilocksExt2, Basefold<GoldilocksExt2, BasefoldRSParams>, P>(
                     self,
@@ -261,14 +265,20 @@ impl CenoOptions {
                     GoldilocksExt2,
                     Jagged<Basefold<GoldilocksExt2, BasefoldRSParams>>,
                     P,
-                >(self, compilation_options, elf_path, Checkpoint::PrepWitnessGen)?;
+                >(
+                    self,
+                    compilation_options,
+                    elf_path,
+                    Checkpoint::PrepWitnessGen,
+                )?;
             }
             (PcsKind::Jagged, FieldType::BabyBear) => {
-                run_elf_inner::<
-                    BabyBearExt4,
-                    Jagged<Basefold<BabyBearExt4, BasefoldRSParams>>,
-                    P,
-                >(self, compilation_options, elf_path, Checkpoint::PrepWitnessGen)?;
+                run_elf_inner::<BabyBearExt4, Jagged<Basefold<BabyBearExt4, BasefoldRSParams>>, P>(
+                    self,
+                    compilation_options,
+                    elf_path,
+                    Checkpoint::PrepWitnessGen,
+                )?;
             }
             (PcsKind::Basefold, FieldType::Goldilocks) => {
                 run_elf_inner::<GoldilocksExt2, Basefold<GoldilocksExt2, BasefoldRSParams>, P>(
@@ -314,16 +324,22 @@ impl CenoOptions {
     ) -> anyhow::Result<()> {
         self.try_setup_logger();
         match (self.pcs, self.field) {
-            (PcsKind::Jagged, FieldType::Goldilocks) => prove_inner::<
-                GoldilocksExt2,
-                Jagged<Basefold<GoldilocksExt2, BasefoldRSParams>>,
-                P,
-            >(self, compilation_options, elf_path, Checkpoint::Complete),
-            (PcsKind::Jagged, FieldType::BabyBear) => prove_inner::<
-                BabyBearExt4,
-                Jagged<Basefold<BabyBearExt4, BasefoldRSParams>>,
-                P,
-            >(self, compilation_options, elf_path, Checkpoint::Complete),
+            (PcsKind::Jagged, FieldType::Goldilocks) => {
+                prove_inner::<GoldilocksExt2, Jagged<Basefold<GoldilocksExt2, BasefoldRSParams>>, P>(
+                    self,
+                    compilation_options,
+                    elf_path,
+                    Checkpoint::Complete,
+                )
+            }
+            (PcsKind::Jagged, FieldType::BabyBear) => {
+                prove_inner::<BabyBearExt4, Jagged<Basefold<BabyBearExt4, BasefoldRSParams>>, P>(
+                    self,
+                    compilation_options,
+                    elf_path,
+                    Checkpoint::Complete,
+                )
+            }
             (PcsKind::Basefold, FieldType::Goldilocks) => {
                 prove_inner::<GoldilocksExt2, Basefold<GoldilocksExt2, BasefoldRSParams>, P>(
                     self,

--- a/ceno_cli/src/commands/verify.rs
+++ b/ceno_cli/src/commands/verify.rs
@@ -7,7 +7,7 @@ use ceno_zkvm::{
 };
 use clap::Parser;
 use ff_ext::{BabyBearExt4, ExtensionField, GoldilocksExt2};
-use mpcs::{Basefold, BasefoldRSParams, PolynomialCommitmentScheme, Whir, WhirDefaultSpec};
+use mpcs::{Basefold, BasefoldRSParams, Jagged, PolynomialCommitmentScheme, Whir, WhirDefaultSpec};
 use serde::Serialize;
 use std::{fs::File, path::PathBuf};
 
@@ -32,6 +32,13 @@ pub struct VerifyCmd {
 impl VerifyCmd {
     pub fn run(self) -> anyhow::Result<()> {
         match (self.pcs, self.field) {
+            (PcsKind::Jagged, FieldType::Goldilocks) => run_inner::<
+                GoldilocksExt2,
+                Jagged<Basefold<GoldilocksExt2, BasefoldRSParams>>,
+            >(self),
+            (PcsKind::Jagged, FieldType::BabyBear) => {
+                run_inner::<BabyBearExt4, Jagged<Basefold<BabyBearExt4, BasefoldRSParams>>>(self)
+            }
             (PcsKind::Basefold, FieldType::Goldilocks) => {
                 run_inner::<GoldilocksExt2, Basefold<GoldilocksExt2, BasefoldRSParams>>(self)
             }

--- a/ceno_zkvm/src/bin/e2e.rs
+++ b/ceno_zkvm/src/bin/e2e.rs
@@ -17,7 +17,8 @@ use clap::Parser;
 use ff_ext::{BabyBearExt4, ExtensionField, GoldilocksExt2};
 use gkr_iop::hal::ProverBackend;
 use mpcs::{
-    Basefold, BasefoldRSParams, PolynomialCommitmentScheme, SecurityLevel, Whir, WhirDefaultSpec,
+    Basefold, BasefoldRSParams, Jagged, PolynomialCommitmentScheme, SecurityLevel, Whir,
+    WhirDefaultSpec,
 };
 use serde::{Serialize, de::DeserializeOwned};
 use std::{fs, panic, panic::AssertUnwindSafe, path::PathBuf};
@@ -233,6 +234,45 @@ fn main() {
     let public_io_digest = public_io_words_to_digest_words(&public_io);
 
     match (args.pcs, args.field) {
+        (PcsKind::Jagged, FieldType::Goldilocks) => {
+            let backend = create_backend(args.max_num_variables, args.security_level);
+            let prover = create_prover(backend);
+            run_inner::<
+                GoldilocksExt2,
+                Jagged<Basefold<GoldilocksExt2, BasefoldRSParams>>,
+                _,
+                _,
+            >(
+                prover,
+                program,
+                platform,
+                multi_prover,
+                &hints,
+                public_io_digest,
+                max_steps,
+                args.proof_file,
+                args.vk_file,
+                Checkpoint::Complete,
+                target_shard_id,
+            )
+        }
+        (PcsKind::Jagged, FieldType::BabyBear) => {
+            let backend = create_backend(args.max_num_variables, args.security_level);
+            let prover = create_prover(backend);
+            run_inner::<BabyBearExt4, Jagged<Basefold<BabyBearExt4, BasefoldRSParams>>, _, _>(
+                prover,
+                program,
+                platform,
+                multi_prover,
+                &hints,
+                public_io_digest,
+                max_steps,
+                args.proof_file,
+                args.vk_file,
+                Checkpoint::Complete,
+                target_shard_id,
+            )
+        }
         (PcsKind::Basefold, FieldType::Goldilocks) => {
             let backend = create_backend(args.max_num_variables, args.security_level);
             let prover = create_prover(backend);

--- a/ceno_zkvm/src/bin/e2e.rs
+++ b/ceno_zkvm/src/bin/e2e.rs
@@ -237,12 +237,7 @@ fn main() {
         (PcsKind::Jagged, FieldType::Goldilocks) => {
             let backend = create_backend(args.max_num_variables, args.security_level);
             let prover = create_prover(backend);
-            run_inner::<
-                GoldilocksExt2,
-                Jagged<Basefold<GoldilocksExt2, BasefoldRSParams>>,
-                _,
-                _,
-            >(
+            run_inner::<GoldilocksExt2, Jagged<Basefold<GoldilocksExt2, BasefoldRSParams>>, _, _>(
                 prover,
                 program,
                 platform,

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -104,6 +104,7 @@ pub fn public_io_words_to_digest_words(words: &[u32]) -> [u32; 8] {
 )]
 pub enum PcsKind {
     #[default]
+    Jagged,
     Basefold,
     Whir,
 }

--- a/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/keccak.rs
@@ -30,7 +30,7 @@ use crate::{
         },
         config::{
             is_debug_compare_enabled, is_gpu_witgen_enabled, is_kind_disabled,
-            should_materialize_witness_on_gpu, should_materialize_witness_on_initial_assign,
+            should_materialize_witness_on_gpu,
         },
         dispatch::{GpuWitgenKind, compute_fetch_params, is_force_cpu_path},
         utils::{
@@ -447,8 +447,7 @@ fn gpu_assign_keccak_inner<E: ExtensionField>(
     let num_instances = step_indices.len();
     let num_rows = num_instances * 32; // 2^5 = 32 rows per instance
     let rotation = KECCAK_ROUNDS_CEIL_LOG2; // = 5
-    let materialize_initial_witness = crate::instructions::gpu::config::is_debug_compare_enabled()
-        || should_materialize_witness_on_initial_assign();
+    let materialize_initial_witness = crate::instructions::gpu::config::is_debug_compare_enabled();
 
     // Step 1: Extract column map
     let col_map = info_span!("col_map").in_scope(|| extract_keccak_column_map(config, num_witin));

--- a/ceno_zkvm/src/instructions/gpu/config.rs
+++ b/ceno_zkvm/src/instructions/gpu/config.rs
@@ -68,10 +68,6 @@ pub(crate) fn is_gpu_witgen_enabled() -> bool {
     *ENABLED.get_or_init(|| {
         let val = std::env::var("CENO_GPU_ENABLE_WITGEN").ok();
         let enabled = matches!(val.as_deref(), Some("1"));
-        eprintln!(
-            "[GPU witgen] CENO_GPU_ENABLE_WITGEN={:?} → enabled={}",
-            val, enabled
-        );
         enabled
     })
 }
@@ -84,15 +80,6 @@ pub(crate) fn is_gpu_witgen_enabled() -> bool {
 ///   can consume the col-major GPU trace directly without a D2H/H2D round-trip
 pub(crate) fn should_materialize_witness_on_gpu() -> bool {
     is_gpu_witgen_enabled()
-}
-
-/// Whether the initial opcode-assignment pass should eagerly materialize witness
-/// RMM/device backing.
-///
-/// Replay metadata is the canonical GPU-witgen source for proving. Cache level
-/// controls later q'/PCS residency, not eager per-chip witness materialization.
-pub(crate) fn should_materialize_witness_on_initial_assign() -> bool {
-    false
 }
 
 /// Whether replayable witness device backing should remain resident after commit.

--- a/ceno_zkvm/src/instructions/gpu/config.rs
+++ b/ceno_zkvm/src/instructions/gpu/config.rs
@@ -86,14 +86,13 @@ pub(crate) fn should_materialize_witness_on_gpu() -> bool {
     is_gpu_witgen_enabled()
 }
 
-/// Whether the initial opcode-assignment pass should eagerly materialize the
-/// witness RMM/device backing.
+/// Whether the initial opcode-assignment pass should eagerly materialize witness
+/// RMM/device backing.
 ///
-/// In cache-none + GPU-witgen mode we keep only replay metadata plus the
-/// shard-resident raw GPU state, and all witness materialization is deferred to
-/// commit / chip proof / opening replay.
+/// Replay metadata is the canonical GPU-witgen source for proving. Cache level
+/// controls later q'/PCS residency, not eager per-chip witness materialization.
 pub(crate) fn should_materialize_witness_on_initial_assign() -> bool {
-    should_materialize_witness_on_gpu() && should_retain_witness_device_backing_after_commit()
+    false
 }
 
 /// Whether replayable witness device backing should remain resident after commit.
@@ -105,6 +104,22 @@ pub(crate) fn should_materialize_witness_on_initial_assign() -> bool {
 ///   demand from shard-resident raw data during chip proof / PCS open
 pub(crate) fn should_retain_witness_device_backing_after_commit() -> bool {
     is_gpu_witgen_enabled() && !matches!(get_gpu_cache_level(), CacheLevel::None)
+}
+
+/// Optional cap for Jagged q' reshape height.
+///
+/// `CENO_GPU_JAGGED_RESHAPE_LOG_HEIGHT` defaults to 26 to preserve the previous
+/// behavior. Smaller values trade more q' columns for lower height-scaled
+/// Basefold Merkle/hasher buffers, which is important on 16GB-class GPUs.
+pub(crate) fn jagged_reshape_log_height_cap() -> usize {
+    use std::sync::OnceLock;
+    static CAP: OnceLock<usize> = OnceLock::new();
+    *CAP.get_or_init(|| {
+        std::env::var("CENO_GPU_JAGGED_RESHAPE_LOG_HEIGHT")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(26)
+    })
 }
 
 /// Set `CENO_GPU_DEBUG_COMPARE_WITGEN=1` to enable GPU vs CPU comparison; default disabled.

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -22,10 +22,7 @@ use tracing::info_span;
 use witness::{InstancePaddingStrategy, RowMajorMatrix, next_pow2_instance_padding};
 
 use super::{
-    config::{
-        is_gpu_witgen_enabled, is_kind_disabled, should_materialize_witness_on_gpu,
-        should_materialize_witness_on_initial_assign,
-    },
+    config::{is_gpu_witgen_enabled, is_kind_disabled, should_materialize_witness_on_gpu},
     utils::debug_compare::{
         debug_compare_final_lk, debug_compare_shard_ec, debug_compare_shardram,
         debug_compare_witness,
@@ -283,8 +280,7 @@ fn gpu_assign_instances_inner<E: ExtensionField, I: Instruction<E>>(
 ) -> Result<(RMMCollections<E::BaseField>, Multiplicity<u64>), ZKVMError> {
     let num_structural_witin = num_structural_witin.max(1);
     let total_instances = step_indices.len();
-    let materialize_initial_witness = crate::instructions::gpu::config::is_debug_compare_enabled()
-        || should_materialize_witness_on_initial_assign();
+    let materialize_initial_witness = crate::instructions::gpu::config::is_debug_compare_enabled();
 
     // Step 1: GPU fills witness matrix (+ LK counters + shard records for merged kinds)
     let (gpu_witness, gpu_lk_counters, gpu_ram_slots, gpu_compact_ec, gpu_compact_addr) =

--- a/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp.rs
@@ -12,7 +12,7 @@ use gkr_iop::{
 };
 use itertools::{Itertools, izip};
 use multilinear_extensions::{ToExpr, util::max_usable_threads};
-use p3::{field::FieldAlgebra, matrix::Matrix};
+use p3::field::FieldAlgebra;
 use rayon::{
     iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator},
     slice::ParallelSlice,

--- a/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp2_add.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp2_add.rs
@@ -11,7 +11,7 @@ use gkr_iop::{
 };
 use itertools::{Itertools, izip};
 use multilinear_extensions::{ToExpr, util::max_usable_threads};
-use p3::{field::FieldAlgebra, matrix::Matrix};
+use p3::field::FieldAlgebra;
 use rayon::{
     iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator},
     slice::ParallelSlice,

--- a/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp2_mul.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp2_mul.rs
@@ -11,7 +11,7 @@ use gkr_iop::{
 };
 use itertools::{Itertools, izip};
 use multilinear_extensions::{ToExpr, util::max_usable_threads};
-use p3::{field::FieldAlgebra, matrix::Matrix};
+use p3::field::FieldAlgebra;
 use rayon::{
     iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator},
     slice::ParallelSlice,

--- a/ceno_zkvm/src/instructions/riscv/ecall/keccak.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/keccak.rs
@@ -12,7 +12,7 @@ use gkr_iop::{
 };
 use itertools::{Itertools, izip};
 use multilinear_extensions::{ToExpr, util::max_usable_threads};
-use p3::{field::FieldAlgebra, matrix::Matrix};
+use p3::field::FieldAlgebra;
 use rayon::{
     iter::{IndexedParallelIterator, ParallelIterator},
     slice::ParallelSlice,

--- a/ceno_zkvm/src/instructions/riscv/ecall/sha_extend.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/sha_extend.rs
@@ -10,7 +10,6 @@ use gkr_iop::{
 };
 use itertools::{Itertools, izip};
 use multilinear_extensions::{ToExpr, WitIn, util::max_usable_threads};
-use p3::matrix::Matrix;
 use rayon::{
     iter::{IndexedParallelIterator, ParallelIterator},
     slice::ParallelSlice,

--- a/ceno_zkvm/src/instructions/riscv/ecall/uint256.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/uint256.rs
@@ -13,7 +13,7 @@ use gkr_iop::{
 use itertools::{Itertools, chain, izip};
 use multilinear_extensions::{ToExpr, util::max_usable_threads};
 use num_bigint::BigUint;
-use p3::{field::FieldAlgebra, matrix::Matrix};
+use p3::field::FieldAlgebra;
 use rayon::{
     iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator},
     slice::ParallelSlice,

--- a/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_add.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_add.rs
@@ -12,7 +12,7 @@ use gkr_iop::{
 };
 use itertools::{Itertools, izip};
 use multilinear_extensions::{ToExpr, util::max_usable_threads};
-use p3::{field::FieldAlgebra, matrix::Matrix};
+use p3::field::FieldAlgebra;
 use rayon::{
     iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator},
     slice::ParallelSlice,

--- a/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_decompress.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_decompress.rs
@@ -13,7 +13,6 @@ use gkr_iop::{
 use itertools::{Itertools, izip};
 use multilinear_extensions::{Expression, ToExpr, util::max_usable_threads};
 use num::BigUint;
-use p3::matrix::Matrix;
 use rayon::{
     iter::{
         IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,

--- a/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_double.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_double.rs
@@ -12,7 +12,7 @@ use gkr_iop::{
 };
 use itertools::{Itertools, izip};
 use multilinear_extensions::{ToExpr, util::max_usable_threads};
-use p3::{field::FieldAlgebra, matrix::Matrix};
+use p3::field::FieldAlgebra;
 use rayon::{
     iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator},
     slice::ParallelSlice,

--- a/ceno_zkvm/src/scheme/gpu/memory.rs
+++ b/ceno_zkvm/src/scheme/gpu/memory.rs
@@ -45,7 +45,6 @@ pub fn init_gpu_mem_tracker<'a>(
 
 const ESTIMATION_TOLERANCE_BYTES: usize = 2 * 1024 * 1024; // max under-estimation error: 2 MB
 const ESTIMATION_SAFETY_MARGIN_BYTES: usize = 10 * 1024 * 1024; // reserved headroom / allowed over-estimate margin: 10 MB
-const SCHEDULER_ESTIMATION_WARNING_MARGIN_BYTES: usize = 512 * 1024 * 1024;
 const SHARD_RAM_TOWER_PROVE_TOLERANCE_BYTES: usize = 16 * 1024 * 1024;
 
 /// Validate that the estimated GPU memory matches actual usage within tolerance.
@@ -96,47 +95,13 @@ pub fn check_gpu_scheduler_mem_estimation_with_context(
     estimated_bytes: usize,
     context: Option<&str>,
 ) {
-    // Scheduler estimates are admission-control estimates, not exact stage-local allocation
-    // estimates. They intentionally include safety margins and conservative lifetime overlap, so
-    // large over-estimates should be surfaced as warnings rather than failing the proof. Under-
-    // estimates remain hard failures because they can admit unsafe concurrent work.
-    if let Some(mem_tracker) = mem_tracker {
-        const ONE_MB: usize = 1024 * 1024;
-        let label = mem_tracker.name();
-        let label = context
-            .filter(|context| !context.is_empty())
-            .map(|context| format!("{label}[{context}]"))
-            .unwrap_or_else(|| label.to_string());
-        let mem_stats = mem_tracker.finish();
-        let actual_bytes = mem_stats.mem_occupancy as usize;
-        let diff = estimated_bytes as isize - actual_bytes as isize;
-        let to_mb = |b: usize| b as f64 / ONE_MB as f64;
-        let diff_mb = diff as f64 / ONE_MB as f64;
-        tracing::info!(
-            "[memcheck] {label}: scheduler_estimated={:.2}MB, actual={:.2}MB, diff={:.2}MB",
-            to_mb(estimated_bytes),
-            to_mb(actual_bytes),
-            diff_mb
-        );
-        if diff < 0 {
-            assert!(
-                (-diff) as usize <= ESTIMATION_TOLERANCE_BYTES,
-                "[memcheck] {label}: scheduler under-estimate! estimated={:.2}MB, actual={:.2}MB, diff={:.2}MB, tolerance={:.2}MB",
-                to_mb(estimated_bytes),
-                to_mb(actual_bytes),
-                diff_mb,
-                to_mb(ESTIMATION_TOLERANCE_BYTES),
-            );
-        } else if diff as usize > SCHEDULER_ESTIMATION_WARNING_MARGIN_BYTES {
-            tracing::warn!(
-                "[memcheck] {label}: scheduler over-estimate warning: estimated={:.2}MB, actual={:.2}MB, diff={:.2}MB, warning_margin={:.2}MB",
-                to_mb(estimated_bytes),
-                to_mb(actual_bytes),
-                diff_mb,
-                to_mb(SCHEDULER_ESTIMATION_WARNING_MARGIN_BYTES),
-            );
-        }
-    }
+    check_gpu_mem_estimation_with_margins(
+        mem_tracker,
+        estimated_bytes,
+        context,
+        ESTIMATION_TOLERANCE_BYTES,
+        ESTIMATION_SAFETY_MARGIN_BYTES,
+    );
 }
 
 fn check_gpu_mem_estimation_with_margins(
@@ -159,7 +124,7 @@ fn check_gpu_mem_estimation_with_margins(
         let diff = estimated_bytes as isize - actual_bytes as isize;
         let to_mb = |b: usize| b as f64 / ONE_MB as f64;
         let diff_mb = diff as f64 / ONE_MB as f64;
-        tracing::info!(
+        tracing::debug!(
             "[memcheck] {label}: estimated={:.2}MB, actual={:.2}MB, diff={:.2}MB",
             to_mb(estimated_bytes),
             to_mb(actual_bytes),
@@ -689,12 +654,35 @@ fn estimate_tower_stage_components<E: ExtensionField, PCS: PolynomialCommitmentS
         elem_size,
         has_logup_numerator,
     );
+    if get_mem_tracking_mode() {
+        let to_mb = |bytes: usize| bytes as f64 / (1024.0 * 1024.0);
+        tracing::debug!(
+            "[mem estimate][tower_components] prod_towers={}, logup_towers={}, num_vars={}, occupied_rows={}, build_total={:.2}MB, build_prod={:.2}MB, build_logup={:.2}MB, build_aux={:.2}MB, prove_total={:.2}MB, prove_local_total={:.2}MB, prove_prod_live={:.2}MB, prove_logup_live={:.2}MB, prove_borrowed={:.2}MB, prove_eq={:.2}MB, prove_sumcheck={:.2}MB",
+            num_prod_towers,
+            num_logup_towers,
+            num_vars,
+            occupied_rows,
+            to_mb(build_bytes),
+            to_mb(build_est.prod_tower_buffer_bytes),
+            to_mb(build_est.logup_tower_buffer_bytes),
+            to_mb(build_est.aux_buffer_bytes),
+            to_mb(prove_est.total_bytes),
+            to_mb(prove_est.local_total_bytes),
+            to_mb(prove_est.prod_tower_buffer_bytes),
+            to_mb(prove_est.logup_tower_buffer_bytes),
+            to_mb(prove_est.prod_borrowed_input_bytes + prove_est.logup_borrowed_input_bytes),
+            to_mb(prove_est.eq_mle_buffer_bytes),
+            to_mb(prove_est.sumcheck_estimate.total_bytes),
+        );
+    }
 
     let tower_input_live_bytes =
         prove_est.prod_tower_buffer_bytes + prove_est.logup_tower_buffer_bytes;
     let borrowed_input_bytes =
         prove_est.prod_borrowed_input_bytes + prove_est.logup_borrowed_input_bytes;
-    let prove_local_bytes = prove_est.total_bytes.saturating_sub(tower_input_live_bytes);
+    let prove_local_bytes = prove_est
+        .local_total_bytes
+        .saturating_sub(tower_input_live_bytes.saturating_sub(borrowed_input_bytes));
 
     (
         build_bytes,
@@ -719,9 +707,23 @@ pub(crate) fn estimate_tower_bytes<E: ExtensionField, PCS: PolynomialCommitmentS
     composed_cs: &ComposedConstrainSystem<E>,
     input: &ProofInput<'_, GpuBackend<E, PCS>>,
 ) -> usize {
-    let (build_bytes, prove_local_bytes, tower_input_live_bytes, _) =
+    let (build_bytes, prove_local_bytes, tower_input_live_bytes, borrowed_input_bytes) =
         estimate_tower_stage_components(composed_cs, input, None);
-    build_bytes.max(tower_input_live_bytes + prove_local_bytes)
+    let prove_bytes = tower_input_live_bytes
+        .saturating_sub(borrowed_input_bytes)
+        .saturating_add(prove_local_bytes);
+    if get_mem_tracking_mode() {
+        let to_mb = |bytes: usize| bytes as f64 / (1024.0 * 1024.0);
+        tracing::debug!(
+            "[mem estimate][tower_local] build={:.2}MB, prove={:.2}MB, tower_live={:.2}MB, borrowed={:.2}MB, prove_local={:.2}MB",
+            to_mb(build_bytes),
+            to_mb(prove_bytes),
+            to_mb(tower_input_live_bytes),
+            to_mb(borrowed_input_bytes),
+            to_mb(prove_local_bytes),
+        );
+    }
+    build_bytes.max(prove_bytes)
 }
 
 /// Estimate GPU memory for trace extraction (get_trace).

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -1295,7 +1295,7 @@ fn jagged_batch_commit_from_host(
     let h = 1usize << log_h;
     let w = total_evaluations.div_ceil(h);
     let padded_total = w * h;
-    let q_len = 1usize << ceil_log2(padded_total.max(1));
+    let q_len = padded_total.max(1);
 
     // q' is large, and `vec![ZERO; q_len]` serializes a full-buffer zero fill
     // before the actual witness copy overwrites most entries. Allocate
@@ -3748,7 +3748,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>
             let h = 1usize << jagged_commitment.reshape_log_height;
             let w = total_evaluations.div_ceil(h);
             let padded_total = w * h;
-            let q_len = 1usize << ceil_log2(padded_total.max(1));
+            let q_len = padded_total.max(1);
             let mut q_evals = vec![BB31Base::ZERO; q_len];
             for (poly_idx, poly) in jagged_commitment.polys.iter().enumerate() {
                 let start = jagged_commitment.cumulative_heights[poly_idx];

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -2559,7 +2559,7 @@ pub(crate) fn build_tower_witness_gpu<E: ExtensionField>(
         let last_layers_refs: Vec<&[GpuPolynomialExt<'_>]> =
             prod_last_layers.iter().map(|v| v.as_slice()).collect();
         let gpu_specs = {
-            cuda_hal.tower.build_prod_tower_dense_from_gpu_polys_batch(
+            cuda_hal.tower.build_prod_tower_from_gpu_polys_batch(
                 cuda_hal,
                 &last_layers_refs,
                 num_vars,
@@ -2567,12 +2567,13 @@ pub(crate) fn build_tower_witness_gpu<E: ExtensionField>(
                 stream.as_ref(),
             )
         }
-        .map_err(|e| {
-            format!(
-                "build_prod_tower_dense_from_gpu_polys_batch failed: {:?}",
-                e
-            )
-        })?;
+        .map_err(|e| format!("build_prod_tower_from_gpu_polys_batch failed: {:?}", e))?;
+        let gpu_specs = unsafe {
+            std::mem::transmute::<
+                Vec<ceno_gpu::GpuProverSpec<'_>>,
+                Vec<ceno_gpu::GpuProverSpec<'static>>,
+            >(gpu_specs)
+        };
         prod_gpu_specs.extend(gpu_specs);
         exit_span!(span_prod);
     }
@@ -2594,19 +2595,20 @@ pub(crate) fn build_tower_witness_gpu<E: ExtensionField>(
             logup_last_layers.iter().map(|v| v.as_slice()).collect();
         let gpu_specs = cuda_hal
             .tower
-            .build_logup_tower_dense_from_gpu_polys_batch(
+            .build_logup_tower_from_gpu_polys_batch(
                 cuda_hal,
                 &last_layers_refs,
                 num_vars,
                 num_towers,
                 stream.as_ref(),
             )
-            .map_err(|e| {
-                format!(
-                    "build_logup_tower_dense_from_gpu_polys_batch failed: {:?}",
-                    e
-                )
-            })?;
+            .map_err(|e| format!("build_logup_tower_from_gpu_polys_batch failed: {:?}", e))?;
+        let gpu_specs = unsafe {
+            std::mem::transmute::<
+                Vec<ceno_gpu::GpuProverSpec<'_>>,
+                Vec<ceno_gpu::GpuProverSpec<'static>>,
+            >(gpu_specs)
+        };
         logup_gpu_specs.extend(gpu_specs);
         exit_span!(span_logup);
     }

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -27,8 +27,8 @@ use ceno_gpu::{
     common::{
         CacheLevel, get_gpu_cache_level,
         jagged::{
-            JaggedSumcheckGpuCtx, eval_cols_at_point_gpu, jagged_batch_open_gpu,
-            jagged_sumcheck_prove_gpu,
+            JaggedSumcheckGpuCtx, batch_commit_gpu_grouped, eval_cols_at_point_gpu,
+            jagged_batch_open_gpu, jagged_sumcheck_prove_gpu,
         },
         sumcheck::CommonTermPlan,
     },
@@ -69,6 +69,7 @@ use std::{
     collections::BTreeMap,
     io::Write,
     iter::{once, repeat_n},
+    mem::MaybeUninit,
     sync::Arc,
 };
 use sumcheck::{
@@ -1183,8 +1184,8 @@ pub(crate) fn normalize_traces_to_device_col_major<E: ExtensionField>(
             &cuda_hal.inner,
             &mut col_major_buf,
             &row_major_buf,
-            rows,
             cols,
+            rows,
         )
         .unwrap_or_else(|e| panic!("failed to transpose trace {idx} to col-major: {e}"));
 
@@ -1207,6 +1208,52 @@ fn jagged_batch_commit_from_host(
     reshape_log_height: usize,
     prefer_device_backing: bool,
 ) -> (GpuJaggedHostPreprocessed, GpuBasefoldPcsData) {
+    if prefer_device_backing
+        && traces
+            .iter()
+            .all(|trace| trace.device_backing_layout() == Some(DeviceMatrixLayout::ColMajor))
+    {
+        let group_width = mpcs::JAGGED_RESHAPE_GROUP_WIDTH;
+        let (preprocessed, mut inner) = batch_commit_gpu_grouped(
+            cuda_hal.as_ref(),
+            traces,
+            reshape_log_height,
+            group_width,
+            |reshape_rmms| {
+                cuda_hal
+                    .basefold
+                    .batch_commit_cache_none(cuda_hal.as_ref(), reshape_rmms)
+            },
+        )
+        .expect("failed to commit Jagged q' with GPU q' construction");
+        let q_host_evals = if matches!(get_gpu_cache_level(), CacheLevel::None) {
+            preprocessed
+                .q_evals
+                .to_vec()
+                .expect("Jagged q' D2H copy failed after GPU commit")
+        } else {
+            Vec::new()
+        };
+        if matches!(get_gpu_cache_level(), CacheLevel::None) {
+            if let Some(rmms) = inner.rmms.as_mut() {
+                for rmm in rmms {
+                    rmm.clear_device_backing();
+                }
+            }
+        }
+        return (
+            GpuJaggedHostPreprocessed {
+                q_host_evals,
+                q_device_evals: Some(preprocessed.q_evals),
+                cumulative_heights: preprocessed.cumulative_heights,
+                poly_heights: preprocessed.poly_heights,
+                total_evaluations: preprocessed.total_evaluations,
+                reshape_log_height: preprocessed.reshape_log_height,
+            },
+            inner,
+        );
+    }
+
     let mut poly_heights = Vec::new();
     for trace in traces {
         for _ in 0..trace.width() {
@@ -1226,7 +1273,16 @@ fn jagged_batch_commit_from_host(
     let padded_total = w * h;
     let q_len = 1usize << ceil_log2(padded_total.max(1));
 
-    let mut q_host = vec![BB31Base::ZERO; q_len];
+    // q' is large, and `vec![ZERO; q_len]` serializes a full-buffer zero fill
+    // before the actual witness copy overwrites most entries. Allocate
+    // uninitialized storage instead; the loops below initialize every real
+    // q' element, and the final parallel pass initializes all padding. If a
+    // panic happens mid-construction, proving aborts and the `MaybeUninit`
+    // buffer will not drop uninitialized field elements.
+    let mut q_host_uninit = Vec::<MaybeUninit<BB31Base>>::with_capacity(q_len);
+    unsafe {
+        q_host_uninit.set_len(q_len);
+    }
     let mut poly_idx = 0usize;
     for trace in traces {
         let rows = trace.height();
@@ -1247,27 +1303,47 @@ fn jagged_batch_commit_from_host(
             let device_values = device_buffer
                 .to_vec()
                 .expect("Jagged trace device backing D2H failed");
-            q_host[start..start + rows * cols]
+            q_host_uninit[start..start + rows * cols]
                 .par_chunks_mut(rows)
                 .enumerate()
                 .for_each(|(col_idx, out)| {
                     let src_start = col_idx * col_rows;
                     let src_end = src_start + col_rows;
-                    out[..col_rows].copy_from_slice(&device_values[src_start..src_end]);
+                    for (dst, src) in out[..col_rows]
+                        .iter_mut()
+                        .zip(&device_values[src_start..src_end])
+                    {
+                        dst.write(*src);
+                    }
+                    for dst in &mut out[col_rows..] {
+                        dst.write(BB31Base::ZERO);
+                    }
                 });
         } else {
             let values = trace.values();
-            q_host[start..start + rows * cols]
+            q_host_uninit[start..start + rows * cols]
                 .par_chunks_mut(rows)
                 .enumerate()
                 .for_each(|(col_idx, out)| {
                     for row_idx in 0..rows {
-                        out[row_idx] = values[row_idx * cols + col_idx];
+                        out[row_idx].write(values[row_idx * cols + col_idx]);
                     }
                 });
         }
         poly_idx += cols;
     }
+    q_host_uninit[total_evaluations..]
+        .par_iter_mut()
+        .for_each(|dst| {
+            dst.write(BB31Base::ZERO);
+        });
+    let q_host = unsafe {
+        let ptr = q_host_uninit.as_mut_ptr() as *mut BB31Base;
+        let len = q_host_uninit.len();
+        let cap = q_host_uninit.capacity();
+        std::mem::forget(q_host_uninit);
+        Vec::from_raw_parts(ptr, len, cap)
+    };
 
     let q_device = cuda_hal
         .alloc_elems_from_host(&q_host, None)
@@ -1637,7 +1713,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>
                     &cuda_hal,
                     &traces_gl64,
                     reshape_log_height,
-                    false,
+                    true,
                 );
                 for trace in &mut traces_gl64 {
                     trace.clear_device_backing();
@@ -3294,11 +3370,10 @@ where
                         transcript,
                         |_round_idx, trace_idx| {
                             let h = 1usize << jagged_data.reshape_log_height;
-                            let inner_rmms = jagged_data
-                                .inner
-                                .rmms
-                                .as_ref()
-                                .expect("Jagged cache-none opening requires inner RMM metadata");
+                            let inner_rmms =
+                                jagged_data.inner.rmms.as_ref().expect(
+                                    "Jagged cache-none opening requires inner RMM metadata",
+                                );
                             assert!(
                                 trace_idx < inner_rmms.len(),
                                 "Jagged inner q' trace index out of range"
@@ -3308,22 +3383,21 @@ where
                                 .map(|rmm| rmm.width())
                                 .sum::<usize>();
                             let group_cols = inner_rmms[trace_idx].width();
-                            let mut reshape_values = vec![BB31Base::ZERO; h * group_cols];
-                            reshape_values
-                                .par_chunks_mut(group_cols)
-                                .enumerate()
-                                .for_each(|(row_idx, row)| {
-                                    for (local_col, value) in row.iter_mut().enumerate() {
-                                        let src_idx = (group_start_col + local_col) * h + row_idx;
-                                        if src_idx < jagged_data.total_evaluations {
-                                            *value = q_host[src_idx];
-                                        }
-                                    }
-                                });
-                            Ok(Some(witness::RowMajorMatrix::new_by_values(
-                                reshape_values,
+                            let start = group_start_col * h;
+                            let end = start + group_cols * h;
+                            let q_view = cuda_hal
+                                .alloc_elems_from_host(&q_host[start..end], None)
+                                .map_err(|e| {
+                                    ceno_gpu::HalError::Unknown(format!(
+                                        "failed to upload Jagged q' group for opening: {e:?}"
+                                    ))
+                                })?;
+                            Ok(Some(witness::RowMajorMatrix::new_by_device_backing(
+                                h,
                                 group_cols,
                                 InstancePaddingStrategy::Default,
+                                q_view,
+                                DeviceMatrixLayout::ColMajor,
                             )))
                         },
                     )

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -1395,26 +1395,32 @@ fn jagged_batch_commit_from_host(
     let q_device = cuda_hal
         .alloc_elems_from_host(&q_host, None)
         .expect("failed to upload Jagged q' evaluations for commit");
-    let reshape_rmms = (0..w)
+    let specs = (0..w)
         .step_by(group_width)
-        .map(|group_start_col| {
+        .map(
+            |_group_start_col| ceno_gpu::common::poseidon2::DeferredRmmSpec {
+                height: h,
+                persist_actual: false,
+            },
+        )
+        .collect_vec();
+    let mut inner = cuda_hal
+        .basefold
+        .batch_commit_cache_none_deferred(cuda_hal.as_ref(), specs, |trace_idx| {
+            let group_start_col = trace_idx * group_width;
             let group_cols = (w - group_start_col).min(group_width);
             let start = group_start_col * h * std::mem::size_of::<BB31Base>();
             let end = start + group_cols * h * std::mem::size_of::<BB31Base>();
             let commit_view = q_device.owned_subrange(start..end);
-            witness::RowMajorMatrix::new_by_device_backing(
+            Ok(witness::RowMajorMatrix::new_by_device_backing(
                 h,
                 group_cols,
                 InstancePaddingStrategy::Default,
                 commit_view,
                 DeviceMatrixLayout::ColMajor,
-            )
+            ))
         })
-        .collect_vec();
-    let mut inner = cuda_hal
-        .basefold
-        .batch_commit_cache_none(cuda_hal.as_ref(), reshape_rmms)
-        .expect("failed to commit Jagged q' with GPU Basefold");
+        .expect("failed to commit Jagged q' with deferred GPU Basefold");
     let q_device_evals = if matches!(get_gpu_cache_level(), CacheLevel::None) {
         if let Some(rmms) = inner.rmms.as_mut() {
             for rmm in rmms {
@@ -1939,27 +1945,14 @@ where
             let start_elem = pcs_data.cumulative_heights[poly_idx];
             let len = pcs_data.poly_heights[poly_idx];
             let gpu_buffer = if let Some(q_evals) = &pcs_data.q_evals {
+                assert_eq!(
+                    len, logical_len,
+                    "Jagged q' MLE extraction would require a padded D2D copy: \
+                     trace_idx={trace_idx}, col_idx={col_idx}, len={len}, logical_len={logical_len}"
+                );
                 let start = start_elem * elem_size;
                 let end = start + len * elem_size;
-                if len == logical_len {
-                    q_evals.owned_subrange(start..end)
-                } else {
-                    let cuda_hal = get_cuda_hal().unwrap();
-                    let src = q_evals.as_slice_range(start..end);
-                    let mut padded_buffer = cuda_hal
-                        .alloc_elems_on_device(logical_len, true, None)
-                        .unwrap_or_else(|err| {
-                            panic!("Jagged q' padded column allocation failed: {err:?}")
-                        });
-                    let mut dst = padded_buffer.as_mut_slice_range(0..len * elem_size);
-                    cuda_hal
-                        .inner
-                        .dtod_copy_sync(&src, &mut dst)
-                        .unwrap_or_else(|err| {
-                            panic!("Jagged q' compact-to-padded D2D copy failed: {err:?}")
-                        });
-                    padded_buffer
-                }
+                q_evals.owned_subrange(start..end)
             } else if let Some(q_host) = pcs_data.q_host_evals.as_ref() {
                 let cuda_hal = get_cuda_hal().unwrap();
                 if len == logical_len {
@@ -3361,105 +3354,101 @@ where
                 .alloc_elems_from_host(q_host, None)
                 .expect("failed to upload Jagged q' for opening")
         };
-        let proof = jagged_batch_open_gpu::<BB31Ext, BabyBearBasefold, _>(
-            &jagged_data.cumulative_heights,
-            jagged_data.total_evaluations,
-            jagged_data.reshape_log_height,
-            &point,
-            &evals,
-            basic_transcript,
-            |num_giga_vars, w, cumulative_heights, eq_row, eq_col, transcript| {
-                let ctx = JaggedSumcheckGpuCtx::<CudaHalBB31>::from_gpu_q_evals(
-                    &cuda_hal,
-                    q_evals,
-                    cumulative_heights,
-                    &eq_row,
-                    &eq_col,
-                    num_giga_vars,
-                )
-                .expect("create Jagged GPU sumcheck ctx");
-                let (proof, rho) = jagged_sumcheck_prove_gpu::<
-                    CudaHalBB31,
-                    BB31Ext,
-                    BB31Base,
-                    GpuMatrix,
-                    GpuPolynomial,
-                    GpuPolynomialExt,
-                    GpuFieldType,
-                >(&cuda_hal, &ctx, transcript, None)
-                .expect("Jagged GPU sumcheck failed");
-                let col_evals = eval_cols_at_point_gpu::<CudaHalBB31, BB31Ext, BB31Base>(
-                    &cuda_hal,
-                    &ctx.q_evals,
-                    &rho[..jagged_data.reshape_log_height],
-                    jagged_data.reshape_log_height,
-                    w,
-                )
-                .expect("Jagged GPU column eval failed");
-                (proof, rho, col_evals)
-            },
-            |rho_row, col_evals, transcript| {
-                let group_width = mpcs::JAGGED_RESHAPE_GROUP_WIDTH;
-                let inner_openings = col_evals
-                    .chunks(group_width)
-                    .map(|evals| (rho_row.clone(), evals.to_vec()))
-                    .collect_vec();
-                let gpu_basefold_proof = if jagged_data.q_evals.is_none() {
-                    let q_host = jagged_data
-                        .q_host_evals
-                        .as_ref()
-                        .expect("Jagged q' host backing missing for cache-none opening");
-                    cuda_hal.basefold.batch_open_with_trace_materializer(
+        let proof =
+            jagged_batch_open_gpu::<BB31Ext, BabyBearBasefold, _>(
+                &jagged_data.cumulative_heights,
+                jagged_data.total_evaluations,
+                jagged_data.reshape_log_height,
+                &point,
+                &evals,
+                basic_transcript,
+                |num_giga_vars, w, cumulative_heights, eq_row, eq_col, transcript| {
+                    let ctx = JaggedSumcheckGpuCtx::<CudaHalBB31>::from_gpu_q_evals(
                         &cuda_hal,
-                        pp_bb31,
-                        vec![(&jagged_data.inner, inner_openings)],
-                        transcript,
-                        |_round_idx, trace_idx| {
-                            let h = 1usize << jagged_data.reshape_log_height;
-                            let w = jagged_data.total_evaluations.div_ceil(h);
-                            let group_start_col = trace_idx * group_width;
-                            assert!(
-                                group_start_col < w,
-                                "Jagged inner q' trace index out of range"
-                            );
-                            let group_cols = (w - group_start_col).min(group_width);
-                            let start = group_start_col * h;
-                            let end = start + group_cols * h;
-                            let q_view = cuda_hal
-                                .alloc_elems_from_host(&q_host[start..end], None)
-                                .map_err(|e| {
+                        q_evals,
+                        cumulative_heights,
+                        &eq_row,
+                        &eq_col,
+                        num_giga_vars,
+                    )
+                    .expect("create Jagged GPU sumcheck ctx");
+                    let (proof, rho) = jagged_sumcheck_prove_gpu::<
+                        CudaHalBB31,
+                        BB31Ext,
+                        BB31Base,
+                        GpuMatrix,
+                        GpuPolynomial,
+                        GpuPolynomialExt,
+                        GpuFieldType,
+                    >(&cuda_hal, &ctx, transcript, None)
+                    .expect("Jagged GPU sumcheck failed");
+                    let col_evals = eval_cols_at_point_gpu::<CudaHalBB31, BB31Ext, BB31Base>(
+                        &cuda_hal,
+                        &ctx.q_evals,
+                        &rho[..jagged_data.reshape_log_height],
+                        jagged_data.reshape_log_height,
+                        w,
+                    )
+                    .expect("Jagged GPU column eval failed");
+                    (proof, rho, col_evals)
+                },
+                |rho_row, col_evals, transcript| {
+                    let group_width = mpcs::JAGGED_RESHAPE_GROUP_WIDTH;
+                    let inner_openings = col_evals
+                        .chunks(group_width)
+                        .map(|evals| (rho_row.clone(), evals.to_vec()))
+                        .collect_vec();
+                    let gpu_basefold_proof = cuda_hal.basefold.batch_open_with_trace_materializer(
+                    &cuda_hal,
+                    pp_bb31,
+                    vec![(&jagged_data.inner, inner_openings)],
+                    transcript,
+                    |_round_idx, trace_idx| {
+                        let h = 1usize << jagged_data.reshape_log_height;
+                        let w = jagged_data.total_evaluations.div_ceil(h);
+                        let group_start_col = trace_idx * group_width;
+                        assert!(group_start_col < w, "Jagged inner q' trace index out of range");
+                        let group_cols = (w - group_start_col).min(group_width);
+                        let start = group_start_col * h;
+                        let end = start + group_cols * h;
+                        let q_view = if let Some(q_evals) = jagged_data.q_evals.as_ref() {
+                            q_evals.owned_subrange(
+                                start * std::mem::size_of::<BB31Base>()
+                                    ..end * std::mem::size_of::<BB31Base>(),
+                            )
+                        } else {
+                            let q_host = jagged_data
+                                .q_host_evals
+                                .as_ref()
+                                .expect("Jagged q' host backing missing for opening");
+                            cuda_hal.alloc_elems_from_host(&q_host[start..end], None).map_err(
+                                |e| {
                                     ceno_gpu::HalError::Unknown(format!(
                                         "failed to upload Jagged q' group for opening: {e:?}"
                                     ))
-                                })?;
-                            Ok(Some(witness::RowMajorMatrix::new_by_device_backing(
-                                h,
-                                group_cols,
-                                InstancePaddingStrategy::Default,
-                                q_view,
-                                DeviceMatrixLayout::ColMajor,
-                            )))
-                        },
-                    )
-                } else {
-                    cuda_hal.basefold.batch_open(
-                        &cuda_hal,
-                        pp_bb31,
-                        vec![(&jagged_data.inner, inner_openings)],
-                        transcript,
-                    )
-                }
+                                },
+                            )?
+                        };
+                        Ok(Some(witness::RowMajorMatrix::new_by_device_backing(
+                            h,
+                            group_cols,
+                            InstancePaddingStrategy::Default,
+                            q_view,
+                            DeviceMatrixLayout::ColMajor,
+                        )))
+                    },
+                )
                 .map_err(|e| mpcs::Error::InvalidPcsOpen(e.to_string()))?;
-                Ok(mpcs::basefold::structure::BasefoldProof {
-                    commits: gpu_basefold_proof.commits,
-                    query_opening_proof: gpu_basefold_proof.query_opening_proof,
-                    sumcheck_proof: gpu_basefold_proof.sumcheck_proof,
-                    final_message: gpu_basefold_proof.final_message,
-                    pow_witness: gpu_basefold_proof.pow_witness,
-                })
-            },
-        )
-        .expect("Jagged GPU batch open failed");
+                    Ok(mpcs::basefold::structure::BasefoldProof {
+                        commits: gpu_basefold_proof.commits,
+                        query_opening_proof: gpu_basefold_proof.query_opening_proof,
+                        sumcheck_proof: gpu_basefold_proof.sumcheck_proof,
+                        final_message: gpu_basefold_proof.final_message,
+                        pow_witness: gpu_basefold_proof.pow_witness,
+                    })
+                },
+            )
+            .expect("Jagged GPU batch open failed");
         proofs.push(proof);
     }
 

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -295,6 +295,18 @@ where
     Some(device_buffer.len() / cols)
 }
 
+fn jagged_trace_physical_rows<T>(trace: &witness::RowMajorMatrix<T>) -> usize
+where
+    T: FieldAlgebra + Default + Sync + Clone + Send + Copy + 'static,
+{
+    if trace.device_backing_layout() == Some(DeviceMatrixLayout::ColMajor) {
+        rmm_col_major_device_rows(trace)
+            .unwrap_or_else(|| panic!("Jagged trace col-major device row count mismatch"))
+    } else {
+        trace.occupied_physical_rows()
+    }
+}
+
 fn pcs_resident_stats(pcs_data_basefold: &GpuBasefoldPcsData) -> PcsResidentStats {
     let digest_tree_bytes =
         pcs_data_basefold.codeword.digest_buf.len() * std::mem::size_of::<BB31Base>();
@@ -1153,6 +1165,7 @@ pub fn prove_ec_sum_quark_impl<'a, E: ExtensionField, PCS: PolynomialCommitmentS
 pub(crate) fn normalize_traces_to_device_col_major<E: ExtensionField>(
     cuda_hal: &Arc<CudaHalBB31>,
     vec_traces: &mut [witness::RowMajorMatrix<E::BaseField>],
+    compact_prefix_rows: bool,
 ) {
     let mut already_col_major = 0usize;
     let mut cpu_upload_and_transpose = 0usize;
@@ -1167,12 +1180,17 @@ pub(crate) fn normalize_traces_to_device_col_major<E: ExtensionField>(
             continue;
         }
 
-        let rows = trace.height();
+        let rows = if compact_prefix_rows {
+            trace.occupied_physical_rows()
+        } else {
+            trace.height()
+        };
         let cols = trace.width();
         if rows == 0 || cols == 0 {
             continue;
         }
-        let host_vals_bb31: &[BB31Base] = unsafe { std::mem::transmute(trace.values()) };
+        let host_vals_bb31: &[BB31Base] =
+            unsafe { std::mem::transmute(&trace.values()[..rows * cols]) };
 
         let row_major_buf = cuda_hal
             .alloc_elems_from_host(host_vals_bb31, None)
@@ -1257,8 +1275,13 @@ fn jagged_batch_commit_from_host(
 
     let mut poly_heights = Vec::new();
     for trace in traces {
+        let physical_rows = jagged_trace_physical_rows(trace);
+        assert!(
+            physical_rows <= trace.height(),
+            "Jagged trace physical rows exceed logical height"
+        );
         for _ in 0..trace.width() {
-            poly_heights.push(trace.height());
+            poly_heights.push(physical_rows);
         }
     }
     let cumulative_heights = std::iter::once(0)
@@ -1286,47 +1309,46 @@ fn jagged_batch_commit_from_host(
     }
     let mut poly_idx = 0usize;
     for trace in traces {
-        let rows = trace.height();
+        let physical_rows = jagged_trace_physical_rows(trace);
         let cols = trace.width();
         let start = cumulative_heights[poly_idx];
+        if physical_rows == 0 {
+            poly_idx += cols;
+            continue;
+        }
         if prefer_device_backing
             && trace.device_backing_layout() == Some(DeviceMatrixLayout::ColMajor)
         {
             let device_buffer = trace
                 .device_backing_ref::<BufferImpl<'static, BB31Base>>()
                 .unwrap_or_else(|| panic!("Jagged trace col-major device backing type mismatch"));
-            let col_rows = rmm_col_major_device_rows(trace)
-                .unwrap_or_else(|| panic!("Jagged trace col-major device row count mismatch"));
             assert!(
-                col_rows <= rows,
+                physical_rows <= trace.height(),
                 "Jagged trace col-major device rows exceed logical height"
             );
             let device_values = device_buffer
                 .to_vec()
                 .expect("Jagged trace device backing D2H failed");
-            q_host_uninit[start..start + rows * cols]
-                .par_chunks_mut(rows)
+            q_host_uninit[start..start + physical_rows * cols]
+                .par_chunks_mut(physical_rows)
                 .enumerate()
                 .for_each(|(col_idx, out)| {
-                    let src_start = col_idx * col_rows;
-                    let src_end = src_start + col_rows;
-                    for (dst, src) in out[..col_rows]
+                    let src_start = col_idx * physical_rows;
+                    let src_end = src_start + physical_rows;
+                    for (dst, src) in out[..physical_rows]
                         .iter_mut()
                         .zip(&device_values[src_start..src_end])
                     {
                         dst.write(*src);
                     }
-                    for dst in &mut out[col_rows..] {
-                        dst.write(BB31Base::ZERO);
-                    }
                 });
         } else {
             let values = trace.values();
-            q_host_uninit[start..start + rows * cols]
-                .par_chunks_mut(rows)
+            q_host_uninit[start..start + physical_rows * cols]
+                .par_chunks_mut(physical_rows)
                 .enumerate()
                 .for_each(|(col_idx, out)| {
-                    for row_idx in 0..rows {
+                    for row_idx in 0..physical_rows {
                         out[row_idx].write(values[row_idx * cols + col_idx]);
                     }
                 });
@@ -1706,7 +1728,11 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>
             if crate::instructions::gpu::config::should_materialize_witness_on_gpu() {
                 let span = entered_span!("[gpu] normalize_trace_backing", profiling_2 = true);
                 let cuda_hal = get_cuda_hal().unwrap();
-                normalize_traces_to_device_col_major::<E>(&cuda_hal, &mut vec_traces);
+                normalize_traces_to_device_col_major::<E>(
+                    &cuda_hal,
+                    &mut vec_traces,
+                    is_jagged_pcs,
+                );
                 drop(cuda_hal);
                 for (idx, trace) in vec_traces.iter().enumerate() {
                     assert!(
@@ -1944,28 +1970,19 @@ where
             let poly_idx = layout.first_poly_idx + col_idx;
             let start_elem = pcs_data.cumulative_heights[poly_idx];
             let len = pcs_data.poly_heights[poly_idx];
+            assert!(
+                len <= logical_len,
+                "Jagged q' compact MLE length exceeds logical length: trace_idx={trace_idx}, col_idx={col_idx}, len={len}, logical_len={logical_len}"
+            );
             let gpu_buffer = if let Some(q_evals) = &pcs_data.q_evals {
-                assert_eq!(
-                    len, logical_len,
-                    "Jagged q' MLE extraction would require a padded D2D copy: \
-                     trace_idx={trace_idx}, col_idx={col_idx}, len={len}, logical_len={logical_len}"
-                );
                 let start = start_elem * elem_size;
                 let end = start + len * elem_size;
                 q_evals.owned_subrange(start..end)
             } else if let Some(q_host) = pcs_data.q_host_evals.as_ref() {
                 let cuda_hal = get_cuda_hal().unwrap();
-                if len == logical_len {
-                    cuda_hal
-                        .alloc_elems_from_host(&q_host[start_elem..start_elem + len], None)
-                        .unwrap_or_else(|err| panic!("Jagged q' column H2D failed: {err:?}"))
-                } else {
-                    let mut column = vec![BB31Base::ZERO; logical_len];
-                    column[..len].copy_from_slice(&q_host[start_elem..start_elem + len]);
-                    cuda_hal
-                        .alloc_elems_from_host(&column, None)
-                        .unwrap_or_else(|err| panic!("Jagged q' padded column H2D failed: {err:?}"))
-                }
+                cuda_hal
+                    .alloc_elems_from_host(&q_host[start_elem..start_elem + len], None)
+                    .unwrap_or_else(|err| panic!("Jagged q' compact column H2D failed: {err:?}"))
             } else {
                 panic!("Jagged q' is missing both device and host backing");
             };

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -23,8 +23,14 @@ use crate::{
 };
 use ceno_gpu::{
     Buffer, CudaHal,
-    bb31::{CudaHalBB31, GpuPolynomial},
-    common::sumcheck::CommonTermPlan,
+    bb31::{CudaHalBB31, GpuFieldType, GpuMatrix, GpuPolynomial, GpuPolynomialExt},
+    common::{
+        jagged::{
+            JaggedSumcheckGpuCtx, eval_cols_at_point_gpu, jagged_batch_open_gpu,
+            jagged_sumcheck_prove_gpu,
+        },
+        sumcheck::CommonTermPlan,
+    },
     get_cuda_mem_info,
 };
 use either::Either;
@@ -35,11 +41,14 @@ use gkr_iop::{
         self, Evaluation, GKRProof, GKRProverOutput,
         layer::{LayerWitness, gpu::utils::extract_mle_relationships_from_monomial_terms},
     },
-    gpu::{GpuBackend, GpuProver, gpu_prover::BB31Ext},
+    gpu::{
+        GpuBackend, GpuBasefoldPcsData, GpuJaggedPcsData, GpuJaggedTraceLayout, GpuPcsData,
+        GpuProver, gpu_prover::BB31Ext,
+    },
     hal::ProverBackend,
 };
 use itertools::{Itertools, chain};
-use mpcs::{Point, PolynomialCommitmentScheme};
+use mpcs::{Basefold, BasefoldRSParams, PCSFriParam, Point, PolynomialCommitmentScheme};
 use multilinear_extensions::{
     Expression, ToExpr,
     mle::{FieldType, IntoMLE, MultilinearExtension},
@@ -52,6 +61,7 @@ use rayon::iter::{
     IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator,
     IntoParallelRefMutIterator, ParallelIterator,
 };
+use rayon::slice::ParallelSliceMut;
 use std::{
     collections::BTreeMap,
     io::Write,
@@ -69,6 +79,152 @@ use witness::{InstancePaddingStrategy, next_pow2_instance_padding};
 use ceno_gpu::common::transpose::matrix_transpose;
 use tracing::info_span;
 use witness::DeviceMatrixLayout;
+
+type BabyBearBasefold = Basefold<BB31Ext, BasefoldRSParams>;
+
+struct GpuJaggedHostPreprocessed {
+    q_evals: BufferImpl<'static, BB31Base>,
+    cumulative_heights: Vec<usize>,
+    poly_heights: Vec<usize>,
+    total_evaluations: usize,
+    reshape_log_height: usize,
+}
+
+fn is_babybear_jagged_pcs<E, PCS>() -> bool
+where
+    E: ExtensionField,
+    PCS: PolynomialCommitmentScheme<E> + 'static,
+{
+    let field_name = std::any::type_name::<E>();
+    let pcs_name = std::any::type_name::<PCS>();
+    field_name.contains("BabyBear") && pcs_name.contains("Jagged")
+}
+
+fn expect_basefold_pcs_data(pcs_data: &GpuPcsData) -> &GpuBasefoldPcsData {
+    match pcs_data {
+        GpuPcsData::Basefold(data) => data,
+        GpuPcsData::Jagged(_) => panic!("expected Basefold GPU PCS data, got Jagged"),
+    }
+}
+
+fn expect_jagged_pcs_data(pcs_data: &GpuPcsData) -> &GpuJaggedPcsData {
+    match pcs_data {
+        GpuPcsData::Jagged(data) => data,
+        GpuPcsData::Basefold(_) => panic!("expected Jagged GPU PCS data, got Basefold"),
+    }
+}
+
+fn jagged_trace_layouts<T>(traces: &[witness::RowMajorMatrix<T>]) -> Vec<GpuJaggedTraceLayout>
+where
+    T: FieldAlgebra + Default + Sync + Clone + Send + Copy,
+{
+    let mut first_poly_idx = 0usize;
+    traces
+        .iter()
+        .map(|trace| {
+            let layout = GpuJaggedTraceLayout {
+                first_poly_idx,
+                num_polys: trace.width(),
+                num_vars: trace.num_vars(),
+            };
+            first_poly_idx += trace.width();
+            layout
+        })
+        .collect()
+}
+
+fn wrap_jagged_commitment_as_pcs<E, PCS>(
+    inner_commit: <BabyBearBasefold as PolynomialCommitmentScheme<BB31Ext>>::Commitment,
+    cumulative_heights: Vec<usize>,
+    reshape_log_height: usize,
+) -> PCS::Commitment
+where
+    E: ExtensionField,
+    PCS: PolynomialCommitmentScheme<E> + 'static,
+{
+    assert!(
+        is_babybear_jagged_pcs::<E, PCS>(),
+        "Jagged GPU commitment wrapper called for non-Jagged PCS: {}",
+        std::any::type_name::<PCS>(),
+    );
+    let jagged_commitment = mpcs::JaggedCommitment::<BB31Ext, BabyBearBasefold> {
+        inner: inner_commit,
+        cumulative_heights,
+        reshape_log_height,
+    };
+    let commit: PCS::Commitment = unsafe { std::mem::transmute_copy(&jagged_commitment) };
+    std::mem::forget(jagged_commitment);
+    commit
+}
+
+fn flatten_jagged_openings_as_native<E: ExtensionField>(
+    poly_heights: &[usize],
+    openings: Vec<(Point<E>, Vec<E>)>,
+) -> Result<(Point<E>, Vec<E>), mpcs::Error> {
+    let max_native_point_len = poly_heights
+        .iter()
+        .map(|&height| ceil_log2(height))
+        .max()
+        .unwrap_or(0);
+    let mut common_point = vec![None; max_native_point_len];
+    let mut evals = Vec::with_capacity(poly_heights.len());
+    let mut poly_idx = 0usize;
+
+    for (point, point_evals) in openings {
+        for value in point_evals {
+            let height = poly_heights.get(poly_idx).ok_or_else(|| {
+                mpcs::Error::InvalidPcsParam("jagged: too many opening evaluations".to_string())
+            })?;
+            let native_num_vars = ceil_log2(*height);
+            if point.len() < native_num_vars {
+                return Err(mpcs::Error::InvalidPcsParam(format!(
+                    "jagged: opening point length {} is smaller than poly num_vars {}",
+                    point.len(),
+                    native_num_vars
+                )));
+            }
+            for (dst, src) in common_point.iter_mut().zip(point.iter()) {
+                match dst {
+                    Some(existing) if *existing != *src => {
+                        return Err(mpcs::Error::InvalidPcsParam(
+                            "jagged: opening points are not prefix-compatible".to_string(),
+                        ));
+                    }
+                    Some(_) => {}
+                    None => *dst = Some(*src),
+                }
+            }
+            let tail_zero_factor = point[native_num_vars..]
+                .iter()
+                .fold(E::ONE, |acc, r| acc * (E::ONE - *r));
+            if tail_zero_factor == E::ZERO {
+                return Err(mpcs::Error::InvalidPcsParam(
+                    "jagged: padded opening tail factor is zero".to_string(),
+                ));
+            }
+            evals.push(value * tail_zero_factor.inverse());
+            poly_idx += 1;
+        }
+    }
+
+    if poly_idx != poly_heights.len() {
+        return Err(mpcs::Error::InvalidPcsParam(format!(
+            "jagged: expected {} opening evaluations, got {}",
+            poly_heights.len(),
+            poly_idx
+        )));
+    }
+
+    let point = common_point
+        .into_iter()
+        .map(|value| {
+            value.ok_or_else(|| {
+                mpcs::Error::InvalidPcsParam("jagged: missing common opening point".to_string())
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok((point, evals))
+}
 
 #[cfg(feature = "gpu")]
 use gkr_iop::gpu::gpu_prover::*;
@@ -134,15 +290,7 @@ where
     Some(device_buffer.len() / cols)
 }
 
-fn pcs_resident_stats(
-    pcs_data_basefold: &BasefoldCommitmentWithWitnessGpu<
-        BB31Base,
-        BufferImpl<BB31Base>,
-        GpuDigestLayer,
-        GpuMatrix<'static>,
-        GpuPolynomial<'static>,
-    >,
-) -> PcsResidentStats {
+fn pcs_resident_stats(pcs_data_basefold: &GpuBasefoldPcsData) -> PcsResidentStats {
     let digest_tree_bytes =
         pcs_data_basefold.codeword.digest_buf.len() * std::mem::size_of::<BB31Base>();
     let codeword_leaves_bytes = pcs_data_basefold
@@ -203,13 +351,10 @@ pub fn log_gpu_pcs_baseline<E, PCS>(
         std::any::TypeId::of::<BB31Base>(),
         "GPU PCS baseline logging only supports BabyBear base field",
     );
-    let pcs_data_basefold: &BasefoldCommitmentWithWitnessGpu<
-        BB31Base,
-        BufferImpl<BB31Base>,
-        GpuDigestLayer,
-        GpuMatrix<'static>,
-        GpuPolynomial<'static>,
-    > = unsafe { std::mem::transmute(pcs_data) };
+    let pcs_data_basefold = match pcs_data {
+        GpuPcsData::Basefold(data) => data,
+        GpuPcsData::Jagged(data) => &data.inner,
+    };
     let pcs = pcs_resident_stats(pcs_data_basefold);
     let mb = |bytes: usize| bytes as f64 / (1024.0 * 1024.0);
     tracing::info!(
@@ -243,13 +388,10 @@ pub fn log_gpu_proof_baseline<E, PCS>(
     let (cuda_free_bytes, cuda_total_bytes) = get_cuda_mem_info().unwrap_or((0usize, 0usize));
     let cuda_used_bytes = cuda_total_bytes.saturating_sub(cuda_free_bytes);
 
-    let pcs_data_basefold: &BasefoldCommitmentWithWitnessGpu<
-        BB31Base,
-        BufferImpl<BB31Base>,
-        GpuDigestLayer,
-        GpuMatrix<'static>,
-        GpuPolynomial<'static>,
-    > = unsafe { std::mem::transmute(witness_data) };
+    let pcs_data_basefold = match witness_data {
+        GpuPcsData::Basefold(data) => data,
+        GpuPcsData::Jagged(data) => &data.inner,
+    };
 
     let pcs = pcs_resident_stats(pcs_data_basefold);
     let fixed_mle_bytes = fixed_mles
@@ -480,7 +622,7 @@ pub(crate) fn extract_out_evals_from_gpu_towers<E: ff_ext::ExtensionField>(
 
 /// Standalone function for prove_rotation that doesn't require &self.
 /// This allows rotation proof generation from parallel task code paths.
-pub fn prove_rotation_impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
+pub fn prove_rotation_impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>(
     composed_cs: &ComposedConstrainSystem<E>,
     input: &ProofInput<'_, GpuBackend<E, PCS>>,
     rt_tower: &Point<E>,
@@ -506,6 +648,7 @@ pub fn prove_rotation_impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>
     let log2_num_instances = input.log2_num_instances();
     let num_threads = optimal_sumcheck_threads(log2_num_instances);
     let num_var_with_rotation = log2_num_instances + composed_cs.rotation_vars().unwrap_or(0);
+
     let wit = LayerWitness(
         chain!(&input.witness, &input.fixed, &input.structural_witness)
             .cloned()
@@ -1054,6 +1197,86 @@ pub(crate) fn normalize_traces_to_device_col_major<E: ExtensionField>(
     );
 }
 
+fn jagged_batch_commit_from_host(
+    cuda_hal: &Arc<CudaHalBB31>,
+    traces: &[witness::RowMajorMatrix<BB31Base>],
+    reshape_log_height: usize,
+) -> (GpuJaggedHostPreprocessed, GpuBasefoldPcsData) {
+    let mut poly_heights = Vec::new();
+    for trace in traces {
+        for _ in 0..trace.width() {
+            poly_heights.push(trace.height());
+        }
+    }
+    let cumulative_heights = std::iter::once(0)
+        .chain(poly_heights.iter().scan(0usize, |acc, &height| {
+            *acc += height;
+            Some(*acc)
+        }))
+        .collect_vec();
+    let total_evaluations = *cumulative_heights.last().unwrap_or(&0);
+    let log_h = reshape_log_height.min(ceil_log2(total_evaluations.max(1)));
+    let h = 1usize << log_h;
+    let w = total_evaluations.div_ceil(h);
+    let padded_total = w * h;
+    let q_len = 1usize << ceil_log2(padded_total.max(1));
+
+    let mut q_host = vec![BB31Base::ZERO; q_len];
+    let mut poly_idx = 0usize;
+    for trace in traces {
+        let rows = trace.height();
+        let cols = trace.width();
+        let start = cumulative_heights[poly_idx];
+        let values = trace.values();
+        q_host[start..start + rows * cols]
+            .par_chunks_mut(rows)
+            .enumerate()
+            .for_each(|(col_idx, out)| {
+                for row_idx in 0..rows {
+                    out[row_idx] = values[row_idx * cols + col_idx];
+                }
+            });
+        poly_idx += cols;
+    }
+
+    let mut reshape_values = vec![BB31Base::ZERO; padded_total];
+    reshape_values
+        .par_chunks_mut(w)
+        .enumerate()
+        .for_each(|(row_idx, row)| {
+            for col_idx in 0..w {
+                let src_idx = col_idx * h + row_idx;
+                if src_idx < total_evaluations {
+                    row[col_idx] = q_host[src_idx];
+                }
+            }
+        });
+
+    let q_evals = cuda_hal
+        .alloc_elems_from_host(&q_host, None)
+        .expect("failed to upload Jagged q' evaluations");
+    let reshape_rmm = witness::RowMajorMatrix::new_by_values(
+        reshape_values,
+        w,
+        InstancePaddingStrategy::Default,
+    );
+    let inner = cuda_hal
+        .basefold
+        .batch_commit(cuda_hal.as_ref(), vec![reshape_rmm])
+        .expect("failed to commit Jagged q' with GPU Basefold");
+
+    (
+        GpuJaggedHostPreprocessed {
+            q_evals,
+            cumulative_heights,
+            poly_heights,
+            total_evaluations,
+            reshape_log_height: log_h,
+        },
+        inner,
+    )
+}
+
 pub fn commit_traces_deferred_cache_none<E, PCS>(
     prover: &GpuProver<GpuBackend<E, PCS>>,
     traces: BTreeMap<usize, DeferredGpuTrace<E>>,
@@ -1064,7 +1287,7 @@ pub fn commit_traces_deferred_cache_none<E, PCS>(
 )
 where
     E: ExtensionField,
-    PCS: PolynomialCommitmentScheme<E>,
+    PCS: PolynomialCommitmentScheme<E> + 'static,
 {
     if std::any::TypeId::of::<E::BaseField>() != std::any::TypeId::of::<BB31Base>() {
         panic!("GPU backend only supports BabyBear base field");
@@ -1086,9 +1309,10 @@ where
         );
     }
 
-    let is_pcs_match = std::mem::size_of::<mpcs::BasefoldCommitmentWithWitness<BB31Ext>>()
+    let is_basefold_pcs = std::mem::size_of::<mpcs::BasefoldCommitmentWithWitness<BB31Ext>>()
         == std::mem::size_of::<PCS::CommitmentWithWitness>();
-    if !is_pcs_match {
+    let is_jagged_pcs = is_babybear_jagged_pcs::<E, PCS>();
+    if !is_basefold_pcs && !is_jagged_pcs {
         panic!("GPU commitment data is not compatible with the PCS");
     }
 
@@ -1108,6 +1332,75 @@ where
         used_bytes as f64 / (1024.0 * 1024.0),
         reserved_bytes as f64 / (1024.0 * 1024.0),
     );
+
+    if is_jagged_pcs {
+        let vec_traces = ordered_sources
+            .into_iter()
+            .enumerate()
+            .map(|(trace_idx, source)| {
+                let witness_rmm: witness::RowMajorMatrix<E::BaseField> = match source {
+                    DeferredGpuTrace::Eager(rmm) => rmm,
+                    DeferredGpuTrace::Replay(plan) => plan
+                        .replay_witness()
+                        .map(|witness_rmm| {
+                            assert_eq!(
+                                witness_rmm.height(),
+                                plan.trace_height,
+                                "replayed trace height changed between plan build and deferred commit",
+                            );
+                            witness_rmm
+                        })
+                        .unwrap_or_else(|e| panic!("failed to replay trace {trace_idx}: {e:?}")),
+                };
+                if witness_rmm.width() == 0 {
+                    tracing::warn!(
+                        "[gpu] replacing zero-width deferred witness trace at index {trace_idx} with a dummy column"
+                    );
+                    witness::RowMajorMatrix::<E::BaseField>::new(
+                        witness_rmm.num_instances(),
+                        1,
+                        InstancePaddingStrategy::Default,
+                    )
+                } else {
+                    witness_rmm
+                }
+            })
+            .collect_vec();
+        let trace_layouts = jagged_trace_layouts(&vec_traces);
+        let mut traces_bb31: Vec<witness::RowMajorMatrix<BB31Base>> =
+            unsafe { std::mem::transmute(vec_traces) };
+        let total_size: usize = traces_bb31
+            .iter()
+            .map(|trace| trace.height() * trace.width())
+            .sum();
+        let reshape_log_height = prover
+            .backend
+            .pp
+            .get_max_message_size_log()
+            .min(ceil_log2(total_size.max(1)));
+        let (preprocessed, inner_pcs_data) =
+            jagged_batch_commit_from_host(&cuda_hal, &traces_bb31, reshape_log_height);
+        for trace in &mut traces_bb31 {
+            trace.clear_device_backing();
+        }
+        let inner_commit = cuda_hal.basefold.get_pure_commitment(&inner_pcs_data);
+        let commit = wrap_jagged_commitment_as_pcs::<E, PCS>(
+            inner_commit,
+            preprocessed.cumulative_heights.clone(),
+            preprocessed.reshape_log_height,
+        );
+        let pcs_data = GpuPcsData::Jagged(GpuJaggedPcsData {
+            inner: inner_pcs_data,
+            q_evals: preprocessed.q_evals,
+            original_traces: traces_bb31,
+            cumulative_heights: preprocessed.cumulative_heights,
+            poly_heights: preprocessed.poly_heights,
+            total_evaluations: preprocessed.total_evaluations,
+            reshape_log_height: preprocessed.reshape_log_height,
+            trace_layouts,
+        });
+        return (vec![], pcs_data, commit);
+    }
 
     let specs = ordered_sources
         .iter()
@@ -1162,12 +1455,12 @@ where
     let basefold_commit = cuda_hal.basefold.get_pure_commitment(&pcs_data);
     let commit: PCS::Commitment = unsafe { std::mem::transmute_copy(&basefold_commit) };
     let pcs_data_generic: <GpuBackend<E, PCS> as ProverBackend>::PcsData =
-        unsafe { std::mem::transmute_copy(&pcs_data) };
-    std::mem::forget(pcs_data);
+        GpuPcsData::Basefold(pcs_data);
     (vec![], pcs_data_generic, commit)
 }
 
-impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> TraceCommitter<GpuBackend<E, PCS>>
+impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>
+    TraceCommitter<GpuBackend<E, PCS>>
     for GpuProver<GpuBackend<E, PCS>>
 {
     fn commit_traces<'a>(
@@ -1198,7 +1491,8 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> TraceCommitter<GpuBa
 
         let is_pcs_match = std::mem::size_of::<mpcs::BasefoldCommitmentWithWitness<BB31Ext>>()
             == std::mem::size_of::<PCS::CommitmentWithWitness>();
-        let (mles, pcs_data, commit) = if is_pcs_match {
+        let is_jagged_pcs = is_babybear_jagged_pcs::<E, PCS>();
+        let (mles, pcs_data, commit) = if is_pcs_match || is_jagged_pcs {
             let mut vec_traces: Vec<witness::RowMajorMatrix<E::BaseField>> =
                 traces.into_values().collect();
             for (trace_idx, trace) in vec_traces.iter_mut().enumerate() {
@@ -1232,12 +1526,17 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> TraceCommitter<GpuBa
                 }
                 exit_span!(span);
             }
-
             let span = entered_span!("[gpu] hal init", profiling_2 = true);
             let cuda_hal = get_cuda_hal().unwrap();
             exit_span!(span);
 
-            let traces_gl64: Vec<witness::RowMajorMatrix<BB31Base>> =
+            let trace_layouts = if is_jagged_pcs {
+                Some(jagged_trace_layouts(&vec_traces))
+            } else {
+                None
+            };
+
+            let mut traces_gl64: Vec<witness::RowMajorMatrix<BB31Base>> =
                 unsafe { std::mem::transmute(vec_traces) };
 
             let span = entered_span!("[gpu] batch_commit", profiling_2 = true);
@@ -1256,25 +1555,50 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> TraceCommitter<GpuBa
                 used_bytes as f64 / (1024.0 * 1024.0),
                 reserved_bytes as f64 / (1024.0 * 1024.0),
             );
-            let pcs_data = cuda_hal
-                .basefold
-                .batch_commit(&cuda_hal, traces_gl64)
-                .unwrap();
+            let pcs_data = if is_jagged_pcs {
+                let total_size: usize = traces_gl64
+                    .iter()
+                    .map(|trace| trace.height() * trace.width())
+                    .sum();
+                let reshape_log_height = self
+                    .backend
+                    .pp
+                    .get_max_message_size_log()
+                    .min(ceil_log2(total_size.max(1)));
+                let (preprocessed, inner_pcs_data) =
+                    jagged_batch_commit_from_host(&cuda_hal, &traces_gl64, reshape_log_height);
+                for trace in &mut traces_gl64 {
+                    trace.clear_device_backing();
+                }
+                let inner_commit = cuda_hal.basefold.get_pure_commitment(&inner_pcs_data);
+                let commit = wrap_jagged_commitment_as_pcs::<E, PCS>(
+                    inner_commit,
+                    preprocessed.cumulative_heights.clone(),
+                    preprocessed.reshape_log_height,
+                );
+                let pcs_data = GpuPcsData::Jagged(GpuJaggedPcsData {
+                    inner: inner_pcs_data,
+                    q_evals: preprocessed.q_evals,
+                    original_traces: traces_gl64,
+                    cumulative_heights: preprocessed.cumulative_heights,
+                    poly_heights: preprocessed.poly_heights,
+                    total_evaluations: preprocessed.total_evaluations,
+                    reshape_log_height: preprocessed.reshape_log_height,
+                    trace_layouts: trace_layouts.expect("jagged trace layouts must exist"),
+                });
+                (pcs_data, commit)
+            } else {
+                let pcs_data = cuda_hal
+                    .basefold
+                    .batch_commit(&cuda_hal, traces_gl64)
+                    .unwrap();
+                let basefold_commit = cuda_hal.basefold.get_pure_commitment(&pcs_data);
+                let commit: PCS::Commitment = unsafe { std::mem::transmute_copy(&basefold_commit) };
+                (GpuPcsData::Basefold(pcs_data), commit)
+            };
             exit_span!(span);
 
-            let span = entered_span!("[gpu] get_pure_commitment", profiling_2 = true);
-            let basefold_commit = cuda_hal.basefold.get_pure_commitment(&pcs_data);
-            exit_span!(span);
-
-            let span = entered_span!("[gpu] transmute back", profiling_2 = true);
-            let commit: PCS::Commitment = unsafe { std::mem::transmute_copy(&basefold_commit) };
-            // transmute pcs_data from GPU specific type to generic PcsData type
-            let pcs_data_generic: <GpuBackend<E, PCS> as ProverBackend>::PcsData =
-                unsafe { std::mem::transmute_copy(&pcs_data) };
-            std::mem::forget(pcs_data);
-            exit_span!(span);
-
-            (vec![], pcs_data_generic, commit)
+            (vec![], pcs_data.0, pcs_data.1)
         } else {
             panic!("GPU commitment data is not compatible with the PCS");
         };
@@ -1291,15 +1615,31 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> TraceCommitter<GpuBa
     ) -> Box<
         dyn Iterator<Item = Arc<<GpuBackend<E, PCS> as ProverBackend>::MultilinearPoly<'a>>> + 'b,
     > {
-        // transmute pcs_data from generic PcsData type to GPU-specific type
-        let pcs_data_basefold: &BasefoldCommitmentWithWitnessGpu<
-            BB31Base,
-            BufferImpl<BB31Base>,
-            GpuDigestLayer,
-            GpuMatrix<'static>,
-            GpuPolynomial<'static>,
-        > = unsafe { std::mem::transmute(pcs_data) };
+        if let GpuPcsData::Jagged(jagged_data) = pcs_data {
+            let total_traces = jagged_data.trace_layouts.len();
+            let mut trace_idx = 0usize;
+            let mut current_iter: std::vec::IntoIter<
+                Arc<<GpuBackend<E, PCS> as ProverBackend>::MultilinearPoly<'a>>,
+            > = Vec::new().into_iter();
 
+            let iter = std::iter::from_fn(move || {
+                loop {
+                    if let Some(poly) = current_iter.next() {
+                        return Some(poly);
+                    }
+                    if trace_idx >= total_traces {
+                        return None;
+                    }
+                    current_iter =
+                        extract_jagged_witness_mles_for_trace::<E>(jagged_data, trace_idx, None, None)
+                            .into_iter();
+                    trace_idx += 1;
+                }
+            });
+            return Box::new(iter);
+        }
+
+        let pcs_data_basefold = expect_basefold_pcs_data(pcs_data);
         let total_traces = pcs_data_basefold.num_traces();
         let mut trace_idx = 0usize;
         let mut current_iter: std::vec::IntoIter<
@@ -1360,6 +1700,158 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> TraceCommitter<GpuBa
 /// one circuit's witnesses just-in-time rather than all circuits eagerly.
 ///
 /// `num_vars` is log2(num_instances) + rotation_vars, used for memory estimation validation.
+pub fn extract_jagged_witness_mles_for_trace<'a, E>(
+    pcs_data: &GpuJaggedPcsData,
+    trace_idx: usize,
+    expected_num: Option<usize>,
+    num_vars: Option<usize>,
+) -> Vec<Arc<MultilinearExtensionGpu<'a, E>>>
+where
+    E: ExtensionField,
+{
+    assert_eq!(
+        std::any::TypeId::of::<E::BaseField>(),
+        std::any::TypeId::of::<BB31Base>(),
+        "GPU Jagged q' extraction only supports BabyBear base field",
+    );
+
+    if let Some(rmm) = pcs_data.original_traces.get(trace_idx) {
+        if let Some(expected_num) = expected_num {
+            assert_eq!(
+                rmm.width(),
+                expected_num,
+                "Jagged trace width mismatch: expected {}, got {}",
+                expected_num,
+                rmm.width(),
+            );
+        }
+        let num_vars = num_vars.unwrap_or(rmm.num_vars());
+        let elem_size = std::mem::size_of::<BB31Base>();
+
+        if rmm.device_backing_layout() == Some(DeviceMatrixLayout::ColMajor) {
+            let device_buffer = rmm
+                .device_backing_ref::<BufferImpl<'static, BB31Base>>()
+                .unwrap_or_else(|| panic!("Jagged trace col-major device backing type mismatch"));
+            let col_rows = rmm_col_major_device_rows(rmm)
+                .unwrap_or_else(|| panic!("Jagged trace col-major device row count mismatch"));
+            assert!(
+                col_rows <= rmm.height(),
+                "Jagged trace col-major device rows exceed logical height"
+            );
+            let col_stride_bytes = col_rows * elem_size;
+            if col_rows < rmm.height() {
+                let cuda_hal = get_cuda_hal().unwrap();
+                return (0..rmm.width())
+                    .map(|col_idx| {
+                        let start = col_idx * col_stride_bytes;
+                        let end = start + col_stride_bytes;
+                        let src = device_buffer.as_slice_range(start..end);
+                        let mut padded_buffer = cuda_hal
+                            .alloc_elems_on_device(rmm.height(), true, None)
+                            .unwrap_or_else(|err| {
+                                panic!("Jagged trace padded column allocation failed: {err:?}")
+                            });
+                        let mut dst = padded_buffer.as_mut_slice_range(0..col_stride_bytes);
+                        cuda_hal
+                            .inner
+                            .dtod_copy_sync(&src, &mut dst)
+                            .unwrap_or_else(|err| {
+                                panic!("Jagged trace compact-to-padded D2D copy failed: {err:?}")
+                            });
+                        let view_poly = GpuPolynomial::new(padded_buffer, num_vars);
+                        let poly_static: GpuPolynomial<'static> =
+                            unsafe { std::mem::transmute(view_poly) };
+                        let mle_static = MultilinearExtensionGpu::from_ceno_gpu_base(poly_static);
+                        Arc::new(unsafe {
+                            std::mem::transmute::<
+                                MultilinearExtensionGpu<'static, E>,
+                                MultilinearExtensionGpu<'a, E>,
+                            >(mle_static)
+                        })
+                    })
+                    .collect();
+            }
+            return (0..rmm.width())
+                .map(|col_idx| {
+                    let start = col_idx * col_stride_bytes;
+                    let end = start + col_stride_bytes;
+                    let view_buf = device_buffer.owned_subrange(start..end);
+                    let view_poly = GpuPolynomial::new(view_buf, num_vars);
+                    let poly_static: GpuPolynomial<'static> =
+                        unsafe { std::mem::transmute(view_poly) };
+                    let mle_static = MultilinearExtensionGpu::from_ceno_gpu_base(poly_static);
+                    Arc::new(unsafe {
+                        std::mem::transmute::<
+                            MultilinearExtensionGpu<'static, E>,
+                            MultilinearExtensionGpu<'a, E>,
+                        >(mle_static)
+                    })
+                })
+                .collect();
+        }
+
+        let cuda_hal = get_cuda_hal().unwrap();
+        let values = rmm.values();
+        return (0..rmm.width())
+            .map(|col_idx| {
+                let mut column = Vec::with_capacity(rmm.height());
+                column.extend((0..rmm.height()).map(|row| values[row * rmm.width() + col_idx]));
+                let column_bb31: Vec<BB31Base> = unsafe {
+                    let mut column = std::mem::ManuallyDrop::new(column);
+                    Vec::from_raw_parts(
+                        column.as_mut_ptr() as *mut BB31Base,
+                        column.len(),
+                        column.capacity(),
+                    )
+                };
+                let gpu_poly = cuda_hal
+                    .alloc_elems_from_host(&column_bb31, None)
+                    .map(|buffer| GpuPolynomial::new(buffer, num_vars))
+                    .unwrap_or_else(|err| panic!("Jagged trace H2D failed: {err:?}"));
+                let mle_static = MultilinearExtensionGpu::from_ceno_gpu_base(gpu_poly);
+                Arc::new(unsafe {
+                    std::mem::transmute::<
+                        MultilinearExtensionGpu<'static, E>,
+                        MultilinearExtensionGpu<'a, E>,
+                    >(mle_static)
+                })
+            })
+            .collect();
+    }
+
+    let layout = pcs_data
+        .trace_layouts
+        .get(trace_idx)
+        .unwrap_or_else(|| panic!("Jagged trace index {trace_idx} out of range"));
+    if let Some(expected_num) = expected_num {
+        assert_eq!(
+            layout.num_polys, expected_num,
+            "Jagged trace width mismatch: expected {}, got {}",
+            expected_num, layout.num_polys,
+        );
+    }
+    let num_vars = num_vars.unwrap_or(layout.num_vars);
+    let elem_size = std::mem::size_of::<BB31Base>();
+
+    (0..layout.num_polys)
+        .map(|col_idx| {
+            let poly_idx = layout.first_poly_idx + col_idx;
+            let start = pcs_data.cumulative_heights[poly_idx] * elem_size;
+            let end = start + pcs_data.poly_heights[poly_idx] * elem_size;
+            let view_buf = pcs_data.q_evals.owned_subrange(start..end);
+            let view_poly = GpuPolynomial::new(view_buf, num_vars);
+            let poly_static: GpuPolynomial<'static> = unsafe { std::mem::transmute(view_poly) };
+            let mle_static = MultilinearExtensionGpu::from_ceno_gpu_base(poly_static);
+            Arc::new(unsafe {
+                std::mem::transmute::<
+                    MultilinearExtensionGpu<'static, E>,
+                    MultilinearExtensionGpu<'a, E>,
+                >(mle_static)
+            })
+        })
+        .collect()
+}
+
 pub fn extract_witness_mles_for_trace<'a, E, PCS>(
     pcs_data: &<GpuBackend<E, PCS> as ProverBackend>::PcsData,
     trace_idx: usize,
@@ -1370,13 +1862,16 @@ where
     E: ExtensionField,
     PCS: PolynomialCommitmentScheme<E>,
 {
-    let pcs_data_basefold: &BasefoldCommitmentWithWitnessGpu<
-        BB31Base,
-        BufferImpl<BB31Base>,
-        GpuDigestLayer,
-        GpuMatrix<'static>,
-        GpuPolynomial<'static>,
-    > = unsafe { std::mem::transmute(pcs_data) };
+    if let GpuPcsData::Jagged(jagged_data) = pcs_data {
+        return extract_jagged_witness_mles_for_trace::<E>(
+            jagged_data,
+            trace_idx,
+            Some(expected_num),
+            Some(num_vars),
+        );
+    }
+
+    let pcs_data_basefold = expect_basefold_pcs_data(pcs_data);
 
     let stream = gkr_iop::gpu::get_thread_stream();
     let cuda_hal = get_cuda_hal().unwrap();
@@ -1437,19 +1932,22 @@ where
     E: ExtensionField,
     PCS: PolynomialCommitmentScheme<E>,
 {
+    if let GpuPcsData::Jagged(jagged_data) = pcs_data {
+        return extract_jagged_witness_mles_for_trace::<E>(
+            jagged_data,
+            trace_idx,
+            Some(expected_num),
+            Some(num_vars),
+        );
+    }
+
     assert_eq!(
         std::any::TypeId::of::<E::BaseField>(),
         std::any::TypeId::of::<BB31Base>(),
         "GPU ShardRAM compact extraction only supports BabyBear base field",
     );
 
-    let pcs_data_basefold: &BasefoldCommitmentWithWitnessGpu<
-        BB31Base,
-        BufferImpl<BB31Base>,
-        GpuDigestLayer,
-        GpuMatrix<'static>,
-        GpuPolynomial<'static>,
-    > = unsafe { std::mem::transmute(pcs_data) };
+    let pcs_data_basefold = expect_basefold_pcs_data(pcs_data);
 
     let Some(rmms) = pcs_data_basefold.rmms.as_ref() else {
         return extract_witness_mles_for_trace::<E, PCS>(
@@ -1609,13 +2107,10 @@ pub fn clear_replayable_trace_device_backing<E, PCS>(
     E: ExtensionField,
     PCS: PolynomialCommitmentScheme<E>,
 {
-    let pcs_data_basefold: &mut BasefoldCommitmentWithWitnessGpu<
-        BB31Base,
-        BufferImpl<BB31Base>,
-        GpuDigestLayer,
-        GpuMatrix<'static>,
-        GpuPolynomial<'static>,
-    > = unsafe { std::mem::transmute(pcs_data) };
+    let pcs_data_basefold = match pcs_data {
+        GpuPcsData::Basefold(data) => data,
+        GpuPcsData::Jagged(_) => return,
+    };
 
     let Some(rmms) = pcs_data_basefold.rmms.as_mut() else {
         return;
@@ -1661,13 +2156,10 @@ where
         std::any::TypeId::of::<BB31Base>(),
         "GPU replay restore only supports BabyBear base field",
     );
-    let pcs_data_basefold: &mut BasefoldCommitmentWithWitnessGpu<
-        BB31Base,
-        BufferImpl<BB31Base>,
-        GpuDigestLayer,
-        GpuMatrix<'static>,
-        GpuPolynomial<'static>,
-    > = unsafe { std::mem::transmute(pcs_data) };
+    let pcs_data_basefold = match pcs_data {
+        GpuPcsData::Basefold(data) => data,
+        GpuPcsData::Jagged(_) => return Ok(()),
+    };
 
     let Some(rmms) = pcs_data_basefold.rmms.as_mut() else {
         return Ok(());
@@ -2639,7 +3131,8 @@ fn frontload_input_opening_point<E: ExtensionField>(
     global_rt[..num_var_with_rotation].to_vec()
 }
 
-impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> RotationProver<GpuBackend<E, PCS>>
+impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>
+    RotationProver<GpuBackend<E, PCS>>
     for GpuProver<GpuBackend<E, PCS>>
 {
     fn prove_rotation<'a>(
@@ -2685,7 +3178,113 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> EccQuarkProver<GpuBa
     }
 }
 
-impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> OpeningProver<GpuBackend<E, PCS>>
+fn open_jagged_gpu<E, PCS>(
+    prover_param: &<PCS as PolynomialCommitmentScheme<E>>::ProverParam,
+    rounds: Vec<(&GpuPcsData, Vec<(Point<E>, Vec<E>)>)>,
+    transcript: &mut (impl Transcript<E> + 'static),
+) -> PCS::Proof
+where
+    E: ExtensionField,
+    PCS: PolynomialCommitmentScheme<E> + 'static,
+{
+    if std::any::TypeId::of::<E>() != std::any::TypeId::of::<BB31Ext>() {
+        panic!("GPU Jagged opening only supports BabyBear field extension");
+    }
+
+    let transcript_any = transcript as &mut dyn std::any::Any;
+    let basic_transcript = transcript_any
+        .downcast_mut::<BasicTranscript<BB31Ext>>()
+        .expect("Type should match");
+    let pp_bb31: &mpcs::basefold::structure::BasefoldProverParams<
+        BB31Ext,
+        mpcs::BasefoldRSParams,
+    > = unsafe { std::mem::transmute(prover_param) };
+    let cuda_hal = get_cuda_hal().unwrap();
+
+    let mut proofs = Vec::with_capacity(rounds.len());
+    for (pcs_data, openings) in rounds {
+        let jagged_data = expect_jagged_pcs_data(pcs_data);
+        let openings_bb31: Vec<(Point<BB31Ext>, Vec<BB31Ext>)> = openings
+            .iter()
+            .map(|(point, evals)| {
+                let point_bb31: &Vec<BB31Ext> = unsafe { std::mem::transmute(point) };
+                let evals_bb31: &Vec<BB31Ext> = unsafe { std::mem::transmute(evals) };
+                (point_bb31.clone(), evals_bb31.clone())
+            })
+            .collect();
+        let (point, evals) =
+            flatten_jagged_openings_as_native(&jagged_data.poly_heights, openings_bb31)
+                .expect("invalid Jagged GPU opening shape");
+        let q_evals_len_bytes = jagged_data.q_evals.len() * std::mem::size_of::<BB31Base>();
+        let q_evals = jagged_data.q_evals.owned_subrange(0..q_evals_len_bytes);
+        let proof = jagged_batch_open_gpu::<BB31Ext, BabyBearBasefold, _>(
+            &jagged_data.cumulative_heights,
+            jagged_data.total_evaluations,
+            jagged_data.reshape_log_height,
+            &point,
+            &evals,
+            basic_transcript,
+            |num_giga_vars, w, cumulative_heights, eq_row, eq_col, transcript| {
+                let ctx = JaggedSumcheckGpuCtx::<CudaHalBB31>::from_gpu_q_evals(
+                    &cuda_hal,
+                    q_evals,
+                    cumulative_heights,
+                    &eq_row,
+                    &eq_col,
+                    num_giga_vars,
+                )
+                .expect("create Jagged GPU sumcheck ctx");
+                let (proof, rho) = jagged_sumcheck_prove_gpu::<
+                    CudaHalBB31,
+                    BB31Ext,
+                    BB31Base,
+                    GpuMatrix,
+                    GpuPolynomial,
+                    GpuPolynomialExt,
+                    GpuFieldType,
+                >(&cuda_hal, &ctx, transcript, None)
+                .expect("Jagged GPU sumcheck failed");
+                let col_evals = eval_cols_at_point_gpu::<CudaHalBB31, BB31Ext, BB31Base>(
+                    &cuda_hal,
+                    &ctx.q_evals,
+                    &rho[..jagged_data.reshape_log_height],
+                    jagged_data.reshape_log_height,
+                    w,
+                )
+                .expect("Jagged GPU column eval failed");
+                (proof, rho, col_evals)
+            },
+            |rho_row, col_evals, transcript| {
+                let gpu_basefold_proof = cuda_hal
+                    .basefold
+                    .batch_open(
+                        &cuda_hal,
+                        pp_bb31,
+                        vec![(&jagged_data.inner, vec![(rho_row, col_evals)])],
+                        transcript,
+                    )
+                    .map_err(|e| mpcs::Error::InvalidPcsOpen(e.to_string()))?;
+                Ok(mpcs::basefold::structure::BasefoldProof {
+                    commits: gpu_basefold_proof.commits,
+                    query_opening_proof: gpu_basefold_proof.query_opening_proof,
+                    sumcheck_proof: gpu_basefold_proof.sumcheck_proof,
+                    final_message: gpu_basefold_proof.final_message,
+                    pow_witness: gpu_basefold_proof.pow_witness,
+                })
+            },
+        )
+        .expect("Jagged GPU batch open failed");
+        proofs.push(proof);
+    }
+
+    let jagged_proof = mpcs::JaggedProof::<BB31Ext, BabyBearBasefold> { rounds: proofs };
+    let proof: PCS::Proof = unsafe { std::mem::transmute_copy(&jagged_proof) };
+    std::mem::forget(jagged_proof);
+    proof
+}
+
+impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>
+    OpeningProver<GpuBackend<E, PCS>>
     for GpuProver<GpuBackend<E, PCS>>
 {
     fn open(
@@ -2731,6 +3330,10 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> OpeningProver<GpuBac
             }));
         }
 
+        if matches!(&witness_data, GpuPcsData::Jagged(_)) {
+            return open_jagged_gpu::<E, PCS>(&self.backend.pp, rounds, transcript);
+        }
+
         // Type conversions using unsafe transmute
         let prover_param = &self.backend.pp;
         let pp_gl64: &mpcs::basefold::structure::BasefoldProverParams<
@@ -2740,13 +3343,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> OpeningProver<GpuBac
         let rounds_gl64: Vec<_> = rounds
             .iter()
             .map(|(commitment, point_eval_pairs)| {
-                let commitment_gl64: &BasefoldCommitmentWithWitnessGpu<
-                    BB31Base,
-                    BufferImpl<BB31Base>,
-                    GpuDigestLayer,
-                    GpuMatrix<'static>,
-                    GpuPolynomial<'static>,
-                > = unsafe { std::mem::transmute(*commitment) };
+                let commitment_gl64 = expect_basefold_pcs_data(commitment);
                 let point_eval_pairs_gl64: Vec<_> = point_eval_pairs
                     .iter()
                     .map(|(point, evals)| {
@@ -2791,7 +3388,7 @@ pub fn open_with_incremental_replay<E, PCS>(
 ) -> PCS::Proof
 where
     E: ExtensionField,
-    PCS: PolynomialCommitmentScheme<E>,
+    PCS: PolynomialCommitmentScheme<E> + 'static,
 {
     if std::any::TypeId::of::<E::BaseField>() != std::any::TypeId::of::<BB31Base>() {
         panic!("GPU backend only supports BabyBear base field");
@@ -2828,19 +3425,17 @@ where
         }));
     }
 
+    if matches!(&witness_data, GpuPcsData::Jagged(_)) {
+        return open_jagged_gpu::<E, PCS>(&prover.backend.pp, rounds, transcript);
+    }
+
     let prover_param = &prover.backend.pp;
     let pp_gl64: &mpcs::basefold::structure::BasefoldProverParams<BB31Ext, mpcs::BasefoldRSParams> =
         unsafe { std::mem::transmute(prover_param) };
     let rounds_gl64: Vec<_> = rounds
         .iter()
         .map(|(commitment, point_eval_pairs)| {
-            let commitment_gl64: &BasefoldCommitmentWithWitnessGpu<
-                BB31Base,
-                BufferImpl<BB31Base>,
-                GpuDigestLayer,
-                GpuMatrix<'static>,
-                GpuPolynomial<'static>,
-            > = unsafe { std::mem::transmute(*commitment) };
+            let commitment_gl64 = expect_basefold_pcs_data(commitment);
             let point_eval_pairs_gl64: Vec<_> = point_eval_pairs
                 .iter()
                 .map(|(point, evals)| {
@@ -2917,7 +3512,8 @@ where
     gpu_proof
 }
 
-impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> DeviceTransporter<GpuBackend<E, PCS>>
+impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>
+    DeviceTransporter<GpuBackend<E, PCS>>
     for GpuProver<GpuBackend<E, PCS>>
 {
     fn transport_proving_key(
@@ -2936,16 +3532,75 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> DeviceTransporter<Gp
             pk.fixed_no_omc_init_commit_wd.as_ref().unwrap().clone()
         };
 
-        // assert pcs match
         let is_pcs_match = std::mem::size_of::<mpcs::BasefoldCommitmentWithWitness<BB31Ext>>()
             == std::mem::size_of::<PCS::CommitmentWithWitness>();
-        assert!(is_pcs_match, "pcs mismatch");
+        let is_jagged_pcs = is_babybear_jagged_pcs::<E, PCS>();
+        assert!(is_pcs_match || is_jagged_pcs, "pcs mismatch");
+
+        let cuda_hal = get_cuda_hal().unwrap();
+
+        if is_jagged_pcs {
+            let jagged_commitment: &mpcs::JaggedCommitmentWithWitness<BB31Ext, BabyBearBasefold> =
+                unsafe { std::mem::transmute_copy(&pcs_data_original.as_ref()) };
+            let pcs_data_basefold = convert_ceno_to_gpu_basefold_commitment::<
+                CudaHalBB31,
+                BB31Ext,
+                BB31Base,
+                GpuDigestLayer,
+                GpuMatrix,
+                GpuPolynomial,
+            >(&cuda_hal, &jagged_commitment.inner)
+            .expect("failed to convert fixed inner basefold commitment to GPU");
+
+            let total_evaluations = jagged_commitment.total_evaluations();
+            let h = 1usize << jagged_commitment.reshape_log_height;
+            let w = total_evaluations.div_ceil(h);
+            let padded_total = w * h;
+            let q_len = 1usize << ceil_log2(padded_total.max(1));
+            let mut q_evals = vec![BB31Base::ZERO; q_len];
+            for (poly_idx, poly) in jagged_commitment.polys.iter().enumerate() {
+                let start = jagged_commitment.cumulative_heights[poly_idx];
+                let len = jagged_commitment.poly_heights[poly_idx];
+                match poly.evaluations() {
+                    FieldType::Base(values) => q_evals[start..start + len]
+                        .copy_from_slice(&values[..len]),
+                    FieldType::Ext(_) => panic!("Jagged fixed q' expects base-field polys"),
+                    FieldType::Unreachable => unreachable!(),
+                }
+            }
+            let q_evals = cuda_hal
+                .alloc_elems_from_host(&q_evals, None)
+                .expect("failed to upload fixed Jagged q'");
+            let fixed_mles: Vec<Arc<MultilinearExtensionGpu<'static, E>>> = jagged_commitment
+                .polys
+                .iter()
+                .map(|mle| {
+                    let mle_e: &MultilinearExtension<'_, E> =
+                        unsafe { std::mem::transmute(mle.as_ref()) };
+                    Arc::new(MultilinearExtensionGpu::from_ceno(&cuda_hal, mle_e))
+                })
+                .collect_vec();
+            let pcs_data = Arc::new(GpuPcsData::Jagged(GpuJaggedPcsData {
+                inner: pcs_data_basefold,
+                q_evals,
+                original_traces: Vec::new(),
+                cumulative_heights: jagged_commitment.cumulative_heights.clone(),
+                poly_heights: jagged_commitment.poly_heights.clone(),
+                total_evaluations,
+                reshape_log_height: jagged_commitment.reshape_log_height,
+                trace_layouts: Vec::new(),
+            }));
+
+            return DeviceProvingKey {
+                pcs_data,
+                fixed_mles,
+            };
+        }
 
         // 1. transmute from PCS::CommitmentWithWitness to BasefoldCommitmentWithWitness<E>
         let basefold_commitment: &mpcs::BasefoldCommitmentWithWitness<BB31Ext> =
             unsafe { std::mem::transmute_copy(&pcs_data_original.as_ref()) };
         // 2. convert from BasefoldCommitmentWithWitness<E> to BasefoldCommitmentWithWitness<BB31Base>
-        let cuda_hal = get_cuda_hal().unwrap();
         let pcs_data_basefold = convert_ceno_to_gpu_basefold_commitment::<
             CudaHalBB31,
             BB31Ext,
@@ -2978,10 +3633,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> DeviceTransporter<Gp
             })
             .collect_vec();
 
-        let pcs_data: <GpuBackend<E, PCS> as ProverBackend>::PcsData =
-            unsafe { std::mem::transmute_copy(&pcs_data_basefold) };
-        std::mem::forget(pcs_data_basefold);
-        let pcs_data = Arc::new(pcs_data);
+        let pcs_data = Arc::new(GpuPcsData::Basefold(pcs_data_basefold));
 
         DeviceProvingKey {
             pcs_data,

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -1353,7 +1353,7 @@ fn jagged_batch_commit_from_host(
             .map(
                 |_group_start_col| ceno_gpu::common::poseidon2::DeferredRmmSpec {
                     height: h,
-                    persist_actual: true,
+                    persist_actual: false,
                 },
             )
             .collect_vec();
@@ -3416,19 +3416,13 @@ where
                         transcript,
                         |_round_idx, trace_idx| {
                             let h = 1usize << jagged_data.reshape_log_height;
-                            let inner_rmms =
-                                jagged_data.inner.rmms.as_ref().expect(
-                                    "Jagged cache-none opening requires inner RMM metadata",
-                                );
+                            let w = jagged_data.total_evaluations.div_ceil(h);
+                            let group_start_col = trace_idx * group_width;
                             assert!(
-                                trace_idx < inner_rmms.len(),
+                                group_start_col < w,
                                 "Jagged inner q' trace index out of range"
                             );
-                            let group_start_col = inner_rmms[..trace_idx]
-                                .iter()
-                                .map(|rmm| rmm.width())
-                                .sum::<usize>();
-                            let group_cols = inner_rmms[trace_idx].width();
+                            let group_cols = (w - group_start_col).min(group_width);
                             let start = group_start_col * h;
                             let end = start + group_cols * h;
                             let q_view = cuda_hal

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -162,75 +162,6 @@ where
     commit
 }
 
-fn flatten_jagged_openings_as_native<E: ExtensionField>(
-    poly_heights: &[usize],
-    openings: Vec<(Point<E>, Vec<E>)>,
-) -> Result<(Point<E>, Vec<E>), mpcs::Error> {
-    let max_native_point_len = poly_heights
-        .iter()
-        .map(|&height| ceil_log2(height))
-        .max()
-        .unwrap_or(0);
-    let mut common_point = vec![None; max_native_point_len];
-    let mut evals = Vec::with_capacity(poly_heights.len());
-    let mut poly_idx = 0usize;
-
-    for (point, point_evals) in openings {
-        for value in point_evals {
-            let height = poly_heights.get(poly_idx).ok_or_else(|| {
-                mpcs::Error::InvalidPcsParam("jagged: too many opening evaluations".to_string())
-            })?;
-            let native_num_vars = ceil_log2(*height);
-            if point.len() < native_num_vars {
-                return Err(mpcs::Error::InvalidPcsParam(format!(
-                    "jagged: opening point length {} is smaller than poly num_vars {}",
-                    point.len(),
-                    native_num_vars
-                )));
-            }
-            for (dst, src) in common_point.iter_mut().zip(point.iter()) {
-                match dst {
-                    Some(existing) if *existing != *src => {
-                        return Err(mpcs::Error::InvalidPcsParam(
-                            "jagged: opening points are not prefix-compatible".to_string(),
-                        ));
-                    }
-                    Some(_) => {}
-                    None => *dst = Some(*src),
-                }
-            }
-            let tail_zero_factor = point[native_num_vars..]
-                .iter()
-                .fold(E::ONE, |acc, r| acc * (E::ONE - *r));
-            if tail_zero_factor == E::ZERO {
-                return Err(mpcs::Error::InvalidPcsParam(
-                    "jagged: padded opening tail factor is zero".to_string(),
-                ));
-            }
-            evals.push(value * tail_zero_factor.inverse());
-            poly_idx += 1;
-        }
-    }
-
-    if poly_idx != poly_heights.len() {
-        return Err(mpcs::Error::InvalidPcsParam(format!(
-            "jagged: expected {} opening evaluations, got {}",
-            poly_heights.len(),
-            poly_idx
-        )));
-    }
-
-    let point = common_point
-        .into_iter()
-        .map(|value| {
-            value.ok_or_else(|| {
-                mpcs::Error::InvalidPcsParam("jagged: missing common opening point".to_string())
-            })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-    Ok((point, evals))
-}
-
 #[cfg(feature = "gpu")]
 use gkr_iop::gpu::gpu_prover::*;
 
@@ -1368,72 +1299,37 @@ fn jagged_batch_commit_from_host(
         Vec::from_raw_parts(ptr, len, cap)
     };
 
+    let q_device = if matches!(get_gpu_cache_level(), CacheLevel::None) {
+        None
+    } else {
+        Some(
+            cuda_hal
+                .alloc_elems_from_host(&q_host, None)
+                .expect("failed to upload Jagged q' evaluations for commit"),
+        )
+    };
     let group_width = mpcs::JAGGED_RESHAPE_GROUP_WIDTH;
-    if matches!(get_gpu_cache_level(), CacheLevel::None) {
-        let specs = (0..w)
-            .step_by(group_width)
-            .map(
-                |_group_start_col| ceno_gpu::common::poseidon2::DeferredRmmSpec {
-                    height: h,
-                    persist_actual: false,
-                },
-            )
-            .collect_vec();
-        let mut inner = cuda_hal
-            .basefold
-            .batch_commit_cache_none_deferred(cuda_hal.as_ref(), specs, |trace_idx| {
-                let group_start_col = trace_idx * group_width;
-                let group_cols = (w - group_start_col).min(group_width);
-                let start = group_start_col * h;
-                let end = start + group_cols * h;
-                let q_view = cuda_hal.alloc_elems_from_host(&q_host[start..end], None)?;
-                Ok(witness::RowMajorMatrix::new_by_device_backing(
-                    h,
-                    group_cols,
-                    InstancePaddingStrategy::Default,
-                    q_view,
-                    DeviceMatrixLayout::ColMajor,
-                ))
-            })
-            .expect("failed to commit Jagged q' with deferred GPU Basefold");
-        if let Some(rmms) = inner.rmms.as_mut() {
-            for rmm in rmms {
-                rmm.clear_device_backing();
-            }
-        }
-        return (
-            GpuJaggedHostPreprocessed {
-                q_host_evals: q_host,
-                q_device_evals: None,
-                cumulative_heights,
-                poly_heights,
-                total_evaluations,
-                reshape_log_height: log_h,
-            },
-            inner,
-        );
-    }
-
-    let q_device = cuda_hal
-        .alloc_elems_from_host(&q_host, None)
-        .expect("failed to upload Jagged q' evaluations for commit");
     let specs = (0..w)
         .step_by(group_width)
-        .map(
-            |_group_start_col| ceno_gpu::common::poseidon2::DeferredRmmSpec {
-                height: h,
-                persist_actual: false,
-            },
-        )
+        .map(|_| ceno_gpu::common::poseidon2::DeferredRmmSpec {
+            height: h,
+            persist_actual: false,
+        })
         .collect_vec();
     let mut inner = cuda_hal
         .basefold
         .batch_commit_cache_none_deferred(cuda_hal.as_ref(), specs, |trace_idx| {
             let group_start_col = trace_idx * group_width;
             let group_cols = (w - group_start_col).min(group_width);
-            let start = group_start_col * h * std::mem::size_of::<BB31Base>();
-            let end = start + group_cols * h * std::mem::size_of::<BB31Base>();
-            let commit_view = q_device.owned_subrange(start..end);
+            let commit_view = if let Some(q_device) = &q_device {
+                let start = group_start_col * h * std::mem::size_of::<BB31Base>();
+                let end = start + group_cols * h * std::mem::size_of::<BB31Base>();
+                q_device.owned_subrange(start..end)
+            } else {
+                let start = group_start_col * h;
+                let end = start + group_cols * h;
+                cuda_hal.alloc_elems_from_host(&q_host[start..end], None)?
+            };
             Ok(witness::RowMajorMatrix::new_by_device_backing(
                 h,
                 group_cols,
@@ -1443,21 +1339,18 @@ fn jagged_batch_commit_from_host(
             ))
         })
         .expect("failed to commit Jagged q' with deferred GPU Basefold");
-    let q_device_evals = if matches!(get_gpu_cache_level(), CacheLevel::None) {
+    if q_device.is_none() {
         if let Some(rmms) = inner.rmms.as_mut() {
             for rmm in rmms {
                 rmm.clear_device_backing();
             }
         }
-        None
-    } else {
-        Some(q_device)
-    };
+    }
 
     (
         GpuJaggedHostPreprocessed {
             q_host_evals: q_host,
-            q_device_evals,
+            q_device_evals: q_device,
             cumulative_heights,
             poly_heights,
             total_evaluations,
@@ -1487,6 +1380,42 @@ fn jagged_q_storage(
             (Some(q_evals), None)
         }
     }
+}
+
+fn finish_jagged_commit<E, PCS>(
+    cuda_hal: &Arc<CudaHalBB31>,
+    preprocessed: GpuJaggedHostPreprocessed,
+    inner: GpuBasefoldPcsData,
+    trace_layouts: Vec<GpuJaggedTraceLayout>,
+) -> (GpuPcsData, PCS::Commitment)
+where
+    E: ExtensionField,
+    PCS: PolynomialCommitmentScheme<E> + 'static,
+{
+    let inner_commit = cuda_hal.basefold.get_pure_commitment(&inner);
+    let commit = wrap_jagged_commitment_as_pcs::<E, PCS>(
+        inner_commit,
+        preprocessed.cumulative_heights.clone(),
+        preprocessed.reshape_log_height,
+    );
+    let (q_evals, q_host_evals) = jagged_q_storage(
+        cuda_hal,
+        preprocessed.q_host_evals,
+        preprocessed.q_device_evals,
+    );
+    (
+        GpuPcsData::Jagged(GpuJaggedPcsData {
+            inner,
+            q_evals,
+            q_host_evals,
+            cumulative_heights: preprocessed.cumulative_heights,
+            poly_heights: preprocessed.poly_heights,
+            total_evaluations: preprocessed.total_evaluations,
+            reshape_log_height: preprocessed.reshape_log_height,
+            trace_layouts,
+        }),
+        commit,
+    )
 }
 
 pub fn commit_traces_deferred_cache_none<E, PCS>(
@@ -1596,27 +1525,8 @@ where
         for trace in &mut traces_bb31 {
             trace.clear_device_backing();
         }
-        let inner_commit = cuda_hal.basefold.get_pure_commitment(&inner_pcs_data);
-        let commit = wrap_jagged_commitment_as_pcs::<E, PCS>(
-            inner_commit,
-            preprocessed.cumulative_heights.clone(),
-            preprocessed.reshape_log_height,
-        );
-        let (q_evals, q_host_evals) = jagged_q_storage(
-            &cuda_hal,
-            preprocessed.q_host_evals,
-            preprocessed.q_device_evals,
-        );
-        let pcs_data = GpuPcsData::Jagged(GpuJaggedPcsData {
-            inner: inner_pcs_data,
-            q_evals,
-            q_host_evals,
-            cumulative_heights: preprocessed.cumulative_heights,
-            poly_heights: preprocessed.poly_heights,
-            total_evaluations: preprocessed.total_evaluations,
-            reshape_log_height: preprocessed.reshape_log_height,
-            trace_layouts,
-        });
+        let (pcs_data, commit) =
+            finish_jagged_commit::<E, PCS>(&cuda_hal, preprocessed, inner_pcs_data, trace_layouts);
         return (vec![], pcs_data, commit);
     }
 
@@ -1796,28 +1706,12 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>
                 for trace in &mut traces_gl64 {
                     trace.clear_device_backing();
                 }
-                let inner_commit = cuda_hal.basefold.get_pure_commitment(&inner_pcs_data);
-                let commit = wrap_jagged_commitment_as_pcs::<E, PCS>(
-                    inner_commit,
-                    preprocessed.cumulative_heights.clone(),
-                    preprocessed.reshape_log_height,
-                );
-                let (q_evals, q_host_evals) = jagged_q_storage(
+                finish_jagged_commit::<E, PCS>(
                     &cuda_hal,
-                    preprocessed.q_host_evals,
-                    preprocessed.q_device_evals,
-                );
-                let pcs_data = GpuPcsData::Jagged(GpuJaggedPcsData {
-                    inner: inner_pcs_data,
-                    q_evals,
-                    q_host_evals,
-                    cumulative_heights: preprocessed.cumulative_heights,
-                    poly_heights: preprocessed.poly_heights,
-                    total_evaluations: preprocessed.total_evaluations,
-                    reshape_log_height: preprocessed.reshape_log_height,
-                    trace_layouts: trace_layouts.expect("jagged trace layouts must exist"),
-                });
-                (pcs_data, commit)
+                    preprocessed,
+                    inner_pcs_data,
+                    trace_layouts.expect("jagged trace layouts must exist"),
+                )
             } else {
                 let pcs_data = cuda_hal
                     .basefold
@@ -2181,16 +2075,6 @@ where
             })
             .collect::<Vec<_>>()
     };
-
-    eprintln!(
-        "[ceno][shard-ram-compact-mle] trace_idx={} cols={} records={} full_rows={} compact_cols={}",
-        trace_idx,
-        expected_num,
-        num_records,
-        full_rows,
-        expected_num.saturating_sub(21),
-    );
-    let _ = std::io::stderr().flush();
 
     mles
 }
@@ -3358,9 +3242,11 @@ where
                 (point_bb31.clone(), evals_bb31.clone())
             })
             .collect();
-        let (point, evals) =
-            flatten_jagged_openings_as_native(&jagged_data.poly_heights, openings_bb31)
-                .expect("invalid Jagged GPU opening shape");
+        let (point, evals) = mpcs::jagged::flatten_padded_openings_as_native(
+            &jagged_data.poly_heights,
+            openings_bb31,
+        )
+        .expect("invalid Jagged GPU opening shape");
         let q_evals = if let Some(q_evals) = &jagged_data.q_evals {
             let q_evals_len_bytes = q_evals.len() * std::mem::size_of::<BB31Base>();
             q_evals.owned_subrange(0..q_evals_len_bytes)

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -2673,7 +2673,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> TowerProver<GpuBacke
         .expect("prove_tower_relation_impl failed");
 
         let estimated_bytes = estimate_tower_bytes::<E, PCS>(composed_cs, input);
-        check_gpu_mem_estimation_with_context(
+        check_gpu_tower_prove_mem_estimation_with_context(
             gpu_mem_tracker,
             estimated_bytes,
             composed_cs

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -1209,6 +1209,7 @@ fn jagged_batch_commit_from_host(
     prefer_device_backing: bool,
 ) -> (GpuJaggedHostPreprocessed, GpuBasefoldPcsData) {
     if prefer_device_backing
+        && !matches!(get_gpu_cache_level(), CacheLevel::None)
         && traces
             .iter()
             .all(|trace| trace.device_backing_layout() == Some(DeviceMatrixLayout::ColMajor))
@@ -1345,10 +1346,55 @@ fn jagged_batch_commit_from_host(
         Vec::from_raw_parts(ptr, len, cap)
     };
 
+    let group_width = mpcs::JAGGED_RESHAPE_GROUP_WIDTH;
+    if matches!(get_gpu_cache_level(), CacheLevel::None) {
+        let specs = (0..w)
+            .step_by(group_width)
+            .map(
+                |_group_start_col| ceno_gpu::common::poseidon2::DeferredRmmSpec {
+                    height: h,
+                    persist_actual: true,
+                },
+            )
+            .collect_vec();
+        let mut inner = cuda_hal
+            .basefold
+            .batch_commit_cache_none_deferred(cuda_hal.as_ref(), specs, |trace_idx| {
+                let group_start_col = trace_idx * group_width;
+                let group_cols = (w - group_start_col).min(group_width);
+                let start = group_start_col * h;
+                let end = start + group_cols * h;
+                let q_view = cuda_hal.alloc_elems_from_host(&q_host[start..end], None)?;
+                Ok(witness::RowMajorMatrix::new_by_device_backing(
+                    h,
+                    group_cols,
+                    InstancePaddingStrategy::Default,
+                    q_view,
+                    DeviceMatrixLayout::ColMajor,
+                ))
+            })
+            .expect("failed to commit Jagged q' with deferred GPU Basefold");
+        if let Some(rmms) = inner.rmms.as_mut() {
+            for rmm in rmms {
+                rmm.clear_device_backing();
+            }
+        }
+        return (
+            GpuJaggedHostPreprocessed {
+                q_host_evals: q_host,
+                q_device_evals: None,
+                cumulative_heights,
+                poly_heights,
+                total_evaluations,
+                reshape_log_height: log_h,
+            },
+            inner,
+        );
+    }
+
     let q_device = cuda_hal
         .alloc_elems_from_host(&q_host, None)
         .expect("failed to upload Jagged q' evaluations for commit");
-    let group_width = mpcs::JAGGED_RESHAPE_GROUP_WIDTH;
     let reshape_rmms = (0..w)
         .step_by(group_width)
         .map(|group_start_col| {

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -25,6 +25,7 @@ use ceno_gpu::{
     Buffer, CudaHal,
     bb31::{CudaHalBB31, GpuFieldType, GpuMatrix, GpuPolynomial, GpuPolynomialExt},
     common::{
+        CacheLevel, get_gpu_cache_level,
         jagged::{
             JaggedSumcheckGpuCtx, eval_cols_at_point_gpu, jagged_batch_open_gpu,
             jagged_sumcheck_prove_gpu,
@@ -56,12 +57,14 @@ use multilinear_extensions::{
     utils::eval_by_expr_constant,
     virtual_poly::{build_eq_x_r_vec, eq_eval},
 };
-use p3::{field::FieldAlgebra, matrix::Matrix};
-use rayon::iter::{
-    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator,
-    IntoParallelRefMutIterator, ParallelIterator,
+use p3::field::FieldAlgebra;
+use rayon::{
+    iter::{
+        IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator,
+        IntoParallelRefMutIterator, ParallelIterator,
+    },
+    slice::ParallelSliceMut,
 };
-use rayon::slice::ParallelSliceMut;
 use std::{
     collections::BTreeMap,
     io::Write,
@@ -83,14 +86,15 @@ use witness::DeviceMatrixLayout;
 type BabyBearBasefold = Basefold<BB31Ext, BasefoldRSParams>;
 
 struct GpuJaggedHostPreprocessed {
-    q_evals: BufferImpl<'static, BB31Base>,
+    q_host_evals: Vec<BB31Base>,
+    q_device_evals: Option<BufferImpl<'static, BB31Base>>,
     cumulative_heights: Vec<usize>,
     poly_heights: Vec<usize>,
     total_evaluations: usize,
     reshape_log_height: usize,
 }
 
-fn is_babybear_jagged_pcs<E, PCS>() -> bool
+pub(crate) fn is_babybear_jagged_pcs<E, PCS>() -> bool
 where
     E: ExtensionField,
     PCS: PolynomialCommitmentScheme<E> + 'static,
@@ -1201,6 +1205,7 @@ fn jagged_batch_commit_from_host(
     cuda_hal: &Arc<CudaHalBB31>,
     traces: &[witness::RowMajorMatrix<BB31Base>],
     reshape_log_height: usize,
+    prefer_device_backing: bool,
 ) -> (GpuJaggedHostPreprocessed, GpuBasefoldPcsData) {
     let mut poly_heights = Vec::new();
     for trace in traces {
@@ -1227,47 +1232,82 @@ fn jagged_batch_commit_from_host(
         let rows = trace.height();
         let cols = trace.width();
         let start = cumulative_heights[poly_idx];
-        let values = trace.values();
-        q_host[start..start + rows * cols]
-            .par_chunks_mut(rows)
-            .enumerate()
-            .for_each(|(col_idx, out)| {
-                for row_idx in 0..rows {
-                    out[row_idx] = values[row_idx * cols + col_idx];
-                }
-            });
+        if prefer_device_backing
+            && trace.device_backing_layout() == Some(DeviceMatrixLayout::ColMajor)
+        {
+            let device_buffer = trace
+                .device_backing_ref::<BufferImpl<'static, BB31Base>>()
+                .unwrap_or_else(|| panic!("Jagged trace col-major device backing type mismatch"));
+            let col_rows = rmm_col_major_device_rows(trace)
+                .unwrap_or_else(|| panic!("Jagged trace col-major device row count mismatch"));
+            assert!(
+                col_rows <= rows,
+                "Jagged trace col-major device rows exceed logical height"
+            );
+            let device_values = device_buffer
+                .to_vec()
+                .expect("Jagged trace device backing D2H failed");
+            q_host[start..start + rows * cols]
+                .par_chunks_mut(rows)
+                .enumerate()
+                .for_each(|(col_idx, out)| {
+                    let src_start = col_idx * col_rows;
+                    let src_end = src_start + col_rows;
+                    out[..col_rows].copy_from_slice(&device_values[src_start..src_end]);
+                });
+        } else {
+            let values = trace.values();
+            q_host[start..start + rows * cols]
+                .par_chunks_mut(rows)
+                .enumerate()
+                .for_each(|(col_idx, out)| {
+                    for row_idx in 0..rows {
+                        out[row_idx] = values[row_idx * cols + col_idx];
+                    }
+                });
+        }
         poly_idx += cols;
     }
 
-    let mut reshape_values = vec![BB31Base::ZERO; padded_total];
-    reshape_values
-        .par_chunks_mut(w)
-        .enumerate()
-        .for_each(|(row_idx, row)| {
-            for col_idx in 0..w {
-                let src_idx = col_idx * h + row_idx;
-                if src_idx < total_evaluations {
-                    row[col_idx] = q_host[src_idx];
-                }
-            }
-        });
-
-    let q_evals = cuda_hal
+    let q_device = cuda_hal
         .alloc_elems_from_host(&q_host, None)
-        .expect("failed to upload Jagged q' evaluations");
-    let reshape_rmm = witness::RowMajorMatrix::new_by_values(
-        reshape_values,
-        w,
-        InstancePaddingStrategy::Default,
-    );
-    let inner = cuda_hal
+        .expect("failed to upload Jagged q' evaluations for commit");
+    let group_width = mpcs::JAGGED_RESHAPE_GROUP_WIDTH;
+    let reshape_rmms = (0..w)
+        .step_by(group_width)
+        .map(|group_start_col| {
+            let group_cols = (w - group_start_col).min(group_width);
+            let start = group_start_col * h * std::mem::size_of::<BB31Base>();
+            let end = start + group_cols * h * std::mem::size_of::<BB31Base>();
+            let commit_view = q_device.owned_subrange(start..end);
+            witness::RowMajorMatrix::new_by_device_backing(
+                h,
+                group_cols,
+                InstancePaddingStrategy::Default,
+                commit_view,
+                DeviceMatrixLayout::ColMajor,
+            )
+        })
+        .collect_vec();
+    let mut inner = cuda_hal
         .basefold
-        .batch_commit(cuda_hal.as_ref(), vec![reshape_rmm])
+        .batch_commit_cache_none(cuda_hal.as_ref(), reshape_rmms)
         .expect("failed to commit Jagged q' with GPU Basefold");
+    let q_device_evals = if matches!(get_gpu_cache_level(), CacheLevel::None) {
+        if let Some(rmms) = inner.rmms.as_mut() {
+            for rmm in rmms {
+                rmm.clear_device_backing();
+            }
+        }
+        None
+    } else {
+        Some(q_device)
+    };
 
     (
         GpuJaggedHostPreprocessed {
-            q_evals,
+            q_host_evals: q_host,
+            q_device_evals,
             cumulative_heights,
             poly_heights,
             total_evaluations,
@@ -1275,6 +1315,28 @@ fn jagged_batch_commit_from_host(
         },
         inner,
     )
+}
+
+fn jagged_q_storage(
+    cuda_hal: &Arc<CudaHalBB31>,
+    q_host_evals: Vec<BB31Base>,
+    q_device_evals: Option<BufferImpl<'static, BB31Base>>,
+) -> (Option<BufferImpl<'static, BB31Base>>, Option<Vec<BB31Base>>) {
+    match get_gpu_cache_level() {
+        CacheLevel::None => (None, Some(q_host_evals)),
+        CacheLevel::Trace | CacheLevel::Full => {
+            let q_evals = q_device_evals.unwrap_or_else(|| {
+                cuda_hal
+                    .alloc_elems_from_host(&q_host_evals, None)
+                    .expect("failed to upload Jagged q' evaluations")
+            });
+            cuda_hal
+                .inner
+                .synchronize()
+                .expect("failed to synchronize Jagged q' upload");
+            (Some(q_evals), None)
+        }
+    }
 }
 
 pub fn commit_traces_deferred_cache_none<E, PCS>(
@@ -1377,9 +1439,10 @@ where
             .backend
             .pp
             .get_max_message_size_log()
+            .min(crate::instructions::gpu::config::jagged_reshape_log_height_cap())
             .min(ceil_log2(total_size.max(1)));
         let (preprocessed, inner_pcs_data) =
-            jagged_batch_commit_from_host(&cuda_hal, &traces_bb31, reshape_log_height);
+            jagged_batch_commit_from_host(&cuda_hal, &traces_bb31, reshape_log_height, true);
         for trace in &mut traces_bb31 {
             trace.clear_device_backing();
         }
@@ -1389,10 +1452,15 @@ where
             preprocessed.cumulative_heights.clone(),
             preprocessed.reshape_log_height,
         );
+        let (q_evals, q_host_evals) = jagged_q_storage(
+            &cuda_hal,
+            preprocessed.q_host_evals,
+            preprocessed.q_device_evals,
+        );
         let pcs_data = GpuPcsData::Jagged(GpuJaggedPcsData {
             inner: inner_pcs_data,
-            q_evals: preprocessed.q_evals,
-            original_traces: traces_bb31,
+            q_evals,
+            q_host_evals,
             cumulative_heights: preprocessed.cumulative_heights,
             poly_heights: preprocessed.poly_heights,
             total_evaluations: preprocessed.total_evaluations,
@@ -1460,8 +1528,7 @@ where
 }
 
 impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>
-    TraceCommitter<GpuBackend<E, PCS>>
-    for GpuProver<GpuBackend<E, PCS>>
+    TraceCommitter<GpuBackend<E, PCS>> for GpuProver<GpuBackend<E, PCS>>
 {
     fn commit_traces<'a>(
         &self,
@@ -1564,9 +1631,14 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>
                     .backend
                     .pp
                     .get_max_message_size_log()
+                    .min(crate::instructions::gpu::config::jagged_reshape_log_height_cap())
                     .min(ceil_log2(total_size.max(1)));
-                let (preprocessed, inner_pcs_data) =
-                    jagged_batch_commit_from_host(&cuda_hal, &traces_gl64, reshape_log_height);
+                let (preprocessed, inner_pcs_data) = jagged_batch_commit_from_host(
+                    &cuda_hal,
+                    &traces_gl64,
+                    reshape_log_height,
+                    false,
+                );
                 for trace in &mut traces_gl64 {
                     trace.clear_device_backing();
                 }
@@ -1576,10 +1648,15 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>
                     preprocessed.cumulative_heights.clone(),
                     preprocessed.reshape_log_height,
                 );
+                let (q_evals, q_host_evals) = jagged_q_storage(
+                    &cuda_hal,
+                    preprocessed.q_host_evals,
+                    preprocessed.q_device_evals,
+                );
                 let pcs_data = GpuPcsData::Jagged(GpuJaggedPcsData {
                     inner: inner_pcs_data,
-                    q_evals: preprocessed.q_evals,
-                    original_traces: traces_gl64,
+                    q_evals,
+                    q_host_evals,
                     cumulative_heights: preprocessed.cumulative_heights,
                     poly_heights: preprocessed.poly_heights,
                     total_evaluations: preprocessed.total_evaluations,
@@ -1630,9 +1707,13 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>
                     if trace_idx >= total_traces {
                         return None;
                     }
-                    current_iter =
-                        extract_jagged_witness_mles_for_trace::<E>(jagged_data, trace_idx, None, None)
-                            .into_iter();
+                    current_iter = extract_jagged_witness_mles_for_trace::<E>(
+                        jagged_data,
+                        trace_idx,
+                        None,
+                        None,
+                    )
+                    .into_iter();
                     trace_idx += 1;
                 }
             });
@@ -1715,110 +1796,6 @@ where
         "GPU Jagged q' extraction only supports BabyBear base field",
     );
 
-    if let Some(rmm) = pcs_data.original_traces.get(trace_idx) {
-        if let Some(expected_num) = expected_num {
-            assert_eq!(
-                rmm.width(),
-                expected_num,
-                "Jagged trace width mismatch: expected {}, got {}",
-                expected_num,
-                rmm.width(),
-            );
-        }
-        let num_vars = num_vars.unwrap_or(rmm.num_vars());
-        let elem_size = std::mem::size_of::<BB31Base>();
-
-        if rmm.device_backing_layout() == Some(DeviceMatrixLayout::ColMajor) {
-            let device_buffer = rmm
-                .device_backing_ref::<BufferImpl<'static, BB31Base>>()
-                .unwrap_or_else(|| panic!("Jagged trace col-major device backing type mismatch"));
-            let col_rows = rmm_col_major_device_rows(rmm)
-                .unwrap_or_else(|| panic!("Jagged trace col-major device row count mismatch"));
-            assert!(
-                col_rows <= rmm.height(),
-                "Jagged trace col-major device rows exceed logical height"
-            );
-            let col_stride_bytes = col_rows * elem_size;
-            if col_rows < rmm.height() {
-                let cuda_hal = get_cuda_hal().unwrap();
-                return (0..rmm.width())
-                    .map(|col_idx| {
-                        let start = col_idx * col_stride_bytes;
-                        let end = start + col_stride_bytes;
-                        let src = device_buffer.as_slice_range(start..end);
-                        let mut padded_buffer = cuda_hal
-                            .alloc_elems_on_device(rmm.height(), true, None)
-                            .unwrap_or_else(|err| {
-                                panic!("Jagged trace padded column allocation failed: {err:?}")
-                            });
-                        let mut dst = padded_buffer.as_mut_slice_range(0..col_stride_bytes);
-                        cuda_hal
-                            .inner
-                            .dtod_copy_sync(&src, &mut dst)
-                            .unwrap_or_else(|err| {
-                                panic!("Jagged trace compact-to-padded D2D copy failed: {err:?}")
-                            });
-                        let view_poly = GpuPolynomial::new(padded_buffer, num_vars);
-                        let poly_static: GpuPolynomial<'static> =
-                            unsafe { std::mem::transmute(view_poly) };
-                        let mle_static = MultilinearExtensionGpu::from_ceno_gpu_base(poly_static);
-                        Arc::new(unsafe {
-                            std::mem::transmute::<
-                                MultilinearExtensionGpu<'static, E>,
-                                MultilinearExtensionGpu<'a, E>,
-                            >(mle_static)
-                        })
-                    })
-                    .collect();
-            }
-            return (0..rmm.width())
-                .map(|col_idx| {
-                    let start = col_idx * col_stride_bytes;
-                    let end = start + col_stride_bytes;
-                    let view_buf = device_buffer.owned_subrange(start..end);
-                    let view_poly = GpuPolynomial::new(view_buf, num_vars);
-                    let poly_static: GpuPolynomial<'static> =
-                        unsafe { std::mem::transmute(view_poly) };
-                    let mle_static = MultilinearExtensionGpu::from_ceno_gpu_base(poly_static);
-                    Arc::new(unsafe {
-                        std::mem::transmute::<
-                            MultilinearExtensionGpu<'static, E>,
-                            MultilinearExtensionGpu<'a, E>,
-                        >(mle_static)
-                    })
-                })
-                .collect();
-        }
-
-        let cuda_hal = get_cuda_hal().unwrap();
-        let values = rmm.values();
-        return (0..rmm.width())
-            .map(|col_idx| {
-                let mut column = Vec::with_capacity(rmm.height());
-                column.extend((0..rmm.height()).map(|row| values[row * rmm.width() + col_idx]));
-                let column_bb31: Vec<BB31Base> = unsafe {
-                    let mut column = std::mem::ManuallyDrop::new(column);
-                    Vec::from_raw_parts(
-                        column.as_mut_ptr() as *mut BB31Base,
-                        column.len(),
-                        column.capacity(),
-                    )
-                };
-                let gpu_poly = cuda_hal
-                    .alloc_elems_from_host(&column_bb31, None)
-                    .map(|buffer| GpuPolynomial::new(buffer, num_vars))
-                    .unwrap_or_else(|err| panic!("Jagged trace H2D failed: {err:?}"));
-                let mle_static = MultilinearExtensionGpu::from_ceno_gpu_base(gpu_poly);
-                Arc::new(unsafe {
-                    std::mem::transmute::<
-                        MultilinearExtensionGpu<'static, E>,
-                        MultilinearExtensionGpu<'a, E>,
-                    >(mle_static)
-                })
-            })
-            .collect();
-    }
-
     let layout = pcs_data
         .trace_layouts
         .get(trace_idx)
@@ -1832,14 +1809,52 @@ where
     }
     let num_vars = num_vars.unwrap_or(layout.num_vars);
     let elem_size = std::mem::size_of::<BB31Base>();
+    let logical_len = 1usize << num_vars;
 
     (0..layout.num_polys)
         .map(|col_idx| {
             let poly_idx = layout.first_poly_idx + col_idx;
-            let start = pcs_data.cumulative_heights[poly_idx] * elem_size;
-            let end = start + pcs_data.poly_heights[poly_idx] * elem_size;
-            let view_buf = pcs_data.q_evals.owned_subrange(start..end);
-            let view_poly = GpuPolynomial::new(view_buf, num_vars);
+            let start_elem = pcs_data.cumulative_heights[poly_idx];
+            let len = pcs_data.poly_heights[poly_idx];
+            let gpu_buffer = if let Some(q_evals) = &pcs_data.q_evals {
+                let start = start_elem * elem_size;
+                let end = start + len * elem_size;
+                if len == logical_len {
+                    q_evals.owned_subrange(start..end)
+                } else {
+                    let cuda_hal = get_cuda_hal().unwrap();
+                    let src = q_evals.as_slice_range(start..end);
+                    let mut padded_buffer = cuda_hal
+                        .alloc_elems_on_device(logical_len, true, None)
+                        .unwrap_or_else(|err| {
+                            panic!("Jagged q' padded column allocation failed: {err:?}")
+                        });
+                    let mut dst = padded_buffer.as_mut_slice_range(0..len * elem_size);
+                    cuda_hal
+                        .inner
+                        .dtod_copy_sync(&src, &mut dst)
+                        .unwrap_or_else(|err| {
+                            panic!("Jagged q' compact-to-padded D2D copy failed: {err:?}")
+                        });
+                    padded_buffer
+                }
+            } else if let Some(q_host) = pcs_data.q_host_evals.as_ref() {
+                let cuda_hal = get_cuda_hal().unwrap();
+                if len == logical_len {
+                    cuda_hal
+                        .alloc_elems_from_host(&q_host[start_elem..start_elem + len], None)
+                        .unwrap_or_else(|err| panic!("Jagged q' column H2D failed: {err:?}"))
+                } else {
+                    let mut column = vec![BB31Base::ZERO; logical_len];
+                    column[..len].copy_from_slice(&q_host[start_elem..start_elem + len]);
+                    cuda_hal
+                        .alloc_elems_from_host(&column, None)
+                        .unwrap_or_else(|err| panic!("Jagged q' padded column H2D failed: {err:?}"))
+                }
+            } else {
+                panic!("Jagged q' is missing both device and host backing");
+            };
+            let view_poly = GpuPolynomial::new(gpu_buffer, num_vars);
             let poly_static: GpuPolynomial<'static> = unsafe { std::mem::transmute(view_poly) };
             let mle_static = MultilinearExtensionGpu::from_ceno_gpu_base(poly_static);
             Arc::new(unsafe {
@@ -3132,8 +3147,7 @@ fn frontload_input_opening_point<E: ExtensionField>(
 }
 
 impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>
-    RotationProver<GpuBackend<E, PCS>>
-    for GpuProver<GpuBackend<E, PCS>>
+    RotationProver<GpuBackend<E, PCS>> for GpuProver<GpuBackend<E, PCS>>
 {
     fn prove_rotation<'a>(
         &self,
@@ -3195,10 +3209,8 @@ where
     let basic_transcript = transcript_any
         .downcast_mut::<BasicTranscript<BB31Ext>>()
         .expect("Type should match");
-    let pp_bb31: &mpcs::basefold::structure::BasefoldProverParams<
-        BB31Ext,
-        mpcs::BasefoldRSParams,
-    > = unsafe { std::mem::transmute(prover_param) };
+    let pp_bb31: &mpcs::basefold::structure::BasefoldProverParams<BB31Ext, mpcs::BasefoldRSParams> =
+        unsafe { std::mem::transmute(prover_param) };
     let cuda_hal = get_cuda_hal().unwrap();
 
     let mut proofs = Vec::with_capacity(rounds.len());
@@ -3215,8 +3227,18 @@ where
         let (point, evals) =
             flatten_jagged_openings_as_native(&jagged_data.poly_heights, openings_bb31)
                 .expect("invalid Jagged GPU opening shape");
-        let q_evals_len_bytes = jagged_data.q_evals.len() * std::mem::size_of::<BB31Base>();
-        let q_evals = jagged_data.q_evals.owned_subrange(0..q_evals_len_bytes);
+        let q_evals = if let Some(q_evals) = &jagged_data.q_evals {
+            let q_evals_len_bytes = q_evals.len() * std::mem::size_of::<BB31Base>();
+            q_evals.owned_subrange(0..q_evals_len_bytes)
+        } else {
+            let q_host = jagged_data
+                .q_host_evals
+                .as_ref()
+                .expect("Jagged q' is missing both device and host backing");
+            cuda_hal
+                .alloc_elems_from_host(q_host, None)
+                .expect("failed to upload Jagged q' for opening")
+        };
         let proof = jagged_batch_open_gpu::<BB31Ext, BabyBearBasefold, _>(
             &jagged_data.cumulative_heights,
             jagged_data.total_evaluations,
@@ -3255,15 +3277,65 @@ where
                 (proof, rho, col_evals)
             },
             |rho_row, col_evals, transcript| {
-                let gpu_basefold_proof = cuda_hal
-                    .basefold
-                    .batch_open(
+                let group_width = mpcs::JAGGED_RESHAPE_GROUP_WIDTH;
+                let inner_openings = col_evals
+                    .chunks(group_width)
+                    .map(|evals| (rho_row.clone(), evals.to_vec()))
+                    .collect_vec();
+                let gpu_basefold_proof = if jagged_data.q_evals.is_none() {
+                    let q_host = jagged_data
+                        .q_host_evals
+                        .as_ref()
+                        .expect("Jagged q' host backing missing for cache-none opening");
+                    cuda_hal.basefold.batch_open_with_trace_materializer(
                         &cuda_hal,
                         pp_bb31,
-                        vec![(&jagged_data.inner, vec![(rho_row, col_evals)])],
+                        vec![(&jagged_data.inner, inner_openings)],
+                        transcript,
+                        |_round_idx, trace_idx| {
+                            let h = 1usize << jagged_data.reshape_log_height;
+                            let inner_rmms = jagged_data
+                                .inner
+                                .rmms
+                                .as_ref()
+                                .expect("Jagged cache-none opening requires inner RMM metadata");
+                            assert!(
+                                trace_idx < inner_rmms.len(),
+                                "Jagged inner q' trace index out of range"
+                            );
+                            let group_start_col = inner_rmms[..trace_idx]
+                                .iter()
+                                .map(|rmm| rmm.width())
+                                .sum::<usize>();
+                            let group_cols = inner_rmms[trace_idx].width();
+                            let mut reshape_values = vec![BB31Base::ZERO; h * group_cols];
+                            reshape_values
+                                .par_chunks_mut(group_cols)
+                                .enumerate()
+                                .for_each(|(row_idx, row)| {
+                                    for (local_col, value) in row.iter_mut().enumerate() {
+                                        let src_idx = (group_start_col + local_col) * h + row_idx;
+                                        if src_idx < jagged_data.total_evaluations {
+                                            *value = q_host[src_idx];
+                                        }
+                                    }
+                                });
+                            Ok(Some(witness::RowMajorMatrix::new_by_values(
+                                reshape_values,
+                                group_cols,
+                                InstancePaddingStrategy::Default,
+                            )))
+                        },
+                    )
+                } else {
+                    cuda_hal.basefold.batch_open(
+                        &cuda_hal,
+                        pp_bb31,
+                        vec![(&jagged_data.inner, inner_openings)],
                         transcript,
                     )
-                    .map_err(|e| mpcs::Error::InvalidPcsOpen(e.to_string()))?;
+                }
+                .map_err(|e| mpcs::Error::InvalidPcsOpen(e.to_string()))?;
                 Ok(mpcs::basefold::structure::BasefoldProof {
                     commits: gpu_basefold_proof.commits,
                     query_opening_proof: gpu_basefold_proof.query_opening_proof,
@@ -3284,8 +3356,7 @@ where
 }
 
 impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>
-    OpeningProver<GpuBackend<E, PCS>>
-    for GpuProver<GpuBackend<E, PCS>>
+    OpeningProver<GpuBackend<E, PCS>> for GpuProver<GpuBackend<E, PCS>>
 {
     fn open(
         &self,
@@ -3513,8 +3584,7 @@ where
 }
 
 impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>
-    DeviceTransporter<GpuBackend<E, PCS>>
-    for GpuProver<GpuBackend<E, PCS>>
+    DeviceTransporter<GpuBackend<E, PCS>> for GpuProver<GpuBackend<E, PCS>>
 {
     fn transport_proving_key(
         &self,
@@ -3562,8 +3632,9 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>
                 let start = jagged_commitment.cumulative_heights[poly_idx];
                 let len = jagged_commitment.poly_heights[poly_idx];
                 match poly.evaluations() {
-                    FieldType::Base(values) => q_evals[start..start + len]
-                        .copy_from_slice(&values[..len]),
+                    FieldType::Base(values) => {
+                        q_evals[start..start + len].copy_from_slice(&values[..len])
+                    }
                     FieldType::Ext(_) => panic!("Jagged fixed q' expects base-field polys"),
                     FieldType::Unreachable => unreachable!(),
                 }
@@ -3582,8 +3653,8 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + 'static>
                 .collect_vec();
             let pcs_data = Arc::new(GpuPcsData::Jagged(GpuJaggedPcsData {
                 inner: pcs_data_basefold,
-                q_evals,
-                original_traces: Vec::new(),
+                q_evals: Some(q_evals),
+                q_host_evals: None,
                 cumulative_heights: jagged_commitment.cumulative_heights.clone(),
                 poly_heights: jagged_commitment.poly_heights.clone(),
                 total_evaluations,

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -247,7 +247,11 @@ impl<
                     if !crate::instructions::gpu::config::is_gpu_witgen_enabled()
                         && witness_rmm.num_instances() > 0
                     {
-                        Some(witness_rmm.height())
+                        Some(if is_babybear_jagged_pcs::<E, PCS>() {
+                            witness_rmm.occupied_physical_rows()
+                        } else {
+                            witness_rmm.height()
+                        })
                     } else {
                         None
                     };

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -10,7 +10,7 @@ use std::{collections::BTreeMap, marker::PhantomData, sync::Arc};
 #[cfg(feature = "gpu")]
 use crate::instructions::gpu::cache::current_replay_cache_stats;
 #[cfg(feature = "gpu")]
-use crate::scheme::gpu::estimate_chip_proof_memory;
+use crate::scheme::gpu::{estimate_chip_proof_memory, is_babybear_jagged_pcs};
 #[cfg(feature = "gpu")]
 use crate::scheme::scheduler::get_chip_proving_mode;
 use crate::scheme::{
@@ -238,8 +238,10 @@ impl<
                 let [witness_rmm, structural_witness_rmm] = witness_rmms;
 
                 #[cfg(feature = "gpu")]
-                let use_deferred_gpu_commit = crate::instructions::gpu::config::is_gpu_witgen_enabled()
-                    && !crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit();
+                let use_deferred_gpu_commit =
+                    crate::instructions::gpu::config::is_gpu_witgen_enabled()
+                        && (!crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit()
+                            || is_babybear_jagged_pcs::<E, PCS>());
                 #[cfg(feature = "gpu")]
                 let trace_rows_for_estimate =
                     if !crate::instructions::gpu::config::is_gpu_witgen_enabled()
@@ -250,23 +252,23 @@ impl<
                         None
                     };
 
-	                #[cfg(feature = "gpu")]
-	                if use_deferred_gpu_commit {
-	                    if let Some(plan) = gpu_replay_plan.clone().filter(|plan| plan.num_witin > 0) {
-	                        deferred_gpu_traces
-	                            .insert(i, crate::scheme::gpu::DeferredGpuTrace::Replay(plan));
-	                    } else if witness_rmm.num_instances() > 0 && witness_rmm.width > 0 {
-	                        deferred_gpu_traces
-	                            .insert(i, crate::scheme::gpu::DeferredGpuTrace::Eager(witness_rmm));
-	                    }
-	                } else if witness_rmm.num_instances() > 0 && witness_rmm.width > 0 {
-	                    wits_rmms.insert(i, witness_rmm);
-	                }
+                #[cfg(feature = "gpu")]
+                if use_deferred_gpu_commit {
+                    if let Some(plan) = gpu_replay_plan.clone().filter(|plan| plan.num_witin > 0) {
+                        deferred_gpu_traces
+                            .insert(i, crate::scheme::gpu::DeferredGpuTrace::Replay(plan));
+                    } else if witness_rmm.num_instances() > 0 && witness_rmm.width > 0 {
+                        deferred_gpu_traces
+                            .insert(i, crate::scheme::gpu::DeferredGpuTrace::Eager(witness_rmm));
+                    }
+                } else if witness_rmm.num_instances() > 0 && witness_rmm.width > 0 {
+                    wits_rmms.insert(i, witness_rmm);
+                }
 
-	                #[cfg(not(feature = "gpu"))]
-	                if witness_rmm.num_instances() > 0 && witness_rmm.width > 0 {
-	                    wits_rmms.insert(i, witness_rmm);
-	                }
+                #[cfg(not(feature = "gpu"))]
+                if witness_rmm.num_instances() > 0 && witness_rmm.width > 0 {
+                    wits_rmms.insert(i, witness_rmm);
+                }
                 structural_rmms.push(structural_witness_rmm);
                 #[cfg(feature = "gpu")]
                 witness_trace_rows.push(trace_rows_for_estimate);
@@ -292,7 +294,8 @@ impl<
                     .map(|i| {
                         #[cfg(feature = "gpu")]
                         let has_trace = if crate::instructions::gpu::config::is_gpu_witgen_enabled()
-                            && !crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit()
+                            && (!crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit()
+                                || is_babybear_jagged_pcs::<E, PCS>())
                         {
                             deferred_gpu_traces.contains_key(&i)
                         } else {
@@ -316,14 +319,16 @@ impl<
                 == std::any::TypeId::of::<gkr_iop::gpu::GpuBackend<E, PCS>>();
             #[cfg(feature = "gpu")]
             let needs_replay_restore = crate::instructions::gpu::config::is_gpu_witgen_enabled()
-                && !crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit()
+                && (!crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit()
+                    || is_babybear_jagged_pcs::<E, PCS>())
                 && using_gpu_backend;
             #[cfg(not(feature = "gpu"))]
             let _needs_replay_restore = false;
 
             #[cfg(feature = "gpu")]
             let use_deferred_gpu_commit = crate::instructions::gpu::config::is_gpu_witgen_enabled()
-                && !crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit()
+                && (!crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit()
+                    || is_babybear_jagged_pcs::<E, PCS>())
                 && using_gpu_backend;
             #[cfg(not(feature = "gpu"))]
             let _use_deferred_gpu_commit = false;

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -532,8 +532,6 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
         #[cfg(feature = "gpu")]
         if cs.zkvm_v1_css.num_witin > 0
             && crate::instructions::gpu::config::is_gpu_witgen_enabled()
-            && !crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit(
-            )
             && (input.witness_rmms[0].has_device_backing()
                 || (num_instances[0] > 0
                     && input.witness_rmms[0].num_instances() == 0
@@ -551,12 +549,15 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
                 shard_steps,
                 indices,
             );
-            assert_eq!(
-                input.witness_rmms[0].num_instances(),
-                0,
-                "{}: cache-none GPU replay path must not keep an eager witness RMM after initial assign",
-                OC::name()
-            );
+            if !crate::instructions::gpu::config::should_retain_witness_device_backing_after_commit(
+            ) {
+                assert_eq!(
+                    input.witness_rmms[0].num_instances(),
+                    0,
+                    "{}: cache-none GPU replay path must not keep an eager witness RMM after initial assign",
+                    OC::name()
+                );
+            }
         }
         assert!(self.witnesses.insert(OC::name(), vec![input]).is_none());
         assert!(

--- a/ceno_zkvm/src/tables/shard_ram.rs
+++ b/ceno_zkvm/src/tables/shard_ram.rs
@@ -26,7 +26,7 @@ use itertools::{Itertools, chain};
 use multilinear_extensions::{Expression, ToExpr, WitIn, util::max_usable_threads};
 use p3::{
     field::{Field, FieldAlgebra},
-    matrix::{Matrix, dense::RowMajorMatrix},
+    matrix::dense::RowMajorMatrix,
     symmetric::Permutation,
 };
 use rayon::{

--- a/gkr_iop/src/gpu/mod.rs
+++ b/gkr_iop/src/gpu/mod.rs
@@ -30,6 +30,7 @@ pub mod gpu_prover {
             basefold::utils::convert_ceno_to_gpu_basefold_commitment,
             buffer::BufferImpl,
             get_ceno_gpu_device_id, get_gpu_cache_level, get_mem_tracking_mode,
+            jagged::GpuJaggedPreprocessed,
             mem_pool::MemTracker,
             mle::{
                 build_mle_as_ceno, ordered_sparse_selector_gpu, rotation_next_base_mle_gpu,
@@ -357,19 +358,44 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> GpuBackend<E, PCS> {
 
 pub type ArcMultilinearExtensionGpu<'a, E> = Arc<MultilinearExtensionGpu<'a, E>>;
 
+pub type GpuBasefoldPcsData = BasefoldCommitmentWithWitnessGpu<
+    BB31Base,
+    BufferImpl<'static, BB31Base>,
+    GpuDigestLayer,
+    GpuMatrix<'static>,
+    GpuPolynomial<'static>,
+>;
+
+#[derive(Clone, Debug)]
+pub struct GpuJaggedTraceLayout {
+    pub first_poly_idx: usize,
+    pub num_polys: usize,
+    pub num_vars: usize,
+}
+
+pub struct GpuJaggedPcsData {
+    pub inner: GpuBasefoldPcsData,
+    pub q_evals: BufferImpl<'static, BB31Base>,
+    pub original_traces: Vec<RowMajorMatrix<BB31Base>>,
+    pub cumulative_heights: Vec<usize>,
+    pub poly_heights: Vec<usize>,
+    pub total_evaluations: usize,
+    pub reshape_log_height: usize,
+    pub trace_layouts: Vec<GpuJaggedTraceLayout>,
+}
+
+pub enum GpuPcsData {
+    Basefold(GpuBasefoldPcsData),
+    Jagged(GpuJaggedPcsData),
+}
+
 impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ProverBackend for GpuBackend<E, PCS> {
     type E = E;
     type Pcs = PCS;
     type MultilinearPoly<'a> = MultilinearExtensionGpu<'static, E>;
     type Matrix = RowMajorMatrix<E::BaseField>;
     #[cfg(feature = "gpu")]
-    type PcsData = BasefoldCommitmentWithWitnessGpu<
-        E::BaseField,
-        BufferImpl<'static, E::BaseField>,
-        GpuDigestLayer,
-        GpuMatrix<'static>,
-        GpuPolynomial<'static>,
-    >;
+    type PcsData = GpuPcsData;
     #[cfg(not(feature = "gpu"))]
     type PcsData = <PCS as PolynomialCommitmentScheme<E>>::CommitmentWithWitness;
 

--- a/gkr_iop/src/gpu/mod.rs
+++ b/gkr_iop/src/gpu/mod.rs
@@ -375,8 +375,8 @@ pub struct GpuJaggedTraceLayout {
 
 pub struct GpuJaggedPcsData {
     pub inner: GpuBasefoldPcsData,
-    pub q_evals: BufferImpl<'static, BB31Base>,
-    pub original_traces: Vec<RowMajorMatrix<BB31Base>>,
+    pub q_evals: Option<BufferImpl<'static, BB31Base>>,
+    pub q_host_evals: Option<Vec<BB31Base>>,
     pub cumulative_heights: Vec<usize>,
     pub poly_heights: Vec<usize>,
     pub total_evaluations: usize,


### PR DESCRIPTION
## Problem

Integrate Jagged PCS into the Ceno prover flow so trace commitments/openings can use Jagged over the existing Basefold PCS.

## Design Rationale

Jagged PCS packs per-chip trace polynomials into q' and reduces batched openings before delegating the final PCS opening to Basefold. The verifier behavior is kept unchanged; prover-side q' opening now reuses inner PCS column MLEs instead of rebuilding a second flat q' buffer.

## Change Highlights

- `ceno_zkvm`: wire Jagged PCS into the CPU proving flow.
- `mpcs`: implement Jagged PCS trait integration and q' indexed view for opening.
- `mpcs`: document Basefold prover param sizing and q' layout assumptions.

## Benchmark / Performance Impact

CPU shard0 benchmark is close to baseline. 

### GPU

Block: `23817600`, GPU, `CENO_GPU_CACHE_LEVEL=1`, reshape height: `24`

| Metric | Basefold baseline | Jagged PCS | Delta | Delta % |
|---|---:|---:|---:|---:|
| E2E total | 91.800s | 83.600s | -8.200s | -8.9% |
| Emulator | 10.200s | 10.100s | -0.100s | -1.0% |
| App prove | 76.500s | 68.600s | -7.900s | -10.3% |
| App verify | 4.020s | 3.590s | -0.430s | -10.7% |
| `commit_traces` | 6.857s | 17.620s | +10.763s | +157.0% |
| `extract_witness_mles` | 3.739s | 0.004s | -3.735s | -99.9% |
| `build_tower_witness_gpu` | 0.323s | 1.428s | +1.105s | +342.1% |
| `prove_tower_relation_gpu` | 24.857s | 22.566s | -2.291s | -9.2% |
| `prove_batched_main_constraints` | 15.457s | 7.646s | -7.811s | -50.5% |
| `pcs_opening` | 15.175s | 10.083s | -5.092s | -33.6% |

Shard count: `15 -> 14` (`-1` shard) on block `23817600`.

Source runs:

- Basefold baseline: https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/25655529702
- Jagged PCS: https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/25921358391
- Baseline summary: https://github.com/scroll-tech/ceno-reth-benchmark/blob/gh-pages/benchmarks-dispatch/refs/heads/feat/batch_main_sumcheck/mainnet23817600-20260511-150859_summary.md
- Jagged PCS summary: https://github.com/scroll-tech/ceno-reth-benchmark/blob/gh-pages/benchmarks-dispatch/refs/heads/feat/jagged_pcs/mainnet23817600-20260515-215037_summary.md

## Testing

```sh
cargo test -p mpcs jagged -- --nocapture
cargo run --config net.git-fetch-with-cli=true --release --package ceno_zkvm --bin e2e -- \
  --platform=ceno --max-cycle-per-shard=1600 \
  examples/target/riscv32im-ceno-zkvm-elf/release/examples/keccak_syscall
```

## Copilot Reviewer Directive (keep this section)

When Copilot reviews this PR, apply `.github/copilot-instructions.md` strictly.


