### PR TITLE
Use peak-cell ecall accounting for shard planning

### DIFF
--- a/ceno_cli/src/sdk.rs
+++ b/ceno_cli/src/sdk.rs
@@ -1,6 +1,8 @@
 use std::{marker::PhantomData, sync::Arc};
 
 use anyhow::{Context, Result};
+#[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+use ceno_emul::StepCellExtractor;
 use ceno_emul::{Platform, Program};
 use ceno_host::CenoStdin;
 use ceno_recursion_v2::{
@@ -10,8 +12,10 @@ use ceno_recursion_v2::{
         warm_child_vk_digest_cache,
     },
 };
+#[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+use ceno_zkvm::e2e::prepare_preflight_aot_program;
 use ceno_zkvm::{
-    e2e::{MultiProver, run_e2e_proof, setup_program},
+    e2e::{MultiProver, run_e2e_proof_with_precompiled_aot, setup_program},
     scheme::{
         ZKVMProof, create_backend, create_prover, hal::ProverDevice,
         mock_prover::LkMultiplicityKey, prover::ZKVMProver, verifier::ZKVMVerifier,
@@ -76,6 +80,8 @@ where
     pub zkvm_pk: Option<Arc<ZKVMProvingKey<E, PCS>>>,
     pub zkvm_vk: Option<ZKVMVerifyingKey<E, PCS>>,
     pub zkvm_prover: Option<ZKVMProver<E, PCS, PB, PD>>,
+    #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+    pub preflight_aot_program: Option<Arc<ceno_emul::aot::AotProgram>>,
 
     aggregation_options: Option<AggregationOptions>,
     _phantom: PhantomData<(SC, VC)>,
@@ -97,6 +103,8 @@ where
             zkvm_pk: None,
             zkvm_vk: None,
             zkvm_prover: None,
+            #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+            preflight_aot_program: None,
             aggregation_options: None,
             _phantom: PhantomData,
         }
@@ -115,6 +123,8 @@ where
             zkvm_pk: None,
             zkvm_vk: None,
             zkvm_prover: None,
+            #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+            preflight_aot_program: None,
             aggregation_options: None,
             _phantom: PhantomData,
         }
@@ -168,6 +178,33 @@ where
         self.zkvm_prover = Some(ZKVMProver::new(pk, device));
     }
 
+    #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+    pub fn prepare_preflight_aot(&mut self, hints: &CenoStdin) {
+        match ceno_emul::EmulatorBackend::from_env()
+            .unwrap_or_else(|err| panic!("invalid emulator backend for SDK AOT preparation: {err}"))
+        {
+            ceno_emul::EmulatorBackend::Interp => {
+                self.preflight_aot_program = None;
+                return;
+            }
+            ceno_emul::EmulatorBackend::Aot => {}
+        }
+        let Some(zkvm_prover) = self.zkvm_prover.as_ref() else {
+            panic!("ZKVMProver is not initialized")
+        };
+        let init_full_mem = zkvm_prover.setup_init_mem(&Vec::from(hints));
+        let ctx = zkvm_prover.pk.program_ctx.as_ref().unwrap();
+        let raw_step_cell_extractor = Arc::clone(&ctx.system_config.config);
+        let step_cell_extractor: Arc<dyn StepCellExtractor> = raw_step_cell_extractor;
+        self.preflight_aot_program = Some(prepare_preflight_aot_program(
+            ctx.program.clone(),
+            &ctx.platform,
+            &ctx.multi_prover,
+            step_cell_extractor,
+            &init_full_mem,
+        ));
+    }
+
     pub fn generate_base_proof(
         &self,
         hints: CenoStdin,
@@ -177,13 +214,15 @@ where
     ) -> Vec<ZKVMProof<E, PCS>> {
         if let Some(zkvm_prover) = self.zkvm_prover.as_ref() {
             let init_full_mem = zkvm_prover.setup_init_mem(&Vec::from(&hints));
-            run_e2e_proof::<E, PCS, PB, PD>(
+            run_e2e_proof_with_precompiled_aot::<E, PCS, PB, PD>(
                 zkvm_prover,
                 &init_full_mem,
                 public_io_digest,
                 max_steps,
                 false,
                 shard_id,
+                #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+                self.preflight_aot_program.clone(),
             )
         } else {
             panic!("ZKVMProver is not initialized")

--- a/ceno_emul/src/aot.rs
+++ b/ceno_emul/src/aot.rs
@@ -1429,7 +1429,7 @@ fn emit_preflight_direct_block_plan_entry(
     writeln!(file, "    movq (%rax), %r9")?;
     writeln!(file, "    addq %r8, %r9")?;
     writeln!(file, "    cmpq %r10, %r9")?;
-    writeln!(file, "    jae {split_label}")?;
+    writeln!(file, "    ja {split_label}")?;
     writeln!(
         file,
         "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_CYCLE_OFFSET}(%r12), %rax"

--- a/ceno_emul/src/tracer.rs
+++ b/ceno_emul/src/tracer.rs
@@ -1457,6 +1457,24 @@ impl PreflightTracer {
             .unwrap_or(0)
     }
 
+    #[inline(always)]
+    fn observe_current_step(&mut self, ecall_code: Option<Word>) {
+        if let Some(planner) = self.planner.as_mut() {
+            let step_cells = self
+                .config
+                .step_cell_extractor
+                .as_ref()
+                .map(|extractor| extractor.cells_for_kind(self.last_kind, ecall_code))
+                .unwrap_or(0);
+            if let Some(ecall_code) = ecall_code {
+                planner.observe_ecall_step(self.cycle, ecall_code, step_cells);
+            } else {
+                planner.observe_step(self.cycle, step_cells);
+            }
+            self.current_shard_start_cycle = planner.current_shard_start_cycle();
+        }
+    }
+
     #[cfg_attr(
         not(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux")),
         allow(dead_code)
@@ -1555,6 +1573,8 @@ impl PreflightTracer {
         self.pc.before = step.pc_before;
         self.last_kind = step.kind;
         self.last_rs1 = None;
+        debug_assert!(!matches!(step.kind, InsnKind::ECALL));
+        self.observe_current_step(None);
 
         if step.flags & NATIVE_TRACE_READ_RS1 != 0 {
             self.track_access(
@@ -1597,25 +1617,6 @@ impl Tracer for PreflightTracer {
 
     #[inline(always)]
     fn advance(&mut self) -> Self::Record {
-        if let Some(planner) = self.planner.as_mut() {
-            // compute whether next step should bump the cycle
-            let step_cells = self
-                .config
-                .step_cell_extractor
-                .as_ref()
-                .map(|extractor| extractor.cells_for_kind(self.last_kind, self.last_rs1))
-                .unwrap_or(0);
-            if matches!(self.last_kind, InsnKind::ECALL) {
-                planner.observe_ecall_step(
-                    self.cycle,
-                    self.last_rs1.unwrap_or_default(),
-                    step_cells,
-                );
-            } else {
-                planner.observe_step(self.cycle, step_cells);
-            }
-            self.current_shard_start_cycle = planner.current_shard_start_cycle();
-        }
         self.cycle += Self::SUBCYCLES_PER_INSN;
         self.reset_register_tracking();
     }
@@ -1634,6 +1635,9 @@ impl Tracer for PreflightTracer {
         self.pc.before = pc.baddr();
         self.last_kind = value.kind;
         self.last_rs1 = None;
+        if !matches!(value.kind, InsnKind::ECALL) {
+            self.observe_current_step(None);
+        }
     }
 
     #[inline(always)]
@@ -1653,6 +1657,7 @@ impl Tracer for PreflightTracer {
         self.register_reads_tracked += 1;
         if matches!(self.last_kind, InsnKind::ECALL) && idx == Platform::reg_ecall() {
             self.last_rs1 = Some(value);
+            self.observe_current_step(Some(value));
         }
         self.track_access(addr, subcycle);
     }
@@ -1847,6 +1852,42 @@ impl<T: fmt::Debug> fmt::Debug for Change<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[derive(Debug)]
+    struct OneCellPerStep;
+
+    impl StepCellExtractor for OneCellPerStep {
+        fn cells_for_kind(&self, _kind: InsnKind, _rs1_value: Option<Word>) -> u64 {
+            1
+        }
+    }
+
+    #[test]
+    fn preflight_splits_before_tracking_current_step_accesses() {
+        let config = PreflightTracerConfig::new(true, 1, Cycle::MAX)
+            .with_step_cell_extractor(Arc::new(OneCellPerStep));
+        let mut tracer = PreflightTracer::new(&CENO_PLATFORM, config);
+        let insn = Instruction {
+            kind: InsnKind::ADDI,
+            ..Default::default()
+        };
+
+        tracer.fetch(0u32.into(), insn);
+        tracer.load_register(1, 0);
+        tracer.advance();
+
+        tracer.fetch(WordAddr::from(PC_STEP_SIZE as u32), insn);
+        tracer.load_register(1, 0);
+
+        assert_eq!(
+            tracer.planner.as_ref().unwrap().shard_cycle_boundaries(),
+            &[PreflightTracer::SUBCYCLES_PER_INSN, 8]
+        );
+        assert_eq!(
+            tracer.next_accesses.get(&4).map(SmallVec::as_slice),
+            Some(&[(Platform::register_vma(1).into(), 8)][..])
+        );
+    }
 
     #[test]
     fn test_step_record_is_copy_and_compact() {

--- a/ceno_emul/src/tracer.rs
+++ b/ceno_emul/src/tracer.rs
@@ -319,6 +319,8 @@ pub struct ShardPlanBuilder {
     max_cycle_per_shard: Cycle,
     current_shard_start_cycle: Cycle,
     cur_cells: u64,
+    cur_ecall_counts: BTreeMap<Word, u64>,
+    cur_ecall_peak_cells: BTreeMap<Word, u64>,
     cur_cycle_in_shard: Cycle,
     cur_step_count: usize,
     max_step_shard: usize,
@@ -336,6 +338,8 @@ impl ShardPlanBuilder {
             max_cycle_per_shard,
             current_shard_start_cycle: initial_cycle,
             cur_cells: 0,
+            cur_ecall_counts: BTreeMap::new(),
+            cur_ecall_peak_cells: BTreeMap::new(),
             cur_cycle_in_shard: 0,
             cur_step_count: 0,
             max_step_shard: 0,
@@ -370,38 +374,150 @@ impl ShardPlanBuilder {
     }
 
     pub fn observe_step(&mut self, step_cycle: Cycle, step_cells: u64) {
+        self.observe_step_with_delta(step_cycle, step_cells, |planner| {
+            planner.cur_cells = planner.cur_cells.saturating_add(step_cells);
+        });
+    }
+
+    fn observe_ecall_step(&mut self, step_cycle: Cycle, ecall_code: Word, base_cells: u64) {
+        self.observe_step_with_delta(
+            step_cycle,
+            self.ecall_step_delta(ecall_code, base_cells),
+            |planner| planner.add_ecall_step(ecall_code, base_cells),
+        );
+    }
+
+    fn observe_step_with_delta(
+        &mut self,
+        step_cycle: Cycle,
+        step_delta: u64,
+        add_step: impl FnOnce(&mut Self),
+    ) {
         assert!(
             !self.finalized,
             "shard plan cannot be extended after finalization"
         );
+        if self.cur_step_count > 0 && self.step_would_exceed_shard(step_delta) {
+            self.finish_current_shard(step_cycle);
+        }
+
+        add_step(self);
+        self.cur_cycle_in_shard = self
+            .cur_cycle_in_shard
+            .saturating_add(FullTracer::SUBCYCLES_PER_INSN);
+        self.cur_step_count = self.cur_step_count.saturating_add(1);
+    }
+
+    fn step_would_exceed_shard(&self, step_delta: u64) -> bool {
         let target = if self.shard_id == 0 {
             self.target_cell_first_shard
         } else {
             self.max_cell_per_shard
         };
+        self.cur_cells.saturating_add(step_delta) > target
+            || self
+                .cur_cycle_in_shard
+                .saturating_add(FullTracer::SUBCYCLES_PER_INSN)
+                >= self.max_cycle_per_shard
+    }
 
-        // always include step in current shard to simplify overall logic
-        self.cur_cells = self.cur_cells.saturating_add(step_cells);
-        self.cur_cycle_in_shard = self
-            .cur_cycle_in_shard
-            .saturating_add(FullTracer::SUBCYCLES_PER_INSN);
-        self.cur_step_count = self.cur_step_count.saturating_add(1);
+    fn finish_current_shard(&mut self, next_shard_cycle: Cycle) {
+        assert!(
+            self.cur_cells > 0 || self.cur_cycle_in_shard > 0,
+            "shard split before accumulating any steps"
+        );
+        self.push_boundary(next_shard_cycle);
+        self.shard_id += 1;
+        self.current_shard_start_cycle = next_shard_cycle;
+        self.cur_cells = 0;
+        self.cur_ecall_counts.clear();
+        self.cur_ecall_peak_cells.clear();
+        self.cur_cycle_in_shard = 0;
+        self.max_step_shard = self.max_step_shard.max(self.cur_step_count);
+        self.cur_step_count = 0;
+    }
 
-        let cycle_limit_hit = self.cur_cycle_in_shard >= self.max_cycle_per_shard;
-        let should_split = self.cur_cells >= target || cycle_limit_hit;
-        if should_split {
-            assert!(
-                self.cur_cells > 0 || self.cur_cycle_in_shard > 0,
-                "shard split before accumulating any steps"
-            );
-            let next_shard_cycle = step_cycle + FullTracer::SUBCYCLES_PER_INSN;
-            self.push_boundary(next_shard_cycle);
-            self.shard_id += 1;
-            self.current_shard_start_cycle = next_shard_cycle;
-            self.cur_cells = 0;
-            self.cur_cycle_in_shard = 0;
-            self.max_step_shard = self.max_step_shard.max(self.cur_step_count);
-            self.cur_step_count = 0;
+    fn add_ecall_step(&mut self, ecall_code: Word, base_cells: u64) {
+        let old_count = self
+            .cur_ecall_counts
+            .get(&ecall_code)
+            .copied()
+            .unwrap_or_default();
+        let new_count = old_count.saturating_add(1);
+        let old_peak = self
+            .cur_ecall_peak_cells
+            .get(&ecall_code)
+            .copied()
+            .unwrap_or_default();
+        let new_peak = ecall_peak_cells(base_cells, new_count);
+        self.cur_ecall_counts.insert(ecall_code, new_count);
+        self.cur_ecall_peak_cells.insert(ecall_code, new_peak);
+        self.cur_cells = self
+            .cur_cells
+            .saturating_add(new_peak.saturating_sub(old_peak));
+    }
+
+    fn ecall_step_delta(&self, ecall_code: Word, base_cells: u64) -> u64 {
+        let old_count = self
+            .cur_ecall_counts
+            .get(&ecall_code)
+            .copied()
+            .unwrap_or_default();
+        let old_peak = self
+            .cur_ecall_peak_cells
+            .get(&ecall_code)
+            .copied()
+            .unwrap_or_default();
+        let new_peak = ecall_peak_cells(base_cells, old_count.saturating_add(1));
+        new_peak.saturating_sub(old_peak)
+    }
+
+    #[cfg(test)]
+    fn ecall_count(&self, ecall_code: Word) -> u64 {
+        self.cur_ecall_counts
+            .get(&ecall_code)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    #[cfg(test)]
+    fn ecall_peak_cells(&self, ecall_code: Word) -> u64 {
+        self.cur_ecall_peak_cells
+            .get(&ecall_code)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    #[cfg(test)]
+    fn cur_cells(&self) -> u64 {
+        self.cur_cells
+    }
+
+    #[cfg(test)]
+    fn cur_step_count(&self) -> usize {
+        self.cur_step_count
+    }
+
+    #[cfg(test)]
+    fn current_shard_id(&self) -> usize {
+        self.shard_id
+    }
+
+    #[cfg(test)]
+    fn ecall_delta_for(&self, ecall_code: Word, base_cells: u64) -> u64 {
+        self.ecall_step_delta(ecall_code, base_cells)
+    }
+
+    fn reset_after_native_shard_split(&mut self) {
+        self.cur_ecall_counts.clear();
+        self.cur_ecall_peak_cells.clear();
+    }
+
+    fn padded_ecall_count(count: u64) -> u64 {
+        if count <= 1 {
+            count
+        } else {
+            count.checked_next_power_of_two().unwrap_or(u64::MAX)
         }
     }
 
@@ -427,6 +543,10 @@ impl ShardPlanBuilder {
             self.shard_cycle_boundaries.push(cycle);
         }
     }
+}
+
+fn ecall_peak_cells(base_cells: u64, count: u64) -> u64 {
+    base_cells.saturating_mul(ShardPlanBuilder::padded_ecall_count(count))
 }
 
 #[cfg(any(test, debug_assertions))]
@@ -1397,6 +1517,7 @@ impl PreflightTracer {
         planner.current_shard_start_cycle = next_shard_cycle;
         planner.max_step_shard = planner.max_step_shard.max(planner.cur_step_count);
         planner.cur_cells = 0;
+        planner.reset_after_native_shard_split();
         planner.cur_cycle_in_shard = 0;
         planner.cur_step_count = 0;
         self.current_shard_start_cycle = next_shard_cycle;
@@ -1484,7 +1605,15 @@ impl Tracer for PreflightTracer {
                 .as_ref()
                 .map(|extractor| extractor.cells_for_kind(self.last_kind, self.last_rs1))
                 .unwrap_or(0);
-            planner.observe_step(self.cycle, step_cells);
+            if matches!(self.last_kind, InsnKind::ECALL) {
+                planner.observe_ecall_step(
+                    self.cycle,
+                    self.last_rs1.unwrap_or_default(),
+                    step_cells,
+                );
+            } else {
+                planner.observe_step(self.cycle, step_cells);
+            }
             self.current_shard_start_cycle = planner.current_shard_start_cycle();
         }
         self.cycle += Self::SUBCYCLES_PER_INSN;
@@ -1801,5 +1930,78 @@ mod tests {
             mem::size_of::<StepRecord>(),
             mem::align_of::<StepRecord>()
         );
+    }
+
+    #[test]
+    fn ecall_peak_cells_is_monotonic_and_padded() {
+        let base = 7;
+        let mut prev = 0;
+        for count in 0..10_000 {
+            let peak = ecall_peak_cells(base, count);
+            assert!(peak >= prev);
+            prev = peak;
+        }
+
+        assert_eq!(ecall_peak_cells(base, 0), 0);
+        assert_eq!(ecall_peak_cells(base, 1), base);
+        assert_eq!(ecall_peak_cells(base, 2), base * 2);
+        assert_eq!(ecall_peak_cells(base, 3), base * 4);
+        assert_eq!(ecall_peak_cells(base, 8192), base * 8192);
+        assert_eq!(ecall_peak_cells(base, 8193), base * 16384);
+    }
+
+    #[test]
+    fn ecall_boundary_crossing_charges_padded_bucket_delta() {
+        let code = 0x1234;
+        let base = 7;
+        let mut planner = ShardPlanBuilder::new(u64::MAX, Cycle::MAX);
+        for i in 0..8192 {
+            planner.observe_ecall_step(FullTracer::SUBCYCLES_PER_INSN * (i + 1), code, base);
+        }
+
+        assert_eq!(planner.ecall_count(code), 8192);
+        assert_eq!(planner.ecall_peak_cells(code), base * 8192);
+        assert_eq!(planner.ecall_delta_for(code, base), base * 8192);
+    }
+
+    #[test]
+    fn ecall_over_budget_step_splits_before_adding_step() {
+        let code = 0x1234;
+        let base = 1;
+        let mut planner = ShardPlanBuilder::new(10, Cycle::MAX);
+        for i in 0..8 {
+            planner.observe_ecall_step(FullTracer::SUBCYCLES_PER_INSN * (i + 1), code, base);
+        }
+        planner.observe_ecall_step(FullTracer::SUBCYCLES_PER_INSN * 9, code, base);
+
+        assert_eq!(
+            planner.shard_cycle_boundaries(),
+            &[FullTracer::SUBCYCLES_PER_INSN, 36]
+        );
+        assert_eq!(planner.current_shard_id(), 1);
+        assert_eq!(planner.cur_step_count(), 1);
+        assert_eq!(planner.ecall_count(code), 1);
+        assert_eq!(planner.cur_cells(), base);
+    }
+
+    #[test]
+    fn repeated_non_keccak_ecall_splits_at_padded_bucket_boundary() {
+        let code = 0x5678;
+        let base = 2;
+        let mut planner = ShardPlanBuilder::new(base * 8192, Cycle::MAX);
+        for i in 0..8192 {
+            planner.observe_ecall_step(FullTracer::SUBCYCLES_PER_INSN * (i + 1), code, base);
+        }
+        planner.observe_ecall_step(FullTracer::SUBCYCLES_PER_INSN * 8193, code, base);
+
+        assert_eq!(
+            planner.shard_cycle_boundaries(),
+            &[
+                FullTracer::SUBCYCLES_PER_INSN,
+                FullTracer::SUBCYCLES_PER_INSN * 8193
+            ]
+        );
+        assert_eq!(planner.ecall_count(code), 1);
+        assert_eq!(planner.cur_cells(), base);
     }
 }

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1827,6 +1827,43 @@ fn assert_witgen_mem_released(shard_id: usize, baseline: u64) {
     );
 }
 
+#[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+pub fn prepare_preflight_aot_program(
+    program: Arc<Program>,
+    platform: &Platform,
+    multi_prover: &MultiProver,
+    step_cell_extractor: Arc<dyn StepCellExtractor>,
+    init_mem_state: &InitMemState,
+) -> Arc<ceno_emul::aot::AotProgram> {
+    let InitMemState {
+        hints: hints_init, ..
+    } = init_mem_state;
+    let tracer_config = PreflightTracerConfig::new(
+        true,
+        multi_prover.max_cell_per_shard,
+        multi_prover.max_cycle_per_shard,
+    )
+    .with_step_cell_extractor(step_cell_extractor);
+    let roots = ceno_emul::aot::sample_preflight_roots(
+        platform,
+        program.clone(),
+        hints_init
+            .iter()
+            .map(|record| (record.addr.into(), record.value)),
+        tracer_config,
+    );
+    let aot = ceno_emul::aot::AotProgram::compile_preflight_direct_with_extra_roots(program, roots)
+        .unwrap_or_else(|err| panic!("AOT compile failed during preflight preparation: {err}"));
+    let report = aot.report();
+    tracing::info!(
+        "AOT compile/load completed in {:?}; blocks={}, reachable_instructions={}",
+        report.compile_load_time,
+        report.block_count,
+        report.reachable_instruction_count
+    );
+    Arc::new(aot)
+}
+
 // Encodes useful early return points of the e2e pipeline
 #[derive(Default, Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub enum Checkpoint {
@@ -2151,8 +2188,6 @@ pub fn run_e2e_with_checkpoint<
     }
 }
 
-// Runs program emulation + witness generation + proving
-#[tracing::instrument(skip_all, name = "run_e2e_proof", fields(profiling_1), level = "trace")]
 #[allow(clippy::too_many_arguments)]
 pub fn run_e2e_proof<
     E: ExtensionField + LkMultiplicityKey,
@@ -2169,6 +2204,37 @@ pub fn run_e2e_proof<
     target_shard_id: Option<usize>,
 ) -> Vec<ZKVMProof<E, PCS>> {
     let ctx = prover.pk.program_ctx.as_ref().unwrap();
+    run_e2e_proof_with_precompiled_aot(
+        prover,
+        init_full_mem,
+        public_io_digest,
+        max_steps,
+        is_mock_proving,
+        target_shard_id,
+        #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+        ctx.preflight_aot_program.clone(),
+    )
+}
+
+#[tracing::instrument(skip_all, name = "run_e2e_proof", fields(profiling_1), level = "trace")]
+#[allow(clippy::too_many_arguments)]
+pub fn run_e2e_proof_with_precompiled_aot<
+    E: ExtensionField + LkMultiplicityKey,
+    PCS: PolynomialCommitmentScheme<E> + Serialize + 'static,
+    PB: ProverBackend<E = E, Pcs = PCS> + 'static,
+    PD: ProverDevice<PB> + 'static,
+>(
+    prover: &ZKVMProver<E, PCS, PB, PD>,
+    init_full_mem: &InitMemState,
+    public_io_digest: [u32; 8],
+    max_steps: usize,
+    is_mock_proving: bool,
+    // for debug purpose
+    target_shard_id: Option<usize>,
+    #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+    precompiled_aot: Option<Arc<ceno_emul::aot::AotProgram>>,
+) -> Vec<ZKVMProof<E, PCS>> {
+    let ctx = prover.pk.program_ctx.as_ref().unwrap();
     // Emulate program
     let raw_step_cell_extractor = Arc::clone(&ctx.system_config.config);
     let step_cell_extractor: Arc<dyn StepCellExtractor> = raw_step_cell_extractor;
@@ -2181,7 +2247,7 @@ pub fn run_e2e_proof<
         &ctx.multi_prover,
         step_cell_extractor,
         #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
-        ctx.preflight_aot_program.clone(),
+        precompiled_aot,
     );
     create_proofs_streaming(
         emul_result,

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -2203,7 +2203,6 @@ pub fn run_e2e_proof<
     // for debug purpose
     target_shard_id: Option<usize>,
 ) -> Vec<ZKVMProof<E, PCS>> {
-    let ctx = prover.pk.program_ctx.as_ref().unwrap();
     run_e2e_proof_with_precompiled_aot(
         prover,
         init_full_mem,
@@ -2212,7 +2211,13 @@ pub fn run_e2e_proof<
         is_mock_proving,
         target_shard_id,
         #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
-        ctx.preflight_aot_program.clone(),
+        prover
+            .pk
+            .program_ctx
+            .as_ref()
+            .unwrap()
+            .preflight_aot_program
+            .clone(),
     )
 }
 

--- a/ceno_zkvm/src/instructions/riscv/rv32im.rs
+++ b/ceno_zkvm/src/instructions/riscv/rv32im.rs
@@ -246,15 +246,6 @@ impl InstructionDispatchBuilder {
     }
 }
 
-const KECCAK_CELL_BLOWUP_NUMERATOR: u64 = 33;
-const KECCAK_CELL_BLOWUP_DENOMINATOR: u64 = 16;
-
-fn estimate_keccak_cells(base_cells: u64) -> u64 {
-    base_cells
-        .saturating_mul(KECCAK_CELL_BLOWUP_NUMERATOR)
-        .div_ceil(KECCAK_CELL_BLOWUP_DENOMINATOR)
-}
-
 impl<E: ExtensionField> Rv32imConfig<E> {
     pub fn construct_circuits(
         cs: &mut ZKVMConstraintSystem<E>,
@@ -375,39 +366,29 @@ impl<E: ExtensionField> Rv32imConfig<E> {
             register_ecall_circuit!(PubIoCommitInstruction<E>, ecall_cells_map);
         let state_continuation_config = register_ecall_circuit!(GlobalState<E>, ecall_cells_map);
 
-        // Keccak precompile is a known hotspot for peak memory.
-        // Its heavy read/write/LK activity inflates tower-witness usage, causing
-        // substantial memory overhead which not reflected on basic column count.
-        //
-        // We estimate this effect by applying an extra scaling factor that models
-        // tower-witness blowup proportional to the number of base columns. Keep
-        // this fractional so the shard planner can avoid Keccak padding cliffs
-        // without the capacity loss of a coarse integer multiplier.
         let keccak_ecall_config = cs.register_opcode_circuit::<KeccakEcallInstruction<E>>();
         let keccak_core_config = cs.register_opcode_circuit::<KeccakCoreInstruction<E>>();
         assert!(
             ecall_cells_map
                 .insert(
                     <KeccakCoreInstruction<E>>::name(),
-                    estimate_keccak_cells(
-                        [
-                            <KeccakEcallInstruction<E>>::name(),
-                            <KeccakCoreInstruction<E>>::name(),
-                        ]
-                        .into_iter()
-                        .map(|name| {
-                            cs.get_cs(&name)
-                                .as_ref()
-                                .map(|cs| {
-                                    (cs.zkvm_v1_css.num_witin as u64
-                                        + cs.zkvm_v1_css.num_structural_witin as u64
-                                        + cs.zkvm_v1_css.num_fixed as u64)
-                                        * (1 << cs.rotation_vars().unwrap_or(0))
-                                })
-                                .unwrap_or_default()
-                        })
-                        .sum::<u64>(),
-                    ),
+                    [
+                        <KeccakEcallInstruction<E>>::name(),
+                        <KeccakCoreInstruction<E>>::name(),
+                    ]
+                    .into_iter()
+                    .map(|name| {
+                        cs.get_cs(&name)
+                            .as_ref()
+                            .map(|cs| {
+                                (cs.zkvm_v1_css.num_witin as u64
+                                    + cs.zkvm_v1_css.num_structural_witin as u64
+                                    + cs.zkvm_v1_css.num_fixed as u64)
+                                    * (1 << cs.rotation_vars().unwrap_or(0))
+                            })
+                            .unwrap_or_default()
+                    })
+                    .sum::<u64>(),
                 )
                 .is_none()
         );
@@ -1200,18 +1181,5 @@ impl<E: ExtensionField> StepCellExtractor for Rv32imConfig<E> {
     #[inline(always)]
     fn cells_for_kind(&self, kind: InsnKind, rs1_value: Option<Word>) -> u64 {
         self.cells_for(kind, rs1_value)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn keccak_cell_estimate_uses_fractional_ceiling() {
-        assert_eq!(estimate_keccak_cells(0), 0);
-        assert_eq!(estimate_keccak_cells(16), 33);
-        assert_eq!(estimate_keccak_cells(17), 36);
-        assert_eq!(estimate_keccak_cells(u64::MAX), u64::MAX.div_ceil(16));
     }
 }


### PR DESCRIPTION
## Problem

`max_cell_per_shard` was accounting ecall-heavy shards as flat trace-cell cost. That let Keccak-heavy shards cross GPU peak-memory cliffs and fail on 24GB-class GPUs, for example block `25551700` with a KeccakCore memory-pool deadlock.

## Design Rationale

Shard planning should approximate peak prover memory, not only accumulated trace cells. This PR keeps native opcode costs static, but accounts ecalls by the marginal delta of a padded cumulative peak estimate. The planner previews the next step before adding it, so a boundary-crossing ecall can split before entering the oversized shard. This keeps preflight deterministic and cheap: static lookups, counters, `next_power_of_two`, and integer subtraction only.

The Keccak-specific multiplier is removed because ecall memory pressure is now handled by the generic ecall accounting path. AOT direct-block splitting uses the same “exceeds target” semantics as the interpreter, so exact-fill blocks are not split early by AOT.

## Change Highlights

- `ceno_emul`: add per-shard ecall count/peak state and preview-before-add shard splitting.
- `ceno_emul`: route ECALL preflight through marginal peak-cell accounting; keep native opcode accounting unchanged.
- `ceno_emul`: align AOT direct-block cell comparison with interpreter exact-fill behavior.
- `ceno_zkvm`: remove the Keccak-only flat cell multiplier and rely on generic ecall peak accounting.

## Benchmark / Performance Impact

### Operation

| Operation | master (s) | this PR (s) | Improve (master -> this PR) |
|-----------|------------|-------------|-----------------------------|
| `23817600` app `create_proof` | 177.035 | 178.823 | -1.788s (-1.01%) |
| `23817600` recursion `create_proof` | 6.444 | 5.710 | +0.735s (+11.40%) |
| `23817600` total GPU `create_proof` | 183.558 | 184.607 | -1.049s (-0.57%) |

### Layer

| Block | Run | `max_cell_per_shard` | Result | `num_shards` | Boundaries |
|-------|-----|----------------------|--------|--------------|------------|
| `25551700` | [PR](https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/29586613675) | `1207959552` | pass | 15 | `[4, 108214020, 225198312, 358636520, 489603112, 621378532, 753051292, 882360216, 1013391176, 1145963932, 1274663648, 1353540048, 1454746776, 1545875388, 1623763592, 1639398732]` |
| `23817600` | [master baseline](https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/29553833078) | `1245708288` | pass | 12 | `[4, 91097468, 193400496, 290776256, 446266392, 577773860, 686065256, 806980972, 952698660, 1029694816, 1117972104, 1200620460, 1247877372]` |
| `23817600` | [PR](https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/29587692568) | `1207959552` | pass | 11 | `[4, 109214576, 242830632, 376689140, 508543284, 639194308, 772153704, 931659244, 1015438228, 1115114760, 1201851256, 1247492952]` |

Benchmark command(s):

```sh
# GitHub Actions workflow_dispatch: ceno-reth-benchmark/.github/workflows/run-benchmark-v2.yml
# mode=prove-stark, gpu_enable_witgen=0, gpu_cache_level=1, gpu_jagged_reshape_log_height=23,
# concurrent_chip_proving=1, gpu_large_task_booking_margin_mb=3048
# PR runs used ceno_version=69ea8df9594285cc09053fdaaad22b05a3228e3e and max_cell_per_shard=1207959552.
```

Environment: self-hosted GitHub Actions GPU runner, RTX 4090-class 24GB GPU, Rust nightly `2025-11-20`.

raw data:

- master: https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/29553833078
- this PR: https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/29586613675, https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/29587692568

## Testing

```sh
cargo fmt
cargo test -p ceno_emul tracer::tests
cargo test -p ceno_zkvm e2e::tests
```

Remote CI validation:

```sh
# 25551700 prove-stark: pass with max_cell_per_shard=1207959552
# 23817600 prove-stark: pass with max_cell_per_shard=1207959552
```

## Risks and Rollout

This changes shard boundaries for ecall-heavy programs. Native-only boundaries should remain unchanged. The main rollout risk is a too-large shard cap on 24GB GPUs; follow-up benchmark tuning found `1207959552 = ((1 << 30) * 9 / 4 / 2)` as the shared passing cap for `25551700` and `23817600`, while `1342177280` failed on `25551700`.

Rollback is straightforward: revert this PR or restore the previous Keccak-specific multiplier and add-after-split accounting.

## Follow-ups (optional)

- Revisit the default `max_cell_per_shard` after more 4090/24GB block coverage.
- Calibrate ecall peak components beyond the current static padded estimator if future blocks expose a tighter memory model need.

## Copilot Reviewer Directive (keep this section)

When Copilot reviews this PR, apply `.github/copilot-instructions.md` strictly.
