### PR TITLE
Limit recursion v2 system to three modules

### DIFF
--- a/ceno_recursion_v2/scripts/extract_air_keygen_meta.sh
+++ b/ceno_recursion_v2/scripts/extract_air_keygen_meta.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+RUST_MIN_STACK="${RUST_MIN_STACK:-67108864}" cargo run --release --quiet --bin air_keygen_meta -- "$@"

--- a/ceno_recursion_v2/scripts/group_bus_failures.py
+++ b/ceno_recursion_v2/scripts/group_bus_failures.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Group Stark interaction-bus balance failures by bus id.
+"""Group Stark debug constraint failures.
 
 Usage:
     python3 scripts/group_bus_failures.py prover.log
@@ -53,32 +53,19 @@ BUS_NAMES = {
     31: "TowerSumcheckInputBus",
     32: "TowerSumcheckOutputBus",
     33: "TowerSumcheckChallengeBus",
-    34: "TowerProdReadClaimInputBus",
+    34: "TowerClaimInputBus",
     35: "TowerProdReadClaimBus",
-    36: "TowerProdWriteClaimInputBus",
-    37: "TowerProdWriteClaimBus",
-    38: "TowerLogupClaimInputBus",
-    39: "TowerLogupClaimBus",
-    40: "TowerReadRootInputBus",
-    41: "TowerReadRootBus",
-    42: "TowerReadInitBus",
-    43: "TowerWriteRootInputBus",
-    44: "TowerWriteRootBus",
-    45: "TowerWriteInitBus",
-    46: "TowerLogupRootInputBus",
-    47: "TowerLogupRootBus",
-    48: "TowerLogupInitBus",
-    49: "AirPresenceBus",
-    50: "ColumnClaimsBus",
-    51: "SelHypercubeBus",
-    52: "SelUniBus",
-    53: "BatchConstraintConductorBus",
-    54: "EqNOuterBus",
-    55: "SymbolicExpressionBus",
-    56: "ExpressionClaimBus",
-    57: "InteractionsFoldingBus",
-    58: "ConstraintsFoldingBus",
-    59: "PvsAirConsistencyBus",
+    36: "TowerProdWriteClaimBus",
+    37: "TowerLogupClaimBus",
+    38: "TowerReadRootInputBus",
+    39: "TowerReadRootBus",
+    40: "TowerReadInitBus",
+    41: "TowerWriteRootInputBus",
+    42: "TowerWriteRootBus",
+    43: "TowerWriteInitBus",
+    44: "TowerLogupRootInputBus",
+    45: "TowerLogupRootBus",
+    46: "PvsAirConsistencyBus",
 }
 
 FAILURE_RE = re.compile(
@@ -87,6 +74,11 @@ FAILURE_RE = re.compile(
 CONNECTION_RE = re.compile(
     r"Air idx:\s*(?P<air_idx>\d+),\s*Air name:\s*(?P<air_name>.*?),\s*count:\s*(?P<count>\d+)"
 )
+CONSTRAINT_RE = re.compile(
+    r"constraints had nonzero value on air (?P<air_name>.*?),row (?P<row>\d+)"
+)
+LEFT_RE = re.compile(r"\bleft:\s*(?P<left>[-]?\d+)")
+RIGHT_RE = re.compile(r"\bright:\s*(?P<right>[-]?\d+)")
 
 
 @dataclass(frozen=True)
@@ -110,6 +102,14 @@ class Failure:
     bus: int
     fields: str
     connections: list[Connection] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ConstraintFailure:
+    air_name: str
+    row: int
+    left: str | None = None
+    right: str | None = None
 
 
 def decode_field(value: int, modulus: int) -> int:
@@ -156,7 +156,35 @@ def parse_failures(lines: list[str], modulus: int) -> list[Failure]:
     return failures
 
 
-def print_summary(failures: list[Failure]) -> None:
+def parse_constraint_failures(lines: list[str]) -> list[ConstraintFailure]:
+    failures: list[ConstraintFailure] = []
+    for idx, line in enumerate(lines):
+        constraint_match = CONSTRAINT_RE.search(line)
+        if not constraint_match:
+            continue
+
+        left: str | None = None
+        right: str | None = None
+        for detail_line in lines[idx + 1 : idx + 6]:
+            if left is None and (left_match := LEFT_RE.search(detail_line)):
+                left = left_match.group("left")
+            if right is None and (right_match := RIGHT_RE.search(detail_line)):
+                right = right_match.group("right")
+            if left is not None and right is not None:
+                break
+
+        failures.append(
+            ConstraintFailure(
+                air_name=constraint_match.group("air_name").strip(),
+                row=int(constraint_match.group("row")),
+                left=left,
+                right=right,
+            )
+        )
+    return failures
+
+
+def print_bus_summary(failures: list[Failure]) -> None:
     by_bus: dict[int, list[Failure]] = defaultdict(list)
     for failure in failures:
         by_bus[failure.bus].append(failure)
@@ -214,6 +242,25 @@ def print_summary(failures: list[Failure]) -> None:
         print()
 
 
+def print_constraint_summary(failures: list[ConstraintFailure]) -> None:
+    if not failures:
+        print("No debug constraint failures found.")
+        return
+
+    print("Debug constraint failures:")
+    for failure, occurrences in sorted(
+        Counter(failures).items(),
+        key=lambda item: (item[0].air_name, item[0].row, item[0].left or "", item[0].right or ""),
+    ):
+        values = ""
+        if failure.left is not None or failure.right is not None:
+            values = f" left={failure.left or '?'} right={failure.right or '?'}"
+        print(
+            f"  air={failure.air_name} row={failure.row}{values} occurrences={occurrences}"
+        )
+    print()
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("logs", nargs="*", type=Path, help="Log files. Reads stdin when omitted.")
@@ -225,8 +272,9 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    failures = parse_failures(read_lines(args.logs), args.modulus)
-    print_summary(failures)
+    lines = read_lines(args.logs)
+    print_constraint_summary(parse_constraint_failures(lines))
+    print_bus_summary(parse_failures(lines, args.modulus))
     return 0
 
 

--- a/ceno_recursion_v2/scripts/run_e2e_test.sh
+++ b/ceno_recursion_v2/scripts/run_e2e_test.sh
@@ -58,14 +58,16 @@ fi
 TEST_ENV=(
     "CENO_RECURSION_V2_FIXTURE_DIR=$FIXTURE_DIR"
     "RUST_MIN_STACK=33554432"
+    "RUST_BACKTRACE=${RUST_BACKTRACE:-1}"
 )
-if [[ -n "${CENO_RECURSION_V2_DEBUG_CONSTRAINTS:-}" ]]; then
-    echo "[test] explicit debug constraints enabled"
-    TEST_ENV+=("CENO_RECURSION_V2_DEBUG_CONSTRAINTS=$CENO_RECURSION_V2_DEBUG_CONSTRAINTS")
+DEBUG_CONSTRAINTS="${CENO_RECURSION_V2_DEBUG_CONSTRAINTS:-1}"
+if [[ "$DEBUG_CONSTRAINTS" != "0" ]]; then
+    echo "[test] debug constraints enabled (set CENO_RECURSION_V2_DEBUG_CONSTRAINTS=0 to disable)"
+    TEST_ENV+=("CENO_RECURSION_V2_DEBUG_CONSTRAINTS=$DEBUG_CONSTRAINTS")
 fi
 
 if env "${TEST_ENV[@]}" cargo test --release \
-        'continuation::tests::prover_integration::agg_prover_single_shard' \
+        'continuation::tests::prover_integration::agg_prover_two_shards' \
         -- --nocapture 2>&1 | tee "$TEST_LOG"; then
     if [[ "$REMOVE_TEST_LOG" == "1" ]]; then
         rm -f "$TEST_LOG"
@@ -73,7 +75,7 @@ if env "${TEST_ENV[@]}" cargo test --release \
 else
     status=$?
     echo ""
-    echo "[test] bus balance failure summary:"
+    echo "[test] debug failure summary:"
     python3 "$BUS_FAILURE_GROUPER" "$TEST_LOG" || true
     echo ""
     echo "[test] full failing log: $TEST_LOG"

--- a/ceno_recursion_v2/src/batch_constraint/mod.rs
+++ b/ceno_recursion_v2/src/batch_constraint/mod.rs
@@ -189,6 +189,7 @@ impl BatchConstraintModule {
         ]
     }
 
+    #[allow(dead_code)]
     pub(crate) fn generate_placeholder_proving_ctxs<SC: StarkProtocolConfig<F = F>>(
         &self,
         cached_symbolic_expr_trace: CommittedTraceData<CpuBackend<SC>>,

--- a/ceno_recursion_v2/src/bin/air_keygen_meta.rs
+++ b/ceno_recursion_v2/src/bin/air_keygen_meta.rs
@@ -1,0 +1,320 @@
+use std::{path::PathBuf, sync::Arc, thread};
+
+use ceno_recursion_v2::{continuation::prover::InnerCpuProver, system::RecursionVk};
+use clap::{Parser, ValueEnum};
+use eyre::{Result, bail};
+use openvm_stark_backend::{
+    SystemParams, WhirConfig, WhirParams, WhirProximityStrategy,
+    interaction::LogUpSecurityParameters,
+};
+use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2CpuEngine, DuplexSponge};
+use serde::Serialize;
+
+type Engine = BabyBearPoseidon2CpuEngine<DuplexSponge>;
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum OutputFormat {
+    Table,
+    Json,
+}
+
+#[derive(Parser, Debug)]
+#[command(about = "Run recursion-v2 keygen and print per-AIR metadata")]
+struct Args {
+    /// Path to a bincode-serialized Ceno ZKVM verifying key.
+    #[arg(long)]
+    vk: Option<PathBuf>,
+
+    /// Directory used to find vk.bin when --vk is omitted.
+    #[arg(long)]
+    fixture_dir: Option<PathBuf>,
+
+    /// Maximum number of child proofs verified by the recursion circuit.
+    #[arg(long, default_value_t = 2)]
+    max_num_proofs: usize,
+
+    /// l_skip used for the small local SystemParams profile.
+    #[arg(long, default_value_t = 5)]
+    l_skip: usize,
+
+    /// n_stack used for the small local SystemParams profile.
+    #[arg(long, default_value_t = 16)]
+    n_stack: usize,
+
+    /// k_whir used for the small local SystemParams profile.
+    #[arg(long, default_value_t = 3)]
+    k_whir: usize,
+
+    /// Configured global SystemParams.max_constraint_degree for keygen.
+    #[arg(long, default_value_t = 5)]
+    max_constraint_degree: usize,
+
+    /// Output format.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Table)]
+    format: OutputFormat,
+}
+
+#[derive(Serialize)]
+struct KeygenMeta {
+    vk_path: PathBuf,
+    max_num_proofs: usize,
+    configured_max_constraint_degree: usize,
+    keygen_max_constraint_degree: usize,
+    air_count: usize,
+    total_trace_width: usize,
+    max_air_constraint_degree: u8,
+    airs: Vec<AirMeta>,
+}
+
+#[derive(Serialize)]
+struct AirMeta {
+    air_idx: usize,
+    air_name: String,
+    trace_width: TraceWidthMeta,
+    max_constraint_degree: u8,
+    num_constraints: usize,
+    num_interactions: usize,
+    need_rot: bool,
+    is_required: bool,
+}
+
+#[derive(Serialize)]
+struct TraceWidthMeta {
+    preprocessed: Option<usize>,
+    cached_mains: Vec<usize>,
+    common_main: usize,
+    main: usize,
+    total: usize,
+}
+
+fn main() -> Result<()> {
+    thread::Builder::new()
+        .name("air-keygen-meta".to_string())
+        .stack_size(64 * 1024 * 1024)
+        .spawn(run)?
+        .join()
+        .map_err(|err| eyre::eyre!("air-keygen-meta thread panicked: {err:?}"))?
+}
+
+fn run() -> Result<()> {
+    let args = Args::parse();
+    let vk_path = vk_path(&args)?;
+    let child_vk = load_vk(&vk_path)?;
+    let params = system_params_zero_pow(
+        args.l_skip,
+        args.n_stack,
+        args.k_whir,
+        args.max_constraint_degree,
+    );
+
+    let meta = match args.max_num_proofs {
+        1 => extract_keygen_meta::<1>(vk_path, child_vk, params),
+        2 => extract_keygen_meta::<2>(vk_path, child_vk, params),
+        4 => extract_keygen_meta::<4>(vk_path, child_vk, params),
+        8 => extract_keygen_meta::<8>(vk_path, child_vk, params),
+        16 => extract_keygen_meta::<16>(vk_path, child_vk, params),
+        max_num_proofs => bail!(
+            "unsupported --max-num-proofs={max_num_proofs}; supported values are 1, 2, 4, 8, 16"
+        ),
+    }?;
+
+    match args.format {
+        OutputFormat::Table => print_table(&meta),
+        OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&meta)?),
+    }
+
+    Ok(())
+}
+
+fn vk_path(args: &Args) -> Result<PathBuf> {
+    if let Some(path) = args.vk.clone() {
+        return Ok(path);
+    }
+
+    let dirs = args
+        .fixture_dir
+        .clone()
+        .into_iter()
+        .chain(std::env::var_os("CENO_RECURSION_V2_FIXTURE_DIR").map(PathBuf::from))
+        .chain([PathBuf::from("./src/imported")]);
+
+    for dir in dirs {
+        let path = dir.join("vk.bin");
+        if path.exists() {
+            return Ok(path);
+        }
+    }
+
+    bail!("could not find vk.bin; pass --vk or --fixture-dir")
+}
+
+fn load_vk(path: &PathBuf) -> Result<RecursionVk> {
+    let bytes = std::fs::read(path)?;
+    let mut vk: RecursionVk = bincode::deserialize(&bytes)?;
+    vk.rebuild_circuit_index();
+    Ok(vk)
+}
+
+fn system_params_zero_pow(
+    l_skip: usize,
+    n_stack: usize,
+    k_whir: usize,
+    max_constraint_degree: usize,
+) -> SystemParams {
+    let log_final_poly_len = (n_stack + l_skip) % k_whir;
+    let log_blowup = 1;
+    let mut params = SystemParams {
+        l_skip,
+        n_stack,
+        w_stack: 1 << 12,
+        log_blowup,
+        whir: whir_config_small(log_blowup, l_skip + n_stack, k_whir, log_final_poly_len),
+        logup: LogUpSecurityParameters {
+            max_interaction_count: 1 << 30,
+            log_max_message_length: 7,
+            pow_bits: 2,
+        },
+        max_constraint_degree,
+    };
+    params.whir.mu_pow_bits = 0;
+    params.whir.folding_pow_bits = 0;
+    params.whir.query_phase_pow_bits = 0;
+    params
+}
+
+fn whir_config_small(
+    log_blowup: usize,
+    log_stacked_height: usize,
+    k_whir: usize,
+    log_final_poly_len: usize,
+) -> WhirConfig {
+    let params = WhirParams {
+        k: k_whir,
+        log_final_poly_len,
+        query_phase_pow_bits: 1,
+        folding_pow_bits: 2,
+        mu_pow_bits: 3,
+        proximity: WhirProximityStrategy::SplitUniqueList {
+            m: 3,
+            list_start_round: 1,
+        },
+    };
+    WhirConfig::new(log_blowup, log_stacked_height, params, 5)
+}
+
+fn extract_keygen_meta<const MAX_NUM_PROOFS: usize>(
+    vk_path: PathBuf,
+    child_vk: RecursionVk,
+    params: SystemParams,
+) -> Result<KeygenMeta> {
+    let configured_max_constraint_degree = params.max_constraint_degree;
+    let prover =
+        InnerCpuProver::<MAX_NUM_PROOFS>::new::<Engine>(Arc::new(child_vk), params, false, None);
+    let air_names = prover.air_names();
+    let vk = prover.get_vk();
+
+    if air_names.len() != vk.inner.per_air.len() {
+        bail!(
+            "AIR name count ({}) did not match keygen VK AIR count ({})",
+            air_names.len(),
+            vk.inner.per_air.len()
+        );
+    }
+
+    let mut total_trace_width = 0usize;
+    let mut max_air_constraint_degree = 0u8;
+    let airs = air_names
+        .into_iter()
+        .zip(vk.inner.per_air.iter())
+        .enumerate()
+        .map(|(air_idx, (air_name, air_vk))| {
+            let width = &air_vk.params.width;
+            let main_width = width.main_width();
+            let total_width = width.total_width();
+            total_trace_width += total_width;
+            max_air_constraint_degree = max_air_constraint_degree.max(air_vk.max_constraint_degree);
+            AirMeta {
+                air_idx,
+                air_name,
+                trace_width: TraceWidthMeta {
+                    preprocessed: width.preprocessed,
+                    cached_mains: width.cached_mains.clone(),
+                    common_main: width.common_main,
+                    main: main_width,
+                    total: total_width,
+                },
+                max_constraint_degree: air_vk.max_constraint_degree,
+                num_constraints: air_vk.symbolic_constraints.constraints.num_constraints(),
+                num_interactions: air_vk.num_interactions(),
+                need_rot: air_vk.params.need_rot,
+                is_required: air_vk.is_required,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    Ok(KeygenMeta {
+        vk_path,
+        max_num_proofs: MAX_NUM_PROOFS,
+        configured_max_constraint_degree,
+        keygen_max_constraint_degree: vk.max_constraint_degree(),
+        air_count: airs.len(),
+        total_trace_width,
+        max_air_constraint_degree,
+        airs,
+    })
+}
+
+fn print_table(meta: &KeygenMeta) {
+    println!("vk_path: {}", meta.vk_path.display());
+    println!(
+        "max_num_proofs={} configured_max_constraint_degree={} keygen_max_constraint_degree={} air_count={} total_trace_width={}",
+        meta.max_num_proofs,
+        meta.configured_max_constraint_degree,
+        meta.keygen_max_constraint_degree,
+        meta.air_count,
+        meta.total_trace_width
+    );
+    println!(
+        "{:>3}  {:<44}  {:>5}  {:>5}  {:>5}  {:>7}  {:>7}  {:>7}  {:>5}  {:>5}  {:>8}",
+        "idx",
+        "air",
+        "prep",
+        "cache",
+        "main",
+        "total",
+        "degree",
+        "constr",
+        "ints",
+        "rot",
+        "required"
+    );
+    for air in &meta.airs {
+        let cached_width: usize = air.trace_width.cached_mains.iter().sum();
+        let preprocessed = air
+            .trace_width
+            .preprocessed
+            .map(|width| width.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        println!(
+            "{:>3}  {:<44}  {:>5}  {:>5}  {:>5}  {:>7}  {:>7}  {:>7}  {:>5}  {:>5}  {:>8}",
+            air.air_idx,
+            truncate(&air.air_name, 44),
+            preprocessed,
+            cached_width,
+            air.trace_width.common_main,
+            air.trace_width.total,
+            air.max_constraint_degree,
+            air.num_constraints,
+            air.num_interactions,
+            air.need_rot,
+            air.is_required
+        );
+    }
+}
+
+fn truncate(value: &str, max_len: usize) -> String {
+    if value.len() <= max_len {
+        return value.to_string();
+    }
+    format!("{}...", &value[..max_len.saturating_sub(3)])
+}

--- a/ceno_recursion_v2/src/circuit/inner/mod.rs
+++ b/ceno_recursion_v2/src/circuit/inner/mod.rs
@@ -29,18 +29,14 @@ pub use trace::*;
 pub struct InnerCircuit<S: AggregationSubCircuit> {
     pub verifier_circuit: Arc<S>,
     pub def_hook_commit: Option<CommitBytes>,
-    pub has_fixed_commit: bool,
-    pub has_fixed_no_omc_init_commit: bool,
     pub instance_public_value_indices: Arc<Vec<Vec<usize>>>,
 }
 
 impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC> for InnerCircuit<S> {
     fn airs(&self) -> Vec<AirRef<SC>> {
         let bus_inventory = self.verifier_circuit.bus_inventory();
-        let transcript_bus = bus_inventory.transcript_bus;
         let public_values_bus = bus_inventory.public_values_bus;
         let cached_commit_bus = bus_inventory.cached_commit_bus;
-        let lookup_challenge_bus = bus_inventory.lookup_challenge_bus;
         let poseidon2_compress_bus = bus_inventory.poseidon2_compress_bus;
         let pvs_air_consistency_bus =
             PvsAirConsistencyBus::new(self.verifier_circuit.next_bus_idx());
@@ -63,14 +59,10 @@ impl<SC: StarkProtocolConfig<F = F>, S: AggregationSubCircuit> Circuit<SC> for I
         }) as AirRef<SC>;
 
         let vm_pvs_air = Arc::new(vm_pvs::VmPvsAir {
-            transcript_bus,
             public_values_bus,
             cached_commit_bus,
-            lookup_challenge_bus,
             pvs_air_consistency_bus,
             deferral_enabled,
-            has_fixed_commit: self.has_fixed_commit,
-            has_fixed_no_omc_init_commit: self.has_fixed_no_omc_init_commit,
             instance_public_value_indices: self.instance_public_value_indices.clone(),
         }) as AirRef<SC>;
 

--- a/ceno_recursion_v2/src/circuit/inner/trace.rs
+++ b/ceno_recursion_v2/src/circuit/inner/trace.rs
@@ -90,6 +90,11 @@ impl InnerTraceGen<CpuBackend<BabyBearPoseidon2Config>> for InnerTraceGenImpl {
                 let mut preflight = Preflight::default();
                 super::verifier::run_preflight(child_vk, proof, &mut preflight, &mut sponge);
                 super::vm_pvs::run_preflight(child_vk, proof, &mut preflight, &mut sponge);
+                let num_lookup_challenge_consumers = proof.chip_proofs.len();
+                preflight.vm_pvs.lookup_challenge_alpha_lookup_count =
+                    num_lookup_challenge_consumers;
+                preflight.vm_pvs.lookup_challenge_beta_lookup_count =
+                    num_lookup_challenge_consumers;
                 (preflight, sponge)
             })
             .unzip();

--- a/ceno_recursion_v2/src/circuit/inner/trace.rs
+++ b/ceno_recursion_v2/src/circuit/inner/trace.rs
@@ -89,12 +89,6 @@ impl InnerTraceGen<CpuBackend<BabyBearPoseidon2Config>> for InnerTraceGenImpl {
                 let mut sponge = initial_transcript.clone();
                 let mut preflight = Preflight::default();
                 super::verifier::run_preflight(child_vk, proof, &mut preflight, &mut sponge);
-                super::vm_pvs::run_preflight(child_vk, proof, &mut preflight, &mut sponge);
-                let num_lookup_challenge_consumers = proof.chip_proofs.len();
-                preflight.vm_pvs.lookup_challenge_alpha_lookup_count =
-                    num_lookup_challenge_consumers;
-                preflight.vm_pvs.lookup_challenge_beta_lookup_count =
-                    num_lookup_challenge_consumers;
                 (preflight, sponge)
             })
             .unzip();

--- a/ceno_recursion_v2/src/circuit/inner/verifier/trace.rs
+++ b/ceno_recursion_v2/src/circuit/inner/verifier/trace.rs
@@ -44,19 +44,23 @@ pub fn generate_proving_ctx(
 
     let mut trace = vec![F::ZERO; rows * width];
 
-    if rows > 0 {
-        let first_row = &mut trace[..width];
+    let valid_rows = proofs.len().max(1);
+    for (row_idx, row) in trace.chunks_exact_mut(width).enumerate() {
+        if row_idx >= valid_rows {
+            continue;
+        }
+
         let base_width = VerifierPvsCols::<u8>::width();
-        let (base_row, def_row) = first_row.split_at_mut(base_width);
+        let (base_row, def_row) = row.split_at_mut(base_width);
 
         let cols: &mut VerifierPvsCols<F> = base_row.borrow_mut();
-        cols.proof_idx = F::ZERO;
+        cols.proof_idx = F::from_usize(row_idx);
         cols.is_valid = F::ONE;
         cols.has_verifier_pvs = F::ZERO;
 
         if deferral_enabled {
             let def_cols: &mut VerifierDeferralCols<F> = def_row.borrow_mut();
-            def_cols.is_last = F::ONE;
+            def_cols.is_last = F::from_bool(row_idx + 1 == valid_rows);
             def_cols.child_pvs.deferral_flag = F::ZERO;
         }
     }

--- a/ceno_recursion_v2/src/circuit/inner/vm_pvs/air.rs
+++ b/ceno_recursion_v2/src/circuit/inner/vm_pvs/air.rs
@@ -1,34 +1,24 @@
 use std::{borrow::Borrow, sync::Arc};
 
 use ceno_emul::{FullTracer as Tracer, WORD_SIZE};
-use ceno_zkvm::{
-    instructions::riscv::constants::{
-        END_CYCLE_IDX, END_PC_IDX, EXIT_CODE_IDX, HEAP_LENGTH_IDX, HEAP_START_ADDR_IDX,
-        HINT_LENGTH_IDX, HINT_START_ADDR_IDX, INIT_CYCLE_IDX, INIT_PC_IDX, PUBIO_DIGEST_IDX,
-        PUBIO_DIGEST_U16_LIMBS, SHARD_ID_IDX, SHARD_RW_SUM_IDX,
-    },
-    structs::VK_DIGEST_LEN,
+use ceno_zkvm::instructions::riscv::constants::{
+    END_CYCLE_IDX, END_PC_IDX, EXIT_CODE_IDX, HEAP_LENGTH_IDX, HEAP_START_ADDR_IDX,
+    HINT_LENGTH_IDX, HINT_START_ADDR_IDX, INIT_CYCLE_IDX, INIT_PC_IDX, PUBIO_DIGEST_IDX,
+    PUBIO_DIGEST_U16_LIMBS, SHARD_ID_IDX, SHARD_RW_SUM_IDX,
 };
 use openvm_circuit_primitives::utils::{and, assert_array_eq, not};
 use openvm_stark_backend::{
     BaseAirWithPublicValues, PartitionedBaseAir, interaction::InteractionBuilder,
 };
-use openvm_stark_sdk::config::baby_bear_poseidon2::{D_EF, DIGEST_SIZE};
 use p3_air::{Air, AirBuilder, AirBuilderWithPublicValues, BaseAir};
 use p3_field::PrimeCharacteristicRing;
 use p3_matrix::Matrix;
-use recursion_circuit::bus::{
-    CachedCommitBus, PublicValuesBus, PublicValuesBusMessage, TranscriptBus, TranscriptBusMessage,
-};
+use recursion_circuit::bus::{CachedCommitBus, PublicValuesBus, PublicValuesBusMessage};
 use stark_recursion_circuit_derive::AlignedBorrow;
 
-use crate::{
-    bus::{LookupChallengeBus, LookupChallengeKind, LookupChallengeMessage},
-    circuit::inner::{
-        bus::{PvsAirConsistencyBus, PvsAirConsistencyMessage},
-        vm_pvs::VmPvs,
-    },
-    utils::TranscriptLabel,
+use crate::circuit::inner::{
+    bus::{PvsAirConsistencyBus, PvsAirConsistencyMessage},
+    vm_pvs::VmPvs,
 };
 
 #[repr(C)]
@@ -38,26 +28,14 @@ pub struct VmPvsCols<F> {
     pub is_valid: F,
     pub is_last: F,
     pub has_verifier_pvs: F,
-    pub vk_digest: [[F; D_EF]; VK_DIGEST_LEN],
-    pub lookup_challenge_alpha: [F; D_EF],
-    pub lookup_challenge_beta: [F; D_EF],
-    pub lookup_challenge_alpha_lookup_count: F,
-    pub lookup_challenge_beta_lookup_count: F,
-    pub fixed_commit_log2_max_codeword_size: F,
-    pub fixed_no_omc_init_commit_log2_max_codeword_size: F,
-    pub witness_commit_log2_max_codeword_size: F,
     pub child_pvs: VmPvs<F>,
 }
 
 pub struct VmPvsAir {
-    pub transcript_bus: TranscriptBus,
     pub public_values_bus: PublicValuesBus,
     pub cached_commit_bus: CachedCommitBus,
-    pub lookup_challenge_bus: LookupChallengeBus,
     pub pvs_air_consistency_bus: PvsAirConsistencyBus,
     pub deferral_enabled: bool,
-    pub has_fixed_commit: bool,
-    pub has_fixed_no_omc_init_commit: bool,
     pub instance_public_value_indices: Arc<Vec<Vec<usize>>>,
 }
 
@@ -197,159 +175,6 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
         //     },
         //     local.is_valid * is_leaf,
         // );
-
-        // Mirror the native verifier transcript prefix exactly:
-        // vk digest, transcript-visible public values, commitments with size
-        // fields, then lookup challenge samples.
-        for (tidx, value) in [(0usize, 1668508018u32), (1usize, 118u32)] {
-            self.transcript_bus.receive(
-                builder,
-                local.proof_idx,
-                TranscriptBusMessage {
-                    tidx: AB::Expr::from_usize(tidx),
-                    value: AB::Expr::from_u32(value),
-                    is_sample: AB::Expr::ZERO,
-                },
-                local.is_valid,
-            );
-        }
-
-        let mut transcript_tidx = TranscriptLabel::Riscv.field_len();
-        for digest in local.vk_digest {
-            self.transcript_bus.observe_ext(
-                builder,
-                local.proof_idx,
-                AB::Expr::from_usize(transcript_tidx),
-                digest,
-                local.is_valid,
-            );
-            transcript_tidx += D_EF;
-        }
-
-        for instance_indices in self.instance_public_value_indices.iter() {
-            for global_pv_idx in instance_indices {
-                self.transcript_bus.receive(
-                    builder,
-                    local.proof_idx,
-                    TranscriptBusMessage {
-                        tidx: AB::Expr::from_usize(transcript_tidx),
-                        value: vm_public_value_by_index::<AB>(local, *global_pv_idx),
-                        is_sample: AB::Expr::ZERO,
-                    },
-                    local.is_valid,
-                );
-                transcript_tidx += 1;
-            }
-        }
-
-        if self.has_fixed_commit {
-            for (didx, value) in local.child_pvs.fixed_commit.iter().enumerate() {
-                self.transcript_bus.receive(
-                    builder,
-                    local.proof_idx,
-                    TranscriptBusMessage {
-                        tidx: AB::Expr::from_usize(transcript_tidx + didx),
-                        value: (*value).into(),
-                        is_sample: AB::Expr::ZERO,
-                    },
-                    local.is_valid,
-                );
-            }
-            transcript_tidx += DIGEST_SIZE;
-            self.transcript_bus.observe(
-                builder,
-                local.proof_idx,
-                AB::Expr::from_usize(transcript_tidx),
-                local.fixed_commit_log2_max_codeword_size,
-                local.is_valid,
-            );
-            transcript_tidx += 1;
-        }
-
-        if self.has_fixed_no_omc_init_commit {
-            for (didx, value) in local.child_pvs.fixed_no_omc_init_commit.iter().enumerate() {
-                self.transcript_bus.receive(
-                    builder,
-                    local.proof_idx,
-                    TranscriptBusMessage {
-                        tidx: AB::Expr::from_usize(transcript_tidx + didx),
-                        value: (*value).into(),
-                        is_sample: AB::Expr::ZERO,
-                    },
-                    local.is_valid,
-                );
-            }
-            transcript_tidx += DIGEST_SIZE;
-            self.transcript_bus.observe(
-                builder,
-                local.proof_idx,
-                AB::Expr::from_usize(transcript_tidx),
-                local.fixed_no_omc_init_commit_log2_max_codeword_size,
-                local.is_valid,
-            );
-            transcript_tidx += 1;
-        }
-
-        for (didx, value) in local.child_pvs.witness_commit.iter().enumerate() {
-            self.transcript_bus.receive(
-                builder,
-                local.proof_idx,
-                TranscriptBusMessage {
-                    tidx: AB::Expr::from_usize(transcript_tidx + didx),
-                    value: (*value).into(),
-                    is_sample: AB::Expr::ZERO,
-                },
-                local.is_valid,
-            );
-        }
-        transcript_tidx += DIGEST_SIZE;
-        self.transcript_bus.observe(
-            builder,
-            local.proof_idx,
-            AB::Expr::from_usize(transcript_tidx),
-            local.witness_commit_log2_max_codeword_size,
-            local.is_valid,
-        );
-        transcript_tidx += 1;
-
-        self.transcript_bus.sample_ext(
-            builder,
-            local.proof_idx,
-            AB::Expr::from_usize(transcript_tidx),
-            local.lookup_challenge_alpha,
-            local.is_valid,
-        );
-        transcript_tidx += D_EF;
-        self.transcript_bus.sample_ext(
-            builder,
-            local.proof_idx,
-            AB::Expr::from_usize(transcript_tidx),
-            local.lookup_challenge_beta,
-            local.is_valid,
-        );
-
-        for i in 0..D_EF {
-            self.lookup_challenge_bus.add_key_with_lookups(
-                builder,
-                local.proof_idx,
-                LookupChallengeMessage {
-                    kind: AB::Expr::from_usize(LookupChallengeKind::Alpha.as_usize()),
-                    word_idx: AB::Expr::from_usize(i),
-                    value: local.lookup_challenge_alpha[i].into(),
-                },
-                local.is_valid * local.lookup_challenge_alpha_lookup_count,
-            );
-            self.lookup_challenge_bus.add_key_with_lookups(
-                builder,
-                local.proof_idx,
-                LookupChallengeMessage {
-                    kind: AB::Expr::from_usize(LookupChallengeKind::Beta.as_usize()),
-                    word_idx: AB::Expr::from_usize(i),
-                    value: local.lookup_challenge_beta[i].into(),
-                },
-                local.is_valid * local.lookup_challenge_beta_lookup_count,
-            );
-        }
 
         // We look up proof metadata from VerifierPvsAir here to ensure consistency on each row.
         self.pvs_air_consistency_bus.lookup_key(

--- a/ceno_recursion_v2/src/circuit/inner/vm_pvs/air.rs
+++ b/ceno_recursion_v2/src/circuit/inner/vm_pvs/air.rs
@@ -3,7 +3,7 @@ use std::{borrow::Borrow, sync::Arc};
 use ceno_emul::{FullTracer as Tracer, WORD_SIZE};
 use ceno_zkvm::{
     instructions::riscv::constants::{
-        END_CYCLE_IDX, END_PC_IDX, EXIT_CODE_IDX, EXIT_PC, HEAP_LENGTH_IDX, HEAP_START_ADDR_IDX,
+        END_CYCLE_IDX, END_PC_IDX, EXIT_CODE_IDX, HEAP_LENGTH_IDX, HEAP_START_ADDR_IDX,
         HINT_LENGTH_IDX, HINT_START_ADDR_IDX, INIT_CYCLE_IDX, INIT_PC_IDX, PUBIO_DIGEST_IDX,
         PUBIO_DIGEST_U16_LIMBS, SHARD_ID_IDX, SHARD_RW_SUM_IDX,
     },
@@ -140,22 +140,14 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             .when(and(local.is_valid, next.is_valid))
             .assert_eq(local.has_verifier_pvs, next.has_verifier_pvs);
 
-        // We constrain segment adjacency so adjacent rows correspond to adjacent segments.
-        // Non-final segments must suspend with EXIT_PC.
-        let suspend_exit_pc = EXIT_PC as u32;
-        let suspend_exit_code_lo = AB::Expr::from_u32(suspend_exit_pc & 0xffff);
-        let suspend_exit_code_hi = AB::Expr::from_u32((suspend_exit_pc >> 16) & 0xffff);
+        // Proof rows are verified in the same order as the native full-trace verifier.
         builder
-            .when(and(local.is_valid, not(local.is_last)))
-            .assert_eq(local.child_pvs.exit_code[0], suspend_exit_code_lo);
-        builder
-            .when(and(local.is_valid, not(local.is_last)))
-            .assert_eq(local.child_pvs.exit_code[1], suspend_exit_code_hi);
+            .when(local.is_valid)
+            .assert_eq(local.child_pvs.shard_id, local.proof_idx);
 
         // When local and next are valid, enforce continuation consistency.
         let mut when_both_valid = builder.when(and(local.is_valid, not(local.is_last)));
         when_both_valid.assert_eq(local.child_pvs.end_pc, next.child_pvs.init_pc);
-        when_both_valid.assert_eq(local.child_pvs.end_cycle, next.child_pvs.init_cycle);
         when_both_valid.assert_eq(
             local.child_pvs.shard_id + AB::Expr::ONE,
             next.child_pvs.shard_id,
@@ -164,6 +156,11 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             local.child_pvs.heap_start_addr
                 + local.child_pvs.heap_shard_len * AB::Expr::from_u32(WORD_SIZE as u32),
             next.child_pvs.heap_start_addr,
+        );
+        when_both_valid.assert_eq(
+            local.child_pvs.hint_start_addr
+                + local.child_pvs.hint_shard_len * AB::Expr::from_u32(WORD_SIZE as u32),
+            next.child_pvs.hint_start_addr,
         );
 
         // Mirror verifier invariant: every shard starts at SUBCYCLES_PER_INSN.
@@ -384,15 +381,45 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             shard_rw_sum,
         } = builder.public_values().borrow();
 
-        // constrain first proof pvs
+        // The aggregate output copies first-proof values except for terminal fields.
+        assert_array_eq(
+            &mut builder.when_first_row(),
+            local.child_pvs.witness_commit,
+            witness_commit,
+        );
         builder
             .when_first_row()
             .assert_eq(local.child_pvs.init_pc, init_pc);
         builder
             .when_first_row()
             .assert_eq(local.child_pvs.init_cycle, init_cycle);
+        builder
+            .when_first_row()
+            .assert_eq(local.child_pvs.shard_id, shard_id);
+        builder
+            .when_first_row()
+            .assert_eq(local.child_pvs.heap_start_addr, heap_start_addr);
+        builder
+            .when_first_row()
+            .assert_eq(local.child_pvs.heap_shard_len, heap_shard_len);
+        builder
+            .when_first_row()
+            .assert_eq(local.child_pvs.hint_start_addr, hint_start_addr);
+        builder
+            .when_first_row()
+            .assert_eq(local.child_pvs.hint_shard_len, hint_shard_len);
+        assert_array_eq(
+            &mut builder.when_first_row(),
+            local.child_pvs.public_io,
+            public_io,
+        );
+        assert_array_eq(
+            &mut builder.when_first_row(),
+            local.child_pvs.shard_rw_sum,
+            shard_rw_sum,
+        );
 
-        // constrain last proof pvs
+        // The aggregate output copies terminal values from the last child proof.
         builder
             .when(local.is_last)
             .assert_eq(local.child_pvs.end_pc, end_pc);
@@ -405,54 +432,16 @@ impl<AB: AirBuilder + InteractionBuilder + AirBuilderWithPublicValues> Air<AB> f
             exit_code,
         );
 
-        // constrain static per-proof public values
-        builder
-            .when(local.is_valid)
-            .assert_eq(local.child_pvs.shard_id, shard_id);
-        builder
-            .when(local.is_valid)
-            .assert_eq(local.child_pvs.heap_start_addr, heap_start_addr);
-        builder
-            .when(local.is_valid)
-            .assert_eq(local.child_pvs.heap_shard_len, heap_shard_len);
-        builder
-            .when(local.is_valid)
-            .assert_eq(local.child_pvs.hint_start_addr, hint_start_addr);
-        builder
-            .when(local.is_valid)
-            .assert_eq(local.child_pvs.hint_shard_len, hint_shard_len);
-        assert_array_eq(
-            &mut builder.when(local.is_valid),
-            local.child_pvs.public_io,
-            public_io,
-        );
-        assert_array_eq(
-            &mut builder.when(local.is_valid),
-            local.child_pvs.shard_rw_sum,
-            shard_rw_sum,
-        );
-
-        // constrain fixed commits
+        // Fixed commits are VK-level data and must match every child proof row.
         assert_array_eq(
             &mut builder.when(local.is_valid),
             local.child_pvs.fixed_commit,
             fixed_commit,
         );
-        builder
-            .when(local.is_valid)
-            .assert_eq(local.child_pvs.init_pc, init_pc);
-        builder
-            .when(local.is_valid)
-            .assert_eq(local.child_pvs.init_cycle, init_cycle);
         assert_array_eq(
             &mut builder.when(local.is_valid),
             local.child_pvs.fixed_no_omc_init_commit,
             fixed_no_omc_init_commit,
-        );
-        assert_array_eq(
-            &mut builder.when(local.is_valid),
-            local.child_pvs.witness_commit,
-            witness_commit,
         );
     }
 }

--- a/ceno_recursion_v2/src/circuit/inner/vm_pvs/mod.rs
+++ b/ceno_recursion_v2/src/circuit/inner/vm_pvs/mod.rs
@@ -1,10 +1,6 @@
 use ceno_zkvm::instructions::riscv::constants::PUBIO_DIGEST_U16_LIMBS;
-use openvm_stark_backend::{FiatShamirTranscript, TranscriptHistory};
-use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, DIGEST_SIZE, F};
-use p3_field::PrimeCharacteristicRing;
+use openvm_stark_sdk::config::baby_bear_poseidon2::DIGEST_SIZE;
 use stark_recursion_circuit_derive::AlignedBorrow;
-
-use crate::system::{Preflight, RecursionField, RecursionProof, RecursionVk};
 
 mod air;
 mod trace;
@@ -35,56 +31,3 @@ pub struct VmPvs<F> {
 
 pub use air::*;
 pub use trace::*;
-
-#[tracing::instrument(level = "trace", skip_all)]
-pub fn run_preflight<TS>(
-    child_vk: &RecursionVk,
-    proof: &RecursionProof,
-    preflight: &mut Preflight,
-    ts: &mut TS,
-) where
-    TS: FiatShamirTranscript<BabyBearPoseidon2Config> + TranscriptHistory,
-{
-    let vk_digest = child_vk.compute_digest();
-    for elem in vk_digest {
-        ts.observe_ext(elem);
-    }
-
-    // Observe public values in canonical circuit-instance order first.
-    for (_, circuit_vk) in child_vk.circuit_vks.iter() {
-        for instance_value in circuit_vk.get_cs().zkvm_v1_css.instance.iter() {
-            ts.observe(
-                proof
-                    .public_values
-                    .query_by_index::<RecursionField>(instance_value.0),
-            );
-        }
-    }
-
-    if let Some(fixed_commit) = child_vk.fixed_commit.as_ref() {
-        for elem in fixed_commit.commit.clone().into_iter() {
-            ts.observe(elem);
-        }
-        ts.observe(F::from_u64(fixed_commit.log2_max_codeword_size as u64));
-    }
-
-    if let Some(fixed_no_omc) = child_vk.fixed_no_omc_init_commit.as_ref() {
-        for elem in fixed_no_omc.commit.clone().into_iter() {
-            ts.observe(elem);
-        }
-        ts.observe(F::from_u64(fixed_no_omc.log2_max_codeword_size as u64));
-    }
-
-    let witin = &proof.witin_commit;
-    for elem in witin.commit.clone().into_iter() {
-        ts.observe(elem);
-    }
-    ts.observe(F::from_u64(witin.log2_max_codeword_size as u64));
-
-    let alpha_ext = ts.sample_ext();
-    let beta_ext = ts.sample_ext();
-    preflight.vm_pvs.lookup_challenge_alpha = alpha_ext;
-    preflight.vm_pvs.lookup_challenge_beta = beta_ext;
-    preflight.vm_pvs.lookup_challenge_alpha_lookup_count = 0;
-    preflight.vm_pvs.lookup_challenge_beta_lookup_count = 0;
-}

--- a/ceno_recursion_v2/src/circuit/inner/vm_pvs/trace.rs
+++ b/ceno_recursion_v2/src/circuit/inner/vm_pvs/trace.rs
@@ -1,10 +1,8 @@
 use ceno_zkvm::instructions::riscv::constants::{LIMB_BITS, LIMB_MASK, PUBIO_DIGEST_U16_LIMBS};
 use openvm_cpu_backend::CpuBackend;
 use openvm_stark_backend::prover::AirProvingContext;
-use openvm_stark_sdk::config::baby_bear_poseidon2::{
-    BabyBearPoseidon2Config, D_EF, DIGEST_SIZE, EF, F,
-};
-use p3_field::{BasedVectorSpace, PrimeCharacteristicRing};
+use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, DIGEST_SIZE, F};
+use p3_field::PrimeCharacteristicRing;
 use p3_matrix::dense::RowMajorMatrix;
 use std::borrow::BorrowMut;
 
@@ -19,12 +17,12 @@ use crate::{
 pub fn generate_proving_ctx(
     child_vk: &RecursionVk,
     proofs: &[RecursionProof],
-    preflights: &[Preflight],
+    _preflights: &[Preflight],
     proofs_type: ProofsType,
     child_is_app: bool,
     deferral_enabled: bool,
 ) -> AirProvingContext<CpuBackend<BabyBearPoseidon2Config>> {
-    debug_assert_eq!(proofs.len(), preflights.len());
+    debug_assert_eq!(proofs.len(), _preflights.len());
     let _ = (proofs_type, child_is_app);
     assert!(
         !deferral_enabled,
@@ -39,26 +37,14 @@ pub fn generate_proving_ctx(
         child_vk
             .fixed_commit
             .as_ref()
-            .map(|commitment| commitment.commit.clone()),
+            .map(|commitment| commitment.commit),
     );
     let fixed_no_omc_init_commit = extract_commit(
         child_vk
             .fixed_no_omc_init_commit
             .as_ref()
-            .map(|commitment| commitment.commit.clone()),
+            .map(|commitment| commitment.commit),
     );
-    let fixed_commit_log2_max_codeword_size = child_vk
-        .fixed_commit
-        .as_ref()
-        .map(|commitment| commitment.log2_max_codeword_size)
-        .unwrap_or_default();
-    let fixed_no_omc_init_commit_log2_max_codeword_size = child_vk
-        .fixed_no_omc_init_commit
-        .as_ref()
-        .map(|commitment| commitment.log2_max_codeword_size)
-        .unwrap_or_default();
-    let vk_digest = child_vk.compute_digest().map(ef_to_limbs);
-
     for (row_idx, row) in trace.chunks_exact_mut(width).enumerate() {
         let (base_row, def_row) = row.split_at_mut(VmPvsCols::<u8>::width());
         let cols: &mut VmPvsCols<F> = base_row.borrow_mut();
@@ -66,23 +52,9 @@ pub fn generate_proving_ctx(
 
         if row_idx < proofs.len() {
             let proof = &proofs[row_idx];
-            let preflight = &preflights[row_idx];
             cols.is_valid = F::ONE;
             cols.is_last = F::from_bool(row_idx + 1 == proofs.len());
             cols.has_verifier_pvs = F::ZERO;
-            cols.vk_digest = vk_digest;
-            cols.lookup_challenge_alpha = ef_to_limbs(preflight.vm_pvs.lookup_challenge_alpha);
-            cols.lookup_challenge_beta = ef_to_limbs(preflight.vm_pvs.lookup_challenge_beta);
-            cols.lookup_challenge_alpha_lookup_count =
-                F::from_usize(preflight.vm_pvs.lookup_challenge_alpha_lookup_count);
-            cols.lookup_challenge_beta_lookup_count =
-                F::from_usize(preflight.vm_pvs.lookup_challenge_beta_lookup_count);
-            cols.fixed_commit_log2_max_codeword_size =
-                F::from_usize(fixed_commit_log2_max_codeword_size);
-            cols.fixed_no_omc_init_commit_log2_max_codeword_size =
-                F::from_usize(fixed_no_omc_init_commit_log2_max_codeword_size);
-            cols.witness_commit_log2_max_codeword_size =
-                F::from_usize(proof.witin_commit.log2_max_codeword_size);
             cols.child_pvs = build_vm_pvs(fixed_commit, fixed_no_omc_init_commit, proof);
         }
 
@@ -117,7 +89,7 @@ fn build_vm_pvs(
     VmPvs {
         fixed_commit,
         fixed_no_omc_init_commit,
-        witness_commit: extract_commit(Some(proof.witin_commit.commit.clone())),
+        witness_commit: extract_commit(Some(proof.witin_commit.commit)),
         exit_code: split_u32_lo_hi(pv.exit_code),
         init_pc: F::from_u32(pv.init_pc),
         init_cycle: F::from_u64(pv.init_cycle),
@@ -156,10 +128,4 @@ fn split_public_io_digest(words: [u32; 8]) -> [F; PUBIO_DIGEST_U16_LIMBS] {
         let limb_idx = idx % 2;
         F::from_u32((words[word_idx] >> (limb_idx * LIMB_BITS)) & LIMB_MASK)
     })
-}
-
-fn ef_to_limbs(value: EF) -> [F; D_EF] {
-    let mut out = [F::ZERO; D_EF];
-    out.copy_from_slice(value.as_basis_coefficients_slice());
-    out
 }

--- a/ceno_recursion_v2/src/continuation/prover/inner/mod.rs
+++ b/ceno_recursion_v2/src/continuation/prover/inner/mod.rs
@@ -291,8 +291,7 @@ where
         self.vk.clone()
     }
 
-    #[cfg(test)]
-    pub(crate) fn air_names(&self) -> Vec<String> {
+    pub fn air_names(&self) -> Vec<String> {
         <InnerCircuit<S> as Circuit<SC>>::airs(self.circuit.as_ref())
             .iter()
             .map(|air| air.name().to_string())

--- a/ceno_recursion_v2/src/continuation/prover/inner/mod.rs
+++ b/ceno_recursion_v2/src/continuation/prover/inner/mod.rs
@@ -82,8 +82,6 @@ impl<
         let circuit = Arc::new(InnerCircuit::new(
             Arc::new(verifier_circuit),
             def_hook_commit.map(|d| d.into()),
-            child_vk.fixed_commit.is_some(),
-            child_vk.fixed_no_omc_init_commit.is_some(),
             instance_public_value_indices,
         ));
         let (pk, vk) = engine.keygen(&circuit.airs());
@@ -129,8 +127,6 @@ impl<
         let circuit = Arc::new(InnerCircuit::new(
             Arc::new(verifier_circuit),
             def_hook_commit.map(|d| d.into()),
-            child_vk.fixed_commit.is_some(),
-            child_vk.fixed_no_omc_init_commit.is_some(),
             instance_public_value_indices,
         ));
         let vk = Arc::new(pk.get_vk());

--- a/ceno_recursion_v2/src/proof_shape/mod.rs
+++ b/ceno_recursion_v2/src/proof_shape/mod.rs
@@ -7,8 +7,8 @@ use openvm_stark_backend::{
     AirRef, FiatShamirTranscript, StarkProtocolConfig, TranscriptHistory,
     p3_maybe_rayon::prelude::*, prover::AirProvingContext,
 };
-use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, F};
-use p3_field::PrimeCharacteristicRing;
+use openvm_stark_sdk::config::baby_bear_poseidon2::{BabyBearPoseidon2Config, D_EF, EF, F};
+use p3_field::{BasedVectorSpace, PrimeCharacteristicRing};
 use p3_matrix::dense::RowMajorMatrix;
 
 use crate::{
@@ -19,7 +19,7 @@ use crate::{
     },
     system::{
         AirModule, BusIndexManager, BusInventory, GlobalCtxCpu, POW_CHECKER_HEIGHT, Preflight,
-        RecursionProof, RecursionVk, TraceGenModule, TraceVData,
+        RecursionField, RecursionProof, RecursionVk, TraceGenModule, TraceVData,
     },
     tracegen::{ModuleChip, RowMajorChip},
 };
@@ -52,6 +52,8 @@ pub struct AirMetadata {
 pub struct ProofShapeModule {
     // Verifying key fields
     per_air: Vec<AirMetadata>,
+    has_fixed_commit: bool,
+    has_fixed_no_omc_init_commit: bool,
 
     // Buses (inventory for external, others are internal)
     bus_inventory: BusInventory,
@@ -82,6 +84,8 @@ impl ProofShapeModule {
         let range_bus = bus_inventory.range_checker_bus;
         Self {
             per_air,
+            has_fixed_commit: child_vk.fixed_commit.is_some(),
+            has_fixed_no_omc_init_commit: child_vk.fixed_no_omc_init_commit.is_some(),
             bus_inventory,
             range_bus,
             permutation_bus: ProofShapePermutationBus::new(b.new_bus_idx()),
@@ -102,7 +106,47 @@ impl ProofShapeModule {
     ) where
         TS: FiatShamirTranscript<BabyBearPoseidon2Config> + TranscriptHistory,
     {
-        let _ = self;
+        let vk_digest = child_vk.compute_digest();
+        for elem in vk_digest {
+            ts.observe_ext(elem);
+        }
+
+        // Observe public values in canonical circuit-instance order. PublicValuesAir constrains
+        // the corresponding TranscriptBus receives; proof-shape owns the surrounding prefix.
+        for (_, circuit_vk) in child_vk.circuit_vks.iter() {
+            for instance_value in circuit_vk.get_cs().zkvm_v1_css.instance.iter() {
+                ts.observe(
+                    proof
+                        .public_values
+                        .query_by_index::<RecursionField>(instance_value.0),
+                );
+            }
+        }
+
+        if let Some(fixed_commit) = child_vk.fixed_commit.as_ref() {
+            for elem in fixed_commit.commit.into_iter() {
+                ts.observe(elem);
+            }
+            ts.observe(F::from_u64(fixed_commit.log2_max_codeword_size as u64));
+        }
+
+        if let Some(fixed_no_omc) = child_vk.fixed_no_omc_init_commit.as_ref() {
+            for elem in fixed_no_omc.commit.into_iter() {
+                ts.observe(elem);
+            }
+            ts.observe(F::from_u64(fixed_no_omc.log2_max_codeword_size as u64));
+        }
+
+        let witin = &proof.witin_commit;
+        for elem in witin.commit.into_iter() {
+            ts.observe(elem);
+        }
+        ts.observe(F::from_u64(witin.log2_max_codeword_size as u64));
+
+        let alpha_ext = ts.sample_ext();
+        let beta_ext = ts.sample_ext();
+        preflight.proof_shape.lookup_challenge_alpha = ef_to_limbs(alpha_ext);
+        preflight.proof_shape.lookup_challenge_beta = ef_to_limbs(beta_ext);
 
         let transcript_start_tidx = ts.len();
         preflight.proof_shape.fork_start_tidx = ts.len();
@@ -248,6 +292,12 @@ fn extract_air_metadata_from_vk(child_vk: &RecursionVk) -> Vec<AirMetadata> {
         .collect_vec()
 }
 
+fn ef_to_limbs(value: EF) -> [F; D_EF] {
+    let mut out = [F::ZERO; D_EF];
+    out.copy_from_slice(value.as_basis_coefficients_slice());
+    out
+}
+
 impl AirModule for ProofShapeModule {
     fn num_airs(&self) -> usize {
         3
@@ -256,6 +306,8 @@ impl AirModule for ProofShapeModule {
     fn airs<SC: StarkProtocolConfig<F = F>>(&self) -> Vec<AirRef<SC>> {
         let proof_shape_air = ProofShapeAir::<4, 8> {
             per_air: self.per_air.clone(),
+            has_fixed_commit: self.has_fixed_commit,
+            has_fixed_no_omc_init_commit: self.has_fixed_no_omc_init_commit,
             idx_encoder: self.idx_encoder.clone(),
             range_bus: self.range_bus,
             permutation_bus: self.permutation_bus,

--- a/ceno_recursion_v2/src/proof_shape/proof_shape/air.rs
+++ b/ceno_recursion_v2/src/proof_shape/proof_shape/air.rs
@@ -17,11 +17,10 @@ use stark_recursion_circuit_derive::AlignedBorrow;
 
 use crate::{
     bus::{
-        AirShapeBus, AirShapeBusMessage, ExpressionClaimNMaxBus, ExpressionClaimNMaxMessage,
-        ForkedTranscriptBus, ForkedTranscriptBusMessage, FractionFolderInputBus,
-        FractionFolderInputMessage, HyperdimBus, HyperdimBusMessage, LiftedHeightsBus,
-        LiftedHeightsBusMessage, LookupChallengeBus, LookupChallengeKind, LookupChallengeMessage,
-        NLiftBus, NLiftMessage, TowerModuleBus, TowerModuleMessage, TowerRootClaimBus,
+        AirShapeBus, AirShapeBusMessage, ExpressionClaimNMaxBus, ForkedTranscriptBus,
+        ForkedTranscriptBusMessage, FractionFolderInputBus, HyperdimBus, HyperdimBusMessage,
+        LiftedHeightsBus, LiftedHeightsBusMessage, LookupChallengeBus, LookupChallengeKind,
+        LookupChallengeMessage, NLiftBus, TowerModuleBus, TowerModuleMessage, TowerRootClaimBus,
         TowerRootClaimMessage, TranscriptBus, TranscriptBusMessage,
     },
     primitives::bus::{RangeCheckerBus, RangeCheckerBusMessage},
@@ -661,36 +660,17 @@ where
             local.is_present * local.is_valid,
         );
 
-        // Send n_max value to expression claim air
-        self.expression_claim_n_max_bus.send(
-            builder,
-            local.proof_idx,
-            ExpressionClaimNMaxMessage {
-                n_max: local.n_max.into(),
-            },
-            AB::Expr::ZERO,
+        // TODO(recursive-circuit-incremental): re-enable these exports once
+        // BatchConstraintModule is active and can consume them:
+        // - ExpressionClaimNMaxBus(n_max)
+        // - NLiftBus(air_idx, n_lift)
+        // - FractionFolderInputBus(num_present_airs)
+        let _ = (
+            &self.expression_claim_n_max_bus,
+            &self.n_lift_bus,
+            &self.fraction_folder_input_bus,
         );
-
-        // Send n_lift to constraint folding air
-        self.n_lift_bus.send(
-            builder,
-            local.proof_idx,
-            NLiftMessage {
-                air_idx: air_idx,
-                n_lift: local.log_height.into(),
-            },
-            AB::Expr::ZERO,
-        );
-
-        // Send count of present airs to fraction folder air
-        self.fraction_folder_input_bus.send(
-            builder,
-            local.proof_idx,
-            FractionFolderInputMessage {
-                num_present_airs: local.num_present,
-            },
-            AB::Expr::ZERO,
-        );
+        let _ = air_idx;
     }
 }
 

--- a/ceno_recursion_v2/src/proof_shape/proof_shape/air.rs
+++ b/ceno_recursion_v2/src/proof_shape/proof_shape/air.rs
@@ -313,7 +313,7 @@ where
                     word_idx: AB::Expr::from_usize(i),
                     value: local.lookup_challenge_alpha[i].into(),
                 },
-                AB::Expr::ZERO,
+                local.is_present * local.is_valid,
             );
         }
         for i in 0..D_EF {
@@ -325,7 +325,7 @@ where
                     word_idx: AB::Expr::from_usize(i),
                     value: local.lookup_challenge_beta[i].into(),
                 },
-                AB::Expr::ZERO,
+                local.is_present * local.is_valid,
             );
         }
 

--- a/ceno_recursion_v2/src/proof_shape/proof_shape/air.rs
+++ b/ceno_recursion_v2/src/proof_shape/proof_shape/air.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Borrow, sync::Arc};
 
+use ceno_zkvm::structs::VK_DIGEST_LEN;
 use itertools::fold;
 use openvm_circuit_primitives::{
     SubAir,
@@ -9,7 +10,7 @@ use openvm_circuit_primitives::{
 use openvm_stark_backend::{
     BaseAirWithPublicValues, PartitionedBaseAir, interaction::InteractionBuilder,
 };
-use openvm_stark_sdk::config::baby_bear_poseidon2::D_EF;
+use openvm_stark_sdk::config::baby_bear_poseidon2::{D_EF, DIGEST_SIZE};
 use p3_air::{Air, AirBuilder, BaseAir};
 use p3_field::{PrimeCharacteristicRing, PrimeField32};
 use p3_matrix::Matrix;
@@ -87,6 +88,13 @@ pub struct ProofShapeCols<F, const NUM_LIMBS: usize> {
     /// forking). Constrained to be identical across all rows within a proof.
     pub lookup_challenge_alpha: [F; D_EF],
     pub lookup_challenge_beta: [F; D_EF],
+    pub vk_digest: [[F; D_EF]; VK_DIGEST_LEN],
+    pub fixed_commit: [F; DIGEST_SIZE],
+    pub fixed_commit_log2_max_codeword_size: F,
+    pub fixed_no_omc_init_commit: [F; DIGEST_SIZE],
+    pub fixed_no_omc_init_commit_log2_max_codeword_size: F,
+    pub witness_commit: [F; DIGEST_SIZE],
+    pub witness_commit_log2_max_codeword_size: F,
     /// Fork-local tidx of the final fork sample merged back into the trunk transcript.
     pub fork_sample_tidx: F,
     /// Trunk tidx where this fork's final sample is observed during merge.
@@ -111,6 +119,8 @@ pub struct ProofShapeVarCols<'a, F> {
 pub struct ProofShapeAir<const NUM_LIMBS: usize, const LIMB_BITS: usize> {
     // Parameters derived from vk
     pub per_air: Vec<AirMetadata>,
+    pub has_fixed_commit: bool,
+    pub has_fixed_no_omc_init_commit: bool,
 
     // Primitives
     pub idx_encoder: Arc<Encoder>,
@@ -332,6 +342,149 @@ where
         ///////////////////////////////////////////////////////////////////////////////////////////
         // TRANSCRIPT OBSERVATIONS
         ///////////////////////////////////////////////////////////////////////////////////////////
+
+        // The RISC-V label is observed before proof-shape preflight starts, but proof-shape owns
+        // the verifier transcript prefix that follows it.
+        for (tidx, value) in [(0usize, 1668508018u32), (1usize, 118u32)] {
+            self.transcript_bus.receive(
+                builder,
+                local.proof_idx,
+                TranscriptBusMessage {
+                    tidx: AB::Expr::from_usize(tidx),
+                    value: AB::Expr::from_u32(value),
+                    is_sample: AB::Expr::ZERO,
+                },
+                local.is_last,
+            );
+        }
+
+        let mut prefix_tidx = TranscriptLabel::Riscv.field_len();
+        for digest in local.vk_digest {
+            self.transcript_bus.observe_ext(
+                builder,
+                local.proof_idx,
+                AB::Expr::from_usize(prefix_tidx),
+                digest,
+                local.is_last,
+            );
+            prefix_tidx += D_EF;
+        }
+
+        let num_public_values = self
+            .per_air
+            .iter()
+            .map(|air_data| air_data.num_public_values)
+            .sum::<usize>();
+        prefix_tidx += num_public_values;
+
+        if self.has_fixed_commit {
+            for (didx, value) in local.fixed_commit.iter().enumerate() {
+                self.transcript_bus.receive(
+                    builder,
+                    local.proof_idx,
+                    TranscriptBusMessage {
+                        tidx: AB::Expr::from_usize(prefix_tidx + didx),
+                        value: (*value).into(),
+                        is_sample: AB::Expr::ZERO,
+                    },
+                    local.is_last,
+                );
+            }
+            prefix_tidx += DIGEST_SIZE;
+            self.transcript_bus.observe(
+                builder,
+                local.proof_idx,
+                AB::Expr::from_usize(prefix_tidx),
+                local.fixed_commit_log2_max_codeword_size,
+                local.is_last,
+            );
+            prefix_tidx += 1;
+        }
+
+        if self.has_fixed_no_omc_init_commit {
+            for (didx, value) in local.fixed_no_omc_init_commit.iter().enumerate() {
+                self.transcript_bus.receive(
+                    builder,
+                    local.proof_idx,
+                    TranscriptBusMessage {
+                        tidx: AB::Expr::from_usize(prefix_tidx + didx),
+                        value: (*value).into(),
+                        is_sample: AB::Expr::ZERO,
+                    },
+                    local.is_last,
+                );
+            }
+            prefix_tidx += DIGEST_SIZE;
+            self.transcript_bus.observe(
+                builder,
+                local.proof_idx,
+                AB::Expr::from_usize(prefix_tidx),
+                local.fixed_no_omc_init_commit_log2_max_codeword_size,
+                local.is_last,
+            );
+            prefix_tidx += 1;
+        }
+
+        for (didx, value) in local.witness_commit.iter().enumerate() {
+            self.transcript_bus.receive(
+                builder,
+                local.proof_idx,
+                TranscriptBusMessage {
+                    tidx: AB::Expr::from_usize(prefix_tidx + didx),
+                    value: (*value).into(),
+                    is_sample: AB::Expr::ZERO,
+                },
+                local.is_last,
+            );
+        }
+        prefix_tidx += DIGEST_SIZE;
+        self.transcript_bus.observe(
+            builder,
+            local.proof_idx,
+            AB::Expr::from_usize(prefix_tidx),
+            local.witness_commit_log2_max_codeword_size,
+            local.is_last,
+        );
+        prefix_tidx += 1;
+
+        self.transcript_bus.sample_ext(
+            builder,
+            local.proof_idx,
+            AB::Expr::from_usize(prefix_tidx),
+            local.lookup_challenge_alpha,
+            local.is_last,
+        );
+        prefix_tidx += D_EF;
+        self.transcript_bus.sample_ext(
+            builder,
+            local.proof_idx,
+            AB::Expr::from_usize(prefix_tidx),
+            local.lookup_challenge_beta,
+            local.is_last,
+        );
+
+        for i in 0..D_EF {
+            self.lookup_challenge_bus.add_key_with_lookups(
+                builder,
+                local.proof_idx,
+                LookupChallengeMessage {
+                    kind: AB::Expr::from_usize(LookupChallengeKind::Alpha.as_usize()),
+                    word_idx: AB::Expr::from_usize(i),
+                    value: local.lookup_challenge_alpha[i].into(),
+                },
+                local.is_last * local.num_present,
+            );
+            self.lookup_challenge_bus.add_key_with_lookups(
+                builder,
+                local.proof_idx,
+                LookupChallengeMessage {
+                    kind: AB::Expr::from_usize(LookupChallengeKind::Beta.as_usize()),
+                    word_idx: AB::Expr::from_usize(i),
+                    value: local.lookup_challenge_beta[i].into(),
+                },
+                local.is_last * local.num_present,
+            );
+        }
 
         self.starting_tidx_bus.receive(
             builder,

--- a/ceno_recursion_v2/src/proof_shape/proof_shape/trace.rs
+++ b/ceno_recursion_v2/src/proof_shape/proof_shape/trace.rs
@@ -1,7 +1,8 @@
 use std::{borrow::BorrowMut, sync::Arc};
 
+use ceno_zkvm::structs::VK_DIGEST_LEN;
 use openvm_circuit_primitives::encoder::Encoder;
-use openvm_stark_sdk::config::baby_bear_poseidon2::{D_EF, EF, F};
+use openvm_stark_sdk::config::baby_bear_poseidon2::{D_EF, DIGEST_SIZE, EF, F};
 use p3_field::{BasedVectorSpace, PrimeCharacteristicRing};
 use p3_matrix::dense::RowMajorMatrix;
 
@@ -54,6 +55,43 @@ fn root_claims_for_chip(proof: &RecursionProof, air_idx: usize) -> (EF, EF, EF, 
 
 fn assign_ext(dst: &mut [F; D_EF], value: EF) {
     dst.copy_from_slice(value.as_basis_coefficients_slice());
+}
+
+fn ef_to_limbs(value: EF) -> [F; D_EF] {
+    let mut out = [F::ZERO; D_EF];
+    assign_ext(&mut out, value);
+    out
+}
+
+fn extract_commit(commit: Option<impl IntoIterator<Item = F>>) -> [F; DIGEST_SIZE] {
+    let mut out = [F::ZERO; DIGEST_SIZE];
+    if let Some(commit) = commit {
+        for (dst, src) in out.iter_mut().zip(commit) {
+            *dst = src;
+        }
+    }
+    out
+}
+
+#[allow(clippy::too_many_arguments)]
+fn assign_transcript_prefix_cols<const NUM_LIMBS: usize>(
+    cols: &mut ProofShapeCols<F, NUM_LIMBS>,
+    vk_digest: [[F; D_EF]; VK_DIGEST_LEN],
+    fixed_commit: [F; DIGEST_SIZE],
+    fixed_commit_log2_max_codeword_size: usize,
+    fixed_no_omc_init_commit: [F; DIGEST_SIZE],
+    fixed_no_omc_init_commit_log2_max_codeword_size: usize,
+    proof: &RecursionProof,
+) {
+    cols.vk_digest = vk_digest;
+    cols.fixed_commit = fixed_commit;
+    cols.fixed_commit_log2_max_codeword_size = F::from_usize(fixed_commit_log2_max_codeword_size);
+    cols.fixed_no_omc_init_commit = fixed_no_omc_init_commit;
+    cols.fixed_no_omc_init_commit_log2_max_codeword_size =
+        F::from_usize(fixed_no_omc_init_commit_log2_max_codeword_size);
+    cols.witness_commit = extract_commit(Some(proof.witin_commit.commit));
+    cols.witness_commit_log2_max_codeword_size =
+        F::from_usize(proof.witin_commit.log2_max_codeword_size);
 }
 
 fn tower_layer_count(chip_proof: &ceno_zkvm::scheme::ZKVMChipProof<RecursionField>) -> usize {
@@ -155,6 +193,29 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> RowMajorChip<F>
         let width = self.placeholder_width();
         let mut trace = vec![F::ZERO; height * width];
         let mut chunks = trace.chunks_exact_mut(width);
+        let vk_digest = child_vk.compute_digest().map(ef_to_limbs);
+        let fixed_commit = extract_commit(
+            child_vk
+                .fixed_commit
+                .as_ref()
+                .map(|commitment| commitment.commit),
+        );
+        let fixed_no_omc_init_commit = extract_commit(
+            child_vk
+                .fixed_no_omc_init_commit
+                .as_ref()
+                .map(|commitment| commitment.commit),
+        );
+        let fixed_commit_log2_max_codeword_size = child_vk
+            .fixed_commit
+            .as_ref()
+            .map(|commitment| commitment.log2_max_codeword_size)
+            .unwrap_or_default();
+        let fixed_no_omc_init_commit_log2_max_codeword_size = child_vk
+            .fixed_no_omc_init_commit
+            .as_ref()
+            .map(|commitment| commitment.log2_max_codeword_size)
+            .unwrap_or_default();
 
         for (proof_idx, (proof, preflight)) in proofs.iter().zip(preflights.iter()).enumerate() {
             let fork_id_by_chip: std::collections::BTreeMap<usize, usize> = proof
@@ -220,6 +281,15 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> RowMajorChip<F>
                 cols.num_columns = F::ZERO;
                 cols.lookup_challenge_alpha = preflight.proof_shape.lookup_challenge_alpha;
                 cols.lookup_challenge_beta = preflight.proof_shape.lookup_challenge_beta;
+                assign_transcript_prefix_cols(
+                    cols,
+                    vk_digest,
+                    fixed_commit,
+                    fixed_commit_log2_max_codeword_size,
+                    fixed_no_omc_init_commit,
+                    fixed_no_omc_init_commit_log2_max_codeword_size,
+                    proof,
+                );
                 if let Some((sample_tidx, sample)) = fork_merge_sample(preflight, fork_id) {
                     cols.fork_sample_tidx = F::from_usize(sample_tidx);
                     cols.merge_tidx =
@@ -274,6 +344,15 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> RowMajorChip<F>
                 cols.num_columns = F::ZERO;
                 cols.lookup_challenge_alpha = preflight.proof_shape.lookup_challenge_alpha;
                 cols.lookup_challenge_beta = preflight.proof_shape.lookup_challenge_beta;
+                assign_transcript_prefix_cols(
+                    cols,
+                    vk_digest,
+                    fixed_commit,
+                    fixed_commit_log2_max_codeword_size,
+                    fixed_no_omc_init_commit,
+                    fixed_no_omc_init_commit_log2_max_codeword_size,
+                    proof,
+                );
                 cols.fork_sample_tidx = F::ZERO;
                 cols.merge_tidx = F::ZERO;
                 cols.fork_merge_sample = [F::ZERO; D_EF];
@@ -316,6 +395,15 @@ impl<const NUM_LIMBS: usize, const LIMB_BITS: usize> RowMajorChip<F>
             cols.num_columns = F::ZERO;
             cols.lookup_challenge_alpha = preflight.proof_shape.lookup_challenge_alpha;
             cols.lookup_challenge_beta = preflight.proof_shape.lookup_challenge_beta;
+            assign_transcript_prefix_cols(
+                cols,
+                vk_digest,
+                fixed_commit,
+                fixed_commit_log2_max_codeword_size,
+                fixed_no_omc_init_commit,
+                fixed_no_omc_init_commit_log2_max_codeword_size,
+                proof,
+            );
             cols.fork_sample_tidx = F::ZERO;
             cols.merge_tidx = F::ZERO;
             cols.fork_merge_sample = [F::ZERO; D_EF];

--- a/ceno_recursion_v2/src/proof_shape/pvs/air.rs
+++ b/ceno_recursion_v2/src/proof_shape/pvs/air.rs
@@ -116,6 +116,8 @@ where
         when_same_air.assert_eq(next.pv_idx, local.pv_idx + AB::Expr::ONE);
         when_same_air.assert_eq(next.tidx, local.tidx + AB::Expr::ONE);
 
+        // VmPvsAir remains active outside the system module and consumes
+        // verifier public values through this bus.
         self.public_values_bus.send(
             builder,
             local.proof_idx,

--- a/ceno_recursion_v2/src/proof_shape/pvs/air.rs
+++ b/ceno_recursion_v2/src/proof_shape/pvs/air.rs
@@ -12,7 +12,7 @@ use ceno_zkvm::structs::VK_DIGEST_LEN;
 use openvm_stark_sdk::config::baby_bear_poseidon2::D_EF;
 
 use crate::{
-    bus::{PublicValuesBus, PublicValuesBusMessage, TranscriptBus},
+    bus::{PublicValuesBus, PublicValuesBusMessage, TranscriptBus, TranscriptBusMessage},
     proof_shape::bus::NumPublicValuesBus,
     subairs::nested_for_loop::{NestedForLoopIoCols, NestedForLoopSubAir},
     utils::TranscriptLabel,
@@ -116,8 +116,8 @@ where
         when_same_air.assert_eq(next.pv_idx, local.pv_idx + AB::Expr::ONE);
         when_same_air.assert_eq(next.tidx, local.tidx + AB::Expr::ONE);
 
-        // VmPvsAir remains active outside the system module and consumes
-        // verifier public values through this bus.
+        // VmPvsAir remains active outside the system module and consumes verifier public values
+        // through this bus.
         self.public_values_bus.send(
             builder,
             local.proof_idx,
@@ -130,7 +130,16 @@ where
         );
         let _ = self.continuations_enabled;
 
-        // VmPvsAir owns the verifier transcript prefix, including these public values.
-        let _ = &self.transcript_bus;
+        // Public values are the per-AIR portion of the verifier transcript prefix.
+        self.transcript_bus.receive(
+            builder,
+            local.proof_idx,
+            TranscriptBusMessage {
+                tidx: local.tidx.into(),
+                value: local.value.into(),
+                is_sample: AB::Expr::ZERO,
+            },
+            local.is_valid,
+        );
     }
 }

--- a/ceno_recursion_v2/src/system/mod.rs
+++ b/ceno_recursion_v2/src/system/mod.rs
@@ -23,8 +23,7 @@ pub use types::{
 use std::{iter, mem, sync::Arc};
 
 use crate::{
-    batch_constraint::{self, BatchConstraintModule},
-    main::MainModule,
+    batch_constraint,
     tower::TowerModule,
     transcript::TranscriptModule,
     utils::{TranscriptLabel, transcript_observe_label},
@@ -42,10 +41,8 @@ use openvm_stark_sdk::{
     p3_baby_bear::Poseidon2BabyBear,
 };
 use p3_field::{BasedVectorSpace, PrimeCharacteristicRing};
-use p3_matrix::Matrix;
 use recursion_circuit::primitives::{
-    exp_bits_len::{ExpBitsLenAir, ExpBitsLenTraceGenerator},
-    pow::{PowerCheckerAir, PowerCheckerCpuTraceGenerator},
+    exp_bits_len::ExpBitsLenTraceGenerator, pow::PowerCheckerCpuTraceGenerator,
 };
 use tracing::Span;
 
@@ -139,20 +136,14 @@ pub struct VerifierSubCircuit<const MAX_NUM_PROOFS: usize> {
     pub(crate) bus_idx_manager: BusIndexManager,
     pub(crate) transcript: TranscriptModule,
     pub(crate) proof_shape: ProofShapeModule,
-    pub(crate) main_module: MainModule,
     pub(crate) gkr: TowerModule,
-    #[allow(dead_code)]
-    pub(crate) batch_constraint: BatchConstraintModule,
 }
 
 #[derive(Copy, Clone)]
 enum TraceModuleRef<'a> {
     Transcript(&'a TranscriptModule),
     ProofShape(&'a ProofShapeModule),
-    Main(&'a MainModule),
     Tower(&'a TowerModule),
-    #[allow(dead_code)]
-    BatchConstraint(&'a BatchConstraintModule),
 }
 
 impl<'a> TraceModuleRef<'a> {
@@ -160,39 +151,7 @@ impl<'a> TraceModuleRef<'a> {
         match self {
             TraceModuleRef::Transcript(_) => "Transcript",
             TraceModuleRef::ProofShape(_) => "ProofShape",
-            TraceModuleRef::Main(_) => "Main",
             TraceModuleRef::Tower(_) => "Tower",
-            TraceModuleRef::BatchConstraint(_) => "BatchConstraint",
-        }
-    }
-
-    #[tracing::instrument(name = "wrapper.run_preflight", level = "trace", skip_all)]
-    fn run_preflight<TS>(
-        self,
-        child_vk: &RecursionVk,
-        proof: &RecursionProof,
-        preflight: &mut Preflight,
-        sponge: &mut TS,
-    ) where
-        TS: FiatShamirTranscript<BabyBearPoseidon2Config>
-            + TranscriptHistory<F = F, State = [F; POSEIDON2_WIDTH]>,
-    {
-        match self {
-            TraceModuleRef::Main(module) => {
-                module.run_preflight(child_vk, proof, preflight, sponge)
-            }
-            TraceModuleRef::Tower(module) => {
-                module.run_preflight(child_vk, proof, preflight, sponge)
-            }
-            TraceModuleRef::BatchConstraint(module) => {
-                module.run_preflight(child_vk, proof, preflight, sponge)
-            }
-            TraceModuleRef::Transcript(_) | TraceModuleRef::ProofShape(_) => {
-                panic!(
-                    "{} module does not participate in per-module preflight",
-                    self.name()
-                )
-            }
         }
     }
 
@@ -203,7 +162,6 @@ impl<'a> TraceModuleRef<'a> {
         child_vk: &RecursionVk,
         proofs: &[RecursionProof],
         preflights: &[Preflight],
-        child_vk_pcs_data: &CommittedTraceData<CpuBackend<SC>>,
         pow_checker_gen: &Arc<PowerCheckerCpuTraceGenerator<2, POW_CHECKER_HEIGHT>>,
         exp_bits_len_gen: &ExpBitsLenTraceGenerator,
         external_data: &VerifierExternalData<'_>,
@@ -230,9 +188,6 @@ impl<'a> TraceModuleRef<'a> {
                 ),
                 required_heights,
             ),
-            TraceModuleRef::Main(module) => {
-                module.generate_proving_ctxs(child_vk, proofs, preflights, &(), required_heights)
-            }
             TraceModuleRef::Tower(module) => module.generate_proving_ctxs(
                 child_vk,
                 proofs,
@@ -240,8 +195,6 @@ impl<'a> TraceModuleRef<'a> {
                 exp_bits_len_gen,
                 required_heights,
             ),
-            TraceModuleRef::BatchConstraint(module) => module
-                .generate_placeholder_proving_ctxs(child_vk_pcs_data.clone(), required_heights),
         }
     }
 }
@@ -305,23 +258,18 @@ impl<const MAX_NUM_PROOFS: usize> VerifierSubCircuit<MAX_NUM_PROOFS> {
             bus_inventory.clone(),
             config.continuations_enabled,
         );
-        let main_module = MainModule::new(&mut bus_idx_manager, bus_inventory.clone());
         let gkr = TowerModule::new(
             child_vk.as_ref(),
             &mut bus_idx_manager,
             bus_inventory.clone(),
         );
-        let batch_constraint =
-            BatchConstraintModule::new(&mut bus_idx_manager, bus_inventory.clone(), MAX_NUM_PROOFS);
 
         VerifierSubCircuit {
             bus_inventory,
             bus_idx_manager,
             transcript,
             proof_shape,
-            main_module,
             gkr,
-            batch_constraint,
         }
     }
 
@@ -402,7 +350,8 @@ impl<const MAX_NUM_PROOFS: usize> VerifierSubCircuit<MAX_NUM_PROOFS> {
             .map(|_| TS::from(poseidon2_perm().clone()))
             .collect();
 
-        // Phase 3: Run Tower + Main on each fork.
+        // Phase 3: Run Tower on each fork. Main is intentionally disabled in
+        // the reduced three-module circuit.
         // Fork-local tidx values are recorded directly; global offsets are
         // computed on demand during trace generation.
 
@@ -428,16 +377,9 @@ impl<const MAX_NUM_PROOFS: usize> VerifierSubCircuit<MAX_NUM_PROOFS> {
             }
 
             let tower_tidx = fs.len();
-            let (tower_schedule, tower_replay) =
+            let (_tower_schedule, tower_replay) =
                 crate::tower::record_and_replay_tower_preflight(fs, child_vk, chip_id, chip_proof);
-
-            let main_claim = crate::tower::derive_tower_input_claim_for_transcript(
-                child_vk,
-                chip_id,
-                chip_proof,
-                &tower_replay,
-                &tower_schedule,
-            );
+            let tower_tidx_end = fs.len();
 
             // Record tower entry with fork-local tidx at tower stage start.
             preflight.gkr.chips.push(TowerChipTranscriptRange {
@@ -449,19 +391,9 @@ impl<const MAX_NUM_PROOFS: usize> VerifierSubCircuit<MAX_NUM_PROOFS> {
                     })
                     .unwrap_or(0),
                 tidx: tower_tidx,
+                tidx_end: tower_tidx_end,
                 fork_idx: fork_id,
                 tower_replay,
-            });
-
-            // Main preflight for this chip.
-            let main_tidx = fs.len();
-            crate::main::record_main_transcript(fs, main_claim);
-
-            preflight.main.chips.push(ChipTranscriptRange {
-                chip_id,
-                instance_idx,
-                tidx: main_tidx,
-                fork_idx: fork_id,
             });
         }
 
@@ -472,15 +404,11 @@ impl<const MAX_NUM_PROOFS: usize> VerifierSubCircuit<MAX_NUM_PROOFS> {
             sponge.observe_ext(sample);
         }
 
-        // Phase 5: batch-constraint transcript replay on the trunk, after the
-        // fork merge and before PCS opening verification.
-        self.batch_constraint
-            .run_preflight(child_vk, proof, &mut preflight, &mut sponge);
-
         // The trunk log now contains pre-fork ops (0..fork_offset), merge ops
-        // (fork_offset..merge_end), and batch-constraint ops after that. The
-        // merge phase adds D_EF samples per fork (from sample_ext on each fork)
-        // and D_EF observations per fork (from observe_ext on trunk).
+        // (fork_offset..merge_end), and no batch-constraint replay in the
+        // reduced three-module circuit. The merge phase adds D_EF samples per
+        // fork (from sample_ext on each fork) and D_EF observations per fork
+        // (from observe_ext on trunk).
         let trunk_log = sponge.into_log();
 
         preflight.proof_shape.fork_start_tidx = fork_offset;
@@ -529,16 +457,14 @@ impl<const MAX_NUM_PROOFS: usize> VerifierSubCircuit<MAX_NUM_PROOFS> {
         let t_n = self.transcript.num_airs();
         let ps_n = self.proof_shape.num_airs();
         let gkr_n = self.gkr.num_airs();
-        let main_n = self.main_module.num_airs();
-        let batch_n = self.batch_constraint.num_airs();
-        let module_air_counts = [t_n, ps_n, gkr_n, main_n, batch_n];
+        let module_air_counts = [t_n, ps_n, gkr_n];
 
         let Some(heights) = required_heights else {
             return (vec![None; module_air_counts.len()], None, None);
         };
 
         let total_module_airs: usize = module_air_counts.iter().sum();
-        let total = total_module_airs + 2;
+        let total = total_module_airs;
         assert_eq!(heights.len(), total);
 
         let mut offset = 0usize;
@@ -547,9 +473,9 @@ impl<const MAX_NUM_PROOFS: usize> VerifierSubCircuit<MAX_NUM_PROOFS> {
             per_module.push(Some(&heights[offset..offset + n]));
             offset += n;
         }
-        debug_assert_eq!(heights.len() - offset, 2);
+        debug_assert_eq!(heights.len(), offset);
 
-        (per_module, Some(heights[offset]), Some(heights[offset + 1]))
+        (per_module, None, None)
     }
 }
 
@@ -582,7 +508,7 @@ impl<SC: StarkProtocolConfig<F = F>, const MAX_NUM_PROOFS: usize>
     >(
         &self,
         child_vk: &RecursionVk,
-        child_vk_pcs_data: CommittedTraceData<CpuBackend<SC>>,
+        _child_vk_pcs_data: CommittedTraceData<CpuBackend<SC>>,
         proofs: &[RecursionProof],
         external_data: &mut VerifierExternalData<'_>,
         initial_transcripts: Vec<TS>,
@@ -622,15 +548,12 @@ impl<SC: StarkProtocolConfig<F = F>, const MAX_NUM_PROOFS: usize>
             Arc::new(PowerCheckerCpuTraceGenerator::<2, POW_CHECKER_HEIGHT>::default());
         let exp_bits_len_gen = ExpBitsLenTraceGenerator::default();
 
-        let (module_required, power_checker_required, exp_bits_len_required) =
-            self.split_required_heights(external_data.required_heights);
+        let (module_required, _, _) = self.split_required_heights(external_data.required_heights);
 
         let modules = [
             TraceModuleRef::Transcript(&self.transcript),
             TraceModuleRef::ProofShape(&self.proof_shape),
             TraceModuleRef::Tower(&self.gkr),
-            TraceModuleRef::Main(&self.main_module),
-            TraceModuleRef::BatchConstraint(&self.batch_constraint),
         ];
 
         let span = Span::current();
@@ -643,7 +566,6 @@ impl<SC: StarkProtocolConfig<F = F>, const MAX_NUM_PROOFS: usize>
                     child_vk,
                     proofs,
                     &preflights,
-                    &child_vk_pcs_data,
                     &power_checker_gen,
                     &exp_bits_len_gen,
                     external_data,
@@ -663,20 +585,7 @@ impl<SC: StarkProtocolConfig<F = F>, const MAX_NUM_PROOFS: usize>
 
         let ctxs_by_module: Vec<Vec<AirProvingContext<CpuBackend<SC>>>> =
             ctxs_by_module.into_iter().collect::<Option<Vec<_>>>()?;
-        let mut ctx_per_trace = ctxs_by_module.into_iter().flatten().collect::<Vec<_>>();
-        if power_checker_required.is_some_and(|h| h != POW_CHECKER_HEIGHT) {
-            return None;
-        }
-        let power_height = power_checker_required.unwrap_or(POW_CHECKER_HEIGHT);
-        let power_trace = power_checker_gen.generate_trace_row_major();
-        if power_trace.height() != power_height {
-            return None;
-        }
-        ctx_per_trace.push(AirProvingContext::simple_no_pis(power_trace));
-
-        let exp_bits_height = exp_bits_len_required;
-        let exp_bits_trace = exp_bits_len_gen.generate_trace_row_major(exp_bits_height)?;
-        ctx_per_trace.push(AirProvingContext::simple_no_pis(exp_bits_trace));
+        let ctx_per_trace = ctxs_by_module.into_iter().flatten().collect::<Vec<_>>();
         Some(ctx_per_trace)
     }
 }
@@ -688,25 +597,10 @@ fn peek_bus_idx(manager: &BusIndexManager) -> BusIndex {
 
 impl<const MAX_NUM_PROOFS: usize> AggregationSubCircuit for VerifierSubCircuit<MAX_NUM_PROOFS> {
     fn airs<SC: StarkProtocolConfig<F = F>>(&self) -> Vec<AirRef<SC>> {
-        let exp_bits_len_air = ExpBitsLenAir::new(
-            self.bus_inventory.exp_bits_len_bus,
-            self.bus_inventory.right_shift_bus,
-        );
-        let power_checker_air = PowerCheckerAir::<2, POW_CHECKER_HEIGHT> {
-            pow_bus: self.bus_inventory.power_checker_bus,
-            range_bus: self.bus_inventory.range_checker_bus,
-        };
-
         iter::empty()
             .chain(self.transcript.airs())
             .chain(self.proof_shape.airs())
             .chain(self.gkr.airs())
-            .chain(self.main_module.airs())
-            .chain(self.batch_constraint.airs())
-            .chain([
-                Arc::new(power_checker_air) as AirRef<_>,
-                Arc::new(exp_bits_len_air) as AirRef<_>,
-            ])
             .collect()
     }
 

--- a/ceno_recursion_v2/src/system/mod.rs
+++ b/ceno_recursion_v2/src/system/mod.rs
@@ -204,28 +204,6 @@ impl<const MAX_NUM_PROOFS: usize> VerifierSubCircuit<MAX_NUM_PROOFS> {
         Self::new_with_options(child_vk, VerifierConfig::default())
     }
 
-    fn vm_pvs_lookup_challenges_from_transcript<TS>(sponge: &TS) -> (EF, EF)
-    where
-        TS: Clone + TranscriptHistory<F = F, State = [F; POSEIDON2_WIDTH]>,
-    {
-        let log = sponge.clone().into_log();
-        let values = log.values();
-        let samples = log.samples();
-        let start = values
-            .len()
-            .checked_sub(2 * D_EF)
-            .expect("VM PVS transcript must end with alpha/beta extension samples");
-        debug_assert!(
-            samples[start..start + 2 * D_EF]
-                .iter()
-                .all(|is_sample| *is_sample),
-            "VM PVS transcript suffix must contain alpha/beta samples"
-        );
-        let alpha = EF::from_basis_coefficients_fn(|i| values[start + i]);
-        let beta = EF::from_basis_coefficients_fn(|i| values[start + D_EF + i]);
-        (alpha, beta)
-    }
-
     pub fn new_with_options(child_vk: Arc<RecursionVk>, config: VerifierConfig) -> Self {
         // let child_mvk = convert_vk_from_zkvm(child_vk.as_ref());
         // let proof_shape_constraint = LinearConstraint {
@@ -303,7 +281,7 @@ impl<const MAX_NUM_PROOFS: usize> VerifierSubCircuit<MAX_NUM_PROOFS> {
     /// Runs preflight for a single proof, with proper transcript forking.
     ///
     /// This mirrors the native verifier's `verify_proof_validity` fork protocol:
-    /// 1. Trunk: proof-shape metadata only (VmPvs preflight already observed/sampled α/β)
+    /// 1. Trunk: proof-shape observes the verifier prefix and samples α/β
     /// 2. Fork: fresh transcript per chip, observe fork prelude, run Tower + Main
     /// 3. Merge: each fork samples 1 ext element → observe into trunk
     #[tracing::instrument(name = "execute_preflight", skip_all)]
@@ -320,24 +298,17 @@ impl<const MAX_NUM_PROOFS: usize> VerifierSubCircuit<MAX_NUM_PROOFS> {
             + Clone,
     {
         let mut preflight = Preflight::default();
-        let (alpha_ext, beta_ext) = Self::vm_pvs_lookup_challenges_from_transcript(&sponge);
-        preflight.vm_pvs.lookup_challenge_alpha = alpha_ext;
-        preflight.vm_pvs.lookup_challenge_beta = beta_ext;
 
         // Phase 1: Trunk operations.
-        // Proof-shape metadata and alpha/beta sampling after pre-verifier transcript observes.
+        // Proof-shape owns the verifier transcript prefix and alpha/beta sampling.
         self.proof_shape
             .run_preflight(child_vk, proof, &mut preflight, &mut sponge);
-        let num_lookup_challenge_consumers = preflight.proof_shape.sorted_trace_vdata.len();
-        preflight.vm_pvs.lookup_challenge_alpha_lookup_count = num_lookup_challenge_consumers;
-        preflight.vm_pvs.lookup_challenge_beta_lookup_count = num_lookup_challenge_consumers;
-
-        // VmPvs is owned by the pre-system preflight. The incoming transcript
-        // has already sampled these two challenges; recover and forward them
-        // so forked chip transcripts bind the same alpha/beta as the native
-        // verifier.
-        preflight.proof_shape.lookup_challenge_alpha = ef_to_limbs(alpha_ext);
-        preflight.proof_shape.lookup_challenge_beta = ef_to_limbs(beta_ext);
+        let alpha_ext =
+            EF::from_basis_coefficients_slice(&preflight.proof_shape.lookup_challenge_alpha)
+                .expect("lookup challenge alpha must have extension-field width");
+        let beta_ext =
+            EF::from_basis_coefficients_slice(&preflight.proof_shape.lookup_challenge_beta)
+                .expect("lookup challenge beta must have extension-field width");
 
         // Mark where merge observations begin in the trunk transcript.
         let fork_offset = sponge.len();
@@ -477,12 +448,6 @@ impl<const MAX_NUM_PROOFS: usize> VerifierSubCircuit<MAX_NUM_PROOFS> {
 
         (per_module, None, None)
     }
-}
-
-fn ef_to_limbs(value: EF) -> [F; D_EF] {
-    let mut out = [F::ZERO; D_EF];
-    out.copy_from_slice(value.as_basis_coefficients_slice());
-    out
 }
 
 impl<SC: StarkProtocolConfig<F = F>, const MAX_NUM_PROOFS: usize>

--- a/ceno_recursion_v2/src/system/preflight/mod.rs
+++ b/ceno_recursion_v2/src/system/preflight/mod.rs
@@ -18,7 +18,6 @@ pub struct Preflight {
     pub main: MainPreflight,
     pub gkr: TowerPreflight,
     pub batch_constraint: BatchConstraintPreflight,
-    pub vm_pvs: VmPvsPreflight,
 }
 
 impl Preflight {
@@ -64,14 +63,6 @@ pub struct ProofShapePreflight {
     pub lookup_challenge_beta: [F; D_EF],
     pub after_forked_challenge_1: EF,
     pub after_forked_challenge_2: EF,
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct VmPvsPreflight {
-    pub lookup_challenge_alpha: EF,
-    pub lookup_challenge_beta: EF,
-    pub lookup_challenge_alpha_lookup_count: usize,
-    pub lookup_challenge_beta_lookup_count: usize,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/ceno_recursion_v2/src/system/preflight/mod.rs
+++ b/ceno_recursion_v2/src/system/preflight/mod.rs
@@ -97,6 +97,8 @@ pub struct TowerChipTranscriptRange {
     pub num_layers: usize,
     /// Fork-local tidx (position within the fork's transcript log).
     pub tidx: usize,
+    /// Fork-local tidx immediately after this tower transcript span.
+    pub tidx_end: usize,
     /// Index into `Preflight::fork_transcripts`.
     pub fork_idx: usize,
     pub tower_replay: TowerReplayResult,

--- a/ceno_recursion_v2/src/tower/input/air.rs
+++ b/ceno_recursion_v2/src/tower/input/air.rs
@@ -2,8 +2,8 @@ use core::borrow::Borrow;
 
 use crate::{
     bus::{
-        MainBus, MainMessage, TowerModuleBus, TowerModuleMessage, TowerRootClaimBus,
-        TowerRootClaimMessage, TranscriptBus,
+        MainBus, TowerModuleBus, TowerModuleMessage, TowerRootClaimBus, TowerRootClaimMessage,
+        TranscriptBus,
     },
     tower::bus::{
         TowerLayerInputBus, TowerLayerInputMessage, TowerLayerOutputBus, TowerLayerOutputMessage,
@@ -398,16 +398,10 @@ impl<AB: AirBuilder + InteractionBuilder> Air<AB> for TowerInputAir {
             local.is_enabled,
         );
 
-        self.main_bus.send(
-            builder,
-            local.proof_idx,
-            MainMessage {
-                chip_idx: local.chip_idx.into(),
-                tidx: local.final_tidx.into(),
-                claim: local.input_layer_claim.map(Into::into),
-            },
-            local.is_enabled * has_interactions.clone(),
-        );
+        // TODO(recursive-circuit-incremental): re-enable the MainBus export
+        // once MainModule is active and can consume Tower input-layer claims.
+        // self.main_bus.send(...);
+        let _ = &self.main_bus;
 
         let root_lambda_label_tidx = local.tidx + out_eval_span;
         for (i, value) in LABEL_COMBINE_VALUES.iter().enumerate() {

--- a/ceno_recursion_v2/src/tower/mod.rs
+++ b/ceno_recursion_v2/src/tower/mod.rs
@@ -1294,7 +1294,7 @@ impl<SC: StarkProtocolConfig<F = F>> TraceGenModule<GlobalCtxCpu, CpuBackend<SC>
 mod debug_tests {
     use super::*;
     use crate::{
-        system::RecursionPcs,
+        system::{BusIndexManager, BusInventory, RecursionPcs},
         utils::{TranscriptLabel, transcript_observe_label},
     };
     use ceno_zkvm::scheme::{constants::NUM_FANIN, verifier::TowerVerify};
@@ -1419,6 +1419,27 @@ mod debug_tests {
             mus,
             ris,
         }
+    }
+
+    fn proof_shape_lookup_challenges(vk: &RecursionVk, proof: &RecursionProof) -> (EF, EF) {
+        let mut bus_idx_manager = BusIndexManager::new();
+        let bus_inventory = BusInventory::new(&mut bus_idx_manager);
+        let module = crate::proof_shape::ProofShapeModule::new(
+            vk,
+            &mut bus_idx_manager,
+            bus_inventory,
+            false,
+        );
+        let mut sponge = default_duplex_sponge_recorder();
+        transcript_observe_label(&mut sponge, TranscriptLabel::Riscv.as_bytes());
+        let mut preflight = Preflight::default();
+        module.run_preflight(vk, proof, &mut preflight, &mut sponge);
+        let alpha =
+            EF::from_basis_coefficients_slice(&preflight.proof_shape.lookup_challenge_alpha)
+                .unwrap();
+        let beta = EF::from_basis_coefficients_slice(&preflight.proof_shape.lookup_challenge_beta)
+            .unwrap();
+        (alpha, beta)
     }
 
     fn manual_first_expected(chip_proof: &ZKVMChipProof<RecursionField>, lambda: EF, eq: EF) -> EF {
@@ -1566,17 +1587,7 @@ mod debug_tests {
         let basic_alpha = basic.read_challenge().elements;
         let basic_beta = basic.read_challenge().elements;
 
-        let mut sponge = default_duplex_sponge_recorder();
-        transcript_observe_label(&mut sponge, TranscriptLabel::Riscv.as_bytes());
-        let mut openvm_preflight = Preflight::default();
-        super::super::circuit::inner::vm_pvs::run_preflight(
-            &vk,
-            &proof,
-            &mut openvm_preflight,
-            &mut sponge,
-        );
-        let openvm_alpha = openvm_preflight.vm_pvs.lookup_challenge_alpha;
-        let openvm_beta = openvm_preflight.vm_pvs.lookup_challenge_beta;
+        let (openvm_alpha, openvm_beta) = proof_shape_lookup_challenges(&vk, &proof);
 
         eprintln!(
             "global basic alpha={:?} beta={:?}; openvm alpha={:?} beta={:?}",
@@ -1681,17 +1692,7 @@ mod debug_tests {
         }
         let basic_schedule = observe_basic_tower(&mut basic_fork, chip_proof);
 
-        let mut sponge = default_duplex_sponge_recorder();
-        transcript_observe_label(&mut sponge, TranscriptLabel::Riscv.as_bytes());
-        let mut openvm_preflight = Preflight::default();
-        super::super::circuit::inner::vm_pvs::run_preflight(
-            &vk,
-            &proof,
-            &mut openvm_preflight,
-            &mut sponge,
-        );
-        let openvm_alpha = openvm_preflight.vm_pvs.lookup_challenge_alpha;
-        let openvm_beta = openvm_preflight.vm_pvs.lookup_challenge_beta;
+        let (openvm_alpha, openvm_beta) = proof_shape_lookup_challenges(&vk, &proof);
         let mut openvm_fork = default_duplex_sponge_recorder();
         transcript_observe_label(&mut openvm_fork, TranscriptLabel::Fork.as_bytes());
         FiatShamirTranscript::<BabyBearPoseidon2Config>::observe_ext(

--- a/ceno_recursion_v2/src/tower/mod.rs
+++ b/ceno_recursion_v2/src/tower/mod.rs
@@ -291,6 +291,7 @@ impl TowerModule {
                         .map(|circuit_vk| tower_layer_count_from_vk(circuit_vk, chip_proof))
                         .unwrap_or(0),
                     tidx,
+                    tidx_end: ts.len(),
                     fork_idx: 0, // unused in forked flow
                     tower_replay,
                 });
@@ -441,6 +442,7 @@ where
     (schedule, replay)
 }
 
+#[allow(dead_code)]
 pub(crate) fn derive_tower_input_claim_for_transcript(
     child_vk: &RecursionVk,
     chip_id: usize,

--- a/ceno_recursion_v2/src/transcript/mod.rs
+++ b/ceno_recursion_v2/src/transcript/mod.rs
@@ -368,10 +368,9 @@ fn trunk_global_export_ranges(preflight: &Preflight) -> Vec<(usize, usize)> {
     if preflight.batch_constraint.lambda_tidx == 0
         && preflight.batch_constraint.tidx_before_univariate == 0
     {
-        // VmPvsAir remains active outside the system module and consumes the
-        // verifier transcript prefix. With BatchConstraint disabled, the trunk
-        // contains only that prefix plus fork-merge observations, so exporting
-        // the full trunk remains balanced.
+        // ProofShape/PublicValues AIRs consume the verifier transcript prefix. With
+        // BatchConstraint disabled, the trunk contains only that prefix plus fork-merge
+        // observations, so exporting the full trunk remains balanced.
         return if log_len == 0 {
             Vec::new()
         } else {

--- a/ceno_recursion_v2/src/transcript/mod.rs
+++ b/ceno_recursion_v2/src/transcript/mod.rs
@@ -353,23 +353,13 @@ fn should_export_global(tidx: usize, ranges: Option<&[(usize, usize)]>) -> bool 
 }
 
 fn fork_global_export_ranges(preflight: &Preflight, fork_idx: usize) -> Vec<(usize, usize)> {
-    let Some(main_tidx) = preflight
-        .main
-        .chips
-        .iter()
-        .find(|entry| entry.fork_idx == fork_idx)
-        .map(|entry| entry.tidx)
-    else {
-        return Vec::new();
-    };
-
     preflight
         .gkr
         .chips
         .iter()
         .filter(|entry| entry.fork_idx == fork_idx)
         .filter(|entry| entry.num_layers > 0)
-        .flat_map(|entry| [(entry.tidx, main_tidx), (main_tidx, main_tidx + D_EF)])
+        .filter_map(|entry| (entry.tidx < entry.tidx_end).then_some((entry.tidx, entry.tidx_end)))
         .collect()
 }
 
@@ -378,6 +368,10 @@ fn trunk_global_export_ranges(preflight: &Preflight) -> Vec<(usize, usize)> {
     if preflight.batch_constraint.lambda_tidx == 0
         && preflight.batch_constraint.tidx_before_univariate == 0
     {
+        // VmPvsAir remains active outside the system module and consumes the
+        // verifier transcript prefix. With BatchConstraint disabled, the trunk
+        // contains only that prefix plus fork-merge observations, so exporting
+        // the full trunk remains balanced.
         return if log_len == 0 {
             Vec::new()
         } else {
@@ -416,10 +410,12 @@ impl AirModule for TranscriptModule {
             transcript_bus: self.bus_inventory.transcript_bus,
             forked_transcript_bus: self.bus_inventory.forked_transcript_bus,
             poseidon2_permute_bus: self.bus_inventory.poseidon2_permute_bus,
-            final_state_bus: self
-                .final_state_bus_enabled
-                .then_some(self.bus_inventory.final_state_bus),
+            // TODO(recursive-circuit-incremental): re-enable final transcript
+            // state export once its consumer module is active in the reduced
+            // recursive circuit.
+            final_state_bus: None,
         };
+        let _ = self.final_state_bus_enabled;
         let poseidon2_air = Poseidon2Air::<F, SBOX_REGISTERS> {
             subair: self.sub_chip.air.clone(),
             poseidon2_permute_bus: self.bus_inventory.poseidon2_permute_bus,


### PR DESCRIPTION
## Summary
- enable only Transcript, ProofShape, and Tower in the recursion v2 system subcircuit
- skip Main and BatchConstraint preflight/trace/AIR wiring for the reduced circuit
- leave TODOs on disabled outbound bus edges while preserving VmPvs transcript/public-values consumers

## Verification
- cargo fmt --all
- cargo check --workspace --all-targets
- cargo make clippy
- CENO_RECURSION_V2_DEBUG_CONSTRAINTS=1 scripts/run_e2e_test.sh
- scripts/run_e2e_test.sh