### PR TITLE
Optimize Secp256k1 add and decompress circuits

### DIFF
--- a/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_decompress.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/weierstrass_decompress.rs
@@ -119,7 +119,7 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> Instruction<E
             vm_state.ts,
         )?;
 
-        let sign_bit_value = layout.layer_exprs.wits.sign_bit;
+        let sign_bit_value = layout.sign_bit_wit();
         let sign_bit = OpFixedRS::<_, { Platform::reg_arg1() }, true>::construct_circuit(
             cb,
             [sign_bit_value.expr(), Expression::ZERO],

--- a/ceno_zkvm/src/instructions/riscv/rv32im.rs
+++ b/ceno_zkvm/src/instructions/riscv/rv32im.rs
@@ -246,7 +246,14 @@ impl InstructionDispatchBuilder {
     }
 }
 
-const KECCAK_CELL_BLOWUP_FACTOR: u64 = 2;
+const KECCAK_CELL_BLOWUP_NUMERATOR: u64 = 33;
+const KECCAK_CELL_BLOWUP_DENOMINATOR: u64 = 16;
+
+fn estimate_keccak_cells(base_cells: u64) -> u64 {
+    base_cells
+        .saturating_mul(KECCAK_CELL_BLOWUP_NUMERATOR)
+        .div_ceil(KECCAK_CELL_BLOWUP_DENOMINATOR)
+}
 
 impl<E: ExtensionField> Rv32imConfig<E> {
     pub fn construct_circuits(
@@ -373,31 +380,34 @@ impl<E: ExtensionField> Rv32imConfig<E> {
         // substantial memory overhead which not reflected on basic column count.
         //
         // We estimate this effect by applying an extra scaling factor that models
-        // tower-witness blowup proportional to the number of base columns.
+        // tower-witness blowup proportional to the number of base columns. Keep
+        // this fractional so the shard planner can avoid Keccak padding cliffs
+        // without the capacity loss of a coarse integer multiplier.
         let keccak_ecall_config = cs.register_opcode_circuit::<KeccakEcallInstruction<E>>();
         let keccak_core_config = cs.register_opcode_circuit::<KeccakCoreInstruction<E>>();
         assert!(
             ecall_cells_map
                 .insert(
                     <KeccakCoreInstruction<E>>::name(),
-                    [
-                        <KeccakEcallInstruction<E>>::name(),
-                        <KeccakCoreInstruction<E>>::name(),
-                    ]
-                    .into_iter()
-                    .map(|name| {
-                        cs.get_cs(&name)
-                            .as_ref()
-                            .map(|cs| {
-                                (cs.zkvm_v1_css.num_witin as u64
-                                    + cs.zkvm_v1_css.num_structural_witin as u64
-                                    + cs.zkvm_v1_css.num_fixed as u64)
-                                    * (1 << cs.rotation_vars().unwrap_or(0))
-                            })
-                            .unwrap_or_default()
-                    })
-                    .sum::<u64>()
-                        * KECCAK_CELL_BLOWUP_FACTOR,
+                    estimate_keccak_cells(
+                        [
+                            <KeccakEcallInstruction<E>>::name(),
+                            <KeccakCoreInstruction<E>>::name(),
+                        ]
+                        .into_iter()
+                        .map(|name| {
+                            cs.get_cs(&name)
+                                .as_ref()
+                                .map(|cs| {
+                                    (cs.zkvm_v1_css.num_witin as u64
+                                        + cs.zkvm_v1_css.num_structural_witin as u64
+                                        + cs.zkvm_v1_css.num_fixed as u64)
+                                        * (1 << cs.rotation_vars().unwrap_or(0))
+                                })
+                                .unwrap_or_default()
+                        })
+                        .sum::<u64>(),
+                    ),
                 )
                 .is_none()
         );
@@ -1190,5 +1200,18 @@ impl<E: ExtensionField> StepCellExtractor for Rv32imConfig<E> {
     #[inline(always)]
     fn cells_for_kind(&self, kind: InsnKind, rs1_value: Option<Word>) -> u64 {
         self.cells_for(kind, rs1_value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keccak_cell_estimate_uses_fractional_ceiling() {
+        assert_eq!(estimate_keccak_cells(0), 0);
+        assert_eq!(estimate_keccak_cells(16), 33);
+        assert_eq!(estimate_keccak_cells(17), 36);
+        assert_eq!(estimate_keccak_cells(u64::MAX), u64::MAX.div_ceil(16));
     }
 }

--- a/ceno_zkvm/src/precompiles/weierstrass.rs
+++ b/ceno_zkvm/src/precompiles/weierstrass.rs
@@ -2,6 +2,7 @@ use generic_array::GenericArray;
 use num::BigUint;
 use sp1_curves::params::NumWords;
 
+pub mod compact_field_relation;
 pub mod test_utils;
 pub mod weierstrass_add;
 pub mod weierstrass_decompress;

--- a/ceno_zkvm/src/precompiles/weierstrass/compact_field_relation.rs
+++ b/ceno_zkvm/src/precompiles/weierstrass/compact_field_relation.rs
@@ -1,0 +1,156 @@
+use derive::AlignedBorrow;
+use ff_ext::{ExtensionField, SmallField};
+use generic_array::{GenericArray, sequence::GenericSequence, typenum::Unsigned};
+use gkr_iop::{circuit_builder::CircuitBuilder, error::CircuitBuilderError};
+use multilinear_extensions::{Expression, ToExpr, WitIn};
+use num::BigUint;
+use p3::field::PrimeCharacteristicRing;
+use sp1_curves::{
+    params::{FieldParameters, Limbs, NumLimbs, limbs_expr_from_vec, limbs_from_vec},
+    polynomial::Polynomial,
+};
+use typenum::U63;
+
+use crate::{
+    gadgets::{
+        util::{compute_root_quotient_and_shift, split_u16_limbs_to_u8_limbs},
+        util_expr::{eval_field_operation, poly_mul_expr},
+    },
+    witness::LkMultiplicity,
+};
+
+// Compact relation audit checklist:
+// - Every caller-owned compact limb array must get explicit assert_bytes/assert_byte_fields.
+// - This helper always byte-checks quotient and witness limbs in populate and eval.
+// - Structural stats should show lookups reduced by removed FieldOpCols, not dropped near zero.
+
+fn to_compact_relation_limbs_field<E, F>(x: &BigUint) -> Limbs<E, U63>
+where
+    E: From<F>,
+    F: p3::field::Field,
+{
+    let mut bytes = x.to_bytes_le();
+    bytes.resize(U63::USIZE, 0);
+    limbs_from_vec(bytes.into_iter().map(F::from_u8).collect())
+}
+
+fn to_compact_relation_limbs_expr<E>(x: &BigUint) -> Limbs<Expression<E>, U63>
+where
+    E: ExtensionField,
+{
+    let mut bytes = x.to_bytes_le();
+    bytes.resize(U63::USIZE, 0);
+    limbs_expr_from_vec(bytes.into_iter().map(E::BaseField::from_u8).collect())
+}
+
+#[derive(Clone, Debug, AlignedBorrow)]
+#[repr(C)]
+pub struct CompactFieldRelationCols<WitT, P: FieldParameters + NumLimbs> {
+    pub(crate) quotient: Limbs<WitT, U63>,
+    pub(crate) witness_low: Limbs<WitT, U63>,
+    pub(crate) witness_high: Limbs<WitT, U63>,
+    pub(crate) _marker: std::marker::PhantomData<P>,
+}
+
+impl<P: FieldParameters + NumLimbs> CompactFieldRelationCols<WitIn, P> {
+    pub fn create<E: ExtensionField, NR, N>(cb: &mut CircuitBuilder<E>, name_fn: N) -> Self
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
+    {
+        let name: String = name_fn().into();
+        Self {
+            quotient: Limbs(GenericArray::generate(|_| {
+                cb.create_witin(|| format!("{}_quotient", name))
+            })),
+            witness_low: Limbs(GenericArray::generate(|_| {
+                cb.create_witin(|| format!("{}_witness_low", name))
+            })),
+            witness_high: Limbs(GenericArray::generate(|_| {
+                cb.create_witin(|| format!("{}_witness_high", name))
+            })),
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<F: SmallField, P: FieldParameters + NumLimbs> CompactFieldRelationCols<F, P> {
+    pub fn populate(
+        &mut self,
+        record: &mut LkMultiplicity,
+        lhs: &Polynomial<F>,
+        rhs: &Polynomial<F>,
+        positive_modulus_offset: &BigUint,
+        quotient: &BigUint,
+    ) {
+        let p_modulus: Polynomial<F> = P::to_limbs_field::<F, _>(&P::modulus()).into();
+        let p_offset: Polynomial<F> =
+            to_compact_relation_limbs_field::<F, _>(positive_modulus_offset).into();
+        let p_quotient: Polynomial<F> = to_compact_relation_limbs_field::<F, _>(quotient).into();
+        let p_vanishing = lhs + &(&p_offset * &p_modulus) - rhs - &(&p_quotient * &p_modulus);
+
+        let p_witness = compute_root_quotient_and_shift(
+            &p_vanishing,
+            P::WITNESS_OFFSET,
+            P::NB_BITS_PER_LIMB as u32,
+            U63::USIZE,
+        );
+        let (p_witness_low, p_witness_high): (Vec<F>, Vec<F>) =
+            split_u16_limbs_to_u8_limbs(&p_witness);
+
+        self.quotient = p_quotient.into();
+        self.witness_low = Limbs(p_witness_low.try_into().unwrap());
+        self.witness_high = Limbs(p_witness_high.try_into().unwrap());
+
+        record.assert_byte_fields(&self.quotient.0);
+        record.assert_byte_fields(&self.witness_low.0);
+        record.assert_byte_fields(&self.witness_high.0);
+    }
+
+    pub fn populate_with_evals(
+        &mut self,
+        record: &mut LkMultiplicity,
+        lhs: &Polynomial<F>,
+        rhs: &Polynomial<F>,
+        positive_modulus_offset: &BigUint,
+        lhs_eval: &BigUint,
+        rhs_eval: &BigUint,
+    ) {
+        let modulus = P::modulus();
+        let numerator = lhs_eval + positive_modulus_offset * &modulus - rhs_eval;
+        debug_assert_eq!(&numerator % &modulus, BigUint::from(0u32));
+        let quotient = numerator / &modulus;
+        self.populate(record, lhs, rhs, positive_modulus_offset, &quotient);
+    }
+}
+
+impl<Expr: Clone, P: FieldParameters + NumLimbs> CompactFieldRelationCols<Expr, P> {
+    pub fn eval<E>(
+        &self,
+        builder: &mut CircuitBuilder<E>,
+        lhs: &Polynomial<Expression<E>>,
+        rhs: &Polynomial<Expression<E>>,
+        positive_modulus_offset: &BigUint,
+    ) -> Result<(), CircuitBuilderError>
+    where
+        E: ExtensionField,
+        Expr: ToExpr<E, Output = Expression<E>>,
+        Expression<E>: From<Expr>,
+    {
+        let p_limbs =
+            Polynomial::from_iter(P::modulus_field_iter::<E::BaseField>().map(|x| x.expr()));
+        let p_offset = to_compact_relation_limbs_expr::<E>(positive_modulus_offset);
+        let p_offset: Polynomial<Expression<E>> = p_offset.into();
+        let p_quotient: Polynomial<Expression<E>> = self.quotient.clone().into();
+        let p_vanishing =
+            lhs + &poly_mul_expr(&p_offset, &p_limbs) - rhs - &poly_mul_expr(&p_quotient, &p_limbs);
+
+        let p_witness_low = self.witness_low.0.iter().into();
+        let p_witness_high = self.witness_high.0.iter().into();
+        eval_field_operation::<E, P>(builder, &p_vanishing, &p_witness_low, &p_witness_high)?;
+
+        builder.assert_bytes(|| "compact relation quotient", &self.quotient.0)?;
+        builder.assert_bytes(|| "compact relation witness_low", &self.witness_low.0)?;
+        builder.assert_bytes(|| "compact relation witness_high", &self.witness_high.0)
+    }
+}

--- a/ceno_zkvm/src/precompiles/weierstrass/weierstrass_add.rs
+++ b/ceno_zkvm/src/precompiles/weierstrass/weierstrass_add.rs
@@ -1028,19 +1028,19 @@ mod tests {
         let zero_p = P::to_limbs_field::<F, _>(&BigUint::from(0u32));
         let zero_u63 = Limbs(GenericArray::generate(|_| F::from_u8(0)));
         let zero_relation = CompactFieldRelationCols {
-            quotient: zero_u63.clone(),
-            witness_low: zero_u63.clone(),
+            quotient: zero_u63,
+            witness_low: zero_u63,
             witness_high: zero_u63,
             _marker: std::marker::PhantomData,
         };
 
         CompactSecp256k1AddAssignWitCols {
-            p_x: zero_p.clone(),
-            p_y: zero_p.clone(),
-            q_x: zero_p.clone(),
-            q_y: zero_p.clone(),
-            slope: zero_p.clone(),
-            x3: zero_p.clone(),
+            p_x: zero_p,
+            p_y: zero_p,
+            q_x: zero_p,
+            q_y: zero_p,
+            slope: zero_p,
+            x3: zero_p,
             y3: zero_p,
             slope_relation: zero_relation.clone(),
             x_relation: zero_relation.clone(),

--- a/ceno_zkvm/src/precompiles/weierstrass/weierstrass_add.rs
+++ b/ceno_zkvm/src/precompiles/weierstrass/weierstrass_add.rs
@@ -52,8 +52,9 @@ use rayon::{
     prelude::{IntoParallelRefIterator, ParallelSlice},
 };
 use sp1_curves::{
-    AffinePoint, EllipticCurve,
+    AffinePoint, CurveType, EllipticCurve,
     params::{FieldParameters, Limbs, NumLimbs, NumWords},
+    polynomial::Polynomial,
 };
 use sumcheck::{
     macros::{entered_span, exit_span},
@@ -66,11 +67,12 @@ use crate::{
     chip_handler::MemoryExpr,
     e2e::ShardContext,
     error::ZKVMError,
-    gadgets::{FieldOperation, field_op::FieldOpCols},
+    gadgets::{FieldOperation, field_op::FieldOpCols, util_expr::poly_mul_expr},
     instructions::riscv::insn_base::{StateInOut, WriteMEM},
     precompiles::{
-        SelectorTypeLayout, utils::merge_u8_slice_to_u16_limbs_pairs_and_extend,
-        weierstrass::EllipticCurveAddInstance,
+        SelectorTypeLayout,
+        utils::merge_u8_slice_to_u16_limbs_pairs_and_extend,
+        weierstrass::{EllipticCurveAddInstance, compact_field_relation::CompactFieldRelationCols},
     },
     scheme::utils::gkr_witness,
     structs::PointAndEval,
@@ -96,11 +98,26 @@ pub struct WeierstrassAddAssignWitCols<WitT, P: FieldParameters + NumLimbs> {
     pub(crate) slope_times_p_x_minus_x: FieldOpCols<WitT, P>,
 }
 
+#[derive(Clone, Debug, AlignedBorrow)]
+#[repr(C)]
+pub struct CompactSecp256k1AddAssignWitCols<WitT, P: FieldParameters + NumLimbs> {
+    pub p_x: Limbs<WitT, P::Limbs>,
+    pub p_y: Limbs<WitT, P::Limbs>,
+    pub q_x: Limbs<WitT, P::Limbs>,
+    pub q_y: Limbs<WitT, P::Limbs>,
+    pub(crate) slope: Limbs<WitT, P::Limbs>,
+    pub(crate) x3: Limbs<WitT, P::Limbs>,
+    pub(crate) y3: Limbs<WitT, P::Limbs>,
+    pub(crate) slope_relation: CompactFieldRelationCols<WitT, P>,
+    pub(crate) x_relation: CompactFieldRelationCols<WitT, P>,
+    pub(crate) y_relation: CompactFieldRelationCols<WitT, P>,
+}
+
 /// Weierstrass addition is implemented by a single layer.
 #[derive(Clone, Debug)]
-#[repr(C)]
-pub struct WeierstrassAddAssignLayer<WitT, P: FieldParameters + NumWords> {
-    pub wits: WeierstrassAddAssignWitCols<WitT, P>,
+pub enum WeierstrassAddAssignLayer<WitT, P: FieldParameters + NumWords> {
+    Generic(WeierstrassAddAssignWitCols<WitT, P>),
+    CompactSecp256k1(CompactSecp256k1AddAssignWitCols<WitT, P>),
 }
 
 #[derive(Clone, Debug)]
@@ -116,21 +133,50 @@ pub struct WeierstrassAddAssignLayout<E: ExtensionField, EC: EllipticCurve> {
 }
 
 impl<E: ExtensionField, EC: EllipticCurve> WeierstrassAddAssignLayout<E, EC> {
+    fn assert_compact_secp256k1_limb_bytes(
+        blu_events: &mut LkMultiplicity,
+        cols: &CompactSecp256k1AddAssignWitCols<E::BaseField, EC::BaseField>,
+    ) {
+        blu_events.assert_byte_fields(&cols.p_x.0);
+        blu_events.assert_byte_fields(&cols.p_y.0);
+        blu_events.assert_byte_fields(&cols.q_x.0);
+        blu_events.assert_byte_fields(&cols.q_y.0);
+        blu_events.assert_byte_fields(&cols.slope.0);
+        blu_events.assert_byte_fields(&cols.x3.0);
+        blu_events.assert_byte_fields(&cols.y3.0);
+    }
+
     fn new(cb: &mut CircuitBuilder<E>) -> Self {
-        let wits = WeierstrassAddAssignWitCols {
-            p_x: Limbs(GenericArray::generate(|_| cb.create_witin(|| "p_x"))),
-            p_y: Limbs(GenericArray::generate(|_| cb.create_witin(|| "p_y"))),
-            q_x: Limbs(GenericArray::generate(|_| cb.create_witin(|| "q_x"))),
-            q_y: Limbs(GenericArray::generate(|_| cb.create_witin(|| "q_y"))),
-            slope_denominator: FieldOpCols::create(cb, || "slope_denominator"),
-            slope_numerator: FieldOpCols::create(cb, || "slope_numerator"),
-            slope: FieldOpCols::create(cb, || "slope"),
-            slope_squared: FieldOpCols::create(cb, || "slope_squared"),
-            p_x_plus_q_x: FieldOpCols::create(cb, || "p_x_plus_q_x"),
-            x3_ins: FieldOpCols::create(cb, || "x3_ins"),
-            p_x_minus_x: FieldOpCols::create(cb, || "p_x_minus_x"),
-            y3_ins: FieldOpCols::create(cb, || "y3_ins"),
-            slope_times_p_x_minus_x: FieldOpCols::create(cb, || "slope_times_p_x_minus_x"),
+        let wits = match EC::CURVE_TYPE {
+            CurveType::Secp256k1 => {
+                WeierstrassAddAssignLayer::CompactSecp256k1(CompactSecp256k1AddAssignWitCols {
+                    p_x: Limbs(GenericArray::generate(|_| cb.create_witin(|| "p_x"))),
+                    p_y: Limbs(GenericArray::generate(|_| cb.create_witin(|| "p_y"))),
+                    q_x: Limbs(GenericArray::generate(|_| cb.create_witin(|| "q_x"))),
+                    q_y: Limbs(GenericArray::generate(|_| cb.create_witin(|| "q_y"))),
+                    slope: Limbs(GenericArray::generate(|_| cb.create_witin(|| "slope"))),
+                    x3: Limbs(GenericArray::generate(|_| cb.create_witin(|| "x3"))),
+                    y3: Limbs(GenericArray::generate(|_| cb.create_witin(|| "y3"))),
+                    slope_relation: CompactFieldRelationCols::create(cb, || "slope_relation"),
+                    x_relation: CompactFieldRelationCols::create(cb, || "x_relation"),
+                    y_relation: CompactFieldRelationCols::create(cb, || "y_relation"),
+                })
+            }
+            _ => WeierstrassAddAssignLayer::Generic(WeierstrassAddAssignWitCols {
+                p_x: Limbs(GenericArray::generate(|_| cb.create_witin(|| "p_x"))),
+                p_y: Limbs(GenericArray::generate(|_| cb.create_witin(|| "p_y"))),
+                q_x: Limbs(GenericArray::generate(|_| cb.create_witin(|| "q_x"))),
+                q_y: Limbs(GenericArray::generate(|_| cb.create_witin(|| "q_y"))),
+                slope_denominator: FieldOpCols::create(cb, || "slope_denominator"),
+                slope_numerator: FieldOpCols::create(cb, || "slope_numerator"),
+                slope: FieldOpCols::create(cb, || "slope"),
+                slope_squared: FieldOpCols::create(cb, || "slope_squared"),
+                p_x_plus_q_x: FieldOpCols::create(cb, || "p_x_plus_q_x"),
+                x3_ins: FieldOpCols::create(cb, || "x3_ins"),
+                p_x_minus_x: FieldOpCols::create(cb, || "p_x_minus_x"),
+                y3_ins: FieldOpCols::create(cb, || "y3_ins"),
+                slope_times_p_x_minus_x: FieldOpCols::create(cb, || "slope_times_p_x_minus_x"),
+            }),
         };
 
         let eq = cb.create_placeholder_structural_witin(|| "weierstrass_add_eq");
@@ -155,7 +201,7 @@ impl<E: ExtensionField, EC: EllipticCurve> WeierstrassAddAssignLayout<E, EC> {
         > = GenericArray::generate(|_| array::from_fn(|_| Expression::WitIn(0)));
 
         Self {
-            layer_exprs: WeierstrassAddAssignLayer { wits },
+            layer_exprs: wits,
             selector_type_layout,
             input32_exprs,
             output32_exprs,
@@ -230,6 +276,71 @@ impl<E: ExtensionField, EC: EllipticCurve> WeierstrassAddAssignLayout<E, EC> {
             );
         }
     }
+
+    #[allow(clippy::too_many_arguments)]
+    fn populate_compact_secp256k1_field_ops(
+        blu_events: &mut LkMultiplicity,
+        cols: &mut CompactSecp256k1AddAssignWitCols<E::BaseField, EC::BaseField>,
+        p_x: BigUint,
+        p_y: BigUint,
+        q_x: BigUint,
+        q_y: BigUint,
+    ) {
+        let modulus = EC::BaseField::modulus();
+        let slope_denominator = (&q_x + &modulus - &p_x) % &modulus;
+        let slope_numerator = (&q_y + &modulus - &p_y) % &modulus;
+        let slope = (&slope_numerator
+            * slope_denominator.modpow(&(modulus.clone() - 2u32), &modulus))
+            % &modulus;
+        let x3 = (&slope * &slope + &modulus - ((&p_x + &q_x) % &modulus)) % &modulus;
+        let y3 = (&slope * ((&p_x + &modulus - &x3) % &modulus) + &modulus - &p_y) % &modulus;
+
+        cols.slope = EC::BaseField::to_limbs_field(&slope);
+        cols.x3 = EC::BaseField::to_limbs_field(&x3);
+        cols.y3 = EC::BaseField::to_limbs_field(&y3);
+
+        let p_slope: Polynomial<E::BaseField> = cols.slope.clone().into();
+        let p_p_x: Polynomial<E::BaseField> = EC::BaseField::to_limbs_field(&p_x).into();
+        let p_p_y: Polynomial<E::BaseField> = EC::BaseField::to_limbs_field(&p_y).into();
+        let p_q_x: Polynomial<E::BaseField> = EC::BaseField::to_limbs_field(&q_x).into();
+        let p_q_y: Polynomial<E::BaseField> = EC::BaseField::to_limbs_field(&q_y).into();
+        let p_x3: Polynomial<E::BaseField> = cols.x3.clone().into();
+        let p_y3: Polynomial<E::BaseField> = cols.y3.clone().into();
+        let p_modulus = Polynomial::from_iter(EC::BaseField::modulus_field_iter::<E::BaseField>());
+
+        let slope_lhs = &p_slope * &(&p_q_x + &p_modulus - &p_p_x);
+        let slope_rhs = &p_q_y + &p_modulus - &p_p_y;
+        cols.slope_relation.populate_with_evals(
+            blu_events,
+            &slope_lhs,
+            &slope_rhs,
+            &modulus,
+            &(&slope * (&q_x + &modulus - &p_x)),
+            &(&q_y + &modulus - &p_y),
+        );
+
+        let x_lhs = &p_x3 + &p_p_x + &p_q_x;
+        let x_rhs = &p_slope * &p_slope;
+        cols.x_relation.populate_with_evals(
+            blu_events,
+            &x_lhs,
+            &x_rhs,
+            &modulus,
+            &(&x3 + &p_x + &q_x),
+            &(&slope * &slope),
+        );
+
+        let y_lhs = &p_y3 + &p_p_y;
+        let y_rhs = &p_slope * &(&p_p_x + &p_modulus - &p_x3);
+        cols.y_relation.populate_with_evals(
+            blu_events,
+            &y_lhs,
+            &y_rhs,
+            &modulus,
+            &(&y3 + &p_y),
+            &(&slope * (&p_x + &modulus - &x3)),
+        );
+    }
 }
 
 impl<E: ExtensionField, EC: EllipticCurve> ProtocolBuilder<E>
@@ -242,79 +353,128 @@ impl<E: ExtensionField, EC: EllipticCurve> ProtocolBuilder<E>
         _params: Self::Params,
     ) -> Result<Self, CircuitBuilderError> {
         let mut layout = WeierstrassAddAssignLayout::new(cb);
-        let wits = &layout.layer_exprs.wits;
+        let (p_x, p_y, q_x, q_y, x3, y3) = match &layout.layer_exprs {
+            WeierstrassAddAssignLayer::Generic(wits) => {
+                // slope = (q.y - p.y) / (q.x - p.x).
+                let slope = {
+                    wits.slope_numerator
+                        .eval(cb, &wits.q_y, &wits.p_y, FieldOperation::Sub)?;
 
-        // slope = (q.y - p.y) / (q.x - p.x).
-        let slope = {
-            wits.slope_numerator
-                .eval(cb, &wits.q_y, &wits.p_y, FieldOperation::Sub)?;
+                    wits.slope_denominator
+                        .eval(cb, &wits.q_x, &wits.p_x, FieldOperation::Sub)?;
 
-            wits.slope_denominator
-                .eval(cb, &wits.q_x, &wits.p_x, FieldOperation::Sub)?;
+                    wits.slope.eval(
+                        cb,
+                        &wits.slope_numerator.result,
+                        &wits.slope_denominator.result,
+                        FieldOperation::Div,
+                    )?;
 
-            wits.slope.eval(
-                cb,
-                &wits.slope_numerator.result,
-                &wits.slope_denominator.result,
-                FieldOperation::Div,
-            )?;
+                    &wits.slope.result
+                };
 
-            &wits.slope.result
+                // x = slope * slope - self.x - other.x.
+                let x = {
+                    wits.slope_squared
+                        .eval(cb, slope, slope, FieldOperation::Mul)?;
+
+                    wits.p_x_plus_q_x
+                        .eval(cb, &wits.p_x, &wits.q_x, FieldOperation::Add)?;
+
+                    wits.x3_ins.eval(
+                        cb,
+                        &wits.slope_squared.result,
+                        &wits.p_x_plus_q_x.result,
+                        FieldOperation::Sub,
+                    )?;
+
+                    &wits.x3_ins.result
+                };
+
+                // y = slope * (p.x - x_3n) - q.y.
+                {
+                    wits.p_x_minus_x
+                        .eval(cb, &wits.p_x, x, FieldOperation::Sub)?;
+
+                    wits.slope_times_p_x_minus_x.eval(
+                        cb,
+                        slope,
+                        &wits.p_x_minus_x.result,
+                        FieldOperation::Mul,
+                    )?;
+
+                    wits.y3_ins.eval(
+                        cb,
+                        &wits.slope_times_p_x_minus_x.result,
+                        &wits.p_y,
+                        FieldOperation::Sub,
+                    )?;
+                }
+
+                (
+                    &wits.p_x,
+                    &wits.p_y,
+                    &wits.q_x,
+                    &wits.q_y,
+                    &wits.x3_ins.result,
+                    &wits.y3_ins.result,
+                )
+            }
+            WeierstrassAddAssignLayer::CompactSecp256k1(wits) => {
+                cb.assert_bytes(|| "compact secp256k1 add p_x", &wits.p_x.0)?;
+                cb.assert_bytes(|| "compact secp256k1 add p_y", &wits.p_y.0)?;
+                cb.assert_bytes(|| "compact secp256k1 add q_x", &wits.q_x.0)?;
+                cb.assert_bytes(|| "compact secp256k1 add q_y", &wits.q_y.0)?;
+                cb.assert_bytes(|| "compact secp256k1 add slope", &wits.slope.0)?;
+                cb.assert_bytes(|| "compact secp256k1 add x3", &wits.x3.0)?;
+                cb.assert_bytes(|| "compact secp256k1 add y3", &wits.y3.0)?;
+
+                let p_slope: Polynomial<Expression<E>> = wits.slope.clone().into();
+                let p_p_x: Polynomial<Expression<E>> = wits.p_x.clone().into();
+                let p_p_y: Polynomial<Expression<E>> = wits.p_y.clone().into();
+                let p_q_x: Polynomial<Expression<E>> = wits.q_x.clone().into();
+                let p_q_y: Polynomial<Expression<E>> = wits.q_y.clone().into();
+                let p_x3: Polynomial<Expression<E>> = wits.x3.clone().into();
+                let p_y3: Polynomial<Expression<E>> = wits.y3.clone().into();
+                let p_modulus = Polynomial::from_iter(
+                    EC::BaseField::modulus_field_iter::<E::BaseField>().map(|x| x.expr()),
+                );
+                let modulus = EC::BaseField::modulus();
+
+                let slope_lhs = poly_mul_expr(&p_slope, &(&p_q_x + &p_modulus - &p_p_x));
+                let slope_rhs = &p_q_y + &p_modulus - &p_p_y;
+                wits.slope_relation
+                    .eval(cb, &slope_lhs, &slope_rhs, &modulus)?;
+
+                let x_lhs = &p_x3 + &p_p_x + &p_q_x;
+                let x_rhs = poly_mul_expr(&p_slope, &p_slope);
+                wits.x_relation.eval(cb, &x_lhs, &x_rhs, &modulus)?;
+
+                let y_lhs = &p_y3 + &p_p_y;
+                let y_rhs = poly_mul_expr(&p_slope, &(&p_p_x + &p_modulus - &p_x3));
+                wits.y_relation.eval(cb, &y_lhs, &y_rhs, &modulus)?;
+
+                (
+                    &wits.p_x, &wits.p_y, &wits.q_x, &wits.q_y, &wits.x3, &wits.y3,
+                )
+            }
         };
-
-        // x = slope * slope - self.x - other.x.
-        let x = {
-            wits.slope_squared
-                .eval(cb, slope, slope, FieldOperation::Mul)?;
-
-            wits.p_x_plus_q_x
-                .eval(cb, &wits.p_x, &wits.q_x, FieldOperation::Add)?;
-
-            wits.x3_ins.eval(
-                cb,
-                &wits.slope_squared.result,
-                &wits.p_x_plus_q_x.result,
-                FieldOperation::Sub,
-            )?;
-
-            &wits.x3_ins.result
-        };
-
-        // y = slope * (p.x - x_3n) - q.y.
-        {
-            wits.p_x_minus_x
-                .eval(cb, &wits.p_x, x, FieldOperation::Sub)?;
-
-            wits.slope_times_p_x_minus_x.eval(
-                cb,
-                slope,
-                &wits.p_x_minus_x.result,
-                FieldOperation::Mul,
-            )?;
-
-            wits.y3_ins.eval(
-                cb,
-                &wits.slope_times_p_x_minus_x.result,
-                &wits.p_y,
-                FieldOperation::Sub,
-            )?;
-        }
 
         // Constraint output32 from wits.x3_ins || wits.y3_ins by converting 8-bit limbs to 2x16-bit felts
         let mut output32 = Vec::with_capacity(<EC::BaseField as NumWords>::WordsCurvePoint::USIZE);
-        for limbs in [&wits.x3_ins.result, &wits.y3_ins.result] {
+        for limbs in [x3, y3] {
             merge_u8_slice_to_u16_limbs_pairs_and_extend::<E>(&limbs.0, &mut output32);
         }
         let output32 = output32.try_into().unwrap();
 
         let mut p_input32 = Vec::with_capacity(<EC::BaseField as NumWords>::WordsCurvePoint::USIZE);
-        for limbs in [&wits.p_x, &wits.p_y] {
+        for limbs in [p_x, p_y] {
             merge_u8_slice_to_u16_limbs_pairs_and_extend::<E>(&limbs.0, &mut p_input32);
         }
         let p_input32 = p_input32.try_into().unwrap();
 
         let mut q_input32 = Vec::with_capacity(<EC::BaseField as NumWords>::WordsCurvePoint::USIZE);
-        for limbs in [&wits.q_x, &wits.q_y] {
+        for limbs in [q_x, q_y] {
             merge_u8_slice_to_u16_limbs_pairs_and_extend::<E>(&limbs.0, &mut q_input32);
         }
         let q_input32 = q_input32.try_into().unwrap();
@@ -384,7 +544,8 @@ impl<E: ExtensionField, EC: EllipticCurve> ProtocolWitnessGenerator<E>
         let num_instances = wits[0].num_instances();
         let nthreads = max_usable_threads();
         let num_instance_per_batch = num_instances.div_ceil(nthreads).max(1);
-        let num_wit_cols = size_of::<WeierstrassAddAssignWitCols<u8, EC::BaseField>>();
+        let first_wit_id = self.first_wit_id();
+        let num_wit_cols = self.num_arithmetic_wit_cols();
         let [wits, structural_wits] = wits;
         let raw_witin_iter = wits.par_batch_iter_mut(num_instance_per_batch);
         let raw_structural_wits_iter = structural_wits.par_batch_iter_mut(num_instance_per_batch);
@@ -397,10 +558,11 @@ impl<E: ExtensionField, EC: EllipticCurve> ProtocolWitnessGenerator<E>
                     .zip_eq(eqs.chunks_mut(self.n_structural_witin))
                     .zip_eq(phase1_instances)
                     .for_each(|((row, eqs), phase1_instance)| {
-                        let cols: &mut WeierstrassAddAssignWitCols<E::BaseField, EC::BaseField> =
-                            row[self.layer_exprs.wits.p_x.0[0].id as usize..][..num_wit_cols] // TODO: Find a better way to write it.
-                                .borrow_mut();
-                        Self::populate_row(phase1_instance, cols, &mut lk_multiplicity);
+                        self.populate_row_from_slice(
+                            phase1_instance,
+                            &mut row[first_wit_id..][..num_wit_cols],
+                            &mut lk_multiplicity,
+                        );
                         for x in eqs.iter_mut() {
                             *x = E::BaseField::ONE;
                         }
@@ -430,6 +592,84 @@ impl<E: ExtensionField, EC: EllipticCurve> WeierstrassAddAssignLayout<E, EC> {
         cols.q_y = EC::BaseField::to_limbs_field(&q_y);
 
         Self::populate_field_ops(new_byte_lookup_events, cols, p_x, p_y, q_x, q_y);
+    }
+
+    fn populate_compact_secp256k1_row(
+        event: &EllipticCurveAddInstance<EC::BaseField>,
+        cols: &mut CompactSecp256k1AddAssignWitCols<E::BaseField, EC::BaseField>,
+        new_byte_lookup_events: &mut LkMultiplicity,
+    ) {
+        let p = &event.p;
+        let p = AffinePoint::<EC>::from_words_le(p);
+        let (p_x, p_y) = (p.x, p.y);
+        let q = &event.q;
+        let q = AffinePoint::<EC>::from_words_le(q);
+        let (q_x, q_y) = (q.x, q.y);
+
+        cols.p_x = EC::BaseField::to_limbs_field(&p_x);
+        cols.p_y = EC::BaseField::to_limbs_field(&p_y);
+        cols.q_x = EC::BaseField::to_limbs_field(&q_x);
+        cols.q_y = EC::BaseField::to_limbs_field(&q_y);
+
+        Self::populate_compact_secp256k1_field_ops(
+            new_byte_lookup_events,
+            cols,
+            p_x,
+            p_y,
+            q_x,
+            q_y,
+        );
+        Self::assert_compact_secp256k1_limb_bytes(new_byte_lookup_events, cols);
+    }
+
+    fn populate_row_from_slice(
+        &self,
+        event: &EllipticCurveAddInstance<EC::BaseField>,
+        row: &mut [E::BaseField],
+        new_byte_lookup_events: &mut LkMultiplicity,
+    ) {
+        match &self.layer_exprs {
+            WeierstrassAddAssignLayer::Generic(_) => {
+                let cols: &mut WeierstrassAddAssignWitCols<E::BaseField, EC::BaseField> =
+                    row.borrow_mut();
+                Self::populate_row(event, cols, new_byte_lookup_events);
+            }
+            WeierstrassAddAssignLayer::CompactSecp256k1(_) => {
+                let cols: &mut CompactSecp256k1AddAssignWitCols<E::BaseField, EC::BaseField> =
+                    row.borrow_mut();
+                Self::populate_compact_secp256k1_row(event, cols, new_byte_lookup_events);
+            }
+        }
+    }
+
+    fn first_wit_id(&self) -> usize {
+        match &self.layer_exprs {
+            WeierstrassAddAssignLayer::Generic(wits) => wits.p_x.0[0].id as usize,
+            WeierstrassAddAssignLayer::CompactSecp256k1(wits) => wits.p_x.0[0].id as usize,
+        }
+    }
+
+    fn num_arithmetic_wit_cols(&self) -> usize {
+        match &self.layer_exprs {
+            WeierstrassAddAssignLayer::Generic(_) => {
+                size_of::<WeierstrassAddAssignWitCols<u8, EC::BaseField>>()
+            }
+            WeierstrassAddAssignLayer::CompactSecp256k1(_) => {
+                size_of::<CompactSecp256k1AddAssignWitCols<u8, EC::BaseField>>()
+            }
+        }
+    }
+
+    fn output_limb_start_ids(&self) -> (usize, usize) {
+        match &self.layer_exprs {
+            WeierstrassAddAssignLayer::Generic(wits) => (
+                wits.x3_ins.result[0].id as usize,
+                wits.y3_ins.result[0].id as usize,
+            ),
+            WeierstrassAddAssignLayer::CompactSecp256k1(wits) => {
+                (wits.x3[0].id as usize, wits.y3[0].id as usize)
+            }
+        }
     }
 }
 
@@ -622,8 +862,7 @@ pub fn run_weierstrass_add<
             })
             .collect_vec();
 
-        let x_output_index_start = layout.layout.layer_exprs.wits.x3_ins.result[0].id as usize;
-        let y_output_index_start = layout.layout.layer_exprs.wits.y3_ins.result[0].id as usize;
+        let (x_output_index_start, y_output_index_start) = layout.layout.output_limb_start_ids();
         let got_outputs = phase1_witness
             .iter_rows()
             .take(num_instances)

--- a/ceno_zkvm/src/precompiles/weierstrass/weierstrass_add.rs
+++ b/ceno_zkvm/src/precompiles/weierstrass/weierstrass_add.rs
@@ -336,7 +336,7 @@ impl<E: ExtensionField, EC: EllipticCurve> WeierstrassAddAssignLayout<E, EC> {
             blu_events,
             &y_lhs,
             &y_rhs,
-            &modulus,
+            &(&BigUint::from(2u32) * &modulus),
             &(&y3 + &p_y),
             &(&slope * (&p_x + &modulus - &x3)),
         );
@@ -452,7 +452,8 @@ impl<E: ExtensionField, EC: EllipticCurve> ProtocolBuilder<E>
 
                 let y_lhs = &p_y3 + &p_p_y;
                 let y_rhs = poly_mul_expr(&p_slope, &(&p_p_x + &p_modulus - &p_x3));
-                wits.y_relation.eval(cb, &y_lhs, &y_rhs, &modulus)?;
+                wits.y_relation
+                    .eval(cb, &y_lhs, &y_rhs, &(BigUint::from(2u32) * &modulus))?;
 
                 (
                     &wits.p_x, &wits.p_y, &wits.q_x, &wits.q_y, &wits.x3, &wits.y3,
@@ -1009,10 +1010,82 @@ mod tests {
     use crate::precompiles::weierstrass::test_utils::random_point_pairs;
     use ff_ext::BabyBearExt4;
     use mpcs::BasefoldDefault;
-    use sp1_curves::weierstrass::{
-        SwCurve, WeierstrassParameters, bls12_381::Bls12381, bn254::Bn254, secp256k1::Secp256k1,
-        secp256r1::Secp256r1,
+    use sp1_curves::{
+        EllipticCurveParameters,
+        weierstrass::{
+            SwCurve, WeierstrassParameters, bls12_381::Bls12381, bn254::Bn254,
+            secp256k1::Secp256k1, secp256r1::Secp256r1,
+        },
     };
+
+    fn compact_secp256k1_zero_cols() -> CompactSecp256k1AddAssignWitCols<
+        <BabyBearExt4 as ExtensionField>::BaseField,
+        <SwCurve<Secp256k1> as EllipticCurveParameters>::BaseField,
+    > {
+        type F = <BabyBearExt4 as ExtensionField>::BaseField;
+        type P = <SwCurve<Secp256k1> as EllipticCurveParameters>::BaseField;
+
+        let zero_p = P::to_limbs_field::<F, _>(&BigUint::from(0u32));
+        let zero_u63 = Limbs(GenericArray::generate(|_| F::from_u8(0)));
+        let zero_relation = CompactFieldRelationCols {
+            quotient: zero_u63.clone(),
+            witness_low: zero_u63.clone(),
+            witness_high: zero_u63,
+            _marker: std::marker::PhantomData,
+        };
+
+        CompactSecp256k1AddAssignWitCols {
+            p_x: zero_p.clone(),
+            p_y: zero_p.clone(),
+            q_x: zero_p.clone(),
+            q_y: zero_p.clone(),
+            slope: zero_p.clone(),
+            x3: zero_p.clone(),
+            y3: zero_p,
+            slope_relation: zero_relation.clone(),
+            x_relation: zero_relation.clone(),
+            y_relation: zero_relation,
+        }
+    }
+
+    fn hex_biguint(s: &[u8]) -> BigUint {
+        BigUint::parse_bytes(s, 16).unwrap()
+    }
+
+    #[test]
+    fn test_compact_secp256k1_add_y_relation_uses_two_modulus_offset() {
+        type E = BabyBearExt4;
+        type EC = SwCurve<Secp256k1>;
+
+        let p_x = hex_biguint(b"f72f2bb83586fca7fa0b85188296f5eabaeb41a5e65a814940e2a20a1bd7ce73");
+        let p_y = hex_biguint(b"65b675cd0492c4f539b21c95055455e8f9bddea5d12982e46e80fa489b0bca16");
+        let q_x = hex_biguint(b"819d7ca7b46108cc721754ef2904acecf5bb9188b80599e9090b20bb257e8454");
+        let q_y = hex_biguint(b"a17a4340f9c08feffa1b1bf13879399bd50e00978b7199cd6d39eb43ad9cedde");
+
+        let modulus = <EC as EllipticCurveParameters>::BaseField::modulus();
+        let slope_denominator = (&q_x + &modulus - &p_x) % &modulus;
+        let slope_numerator = (&q_y + &modulus - &p_y) % &modulus;
+        let slope = (&slope_numerator
+            * slope_denominator.modpow(&(modulus.clone() - 2u32), &modulus))
+            % &modulus;
+        let x3 = (&slope * &slope + &modulus - ((&p_x + &q_x) % &modulus)) % &modulus;
+        let y3 = (&slope * ((&p_x + &modulus - &x3) % &modulus) + &modulus - &p_y) % &modulus;
+
+        let y_lhs_eval = &y3 + &p_y;
+        let y_rhs_eval = &slope * (&p_x + &modulus - &x3);
+        assert!(y_lhs_eval + &modulus * &modulus < y_rhs_eval);
+
+        let mut record = LkMultiplicity::default();
+        let mut cols = compact_secp256k1_zero_cols();
+        WeierstrassAddAssignLayout::<E, EC>::populate_compact_secp256k1_field_ops(
+            &mut record,
+            &mut cols,
+            p_x,
+            p_y,
+            q_x,
+            q_y,
+        );
+    }
 
     fn test_weierstrass_add_helper<WP: WeierstrassParameters>() {
         type E = BabyBearExt4;

--- a/ceno_zkvm/src/precompiles/weierstrass/weierstrass_decompress.rs
+++ b/ceno_zkvm/src/precompiles/weierstrass/weierstrass_decompress.rs
@@ -72,15 +72,18 @@ use crate::{
     error::ZKVMError,
     gadgets::{
         FieldOperation, field_inner_product::FieldInnerProductCols, field_op::FieldOpCols,
-        field_sqrt::FieldSqrtCols, range::FieldLtCols,
+        field_sqrt::FieldSqrtCols, range::FieldLtCols, util_expr::poly_mul_expr,
     },
     instructions::riscv::{
         constants::UINT_LIMBS,
         insn_base::{StateInOut, WriteMEM},
     },
     precompiles::{
-        SelectorTypeLayout, utils::merge_u8_slice_to_u16_limbs_pairs_and_extend,
-        weierstrass::EllipticCurveDecompressInstance,
+        SelectorTypeLayout,
+        utils::merge_u8_slice_to_u16_limbs_pairs_and_extend,
+        weierstrass::{
+            EllipticCurveDecompressInstance, compact_field_relation::CompactFieldRelationCols,
+        },
     },
     scheme::utils::gkr_witness,
     structs::PointAndEval,
@@ -105,11 +108,28 @@ pub struct WeierstrassDecompressWitCols<WitT, P: FieldParameters + NumLimbs + Nu
     pub(crate) neg_y: FieldOpCols<WitT, P>,
 }
 
+#[derive(Clone, Debug, AlignedBorrow)]
+#[repr(C)]
+pub struct CompactSecp256k1DecompressWitCols<WitT, P: FieldParameters + NumLimbs + NumWords> {
+    pub sign_bit: WitT,
+    pub(crate) x_limbs: Limbs<WitT, P::Limbs>,
+    pub(crate) y_limbs: Limbs<WitT, P::Limbs>,
+    pub(crate) old_output32: GenericArray<[WitT; UINT_LIMBS], P::WordsFieldElement>,
+    pub(crate) range_x: FieldLtCols<WitT, P>,
+    pub(crate) neg_y_range_check: FieldLtCols<WitT, P>,
+    pub(crate) x_2: Limbs<WitT, P::Limbs>,
+    pub(crate) rhs: Limbs<WitT, P::Limbs>,
+    pub(crate) x_2_relation: CompactFieldRelationCols<WitT, P>,
+    pub(crate) rhs_relation: CompactFieldRelationCols<WitT, P>,
+    pub(crate) pos_y: FieldSqrtCols<WitT, P>,
+    pub(crate) neg_y: FieldOpCols<WitT, P>,
+}
+
 /// Weierstrass decompress is implemented by a single layer.
 #[derive(Clone, Debug)]
-#[repr(C)]
-pub struct WeierstrassDecompressLayer<WitT, P: FieldParameters + NumWords> {
-    pub wits: WeierstrassDecompressWitCols<WitT, P>,
+pub enum WeierstrassDecompressLayer<WitT, P: FieldParameters + NumWords> {
+    Generic(WeierstrassDecompressWitCols<WitT, P>),
+    CompactSecp256k1(CompactSecp256k1DecompressWitCols<WitT, P>),
 }
 
 #[derive(Clone, Debug)]
@@ -128,27 +148,60 @@ pub struct WeierstrassDecompressLayout<E: ExtensionField, EC: EllipticCurve> {
 impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters>
     WeierstrassDecompressLayout<E, EC>
 {
+    fn assert_compact_secp256k1_limb_bytes(
+        record: &mut LkMultiplicity,
+        cols: &CompactSecp256k1DecompressWitCols<E::BaseField, EC::BaseField>,
+    ) {
+        record.assert_byte_fields(&cols.x_limbs.0);
+        record.assert_byte_fields(&cols.x_2.0);
+        record.assert_byte_fields(&cols.rhs.0);
+        record.assert_byte_fields(&cols.y_limbs.0);
+    }
+
     fn new(cb: &mut CircuitBuilder<E>) -> Self {
         match EC::CURVE_TYPE {
             CurveType::Secp256k1 | CurveType::Secp256r1 => {}
             _ => panic!("Unsupported curve"),
         }
 
-        let wits = WeierstrassDecompressWitCols {
-            sign_bit: cb.create_bit(|| "sign_bit").unwrap(),
-            x_limbs: Limbs(GenericArray::generate(|_| cb.create_witin(|| "x"))),
-            y_limbs: Limbs(GenericArray::generate(|_| cb.create_witin(|| "y"))),
-            old_output32: GenericArray::generate(|i| {
-                array::from_fn(|j| cb.create_witin(|| format!("old_output32_{}_{}", i, j)))
-            }),
-            range_x: FieldLtCols::create(cb, || "range_x"),
-            neg_y_range_check: FieldLtCols::create(cb, || "neg_y_range_check"),
-            x_2: FieldOpCols::create(cb, || "x_2"),
-            x_3: FieldOpCols::create(cb, || "x_3"),
-            ax_plus_b: FieldInnerProductCols::create(cb, || "ax_plus_b"),
-            x_3_plus_b_plus_ax: FieldOpCols::create(cb, || "x_3_plus_b_plus_ax"),
-            pos_y: FieldSqrtCols::create(cb, || "y"),
-            neg_y: FieldOpCols::create(cb, || "neg_y"),
+        let wits = match EC::CURVE_TYPE {
+            CurveType::Secp256k1 => {
+                WeierstrassDecompressLayer::CompactSecp256k1(CompactSecp256k1DecompressWitCols {
+                    sign_bit: cb.create_bit(|| "sign_bit").unwrap(),
+                    x_limbs: Limbs(GenericArray::generate(|_| cb.create_witin(|| "x"))),
+                    y_limbs: Limbs(GenericArray::generate(|_| cb.create_witin(|| "y"))),
+                    old_output32: GenericArray::generate(|i| {
+                        array::from_fn(|j| cb.create_witin(|| format!("old_output32_{}_{}", i, j)))
+                    }),
+                    range_x: FieldLtCols::create(cb, || "range_x"),
+                    neg_y_range_check: FieldLtCols::create(cb, || "neg_y_range_check"),
+                    x_2: Limbs(GenericArray::generate(|_| cb.create_witin(|| "x_2"))),
+                    rhs: Limbs(GenericArray::generate(|_| cb.create_witin(|| "rhs"))),
+                    x_2_relation: CompactFieldRelationCols::create(cb, || "x_2_relation"),
+                    rhs_relation: CompactFieldRelationCols::create(cb, || "rhs_relation"),
+                    pos_y: FieldSqrtCols::create(cb, || "y"),
+                    neg_y: FieldOpCols::create(cb, || "neg_y"),
+                })
+            }
+            CurveType::Secp256r1 => {
+                WeierstrassDecompressLayer::Generic(WeierstrassDecompressWitCols {
+                    sign_bit: cb.create_bit(|| "sign_bit").unwrap(),
+                    x_limbs: Limbs(GenericArray::generate(|_| cb.create_witin(|| "x"))),
+                    y_limbs: Limbs(GenericArray::generate(|_| cb.create_witin(|| "y"))),
+                    old_output32: GenericArray::generate(|i| {
+                        array::from_fn(|j| cb.create_witin(|| format!("old_output32_{}_{}", i, j)))
+                    }),
+                    range_x: FieldLtCols::create(cb, || "range_x"),
+                    neg_y_range_check: FieldLtCols::create(cb, || "neg_y_range_check"),
+                    x_2: FieldOpCols::create(cb, || "x_2"),
+                    x_3: FieldOpCols::create(cb, || "x_3"),
+                    ax_plus_b: FieldInnerProductCols::create(cb, || "ax_plus_b"),
+                    x_3_plus_b_plus_ax: FieldOpCols::create(cb, || "x_3_plus_b_plus_ax"),
+                    pos_y: FieldSqrtCols::create(cb, || "y"),
+                    neg_y: FieldOpCols::create(cb, || "neg_y"),
+                })
+            }
+            _ => panic!("Unsupported curve"),
         };
 
         let eq = cb.create_placeholder_structural_witin(|| "weierstrass_decompress_eq");
@@ -175,7 +228,7 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters>
         > = GenericArray::generate(|_| array::from_fn(|_| Expression::WitIn(0)));
 
         Self {
-            layer_exprs: WeierstrassDecompressLayer { wits },
+            layer_exprs: wits,
             selector_type_layout,
             input32_exprs,
             old_output32_exprs,
@@ -234,6 +287,68 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters>
             cols.y_limbs = EC::BaseField::to_limbs_field(&neg_y);
         }
     }
+
+    #[allow(clippy::too_many_arguments)]
+    fn populate_compact_secp256k1(
+        record: &mut LkMultiplicity,
+        cols: &mut CompactSecp256k1DecompressWitCols<E::BaseField, EC::BaseField>,
+        instance: &EllipticCurveDecompressInstance<EC::BaseField>,
+    ) {
+        cols.sign_bit = E::BaseField::from_bool(instance.sign_bit);
+        cols.old_output32 = GenericArray::generate(|i| {
+            [
+                E::BaseField::from_u32(instance.old_y_words[i] & ((1 << 16) - 1)),
+                E::BaseField::from_u32((instance.old_y_words[i] >> 16) & ((1 << 16) - 1)),
+            ]
+        });
+
+        let x = &instance.x;
+        let modulus = EC::BaseField::modulus();
+        cols.x_limbs = EC::BaseField::to_limbs_field(x);
+        cols.range_x.populate(record, x, &modulus);
+
+        let x_2 = (x * x) % &modulus;
+        let rhs = (&x_2 * x + BigUint::from(7u32)) % &modulus;
+        cols.x_2 = EC::BaseField::to_limbs_field(&x_2);
+        cols.rhs = EC::BaseField::to_limbs_field(&rhs);
+
+        let p_x: Polynomial<E::BaseField> = cols.x_limbs.clone().into();
+        let p_x_2: Polynomial<E::BaseField> = cols.x_2.clone().into();
+        let p_rhs: Polynomial<E::BaseField> = cols.rhs.clone().into();
+        let p_seven = Polynomial::from_coefficients(&[E::BaseField::from_u8(7)]);
+
+        cols.x_2_relation.populate_with_evals(
+            record,
+            &p_x_2,
+            &(&p_x * &p_x),
+            &modulus,
+            &x_2,
+            &(x * x),
+        );
+
+        cols.rhs_relation.populate_with_evals(
+            record,
+            &p_rhs,
+            &(&p_x_2 * &p_x + &p_seven),
+            &modulus,
+            &rhs,
+            &(&x_2 * x + BigUint::from(7u32)),
+        );
+
+        let y = cols.pos_y.populate(record, &rhs, secp256k1_sqrt);
+
+        let zero = BigUint::zero();
+        let neg_y = cols.neg_y.populate(record, &zero, &y, FieldOperation::Sub);
+        cols.neg_y_range_check.populate(record, &neg_y, &modulus);
+
+        if cols.pos_y.lsb.to_canonical_u64() == instance.sign_bit as u64 {
+            cols.y_limbs = EC::BaseField::to_limbs_field(&y);
+        } else {
+            cols.y_limbs = EC::BaseField::to_limbs_field(&neg_y);
+        }
+
+        Self::assert_compact_secp256k1_limb_bytes(record, cols);
+    }
 }
 
 impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> ProtocolBuilder<E>
@@ -249,80 +364,127 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> ProtocolBuild
             CurveType::Secp256k1 | CurveType::Secp256r1 => WeierstrassDecompressLayout::new(cb),
             _ => panic!("Unsupported curve"),
         };
-        let wits = &layout.layer_exprs.wits;
+        let (x_limbs, y_limbs, old_output32) = match &layout.layer_exprs {
+            WeierstrassDecompressLayer::Generic(wits) => {
+                let x_limbs = &wits.x_limbs;
+                let max_num_limbs = EC::BaseField::to_limbs_expr(&EC::BaseField::modulus());
 
-        let x_limbs = &wits.x_limbs;
-        let max_num_limbs = EC::BaseField::to_limbs_expr(&EC::BaseField::modulus());
+                wits.range_x.eval(cb, x_limbs, &max_num_limbs)?;
+                wits.x_2.eval(cb, x_limbs, x_limbs, FieldOperation::Mul)?;
+                wits.x_3
+                    .eval(cb, &wits.x_2.result, x_limbs, FieldOperation::Mul)?;
 
-        wits.range_x.eval(cb, x_limbs, &max_num_limbs)?;
-        wits.x_2.eval(cb, x_limbs, x_limbs, FieldOperation::Mul)?;
-        wits.x_3
-            .eval(cb, &wits.x_2.result, x_limbs, FieldOperation::Mul)?;
+                let b_const = EC::BaseField::to_limbs_expr::<E>(&EC::b_int());
+                let a_const = EC::BaseField::to_limbs_expr::<E>(&EC::a_int());
+                let params = [a_const, b_const];
+                let p_x: Polynomial<Expression<E>> = x_limbs.clone().into();
+                let p_one: Polynomial<Expression<E>> =
+                    EC::BaseField::to_limbs_expr::<E>(&BigUint::one()).into();
+                wits.ax_plus_b.eval(cb, &params, &[p_x, p_one])?;
+                wits.x_3_plus_b_plus_ax.eval(
+                    cb,
+                    &wits.x_3.result,
+                    &wits.ax_plus_b.result,
+                    FieldOperation::Add,
+                )?;
 
-        let b_const = EC::BaseField::to_limbs_expr::<E>(&EC::b_int());
-        let a_const = EC::BaseField::to_limbs_expr::<E>(&EC::a_int());
-        let params = [a_const, b_const];
-        let p_x: Polynomial<Expression<E>> = x_limbs.clone().into();
-        let p_one: Polynomial<Expression<E>> =
-            EC::BaseField::to_limbs_expr::<E>(&BigUint::one()).into();
-        wits.ax_plus_b.eval(cb, &params, &[p_x, p_one])?;
-        wits.x_3_plus_b_plus_ax.eval(
-            cb,
-            &wits.x_3.result,
-            &wits.ax_plus_b.result,
-            FieldOperation::Add,
-        )?;
+                wits.neg_y.eval(
+                    cb,
+                    &[Expression::<E>::ZERO].iter(),
+                    &wits.pos_y.multiplication.result,
+                    FieldOperation::Sub,
+                )?;
+                let modulus_limbs = EC::BaseField::to_limbs_expr(&EC::BaseField::modulus());
+                wits.neg_y_range_check
+                    .eval(cb, &wits.neg_y.result, &modulus_limbs)?;
 
-        wits.neg_y.eval(
-            cb,
-            &[Expression::<E>::ZERO].iter(),
-            &wits.pos_y.multiplication.result,
-            FieldOperation::Sub,
-        )?;
-        // Range check the `neg_y.result` to be canonical.
-        let modulus_limbs = EC::BaseField::to_limbs_expr(&EC::BaseField::modulus());
-        wits.neg_y_range_check
-            .eval(cb, &wits.neg_y.result, &modulus_limbs)?;
+                wits.pos_y
+                    .eval(cb, &wits.x_3_plus_b_plus_ax.result, wits.pos_y.lsb)?;
 
-        // Constrain that `y` is a square root. Note that `y.multiplication.result` is constrained
-        // to be canonical here. Since `y_limbs` is constrained to be either
-        // `y.multiplication.result` or `neg_y.result`, `y_limbs` will be canonical.
-        wits.pos_y
-            .eval(cb, &wits.x_3_plus_b_plus_ax.result, wits.pos_y.lsb)?;
+                let cond: Expression<E> = 1
+                    - (wits.pos_y.lsb.expr() + wits.sign_bit.expr()
+                        - 2 * wits.pos_y.lsb.expr() * wits.sign_bit.expr());
+                for (y, sqrt_y, neg_sqrt_y) in izip!(
+                    wits.y_limbs.0.iter(),
+                    wits.pos_y.multiplication.result.0.iter(),
+                    wits.neg_y.result.0.iter()
+                ) {
+                    cb.condition_require_equal(
+                        || "when lsb == sign_bit, y_limbs = sqrt(y), otherwise y_limbs = -sqrt(y)",
+                        cond.expr(),
+                        y.expr(),
+                        sqrt_y.expr(),
+                        neg_sqrt_y.expr(),
+                    )?;
+                }
 
-        // When the sign rule is LeastSignificantBit, the sign_bit should match the parity
-        // of the result. The parity of the square root result is given by the wits.y.lsb
-        // value. Thus, if the sign_bit matches the wits.y.lsb value, then the result
-        // should be the square root of the y value. Otherwise, the result should be the
-        // negative square root of the y value.
-        let cond: Expression<E> = 1
-            - (wits.pos_y.lsb.expr() + wits.sign_bit.expr()
-                - 2 * wits.pos_y.lsb.expr() * wits.sign_bit.expr());
-        for (y, sqrt_y, neg_sqrt_y) in izip!(
-            wits.y_limbs.0.iter(),
-            wits.pos_y.multiplication.result.0.iter(),
-            wits.neg_y.result.0.iter()
-        ) {
-            cb.condition_require_equal(
-                || "when lsb == sign_bit, y_limbs = sqrt(y), otherwise y_limbs = -sqrt(y)",
-                cond.expr(),
-                y.expr(),
-                sqrt_y.expr(),
-                neg_sqrt_y.expr(),
-            )?;
-        }
+                (&wits.x_limbs, &wits.y_limbs, &wits.old_output32)
+            }
+            WeierstrassDecompressLayer::CompactSecp256k1(wits) => {
+                cb.assert_bytes(|| "compact secp256k1 decompress x", &wits.x_limbs.0)?;
+                cb.assert_bytes(|| "compact secp256k1 decompress x_2", &wits.x_2.0)?;
+                cb.assert_bytes(|| "compact secp256k1 decompress rhs", &wits.rhs.0)?;
+                cb.assert_bytes(|| "compact secp256k1 decompress y", &wits.y_limbs.0)?;
+
+                let max_num_limbs = EC::BaseField::to_limbs_expr(&EC::BaseField::modulus());
+                wits.range_x.eval(cb, &wits.x_limbs, &max_num_limbs)?;
+
+                let p_x: Polynomial<Expression<E>> = wits.x_limbs.clone().into();
+                let p_x_2: Polynomial<Expression<E>> = wits.x_2.clone().into();
+                let p_rhs: Polynomial<Expression<E>> = wits.rhs.clone().into();
+                let p_seven = Polynomial::new(vec![E::BaseField::from_u8(7).expr()]);
+                let modulus = EC::BaseField::modulus();
+
+                let x_2_rhs = poly_mul_expr(&p_x, &p_x);
+                wits.x_2_relation.eval(cb, &p_x_2, &x_2_rhs, &modulus)?;
+
+                let rhs_rhs = poly_mul_expr(&p_x_2, &p_x) + &p_seven;
+                wits.rhs_relation.eval(cb, &p_rhs, &rhs_rhs, &modulus)?;
+
+                wits.neg_y.eval(
+                    cb,
+                    &[Expression::<E>::ZERO].iter(),
+                    &wits.pos_y.multiplication.result,
+                    FieldOperation::Sub,
+                )?;
+                let modulus_limbs = EC::BaseField::to_limbs_expr(&modulus);
+                wits.neg_y_range_check
+                    .eval(cb, &wits.neg_y.result, &modulus_limbs)?;
+
+                wits.pos_y.eval(cb, &wits.rhs, wits.pos_y.lsb)?;
+
+                let cond: Expression<E> = 1
+                    - (wits.pos_y.lsb.expr() + wits.sign_bit.expr()
+                        - 2 * wits.pos_y.lsb.expr() * wits.sign_bit.expr());
+                for (y, sqrt_y, neg_sqrt_y) in izip!(
+                    wits.y_limbs.0.iter(),
+                    wits.pos_y.multiplication.result.0.iter(),
+                    wits.neg_y.result.0.iter()
+                ) {
+                    cb.condition_require_equal(
+                        || "when lsb == sign_bit, y_limbs = sqrt(y), otherwise y_limbs = -sqrt(y)",
+                        cond.expr(),
+                        y.expr(),
+                        sqrt_y.expr(),
+                        neg_sqrt_y.expr(),
+                    )?;
+                }
+
+                (&wits.x_limbs, &wits.y_limbs, &wits.old_output32)
+            }
+        };
 
         let mut output32 =
             Vec::with_capacity(<EC::BaseField as NumWords>::WordsFieldElement::USIZE);
         merge_u8_slice_to_u16_limbs_pairs_and_extend::<E>(
-            &wits.y_limbs.0.iter().rev().cloned().collect::<Vec<_>>(),
+            &y_limbs.0.iter().rev().cloned().collect::<Vec<_>>(),
             &mut output32,
         );
         let output32 = output32.try_into().unwrap();
 
         let mut input32 = Vec::with_capacity(<EC::BaseField as NumWords>::WordsFieldElement::USIZE);
         merge_u8_slice_to_u16_limbs_pairs_and_extend::<E>(
-            &wits.x_limbs.0.iter().rev().cloned().collect::<Vec<_>>(),
+            &x_limbs.0.iter().rev().cloned().collect::<Vec<_>>(),
             &mut input32,
         );
         let input32 = input32.try_into().unwrap();
@@ -331,7 +493,7 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> ProtocolBuild
         layout.input32_exprs = input32;
         layout.output32_exprs = output32;
         layout.old_output32_exprs =
-            GenericArray::generate(|i| array::from_fn(|j| wits.old_output32[i][j].expr()));
+            GenericArray::generate(|i| array::from_fn(|j| old_output32[i][j].expr()));
 
         Ok(layout)
     }
@@ -396,8 +558,8 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> ProtocolWitne
         let nthreads = max_usable_threads();
         let num_instance_per_batch = num_instances.div_ceil(nthreads).max(1);
 
-        // The number of columns used for weierstrass decompress subcircuit.
-        let num_main_wit_cols = size_of::<WeierstrassDecompressWitCols<u8, EC::BaseField>>();
+        let first_wit_id = self.first_wit_id();
+        let num_main_wit_cols = self.num_arithmetic_wit_cols();
 
         let [wits, structural_wits] = wits;
         let raw_witin_iter = wits.par_batch_iter_mut(num_instance_per_batch);
@@ -411,16 +573,73 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> ProtocolWitne
                     .zip_eq(eqs.chunks_mut(self.n_structural_witin))
                     .zip_eq(phase1_instances)
                     .for_each(|((row, eqs), phase1_instance)| {
-                        let cols: &mut WeierstrassDecompressWitCols<E::BaseField, EC::BaseField> =
-                            row[self.layer_exprs.wits.sign_bit.id as usize..][..num_main_wit_cols] // TODO: Find a better way to write it.
-                                .borrow_mut();
-                        Self::populate(&mut lk_multiplicity, cols, phase1_instance);
+                        self.populate_row_from_slice(
+                            &mut lk_multiplicity,
+                            &mut row[first_wit_id..][..num_main_wit_cols],
+                            phase1_instance,
+                        );
 
                         for x in eqs.iter_mut() {
                             *x = E::BaseField::ONE;
                         }
                     });
             });
+    }
+}
+
+impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters>
+    WeierstrassDecompressLayout<E, EC>
+{
+    fn populate_row_from_slice(
+        &self,
+        record: &mut LkMultiplicity,
+        row: &mut [E::BaseField],
+        instance: &EllipticCurveDecompressInstance<EC::BaseField>,
+    ) {
+        match &self.layer_exprs {
+            WeierstrassDecompressLayer::Generic(_) => {
+                let cols: &mut WeierstrassDecompressWitCols<E::BaseField, EC::BaseField> =
+                    row.borrow_mut();
+                Self::populate(record, cols, instance);
+            }
+            WeierstrassDecompressLayer::CompactSecp256k1(_) => {
+                let cols: &mut CompactSecp256k1DecompressWitCols<E::BaseField, EC::BaseField> =
+                    row.borrow_mut();
+                Self::populate_compact_secp256k1(record, cols, instance);
+            }
+        }
+    }
+
+    fn first_wit_id(&self) -> usize {
+        match &self.layer_exprs {
+            WeierstrassDecompressLayer::Generic(wits) => wits.sign_bit.id as usize,
+            WeierstrassDecompressLayer::CompactSecp256k1(wits) => wits.sign_bit.id as usize,
+        }
+    }
+
+    fn num_arithmetic_wit_cols(&self) -> usize {
+        match &self.layer_exprs {
+            WeierstrassDecompressLayer::Generic(_) => {
+                size_of::<WeierstrassDecompressWitCols<u8, EC::BaseField>>()
+            }
+            WeierstrassDecompressLayer::CompactSecp256k1(_) => {
+                size_of::<CompactSecp256k1DecompressWitCols<u8, EC::BaseField>>()
+            }
+        }
+    }
+
+    pub(crate) fn sign_bit_wit(&self) -> WitIn {
+        match &self.layer_exprs {
+            WeierstrassDecompressLayer::Generic(wits) => wits.sign_bit,
+            WeierstrassDecompressLayer::CompactSecp256k1(wits) => wits.sign_bit,
+        }
+    }
+
+    fn y_output_limb_start_id(&self) -> usize {
+        match &self.layer_exprs {
+            WeierstrassDecompressLayer::Generic(wits) => wits.y_limbs.0[0].id as usize,
+            WeierstrassDecompressLayer::CompactSecp256k1(wits) => wits.y_limbs.0[0].id as usize,
+        }
     }
 }
 
@@ -613,7 +832,7 @@ pub fn run_weierstrass_decompress<
             )
             .collect_vec();
 
-        let y_output_index_start = layout.layout.layer_exprs.wits.y_limbs.0[0].id as usize;
+        let y_output_index_start = layout.layout.y_output_limb_start_id();
         let got_outputs = phase1_witness
             .iter_rows()
             .take(num_instances)

--- a/ceno_zkvm/src/precompiles/weierstrass/weierstrass_double.rs
+++ b/ceno_zkvm/src/precompiles/weierstrass/weierstrass_double.rs
@@ -52,8 +52,9 @@ use rayon::{
     prelude::{IntoParallelRefIterator, ParallelSlice},
 };
 use sp1_curves::{
-    AffinePoint, EllipticCurve,
-    params::{FieldParameters, Limbs, NumLimbs, NumWords, limbs_expr_from_vec, limbs_from_vec},
+    AffinePoint, CurveType, EllipticCurve,
+    params::{FieldParameters, Limbs, NumLimbs, NumWords},
+    polynomial::Polynomial,
     weierstrass::WeierstrassParameters,
 };
 use sumcheck::{
@@ -61,49 +62,26 @@ use sumcheck::{
     util::optimal_sumcheck_threads,
 };
 use transcript::{BasicTranscript, Transcript};
-use typenum::U63;
 use witness::{InstancePaddingStrategy, RowMajorMatrix};
 
 use crate::{
     chip_handler::MemoryExpr,
     e2e::ShardContext,
     error::ZKVMError,
-    gadgets::{
-        FieldOperation,
-        field_op::FieldOpCols,
-        util::{compute_root_quotient_and_shift, split_u16_limbs_to_u8_limbs},
-        util_expr::{eval_field_operation, poly_mul_expr},
-    },
+    gadgets::{FieldOperation, field_op::FieldOpCols, util_expr::poly_mul_expr},
     instructions::riscv::insn_base::{StateInOut, WriteMEM},
     precompiles::{
-        SelectorTypeLayout, utils::merge_u8_slice_to_u16_limbs_pairs_and_extend,
-        weierstrass::EllipticCurveDoubleInstance,
+        SelectorTypeLayout,
+        utils::merge_u8_slice_to_u16_limbs_pairs_and_extend,
+        weierstrass::{
+            EllipticCurveDoubleInstance, compact_field_relation::CompactFieldRelationCols,
+        },
     },
     scheme::utils::gkr_witness,
     structs::PointAndEval,
     witness::LkMultiplicity,
 };
 use p3::field::PrimeCharacteristicRing;
-use sp1_curves::{CurveType, polynomial::Polynomial};
-
-fn to_compact_relation_limbs_field<E, F>(x: &BigUint) -> Limbs<E, U63>
-where
-    E: From<F>,
-    F: p3::field::Field,
-{
-    let mut bytes = x.to_bytes_le();
-    bytes.resize(U63::USIZE, 0);
-    limbs_from_vec(bytes.into_iter().map(F::from_u8).collect())
-}
-
-fn to_compact_relation_limbs_expr<E>(x: &BigUint) -> Limbs<Expression<E>, U63>
-where
-    E: ExtensionField,
-{
-    let mut bytes = x.to_bytes_le();
-    bytes.resize(U63::USIZE, 0);
-    limbs_expr_from_vec(bytes.into_iter().map(E::BaseField::from_u8).collect())
-}
 
 #[derive(Clone, Debug, AlignedBorrow)]
 #[repr(C)]
@@ -121,102 +99,6 @@ pub struct GenericWeierstrassDoubleAssignWitCols<WitT, P: FieldParameters + NumL
     pub(crate) p_x_minus_x: FieldOpCols<WitT, P>,
     pub(crate) y3_ins: FieldOpCols<WitT, P>,
     pub(crate) slope_times_p_x_minus_x: FieldOpCols<WitT, P>,
-}
-
-#[derive(Clone, Debug, AlignedBorrow)]
-#[repr(C)]
-pub struct CompactFieldRelationCols<WitT, P: FieldParameters + NumLimbs> {
-    pub(crate) quotient: Limbs<WitT, U63>,
-    pub(crate) witness_low: Limbs<WitT, U63>,
-    pub(crate) witness_high: Limbs<WitT, U63>,
-    pub(crate) _marker: std::marker::PhantomData<P>,
-}
-
-impl<P: FieldParameters + NumLimbs> CompactFieldRelationCols<WitIn, P> {
-    pub fn create<E: ExtensionField, NR, N>(cb: &mut CircuitBuilder<E>, name_fn: N) -> Self
-    where
-        NR: Into<String>,
-        N: FnOnce() -> NR,
-    {
-        let name: String = name_fn().into();
-        Self {
-            quotient: Limbs(GenericArray::generate(|_| {
-                cb.create_witin(|| format!("{}_quotient", name))
-            })),
-            witness_low: Limbs(GenericArray::generate(|_| {
-                cb.create_witin(|| format!("{}_witness_low", name))
-            })),
-            witness_high: Limbs(GenericArray::generate(|_| {
-                cb.create_witin(|| format!("{}_witness_high", name))
-            })),
-            _marker: std::marker::PhantomData,
-        }
-    }
-}
-
-impl<F: SmallField, P: FieldParameters + NumLimbs> CompactFieldRelationCols<F, P> {
-    pub fn populate(
-        &mut self,
-        record: &mut LkMultiplicity,
-        lhs: &Polynomial<F>,
-        rhs: &Polynomial<F>,
-        positive_modulus_offset: &BigUint,
-        quotient: &BigUint,
-    ) {
-        let p_modulus: Polynomial<F> = P::to_limbs_field::<F, _>(&P::modulus()).into();
-        let p_offset: Polynomial<F> =
-            to_compact_relation_limbs_field::<F, _>(positive_modulus_offset).into();
-        let p_quotient: Polynomial<F> = to_compact_relation_limbs_field::<F, _>(quotient).into();
-        let p_vanishing = lhs + &(&p_offset * &p_modulus) - rhs - &(&p_quotient * &p_modulus);
-
-        let p_witness = compute_root_quotient_and_shift(
-            &p_vanishing,
-            P::WITNESS_OFFSET,
-            P::NB_BITS_PER_LIMB as u32,
-            U63::USIZE,
-        );
-        let (p_witness_low, p_witness_high): (Vec<F>, Vec<F>) =
-            split_u16_limbs_to_u8_limbs(&p_witness);
-
-        self.quotient = p_quotient.into();
-        self.witness_low = Limbs(p_witness_low.try_into().unwrap());
-        self.witness_high = Limbs(p_witness_high.try_into().unwrap());
-
-        record.assert_byte_fields(&self.quotient.0);
-        record.assert_byte_fields(&self.witness_low.0);
-        record.assert_byte_fields(&self.witness_high.0);
-    }
-}
-
-impl<Expr: Clone, P: FieldParameters + NumLimbs> CompactFieldRelationCols<Expr, P> {
-    pub fn eval<E>(
-        &self,
-        builder: &mut CircuitBuilder<E>,
-        lhs: &Polynomial<Expression<E>>,
-        rhs: &Polynomial<Expression<E>>,
-        positive_modulus_offset: &BigUint,
-    ) -> Result<(), CircuitBuilderError>
-    where
-        E: ExtensionField,
-        Expr: ToExpr<E, Output = Expression<E>>,
-        Expression<E>: From<Expr>,
-    {
-        let p_limbs =
-            Polynomial::from_iter(P::modulus_field_iter::<E::BaseField>().map(|x| x.expr()));
-        let p_offset = to_compact_relation_limbs_expr::<E>(positive_modulus_offset);
-        let p_offset: Polynomial<Expression<E>> = p_offset.into();
-        let p_quotient: Polynomial<Expression<E>> = self.quotient.clone().into();
-        let p_vanishing =
-            lhs + &poly_mul_expr(&p_offset, &p_limbs) - rhs - &poly_mul_expr(&p_quotient, &p_limbs);
-
-        let p_witness_low = self.witness_low.0.iter().into();
-        let p_witness_high = self.witness_high.0.iter().into();
-        eval_field_operation::<E, P>(builder, &p_vanishing, &p_witness_low, &p_witness_high)?;
-
-        builder.assert_bytes(|| "compact relation quotient", &self.quotient.0)?;
-        builder.assert_bytes(|| "compact relation witness_low", &self.witness_low.0)?;
-        builder.assert_bytes(|| "compact relation witness_high", &self.witness_high.0)
-    }
 }
 
 #[derive(Clone, Debug, AlignedBorrow)]


### PR DESCRIPTION
## Problem

`Ecall_WeierstrassAddAssign_Secp256k1` and `Ecall_WeierstrassDecompress_Secp256k1` still used generic multi-`FieldOpCols` layouts after the Secp256k1 double optimization. This kept avoidable witness columns, lookup operations, and zero constraints in hot elliptic-curve precompile paths.

The first compact add/decompress version also exposed a scheduler side effect: lower EC preflight cell estimates let the block planner pack more Keccak calls into one shard, crossing the KeccakCore `2^18 -> 2^19` padding cliff and triggering a CI memory-pool OOM on block `23817600`.

## Design Rationale

Reuse the compact fused modular-relation strategy from PR #1385 for Secp256k1 add and decompress only.

For Secp256k1 add, replace the 9-step generic field-op chain with three fused relations:

- `slope * (q_x - p_x) = q_y - p_y`
- `x3 + p_x + q_x = slope^2`
- `y3 + p_y = slope * (p_x - x3)`

For Secp256k1 decompress, keep the existing square-root proof and sign-bit selection, but compact the RHS construction to:

- `x2 = x^2`
- `rhs = x2 * x + 7`

The syscall ABI, opcode names, memory records, writeback behavior, and guest-visible semantics are unchanged. Non-Secp256k1 add/decompress layouts stay on the generic path.

The compact relation helper includes explicit byte/range checks for compact witness limbs, carries, quotients, and relation outputs. This preserves the audit requirement from PR #1385 and avoids dropping lookup/range constraints while reducing duplicated relation logic.

Keccak preflight weighting was adjusted from a coarse `2x` multiplier to a fractional `33/16` static estimate. This is planner-only and prevents Keccak shard packing from crossing the 8192-instance padding cliff without the capacity loss of a coarse `3x` multiplier.

## Change Highlights

- `ceno_zkvm`: share compact Weierstrass field-relation helper across compact EC layouts.
- `ceno_zkvm`: route only `CurveType::Secp256k1` add through the compact three-relation layout.
- `ceno_zkvm`: route only `CurveType::Secp256k1` decompress RHS through the compact two-relation layout.
- `ceno_zkvm`: keep `Bn254`, `Bls12381`, and `Secp256r1` add/decompress behavior unchanged.
- `ceno_zkvm`: add tests covering compact Secp256k1 add relation offset/range behavior and Keccak preflight cell estimate rounding.
- `ceno_zkvm`: tune Keccak preflight cell estimate to avoid memory-pool OOM caused by shifted shard boundaries.

## Benchmark / Performance Impact

Structural measurements use PR #1385 head (`722cd60f`, after compact Secp256k1 double) as the baseline.

`Ecall_WeierstrassAddAssign_Secp256k1`:

| Metric | Baseline | This PR | Delta |
|--------|----------|---------|-------|
| Witness columns | 1935 | 906 | -1029 (-53.2%) |
| Lookup operations | 921 | 475 | -446 (-48.4%) |
| Total zero constraints | 602 | 317 | -285 (-47.3%) |
| Max zero-constraint degree | 2 | 2 | unchanged |
| Main zerocheck sumcheck degree | 3 | 3 | unchanged |

`Ecall_WeierstrassDecompress_Secp256k1`:

| Metric | Baseline | This PR | Delta |
|--------|----------|---------|-------|
| Witness columns | 1393 | 1083 | -310 (-22.3%) |
| Lookup operations | 625 | 505 | -120 (-19.2%) |
| Total zero constraints | 634 | 570 | -64 (-10.1%) |
| Max zero-constraint degree | 3 | 3 | unchanged |
| Main zerocheck sumcheck degree | 4 | 4 | unchanged |

CI benchmark baseline is PR #1385's benchmark result. This PR result uses `feat/ec_add_decompress_opt` with the updated default `max_cell_per_shard=1245708288`.

Block `23817600`:

| Metric | PR #1385 baseline | This PR | Delta |
|--------|-------------------|---------|-------|
| Run | [29321553436](https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/29321553436) | [29344335505](https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/29344335505) | - |
| Ceno version | `abaa2ca027b7bc5af06b5474933515030dba7ded` | `feat/ec_add_decompress_opt` | - |
| max_cell_per_shard | `1207959552` | `1245708288` | +3.125% |
| E2E total time | 187.000s | 188.000s | +1.000s (+0.5%) |
| Profiled total | 72.700s | 72.870s | +0.170s (+0.2%) |
| App prove | 55.600s | 56.400s | +0.800s (+1.4%) |
| Recursion | 10.500s | 9.950s | -0.550s (-5.2%) |
| Total create proof | 183.645s | 184.306s | +0.661s (+0.4%) |
| Prove tower relation GPU | 179.100s | 167.664s | -11.436s (-6.4%) |
| App prove breakdown total | 235.889s | 225.230s | -10.659s (-4.5%) |
| Keccak/GPU shards | 12 | 12 | unchanged |
| Max KeccakCore instances | 7922 | 7993 | +71 (+0.9%) |

Block `25529400`:

| Metric | PR #1385 baseline | This PR | Delta |
|--------|-------------------|---------|-------|
| Run | [29322399330](https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/29322399330) | [29345347027](https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/29345347027) | - |
| Ceno version | `abaa2ca027b7bc5af06b5474933515030dba7ded` | `feat/ec_add_decompress_opt` | - |
| max_cell_per_shard | `1207959552` | `1245708288` | +3.125% |
| E2E total time | 164.000s | 161.000s | -3.000s (-1.8%) |
| Profiled total | 113.200s | 110.800s | -2.400s (-2.1%) |
| App prove | 88.100s | 87.300s | -0.800s (-0.9%) |
| Recursion | 13.700s | 12.200s | -1.500s (-10.9%) |
| Total create proof | 159.011s | 157.436s | -1.575s (-1.0%) |
| Prove tower relation GPU | 273.248s | 292.534s | +19.286s (+7.1%) |
| App prove breakdown total | 372.328s | 385.081s | +12.753s (+3.4%) |
| Keccak/GPU shards | 19 | 19 | unchanged |
| Max KeccakCore instances | 7985 | 8075 | +90 (+1.1%) |

OOM regression check:

| Block | Previous problematic run | Latest this PR run | Result |
|-------|--------------------------|--------------------|--------|
| `23817600` | [29337463675](https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/29337463675): failed with `Remaining tasks are too big for the memory pool`, max KeccakCore `8256` | [29344335505](https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/29344335505): 12 shards, max KeccakCore `7993` | Passed; Keccak OOM did not appear. |
| `25529400` | Historical stress block for the same memory-pool error | [29345347027](https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/29345347027): 19 shards, max KeccakCore `8075` | Passed; Keccak OOM did not appear. |

Raw summaries:

- PR #1385 baseline, block `23817600`: https://github.com/scroll-tech/ceno-reth-benchmark/blob/gh-pages/benchmarks-dispatch/refs/heads/feat/preflight/mainnet23817600-20260714-172621_summary.md
- This PR, block `23817600`: https://github.com/scroll-tech/ceno-reth-benchmark/blob/gh-pages/benchmarks-dispatch/refs/heads/feat/preflight/mainnet23817600-20260714-231519_summary.md
- PR #1385 baseline, block `25529400`: https://github.com/scroll-tech/ceno-reth-benchmark/blob/gh-pages/benchmarks-dispatch/refs/heads/feat/preflight/mainnet25529400-20260714-173957_summary.md
- This PR, block `25529400`: https://github.com/scroll-tech/ceno-reth-benchmark/blob/gh-pages/benchmarks-dispatch/refs/heads/feat/preflight/mainnet25529400-20260714-232908_summary.md

### Operation

| Operation | PR #1385 baseline | this PR | Improve (baseline -> this PR) |
|-----------|-------------------|---------|-------------------------------|
| Secp256k1 add syscall | Structural only | Structural only | Witness columns -53.2%, lookups -48.4%, zero constraints -47.3% |
| Secp256k1 decompress syscall | Structural only | Structural only | Witness columns -22.3%, lookups -19.2%, zero constraints -10.1% |

### Layer

| Layer | PR #1385 baseline (s) | this PR (s) | Improve (baseline -> this PR) |
|-------|-----------------------|-------------|-------------------------------|
| App prove, block `23817600` | 55.600 | 56.400 | +0.800s (+1.4%) |
| Recursion, block `23817600` | 10.500 | 9.950 | -0.550s (-5.2%) |
| E2E total, block `23817600` | 187.000 | 188.000 | +1.000s (+0.5%) |
| App prove, block `25529400` | 88.100 | 87.300 | -0.800s (-0.9%) |
| Recursion, block `25529400` | 13.700 | 12.200 | -1.500s (-10.9%) |
| E2E total, block `25529400` | 164.000 | 161.000 | -3.000s (-1.8%) |

Benchmark command(s):

```sh
# GitHub Actions workflow_dispatch: Ceno Benchmark v2
# Baseline: PR #1385 runs 29321553436 and 29322399330
# This PR: block_number=23817600, CENO_PINNED_REF_VALUE=feat/ec_add_decompress_opt, max_cell_per_shard=1245708288
# This PR: block_number=25529400, CENO_PINNED_REF_VALUE=feat/ec_add_decompress_opt, max_cell_per_shard=1245708288
```

Environment (CPU/GPU, core count, rust toolchain, commit hash):

GitHub Actions `scroll-tech/ceno-reth-benchmark` workflow `Ceno Benchmark v2`; same launch parameters as PR #1385 benchmark runs except Ceno version and `max_cell_per_shard`. This PR was benchmarked from branch `feat/ec_add_decompress_opt` with `max_cell_per_shard=1245708288`.

raw data:

- PR #1385 baseline, block `23817600`: https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/29321553436
- This PR, block `23817600`: https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/29344335505
- PR #1385 baseline, block `25529400`: https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/29322399330
- This PR, block `25529400`: https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/29345347027

## Testing

```sh
cargo fmt --check
cargo check -p ceno_zkvm --tests
RUST_MIN_STACK=33554432 cargo test -p ceno_zkvm test_compact_secp256k1_add_y_relation_uses_two_modulus_offset -- --nocapture
RUST_MIN_STACK=33554432 cargo test -p ceno_zkvm weierstrass_add -- --nocapture
RUST_MIN_STACK=33554432 cargo test -p ceno_zkvm weierstrass_decompress -- --nocapture
cargo test -p ceno_zkvm keccak_cell_estimate_uses_fractional_ceiling -- --nocapture
cargo build --release -p examples --example secp256k1_add_syscall
cargo build --release -p examples --example secp256k1_decompress_syscall
```

## Risks and Rollout

Risk is limited to Secp256k1 add/decompress precompile circuits and the static Keccak preflight scheduler estimate. Rollback is to restore the generic Secp256k1 add/decompress layouts and the previous Keccak preflight multiplier.

The compact relation helper explicitly range-checks compact witness limbs, output/result limbs, carry limbs, and quotient limbs. The structural lookup-operation drop is explained by removed generic `FieldOpCols`, not by missing range checks.

## Follow-ups (optional)

- Revisit Keccak scheduler estimation with a more exact per-chip memory model if additional shard-boundary cliffs appear.

## Copilot Reviewer Directive (keep this section)

When Copilot reviews this PR, apply `.github/copilot-instructions.md` strictly.
