### PR TITLE
fix(soundness): bind ShardRam y-sign to is_global_write

### DIFF
--- a/ceno_recursion/src/zkvm_verifier/verifier.rs
+++ b/ceno_recursion/src/zkvm_verifier/verifier.rs
@@ -307,9 +307,21 @@ pub fn verify_zkvm_proof<C: Config<F = F>>(
                 let num_lks: Var<C::N> =
                     builder.eval(C::N::from_canonical_usize(chip_vk.get_cs().num_lks()));
 
+                // Chips with EC-sum ops carry an extra hypercube variable; the
+                // prover fills it with EC-tree internal nodes that are inactive
+                // via `selector_zero = 0` and thus collapse to dummy lookup
+                // queries. Mirror the native verifier's adjustment here so the
+                // dummy multiplicity matches the prover.
+                let ecc_row_factor: usize = if circuit_vk.get_cs().has_ecc_ops() {
+                    2
+                } else {
+                    1
+                };
                 // each padding instance contribute to (2^rotation_vars) dummy lookup padding
-                let next_pow2_instance: Var<C::N> =
+                let next_pow2_chip_rows: Var<C::N> =
                     pow_2(builder, chip_proof.log2_num_instances.get_var());
+                let next_pow2_instance: Var<C::N> =
+                    builder.eval(next_pow2_chip_rows * C::N::from_canonical_usize(ecc_row_factor));
                 let num_padded_instance: Var<C::N> =
                     builder.eval(next_pow2_instance - chip_proof.sum_num_instances.clone());
                 let rotation_var: Var<C::N> = builder.constant(C::N::from_canonical_usize(

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1497,6 +1497,30 @@ pub fn generate_witness<'a, E: ExtensionField>(
                         &mut zkvm_witness,
                     )
             }).unwrap();
+
+            // Assign continuation circuits (LocalFinal + ShardRam) before
+            // `finalize_lk_multiplicities`: ShardRam's per-row y6_lo byte /
+            // LTU lookups must land in `combined_lk_mlt` so the U8 / LTU
+            // table `mlt` columns balance the logup grand product. LocalFinal
+            // does not consume `combined_lk_mlt`, so running it pre-finalize
+            // is safe — `assign_table_circuit` tolerates a not-yet-finalized
+            // multiplicity by passing an empty slice.
+            info_span!("assign_continuation").in_scope(|| {
+                system_config
+                    .mmu_config
+                    .assign_continuation_circuit(
+                        &system_config.zkvm_cs,
+                        &shard_ctx,
+                        &mut zkvm_witness,
+                        &pi,
+                        &emul_result.final_mem_state.reg,
+                        &emul_result.final_mem_state.mem,
+                        &emul_result.final_mem_state.hints,
+                        &emul_result.final_mem_state.stack,
+                        &emul_result.final_mem_state.heap,
+                    )
+            }).unwrap();
+
             info_span!("finalize_lk_multiplicities").in_scope(|| {
                 zkvm_witness.finalize_lk_multiplicities();
             });
@@ -1533,6 +1557,23 @@ pub fn generate_witness<'a, E: ExtensionField>(
                         &cpu_dispatch_ctx,
                         shard_steps,
                         &mut cpu_witness,
+                    )
+                    .unwrap();
+                // Mirror the main path so `combined_lk_mlt` comparison stays
+                // meaningful: continuation pushes ShardRamCircuit's per-row
+                // y6_lo lookups into `lk_mlts` before finalize.
+                system_config
+                    .mmu_config
+                    .assign_continuation_circuit(
+                        &system_config.zkvm_cs,
+                        &cpu_shard_ctx,
+                        &mut cpu_witness,
+                        &pi,
+                        &emul_result.final_mem_state.reg,
+                        &emul_result.final_mem_state.mem,
+                        &emul_result.final_mem_state.hints,
+                        &emul_result.final_mem_state.stack,
+                        &emul_result.final_mem_state.heap,
                     )
                     .unwrap();
                 cpu_witness.finalize_lk_multiplicities();
@@ -1622,22 +1663,6 @@ pub fn generate_witness<'a, E: ExtensionField>(
                         &mut zkvm_witness,
                         &pi,
                         &emul_result.final_mem_state.hints,
-                        &emul_result.final_mem_state.heap,
-                    )
-            }).unwrap();
-
-            info_span!("assign_continuation").in_scope(|| {
-                system_config
-                    .mmu_config
-                    .assign_continuation_circuit(
-                        &system_config.zkvm_cs,
-                        &shard_ctx,
-                        &mut zkvm_witness,
-                        &pi,
-                        &emul_result.final_mem_state.reg,
-                        &emul_result.final_mem_state.mem,
-                        &emul_result.final_mem_state.hints,
-                        &emul_result.final_mem_state.stack,
                         &emul_result.final_mem_state.heap,
                     )
             }).unwrap();

--- a/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
@@ -7,7 +7,7 @@ use rustc_hash::FxHashSet;
 use crate::{
     e2e::ShardContext,
     error::ZKVMError,
-    tables::{MemFinalRecord, ShardRamConfig, ShardRamRecord},
+    tables::{MemFinalRecord, ShardRamConfig, ShardRamRecord, Y6_LO_TOP_BYTE_LT_BOUND},
 };
 
 /// Filter and construct a cross-shard ShardRamRecord without EC computation.
@@ -515,7 +515,7 @@ pub(crate) fn try_gpu_assign_shard_ram<E: ExtensionField>(
         for i in 0..3 {
             lk_multiplicity.assert_const_range((y6_lo >> (8 * i)) & 0xff, 8);
         }
-        lk_multiplicity.lookup_ltu_byte((y6_lo >> 24) & 0xff, 60);
+        lk_multiplicity.lookup_ltu_byte((y6_lo >> 24) & 0xff, Y6_LO_TOP_BYTE_LT_BOUND);
     }
 
     Ok(Some([raw_witin, raw_structural_witin]))
@@ -1014,7 +1014,7 @@ pub(crate) fn try_gpu_assign_shared_circuit<E: ExtensionField>(
                 for i in 0..3 {
                     local.assert_const_range((y6_lo >> (8 * i)) & 0xff, 8);
                 }
-                local.lookup_ltu_byte((y6_lo >> 24) & 0xff, 60);
+                local.lookup_ltu_byte((y6_lo >> 24) & 0xff, Y6_LO_TOP_BYTE_LT_BOUND);
             });
             Ok(lk_multiplicity.into_finalize_result())
         },

--- a/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
@@ -198,13 +198,18 @@ pub fn gpu_batch_continuation_ec_on_device(
 }
 
 /// Try to run ShardRamCircuit assign_instances on GPU.
-/// Returns `Ok(None)` if GPU is unavailable or disabled.
+/// Returns `Ok(None)` if GPU is unavailable or disabled. On success the
+/// y6_lo byte / LTU lookup multiplicity is derived from `steps` and pushed
+/// into `lk_multiplicity` so the caller sees the same per-row contribution
+/// the CPU `assign_instance` path would have made.
 pub(crate) fn try_gpu_assign_shard_ram<E: ExtensionField>(
     config: &ShardRamConfig<E>,
     num_witin: usize,
     num_structural_witin: usize,
+    lk_multiplicity: &mut crate::witness::LkMultiplicity,
     steps: &[crate::tables::ShardRamInput<E>],
 ) -> Result<Option<crate::tables::RMMCollections<E::BaseField>>, ZKVMError> {
+    use crate::scheme::constants::SEPTIC_EXTENSION_DEGREE;
     use ceno_gpu::{
         Buffer, CudaHal,
         bb31::CudaHalBB31,
@@ -496,6 +501,23 @@ pub(crate) fn try_gpu_assign_shard_ram<E: ExtensionField>(
         );
     }
 
+    // The GPU witness kernel above writes the row data but does not run
+    // the per-row `assign_instance` CPU path that pushes the y6_lo byte /
+    // LTU lookup multiplicity. Derive the same contribution from `steps`
+    // here so the caller's `lk_multiplicity` mirrors the CPU branch and
+    // `combined_lk_mlt` balances the U8 / LTU table `mlt` columns. Source
+    // of truth for the queries is `ShardRamConfig::configure`.
+    for step in steps {
+        let y6_lo = crate::tables::y6_lo_value::<E>(
+            step.ec_point.point.y.0[SEPTIC_EXTENSION_DEGREE - 1],
+            step.record.is_to_write_set,
+        );
+        for i in 0..3 {
+            lk_multiplicity.assert_const_range((y6_lo >> (8 * i)) & 0xff, 8);
+        }
+        lk_multiplicity.lookup_ltu_byte((y6_lo >> 24) & 0xff, 60);
+    }
+
     Ok(Some([raw_witin, raw_structural_witin]))
 }
 
@@ -749,7 +771,10 @@ pub(crate) fn try_gpu_assign_shard_ram_from_device<E: ExtensionField>(
 }
 
 /// Full GPU pipeline for assign_shared_circuit: device-resident EC merge + partition + assign.
-/// Returns `Ok(None)` if GPU is unavailable, `Ok(Some(inputs))` on success.
+/// Returns `Ok(None)` if GPU is unavailable, `Ok(Some((inputs, lk_mlt)))` on
+/// success — `lk_mlt` carries the y6_lo byte / LTU lookup multiplicity that
+/// `ShardRamConfig::configure` consumes (mirrors the per-row CPU push in
+/// `ShardRamCircuit::assign_instance`).
 #[allow(clippy::type_complexity)]
 pub(crate) fn try_gpu_assign_shared_circuit<E: ExtensionField>(
     shard_ctx: &crate::e2e::ShardContext,
@@ -762,7 +787,13 @@ pub(crate) fn try_gpu_assign_shared_circuit<E: ExtensionField>(
     num_witin: usize,
     num_structural_witin: usize,
     max_chunk: usize,
-) -> Result<Option<Vec<crate::structs::ChipInput<E>>>, ZKVMError> {
+) -> Result<
+    Option<(
+        Vec<crate::structs::ChipInput<E>>,
+        gkr_iop::utils::lk_multiplicity::Multiplicity<u64>,
+    )>,
+    ZKVMError,
+> {
     use crate::{
         instructions::gpu::{
             chips::shard_ram::gpu_batch_continuation_ec_on_device,
@@ -770,8 +801,10 @@ pub(crate) fn try_gpu_assign_shared_circuit<E: ExtensionField>(
         },
         structs::{ChipInput, ZKVMWitnesses},
         tables::{ShardRamCircuit, ShardRamRecord, TableCircuit},
+        witness::LkMultiplicity,
     };
     use ceno_gpu::Buffer;
+    use ff_ext::SmallField;
     use gkr_iop::gpu::get_cuda_hal;
     use rayon::prelude::*;
     use tracing::info_span;
@@ -943,8 +976,51 @@ pub(crate) fn try_gpu_assign_shared_circuit<E: ExtensionField>(
         total_records - num_writes,
     );
 
-    // 7. GPU assign_instances from device buffer (chunked by max_cross_shard)
     let record_u32s = std::mem::size_of::<ceno_gpu::common::witgen::types::GpuShardRamRecord>() / 4;
+    // GpuShardRamRecord (#[repr(C)]) layout — derived from shard_ram_record_to_gpu
+    // above: 4xu32 leader (addr, ram_type, value, _pad0), 3xu64
+    // (shard, local_clk, global_clk), 2xu32 (is_to_write_set, nonce),
+    // [u32; 7] point_x, [u32; 7] point_y. Total = 26 u32s.
+    debug_assert_eq!(record_u32s, 26, "GpuShardRamRecord layout changed");
+    const IS_TO_WRITE_SET_U32_OFFSET: usize = 10;
+    const POINT_Y6_U32_OFFSET: usize = 25;
+
+    // 6.5. Derive ShardRam's per-row y6_lo byte / LTU lookup multiplicity
+    // from the partitioned device buffer. Mirrors the per-row CPU push in
+    // `ShardRamCircuit::assign_instance`; the constraint these queries serve
+    // lives in `ShardRamConfig::configure` (y6_lo bytes + lookup_ltu_byte).
+    let lk_mlt = info_span!("gpu_shard_ram_derive_lk_mlt", n = total_records).in_scope(
+        || -> Result<gkr_iop::utils::lk_multiplicity::Multiplicity<u64>, ZKVMError> {
+            if total_records == 0 {
+                return Ok(gkr_iop::utils::lk_multiplicity::Multiplicity::default());
+            }
+            let host_data: Vec<u32> = partitioned_buf.to_vec().map_err(|e| {
+                ZKVMError::InvalidWitness(
+                    format!("[GPU full pipeline] partitioned_buf D2H: {e}").into(),
+                )
+            })?;
+            debug_assert_eq!(host_data.len(), total_records * record_u32s);
+            let prime = <E::BaseField as SmallField>::MODULUS_U64;
+            let lk_multiplicity = LkMultiplicity::default();
+            host_data.par_chunks_exact(record_u32s).for_each(|rec| {
+                let mut local = lk_multiplicity.clone();
+                let is_to_write_set = rec[IS_TO_WRITE_SET_U32_OFFSET] != 0;
+                let y6 = rec[POINT_Y6_U32_OFFSET] as u64;
+                let y6_lo = if is_to_write_set {
+                    prime - 1 - y6
+                } else {
+                    y6 - 1
+                };
+                for i in 0..3 {
+                    local.assert_const_range((y6_lo >> (8 * i)) & 0xff, 8);
+                }
+                local.lookup_ltu_byte((y6_lo >> 24) & 0xff, 60);
+            });
+            Ok(lk_multiplicity.into_finalize_result())
+        },
+    )?;
+
+    // 7. GPU assign_instances from device buffer (chunked by max_cross_shard)
 
     let circuit_inputs =
         info_span!("shard_ram_assign_from_device", n = total_records).in_scope(|| {
@@ -993,7 +1069,7 @@ pub(crate) fn try_gpu_assign_shared_circuit<E: ExtensionField>(
         total_records,
     );
 
-    Ok(Some(circuit_inputs))
+    Ok(Some((circuit_inputs, lk_mlt)))
 }
 
 #[cfg(test)]

--- a/ceno_zkvm/src/instructions/riscv/rv32im/mmu.rs
+++ b/ceno_zkvm/src/instructions/riscv/rv32im/mmu.rs
@@ -139,6 +139,16 @@ impl<E: ExtensionField> MmuConfig<E> {
         Ok(())
     }
 
+    /// Assign LocalFinalCircuit and ShardRamCircuit witnesses. Must run
+    /// *before* `ZKVMWitnesses::finalize_lk_multiplicities`:
+    /// - `ShardRamCircuit` accumulates its per-row y6_lo byte / LTU lookups
+    ///   into `lk_mlts` via `assign_shared_circuit` (which threads a shared
+    ///   `LkMultiplicity` through `assign_instances_with_lk_multiplicities`),
+    ///   so they land in `combined_lk_mlt` and balance the U8 / LTU table
+    ///   `mlt` columns.
+    /// - `LocalFinalCircuit` does not consume `combined_lk_mlt`; the regular
+    ///   `assign_table_circuit` entry tolerates a not-yet-finalized
+    ///   multiplicity by passing an empty slice.
     #[allow(clippy::too_many_arguments)]
     pub fn assign_continuation_circuit(
         &self,

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -698,8 +698,20 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>
             // compute logup_sum padding
             // getting the number of dummy padding item that we used in this opcode circuit
             let num_lks = circuit_vk.get_cs().num_lks();
+            // Chips with EC-sum ops carry an extra hypercube variable (one extra
+            // log2 row dimension) that the prover fills with EC-tree internal
+            // nodes; those rows are not "active" instances and their lookup
+            // queries collapse to the dummy_table_item via `selector_zero = 0`.
+            // Mirror that here so the verifier subtracts the right number of
+            // dummy queries.
+            let ecc_row_factor = if circuit_vk.get_cs().has_ecc_ops() {
+                2
+            } else {
+                1
+            };
+            let padded_rows = next_pow2_instance_padding(num_instance) * ecc_row_factor;
             // each padding instance contribute to (2^rotation_vars) dummy lookup padding
-            let num_padded_instance = (next_pow2_instance_padding(num_instance) - num_instance)
+            let num_padded_instance = (padded_rows - num_instance)
                 * (1 << circuit_vk.get_cs().rotation_vars().unwrap_or(0));
             // each instance contribute to (2^rotation_vars - rotated) dummy lookup padding
             let num_instance_non_selected = num_instance

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -8,6 +8,7 @@ use crate::{
         ECPoint, MemFinalRecord, RMMCollections, ShardRamCircuit, ShardRamInput, ShardRamRecord,
         TableCircuit,
     },
+    witness::LkMultiplicity,
 };
 use ceno_emul::{Addr, CENO_PLATFORM, Platform, RegIdx, StepIndex, StepRecord, WordAddr};
 use ff_ext::{ExtensionField, PoseidonField};
@@ -471,13 +472,15 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
         config: &TC::TableConfig,
         input: &TC::WitnessInput<'_>,
     ) -> Result<(), ZKVMError> {
-        assert!(self.combined_lk_mlt.is_some());
         let cs = cs.get_cs(&TC::name()).unwrap();
+        let empty_mlt: Vec<FxHashMap<u64, usize>> = Vec::new();
+        // Scope the immutable borrow of `self.combined_lk_mlt` so the
+        // `self.witnesses.insert` mutable borrow below is legal.
         let witness = TC::assign_instances(
             config,
             cs.zkvm_v1_css.num_witin as usize,
             cs.zkvm_v1_css.num_structural_witin as usize,
-            self.combined_lk_mlt.as_ref().unwrap(),
+            self.combined_lk_mlt.as_ref().unwrap_or(&empty_mlt),
             input,
         )?;
         let witness_instances = witness[0].num_instances();
@@ -645,19 +648,25 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
             }
         }
 
-        assert!(self.combined_lk_mlt.is_some());
+        assert!(self.combined_lk_mlt.is_none());
         let cs = cs.get_cs(&ShardRamCircuit::<E>::name()).unwrap();
         let n_global = global_input.len();
+        // `ShardRamCircuit::assign_instances` ignores the `multiplicity`
+        // argument (its lookup contribution is derived externally above), so
+        // an empty slice is sufficient here and matches the pre-finalize
+        // ordering: `combined_lk_mlt` is intentionally `None` at this point.
+        let lk_multiplicity = LkMultiplicity::default();
         let circuit_inputs =
             info_span!("shard_ram_assign_instances", n = n_global).in_scope(|| {
                 global_input
                     .par_chunks(shard_ctx.max_num_cross_shard_accesses)
                     .map(|shard_accesses| {
-                        let witness = ShardRamCircuit::assign_instances(
+                        let mut lk_multiplicity = lk_multiplicity.clone();
+                        let witness = ShardRamCircuit::assign_instances_with_lk_multiplicities(
                             config,
                             cs.zkvm_v1_css.num_witin as usize,
                             cs.zkvm_v1_css.num_structural_witin as usize,
-                            self.combined_lk_mlt.as_ref().unwrap(),
+                            &mut lk_multiplicity,
                             shard_accesses,
                         )?;
                         let num_reads = shard_accesses
@@ -674,6 +683,15 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
                     })
                     .collect::<Result<Vec<_>, ZKVMError>>()
             })?;
+
+        assert!(
+            self.lk_mlts
+                .insert(
+                    ShardRamCircuit::<E>::name(),
+                    lk_multiplicity.into_finalize_result()
+                )
+                .is_none()
+        );
         // set num_read, num_write as separate instance
         assert!(
             self.witnesses
@@ -687,6 +705,11 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
     /// Full GPU pipeline for assign_shared_circuit: keep data on device, minimal CPU roundtrips.
     ///
     /// Returns Ok(true) if successful, Ok(false) if unavailable (no shared device buffers).
+    /// On success, inserts both `ChipInput` and `ShardRamCircuit`'s derived
+    /// lookup multiplicity (for the y6_lo byte / LTU queries) into
+    /// `self.witnesses` / `self.lk_mlts` so the subsequent
+    /// `finalize_lk_multiplicities` folds the contribution into
+    /// `combined_lk_mlt` — matching the CPU shortcut's invariant.
     #[cfg(feature = "gpu")]
     fn try_assign_shared_circuit_gpu(
         &mut self,
@@ -695,7 +718,7 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
         final_mem: &[(&'static str, Option<Range<Addr>>, &[MemFinalRecord])],
         config: &<ShardRamCircuit<E> as TableCircuit<E>>::TableConfig,
     ) -> Result<bool, ZKVMError> {
-        assert!(self.combined_lk_mlt.is_some());
+        assert!(self.combined_lk_mlt.is_none());
         let cs_inner = cs.get_cs(&ShardRamCircuit::<E>::name()).unwrap();
         let num_witin = cs_inner.zkvm_v1_css.num_witin as usize;
         let num_structural_witin = cs_inner.zkvm_v1_css.num_structural_witin as usize;
@@ -708,10 +731,15 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
             num_structural_witin,
             shard_ctx.max_num_cross_shard_accesses,
         )? {
-            Some(circuit_inputs) => {
+            Some((circuit_inputs, lk_mlt)) => {
                 assert!(
                     self.witnesses
                         .insert(ShardRamCircuit::<E>::name(), circuit_inputs)
+                        .is_none()
+                );
+                assert!(
+                    self.lk_mlts
+                        .insert(ShardRamCircuit::<E>::name(), lk_mlt)
                         .is_none()
                 );
                 Ok(true)

--- a/ceno_zkvm/src/tables/mod.rs
+++ b/ceno_zkvm/src/tables/mod.rs
@@ -4,6 +4,7 @@ use gkr_iop::{
     chip::Chip,
     gkr::{GKRCircuit, layer::Layer},
     selector::SelectorType,
+    utils::lk_multiplicity::LkMultiplicity,
 };
 use itertools::Itertools;
 use multilinear_extensions::ToExpr;
@@ -95,11 +96,25 @@ pub trait TableCircuit<E: ExtensionField> {
         input: &Self::FixedInput,
     ) -> RowMajorMatrix<E::BaseField>;
 
+    fn assign_instances_with_lk_multiplicities(
+        _config: &Self::TableConfig,
+        _num_witin: usize,
+        _num_structural_witin: usize,
+        _lk_multiplicity: &mut LkMultiplicity,
+        _input: &Self::WitnessInput<'_>,
+    ) -> Result<RMMCollections<E::BaseField>, ZKVMError> {
+        unimplemented!(
+            "assign_instances_with_lk_multiplicities is not implemented for this table circuit"
+        )
+    }
+
     fn assign_instances(
-        config: &Self::TableConfig,
-        num_witin: usize,
-        num_structural_witin: usize,
-        multiplicity: &[FxHashMap<u64, usize>],
-        input: &Self::WitnessInput<'_>,
-    ) -> Result<RMMCollections<E::BaseField>, ZKVMError>;
+        _config: &Self::TableConfig,
+        _num_witin: usize,
+        _num_structural_witin: usize,
+        _multiplicity: &[FxHashMap<u64, usize>],
+        _input: &Self::WitnessInput<'_>,
+    ) -> Result<RMMCollections<E::BaseField>, ZKVMError> {
+        unimplemented!("assign_instances is not implemented for this table circuit")
+    }
 }

--- a/ceno_zkvm/src/tables/shard_ram.rs
+++ b/ceno_zkvm/src/tables/shard_ram.rs
@@ -132,9 +132,8 @@ impl ShardRamRecord {
                 hasher.permute(input.clone())[0..SEPTIC_EXTENSION_DEGREE].into();
             if let Some(p) = SepticPoint::from_x(x) {
                 let y6 = (p.y.0)[SEPTIC_EXTENSION_DEGREE - 1].to_canonical_u64();
-                // Skip the 2-torsion case where (x, y) == (x, -y); the y-sign
-                // binding in the circuit cannot distinguish read from write
-                // when y6 = 0.
+                // Reject cases where y6 = 0 because then the y-sign
+                // binding in the circuit cannot distinguish read from write.
                 if y6 != 0 {
                     // Strict `>`: `prime / 2 = (p-1)/2` belongs to the lower
                     // half (read region `[1, (p-1)/2]`). Using `>=` would

--- a/ceno_zkvm/src/tables/shard_ram.rs
+++ b/ceno_zkvm/src/tables/shard_ram.rs
@@ -41,6 +41,8 @@ use witness::{InstancePaddingStrategy, next_pow2_instance_padding, set_val};
 
 use crate::{instructions::riscv::constants::UInt, scheme::constants::SEPTIC_EXTENSION_DEGREE};
 
+pub(crate) const Y6_LO_TOP_BYTE_LT_BOUND: u64 = 60;
+
 /// A record for a read/write into the shard RAM
 #[derive(Debug, Clone)]
 pub struct ShardRamRecord {
@@ -305,7 +307,7 @@ impl<E: ExtensionField> ShardRamConfig<E> {
         // `lookup_ltu_byte(a, b, 1)` asserts `a, b` are bytes and `a < b`.
         cb.lookup_ltu_byte(
             y6_lo_bytes[3].expr(),
-            E::BaseField::from_canonical_u64(60).expr(),
+            E::BaseField::from_canonical_u64(Y6_LO_TOP_BYTE_LT_BOUND).expr(),
             Expression::ONE,
         )?;
         let y6_lo = y6_lo_bytes[0].expr()
@@ -423,7 +425,7 @@ impl<E: ExtensionField> ShardRamCircuit<E> {
             let b = (y6_lo_u64 >> (8 * i)) & 0xff;
             lk_multiplicity.assert_const_range(b, 8);
         }
-        lk_multiplicity.lookup_ltu_byte((y6_lo_u64 >> 24) & 0xff, 60);
+        lk_multiplicity.lookup_ltu_byte((y6_lo_u64 >> 24) & 0xff, Y6_LO_TOP_BYTE_LT_BOUND);
 
         let ram_type = E::BaseField::from_canonical_u32(record.ram_type as u32);
         let mut input = [E::BaseField::ZERO; 16];

--- a/ceno_zkvm/src/tables/shard_ram.rs
+++ b/ceno_zkvm/src/tables/shard_ram.rs
@@ -1,4 +1,3 @@
-use rustc_hash::FxHashMap;
 use std::{iter::repeat_n, marker::PhantomData};
 
 use crate::{
@@ -133,24 +132,32 @@ impl ShardRamRecord {
                 hasher.permute(input.clone())[0..SEPTIC_EXTENSION_DEGREE].into();
             if let Some(p) = SepticPoint::from_x(x) {
                 let y6 = (p.y.0)[SEPTIC_EXTENSION_DEGREE - 1].to_canonical_u64();
-                let is_y_in_2nd_half = y6 >= (prime / 2);
+                // Skip the 2-torsion case where (x, y) == (x, -y); the y-sign
+                // binding in the circuit cannot distinguish read from write
+                // when y6 = 0.
+                if y6 != 0 {
+                    // Strict `>`: `prime / 2 = (p-1)/2` belongs to the lower
+                    // half (read region `[1, (p-1)/2]`). Using `>=` would
+                    // misclassify it and produce `y6_lo = (p-1)/2` whose top
+                    // byte b3 = 60 fails `lookup_ltu_byte(b3, 60, 1)`.
+                    let is_y_in_2nd_half = y6 > (prime / 2);
 
-                // we negate y if needed
-                // to ensure read => y in [0, p/2) and write => y in [p/2, p)
-                let negate = match (self.is_to_write_set, is_y_in_2nd_half) {
-                    (true, false) => true, // write, y in [0, p/2)
-                    (false, true) => true, // read, y in [p/2, p)
-                    _ => false,
-                };
+                    // Enforce convention:
+                    //   is_to_write_set = 0 (read)  => y6 in [1, (p-1)/2]
+                    //   is_to_write_set = 1 (write) => y6 in [(p+1)/2, p-1]
+                    let negate = matches!(
+                        (self.is_to_write_set, is_y_in_2nd_half),
+                        (true, false) | (false, true)
+                    );
 
-                let point = if negate { -p } else { p };
+                    let point = if negate { -p } else { p };
 
-                return ECPoint { nonce, point };
-            } else {
-                // try again with different nonce
-                nonce += 1;
-                input[6] = E::BaseField::from_canonical_u32(nonce);
+                    return ECPoint { nonce, point };
+                }
             }
+            // try again with different nonce
+            nonce += 1;
+            input[6] = E::BaseField::from_canonical_u32(nonce);
         }
     }
 }
@@ -180,6 +187,9 @@ pub struct ShardRamConfig<E: ExtensionField> {
     pub(crate) x: Vec<WitIn>,
     pub(crate) y: Vec<WitIn>,
     pub(crate) slope: Vec<WitIn>,
+    // Byte limbs of `y6_lo`, the helper that binds `y[SEPTIC_EXTENSION_DEGREE - 1]`
+    // to `is_global_write` in `configure`.
+    pub(crate) y6_lo_bytes: [WitIn; 4],
     pub(crate) perm_config: Poseidon2Config<E, 16, 7, 1, 4, 13>,
 }
 
@@ -273,12 +283,45 @@ impl<E: ExtensionField> ShardRamConfig<E> {
             cb.require_equal(|| "x = poseidon2's output", xi.expr(), hasher_output)?;
         }
 
-        // both (x, y) and (x, -y) are valid ec points
-        // if is_global_write = 1, then y should be in [0, p/2)
-        // if is_global_write = 0, then y should be in [p/2, p)
-
-        // TODO: enforce 0 <= y < p/2 if is_global_write = 1
-        //       enforce p/2 <= y < p if is_global_write = 0
+        // Bind the sign of y[SEPTIC_EXTENSION_DEGREE - 1] (call it y6) to
+        // is_global_write:
+        //   is_global_write = 0 (read)  => y6 in [1, (p-1)/2]
+        //   is_global_write = 1 (write) => y6 in [(p+1)/2, p-1]
+        // y6_lo is witnessed as four byte limbs with the top byte < 60.
+        // For BabyBear, (p-1)/2 = 60 * 2^24 exactly, so the byte bound
+        // gives y6_lo in [0, (p-1)/2). Branch equality:
+        //   read  : y6 = y6_lo + 1
+        //   write : y6 + y6_lo + 1 = 0 (mod p)
+        // y6 = 0 is the unique fixed point; `to_ec_point` rejects it.
+        assert_eq!(
+            <E::BaseField as SmallField>::MODULUS_U64,
+            0x7800_0001,
+            "y6_lo byte bound assumes BabyBear's (p-1)/2 = 60 * 2^24"
+        );
+        let y6_lo_bytes: [WitIn; 4] =
+            std::array::from_fn(|i| cb.create_witin(|| format!("y6_lo_b{i}")));
+        for (i, w) in y6_lo_bytes.iter().enumerate().take(3) {
+            cb.assert_byte(|| format!("y6_lo_b{i} byte"), w.expr())?;
+        }
+        // `lookup_ltu_byte(a, b, 1)` asserts `a, b` are bytes and `a < b`.
+        cb.lookup_ltu_byte(
+            y6_lo_bytes[3].expr(),
+            E::BaseField::from_canonical_u64(60).expr(),
+            Expression::ONE,
+        )?;
+        let y6_lo = y6_lo_bytes[0].expr()
+            + y6_lo_bytes[1].expr() * E::BaseField::from_canonical_u64(1 << 8).expr()
+            + y6_lo_bytes[2].expr() * E::BaseField::from_canonical_u64(1 << 16).expr()
+            + y6_lo_bytes[3].expr() * E::BaseField::from_canonical_u64(1 << 24).expr();
+        let y6 = y[SEPTIC_EXTENSION_DEGREE - 1].expr();
+        cb.condition_require_equal(
+            || "y6 binds to is_global_write",
+            is_global_write.expr(),
+            y6,
+            E::BaseField::from_canonical_u64(<E::BaseField as SmallField>::MODULUS_U64 - 1).expr()
+                - y6_lo.clone(),
+            y6_lo + Expression::ONE,
+        )?;
 
         Ok(ShardRamConfig {
             x,
@@ -292,6 +335,7 @@ impl<E: ExtensionField> ShardRamConfig<E> {
             local_clk,
             nonce,
             is_global_write,
+            y6_lo_bytes,
             perm_config,
         })
     }
@@ -311,11 +355,26 @@ pub struct ShardRamInput<E: ExtensionField> {
     pub ec_point: ECPoint<E>,
 }
 
+/// Decode `y6_lo` (the byte-decomposed helper bound to `is_global_write` in
+/// `ShardRamConfig::configure`) from a witnessed `y6` field element. Mirrors
+/// the prover-side derivation done inside the per-row witness assignment;
+/// `to_ec_point` guarantees `y6 != 0` and the half-of-field convention, so
+/// neither branch underflows.
+pub(crate) fn y6_lo_value<E: ExtensionField>(y6: E::BaseField, is_to_write_set: bool) -> u64 {
+    let prime = <E::BaseField as SmallField>::MODULUS_U64;
+    let y6_u64 = y6.to_canonical_u64();
+    if is_to_write_set {
+        prime - 1 - y6_u64
+    } else {
+        y6_u64 - 1
+    }
+}
+
 impl<E: ExtensionField> ShardRamCircuit<E> {
     fn assign_instance(
         config: &ShardRamConfig<E>,
         instance: &mut [E::BaseField],
-        _lk_multiplicity: &mut LkMultiplicity,
+        lk_multiplicity: &mut LkMultiplicity,
         input: &ShardRamInput<E>,
     ) -> Result<(), crate::error::ZKVMError> {
         // assign basic fields
@@ -349,6 +408,23 @@ impl<E: ExtensionField> ShardRamCircuit<E> {
             .for_each(|(witin, fe)| {
                 instance[witin.id as usize] = *fe;
             });
+
+        // y6_lo byte limbs for the y-sign binding constraint in `configure`.
+        // `to_ec_point` guarantees y6 != 0 and the half-of-field convention,
+        // so the subtraction below never underflows.
+        let y6_lo_u64 = y6_lo_value::<E>(
+            point.y.0[SEPTIC_EXTENSION_DEGREE - 1],
+            record.is_to_write_set,
+        );
+        for i in 0..4 {
+            let b = (y6_lo_u64 >> (8 * i)) & 0xff;
+            set_val!(instance, config.y6_lo_bytes[i], b);
+        }
+        for i in 0..3 {
+            let b = (y6_lo_u64 >> (8 * i)) & 0xff;
+            lk_multiplicity.assert_const_range(b, 8);
+        }
+        lk_multiplicity.lookup_ltu_byte((y6_lo_u64 >> 24) & 0xff, 60);
 
         let ram_type = E::BaseField::from_canonical_u32(record.ram_type as u32);
         let mut input = [E::BaseField::ZERO; 16];
@@ -483,11 +559,11 @@ impl<E: ExtensionField> TableCircuit<E> for ShardRamCircuit<E> {
     }
 
     /// steps format: local reads ++ local writes
-    fn assign_instances(
+    fn assign_instances_with_lk_multiplicities(
         config: &Self::TableConfig,
         num_witin: usize,
         num_structural_witin: usize,
-        _multiplicity: &[FxHashMap<u64, usize>],
+        lk_multiplicity: &mut LkMultiplicity,
         steps: &Self::WitnessInput<'_>,
     ) -> Result<RMMCollections<E::BaseField>, ZKVMError> {
         if steps.is_empty() {
@@ -499,9 +575,13 @@ impl<E: ExtensionField> TableCircuit<E> for ShardRamCircuit<E> {
 
         #[cfg(feature = "gpu")]
         {
-            if let Some(result) =
-                Self::try_gpu_assign_instances(config, num_witin, num_structural_witin, steps)?
-            {
+            if let Some(result) = Self::try_gpu_assign_instances(
+                config,
+                num_witin,
+                num_structural_witin,
+                lk_multiplicity,
+                steps,
+            )? {
                 return Ok(result);
             }
         }
@@ -547,7 +627,6 @@ impl<E: ExtensionField> TableCircuit<E> for ShardRamCircuit<E> {
         let n = next_pow2_instance_padding(steps.len());
         // compute the input for the binary tree for ec point summation
 
-        let lk_multiplicity = LkMultiplicity::default();
         // *2 because we need to store the internal nodes of binary tree for ec point summation
         let num_rows_padded = 2 * n;
 
@@ -692,12 +771,14 @@ impl<E: ExtensionField> ShardRamCircuit<E> {
         config: &ShardRamConfig<E>,
         num_witin: usize,
         num_structural_witin: usize,
+        lk_multiplicity: &mut LkMultiplicity,
         steps: &[ShardRamInput<E>],
     ) -> Result<Option<RMMCollections<E::BaseField>>, ZKVMError> {
         crate::instructions::gpu::chips::shard_ram::try_gpu_assign_shard_ram(
             config,
             num_witin,
             num_structural_witin,
+            lk_multiplicity,
             steps,
         )
     }
@@ -735,14 +816,17 @@ mod tests {
     use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt, util::SubscriberInitExt};
     use transcript::BasicTranscript;
 
+    use super::ECPoint;
     use crate::{
         circuit_builder::{CircuitBuilder, ConstraintSystem},
         scheme::{
             PublicValues, constants::SEPTIC_EXTENSION_DEGREE, create_backend, create_prover,
-            hal::ProofInput, prover::ZKVMProver, septic_curve::SepticPoint,
+            hal::ProofInput, mock_prover::MockProver, prover::ZKVMProver,
+            septic_curve::SepticPoint,
         },
         structs::{ComposedConstrainSystem, ProgramParams, RAMType, ZKVMProvingKey},
         tables::{ShardRamCircuit, ShardRamInput, ShardRamRecord, TableCircuit},
+        witness::LkMultiplicity,
     };
     #[cfg(feature = "gpu")]
     use gkr_iop::{
@@ -845,11 +929,12 @@ mod tests {
         let public_value = PublicValues::new(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, [0; 8], shard_rw_sum);
 
         // assign witness
-        let witness = ShardRamCircuit::assign_instances(
+        let mut lk_multiplicity = LkMultiplicity::default();
+        let witness = ShardRamCircuit::assign_instances_with_lk_multiplicities(
             &config,
             cs.num_witin as usize,
             cs.num_structural_witin as usize,
-            &[],
+            &mut lk_multiplicity,
             &input,
         )
         .unwrap();
@@ -937,5 +1022,99 @@ mod tests {
         let (_proof, _main_job) = zkvm_prover
             .create_chip_proof(&mut task, &mut transcript)
             .unwrap();
+    }
+
+    /// Drive a single ShardRam row through the full `configure` +
+    /// `assign_instances` pipeline and validate with `MockProver`.
+    ///
+    /// * The honest witness satisfies every assert-zero and lookup
+    ///   constraint MockProver checks.
+    /// * Negating the EC point but reusing the original record causes
+    ///   `assign_instance` to derive `y6_lo` such that the algebraic
+    ///   branch equality still holds, but the top byte
+    ///   `b3 = (y6_lo >> 24) & 0xff` lands in `[60, 256)`. The query
+    ///   `(Ltu, b3, 60, 1)` is missing from the LTU table (which only
+    ///   carries `(Ltu, b3, 60, 0)` for `b3 >= 60`), so the
+    ///   `lookup_Ltu` constraint rejects the tampered row.
+    #[test]
+    fn test_shard_ram_y_sign_circuit_rejects_negation() {
+        let perm = <F as PoseidonField>::get_default_perm();
+
+        let mut cs = ConstraintSystem::new(|| "y_sign");
+        let mut cb = CircuitBuilder::<E>::new(&mut cs);
+        let (config, _gkr) =
+            ShardRamCircuit::<E>::build_gkr_iop_circuit(&mut cb, &ProgramParams::default())
+                .unwrap();
+        let num_witin = cb.cs.num_witin as usize;
+        let num_structural = cb.cs.num_structural_witin as usize;
+        // Pass a concrete challenge so `assert_with_expected_errors` routes
+        // through `run_with_challenge`; the no-challenge `run` path drops
+        // `structural_witin` and ShardRam relies on `selector_zero` to gate
+        // its lookup queries.
+        let mut rng = thread_rng();
+        let challenge = [E::random(&mut rng), E::random(&mut rng)];
+
+        for is_to_write_set in [true, false] {
+            let record = ShardRamRecord {
+                addr: 0x1000,
+                ram_type: RAMType::Memory,
+                value: 0x1234_5678,
+                shard: if is_to_write_set { 1 } else { 2 },
+                local_clk: if is_to_write_set { 7 } else { 0 },
+                global_clk: 13,
+                is_to_write_set,
+            };
+            let ec = record.to_ec_point::<E, Perm>(&perm);
+
+            // Honest row: every constraint MockProver checks must be
+            // satisfied.
+            let honest = [ShardRamInput {
+                name: "honest",
+                record: record.clone(),
+                ec_point: ec.clone(),
+            }];
+            let mut honest_lkm = LkMultiplicity::default();
+            let honest_witness = ShardRamCircuit::<E>::assign_instances_with_lk_multiplicities(
+                &config,
+                num_witin,
+                num_structural,
+                &mut honest_lkm,
+                &honest,
+            )
+            .unwrap();
+            MockProver::<E>::assert_satisfied_raw(&cb, honest_witness, &[], Some(challenge), None);
+
+            // Tampered row: negate the EC point. `assign_instance` re-derives
+            // `y6_lo` from the witnessed `y6`, keeping the branch equality
+            // intact, so only the `lookup_Ltu` byte bound catches the wrong
+            // sign.
+            let tampered = [ShardRamInput {
+                name: "tampered",
+                record,
+                ec_point: ECPoint {
+                    nonce: ec.nonce,
+                    point: -ec.point,
+                },
+            }];
+            let mut tampered_lkm = LkMultiplicity::default();
+            let [w, sw] = ShardRamCircuit::<E>::assign_instances_with_lk_multiplicities(
+                &config,
+                num_witin,
+                num_structural,
+                &mut tampered_lkm,
+                &tampered,
+            )
+            .unwrap();
+            MockProver::<E>::assert_with_expected_errors(
+                &cb,
+                &[],
+                &w.to_mles().into_iter().map(|v| v.into()).collect_vec(),
+                &sw.to_mles().into_iter().map(|v| v.into()).collect_vec(),
+                &[],
+                &["lookup_Ltu"],
+                Some(challenge),
+                None,
+            );
+        }
     }
 }


### PR DESCRIPTION
## Problem

Issue #1338 reproduces a soundness break on `master`. For the same RISC-V
execution, the base verifier *and* the recursion verifier both accept two
distinct proof batches whose public per-shard `shard_rw_sum` values differ
on all 17 shards. The attacker takes an honest witness, replaces every
cross-shard EC accumulator leaf `(x, y)` with its inverse `(x, -y)`,
updates `shard_rw_sum`, and reproves.

Root cause: `ceno_zkvm/src/tables/shard_ram.rs:276-281` was a TODO. The
host code in `ShardRamRecord::to_ec_point` encodes read vs write in the
sign of `y[6]`, but the circuit only constrained the curve equation and
the EC sum — never tying `y[6]`'s half-of-field to `is_global_write`.
Both `(x, y)` and `(x, -y)` satisfied every existing check, so the public
summary of cross-shard RAM flow was unbound.

The defect survives recursion (the reporter's PoC verifies through the
recursion verifier program).

## Design Rationale

Approach borrows the **idea** from SP1's
`crates/core/machine/src/operations/global_interaction.rs:210-236`,
not its column layout. Three pieces:

1. **Offset by +1.** Express `y[6]` in terms of a fresh witness `y6_lo`
   so `y[6] = 0` is never valid in either branch (it is invariant under the negate operation, thus make it impossible to  distinguish read and write).
2. **Safe band + prover retry.** Restrict `y6_lo` to `[0, (p-1)/2)`. For
   the rare exception `y[6] = 0` (probability `~1/p ≈ 2^-31` per record)
   the host rejects and retries with a new `nonce`.
3. **Byte-decomposition range check.** `y6_lo` decomposed into four byte
   limbs `b0..b3` (`assert_byte` for `b0..b2`, `lookup_ltu_byte(b3, 60, 1)`
   for `b3`). For BabyBear, `(p-1)/2 = 60·2^24` exactly, so `b3 < 60`
   gives the tightest no-overlap band.

In-circuit branch equality via `condition_require_equal`:

- read  (`is_global_write = 0`): `y[6] = y6_lo + 1`  ⇒ `y[6] ∈ [1, (p-1)/2]`
- write (`is_global_write = 1`): `y[6] = p - 1 - y6_lo` ⇒ `y[6] ∈ [(p+1)/2, p-1]`

Union covers `[1, p-1]` with no overlap; `y[6] = 0` is excluded.

**Why not a single `AssertLtConfig(y6_lo, (p-1)/2, max_bits=30)`?**
On BabyBear (`p = 0x78000001`, 31-bit) the AssertLt gadget only
constrains `lhs - rhs ≡ diff - 2^max_bits (mod p)` with `diff ∈ [0, 2^30)`
— it does not pre-bound `lhs` to be canonical-small. A malicious
`y6_lo ∈ [0x74000001, p-1]` (≈ 2^26 values) produces a *field-wrap* diff
that still fits in 30 bits, so the constraint accepts upper-half values
and the exploit survives. Byte-decomposing first kills the wrap. Ceno's
`DynamicRangeTableCircuit<E, 18>` also does not carry 30-bit lookup
entries, so a direct `assert_const_range(_, 30)` is not available
anyway.

**Why M = 60 (vs SP1's 63).** SP1 targets KoalaBear; its `(p-1)/2 =
0x3f800000`, so 63 leaves a small safety band. For BabyBear,
`(p-1)/2 = 60·2^24` exactly — 63 would let `y[6]` straddle `p/2` and
reintroduce the ambiguity.

Also corrects the stale comment that previously had the convention
reversed (claimed write ⇒ lower half, opposite of what the host code
does).

## Change Highlights

### `ceno_zkvm/src/tables/shard_ram.rs` — chip-level y-sign binding

- `ShardRamRecord::to_ec_point`: reject `y6 == 0` and try the next
  `nonce`. Classify with strict `y6 > prime / 2` so the boundary
  `(p-1)/2` correctly stays in the read region (a previous draft used
  `>=` which misclassified that single boundary value and would have
  produced an out-of-range `y6_lo` for both branches).
- `ShardRamConfig`: new field `y6_lo_bytes: [WitIn; 4]`.
- `ShardRamConfig::configure`: replace the TODO with the byte
  decomposition, byte-range / LTU lookups, and the
  `condition_require_equal` branch equality.
- `ShardRamCircuit::assign_instance`: compute `y6_lo` from `y[6]` and
  `is_to_write_set` via a small `y6_lo_value` helper, assign byte
  limbs, register byte and LTU multiplicities.
- New test `test_shard_ram_y_sign_circuit_rejects_negation` drives
  `assign_instances_with_lk_multiplicities` + `MockProver` over one
  honest row and one sign-flipped row, asserting `lookup_Ltu` rejects
  the tampered witness. A concrete challenge is supplied so the
  no-challenge `run` path doesn't drop `structural_witin`.

### Lookup-multiplicity plumbing for ShardRam

ShardRam's per-row y6_lo byte / LTU lookups must reach
`combined_lk_mlt` so the U8 / LTU table `mlt` columns balance.
ShardRam runs after opcode + dummy circuits, before
`finalize_lk_multiplicities`. To surface mlt without burdening every
other table circuit:

- `ceno_zkvm/src/tables/mod.rs`: `TableCircuit` trait gains a second
  default-unimplemented method
  `assign_instances_with_lk_multiplicities` alongside the existing
  `assign_instances`. ShardRam overrides the former; every other
  table keeps overriding the latter.
- `ceno_zkvm/src/structs.rs`: `ZKVMWitnesses::assign_shared_circuit`
  threads a `LkMultiplicity::default()` through ShardRam's
  parallel-chunk witgen and inserts
  `lk_multiplicity.into_finalize_result()` into
  `lk_mlts["ShardRamCircuit"]` before finalize. Asserts swap from
  `combined_lk_mlt.is_some()` to `is_none()` to lock the ordering.
  `assign_table_circuit` tolerates `combined_lk_mlt = None` by
  passing an empty multiplicity slice, so `LocalFinalCircuit` (which
  ignores the argument anyway) can also run before finalize.
- `ceno_zkvm/src/e2e.rs`: move
  `MmuConfig::assign_continuation_circuit` (LocalFinal + ShardRam) to
  just before `finalize_lk_multiplicities`. Mirror the move inside
  the GPU debug-compare block so `combined_lk_mlt` diff stays
  meaningful.
- `ceno_zkvm/src/instructions/riscv/rv32im/mmu.rs`: docstring updated
  to describe the new ordering invariant.

### Device-resident GPU shortcut for ShardRam (mlt mirror)

`ZKVMWitnesses::try_assign_shared_circuit_gpu` dispatches into
`instructions::gpu::chips::shard_ram::try_gpu_assign_shared_circuit`
to keep the continuation EC computation device-resident
(`gpu_batch_continuation_ec_on_device` + `merge_and_partition_records`)
when `is_gpu_witgen_enabled()`. The GPU kernels never enter the CPU
`assign_instance` per-row push, so the y6_lo lookup multiplicity is
derived host-side:

- After step 6 of `try_gpu_assign_shared_circuit` (merge+partition),
  D2H `partitioned_buf` once to `Vec<u32>` and walk it with stride
  `record_u32s = 26` (`GpuShardRamRecord` `#[repr(C)]` layout).
  Per record extract `is_to_write_set` (u32 offset 10) and
  `point_y[6]` (u32 offset 25), compute `y6_lo`, push the same
  4 lookup queries the CPU path emits per row, then
  `into_finalize_result()` and return alongside the chunked
  `Vec<ChipInput<E>>`. `debug_assert_eq!(record_u32s, 26)` guards
  against `ceno_gpu` layout drift.
- `try_assign_shared_circuit_gpu` inserts both `ChipInput` and the
  derived multiplicity into `self.witnesses` /
  `self.lk_mlts["ShardRamCircuit"]` so finalize folds the GPU-path
  contribution into `combined_lk_mlt` the same way the CPU shortcut
  does.

### Verifier: account for `has_ecc_ops` row doubling

`ShardRamCircuit::has_ecc_ops()` adds an extra hypercube variable;
the chip matrix has `2 * next_pow2(num_instance)` rows where the
back half is EC-tree internal nodes with `selector_zero = 0`. Before
this fix the chip had `num_lks = 0`, so the verifier's
`dummy_table_item_multiplicity` correction never had to consider it.
With the new byte/LTU queries the correction under-counted dummy
lookups by a factor of 2 and shard verification failed with
`logup_sum != 0`.

- `ceno_zkvm/src/scheme/verifier.rs`: multiply `next_pow2_instance`
  by 2 when `circuit_vk.get_cs().has_ecc_ops()`.
- `ceno_recursion/src/zkvm_verifier/verifier.rs`: mirror the same
  adjustment in the recursive verifier (lockstep per CLAUDE.md).

## Benchmark / Performance Impact

Per ShardRam row this PR adds **4 byte WitIn columns** plus 3 byte-range
and 1 LTU lookup multiplicities. ShardRam rows scale with cross-shard
RAM events, not with cycles, so the absolute cost is sub-percent on the
prover. No full prover bench was rerun (no hot-loop arithmetic changed).

Existing `test_shard_ram_circuit` (170k reads + 1420 writes, full chip
proof) runtime is unchanged within noise:

```text
master   : ~5.0 s
this PR  : ~5.0 s
```

## Testing

```sh
cargo fmt --all --check
cargo check --workspace --all-targets
cargo check --workspace --all-targets --release
cargo make clippy
cargo clippy --workspace --all-targets --release -- -D warnings
RUST_MIN_STACK=33554432 cargo test --workspace --lib --release
cargo run --release --package ceno_zkvm --features sanity-check --bin e2e -- \
  --platform=ceno --max-cycle-per-shard=20000 --hints=10 --public-io=4191 \
  examples/target/riscv32im-ceno-zkvm-elf/release/examples/fibonacci
```

All pass locally on BabyBear. `test_shard_ram_circuit` and
`test_shard_ram_y_sign_circuit_rejects_negation` are green. End-to-end
multi-shard fibonacci verifies `ShardRamCircuit` and `LocalRAMTableFinal`
on every shard with `exit code 0. Success.`

`cargo make tests` / `cargo make tests_goldilock` should be re-run by
CI; the change is gated to BabyBear via a `debug_assert_eq!` on
`MODULUS_U64` and goldilocks does not exercise shard_ram (per
`integration.yml` commented-out lines and CLAUDE.md).

## Risks and Rollout

- **Soundness.** Closes #1338. The new constraint only adds local byte
  arithmetic and existing lookups — no change to transcript, sumcheck,
  PCS, or EC accumulation. Recursive and native verifiers move in
  lockstep (the `has_ecc_ops` row-factor fix lands in both).
- **GPU.** The device-resident GPU shortcut now derives the y6_lo
  lookup multiplicity host-side from the merged partitioned device
  buffer (single D2H of ~26 u32 × records). Layout assumption is
  guarded by `debug_assert_eq!(record_u32s, 26)` against
  `ceno_gpu::GpuShardRamRecord`. CPU + GPU paths converge on the same
  `combined_lk_mlt` contribution; runtime verification with
  `CENO_GPU_ENABLE_WITGEN=1 --features gpu` on a CUDA host is
  recommended before tag.
- **Recursion.** The recursive verifier mirrors the native verifier's
  `has_ecc_ops` × 2 row adjustment; no separate constraint-system
  change is needed for the y-sign binding itself.
- **Field support.** Hardcodes the BabyBear constant `M = 60`. A
  `debug_assert_eq!(MODULUS_U64, 0x78000001, ...)` guards against
  accidental use on a different field; shard_ram is BabyBear-only
  today per CLAUDE.md.

## Follow-ups

- The remaining #1340 TODOs (`local read ⇄ global write` pairing on
  `shard_ram.rs:235-236`, `shard == shard_id` binding on line 244) are
  intentionally out of scope here.

Fixes #1338.
Partially addresses #1340.

## Copilot Reviewer Directive (keep this section)

When Copilot reviews this PR, apply `.github/copilot-instructions.md` strictly.
