### PR TITLE
Model shard costs from circuit peak memory

### DIFF
--- a/ceno_emul/src/aot.rs
+++ b/ceno_emul/src/aot.rs
@@ -142,6 +142,10 @@ const AOT_CTX_PREFLIGHT_NUM_INSTANCES_OFFSET: usize = 416;
 #[allow(dead_code)]
 const AOT_CTX_PREFLIGHT_NUM_CHIPS_OFFSET: usize = 424;
 const AOT_CTX_PREFLIGHT_PENDING_BLOCK_OFFSET: usize = 432;
+const AOT_CTX_PREFLIGHT_PLANNER_CUR_TRACE_OFFSET: usize = 440;
+const AOT_CTX_PREFLIGHT_PLANNER_CUR_MAIN_OFFSET: usize = 448;
+const AOT_CTX_PREFLIGHT_PLANNER_CUR_TOWER_OFFSET: usize = 456;
+const AOT_CTX_PREFLIGHT_TOWER_COST_TABLE_OFFSET: usize = 464;
 
 const AOT_TRACE_MODE_NONE: u32 = 0;
 const AOT_TRACE_MODE_CALLBACK: u32 = 1;
@@ -231,10 +235,14 @@ struct AotRuntimeContext {
     preflight_block_cells_table: *const u64,
     preflight_block_cost_descriptors: *const AotBlockCostDescriptor,
     preflight_chip_contributions: *const AotChipContribution,
-    preflight_cost_table: *const u64,
+    preflight_cost_table: *const AotAdditiveCost,
     preflight_num_instances: *mut u64,
     preflight_num_chips: usize,
     preflight_pending_block: usize,
+    preflight_planner_cur_trace_cells: *mut u64,
+    preflight_planner_cur_main_peak: *mut u64,
+    preflight_planner_cur_tower_peak: *mut u64,
+    preflight_tower_cost_table: *const u64,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -242,7 +250,9 @@ struct AotRuntimeContext {
 struct AotBlockCostDescriptor {
     contribution_offset: u32,
     contribution_count: u32,
-    standalone_cost: u64,
+    standalone_trace_cells: u64,
+    standalone_main_peak: u64,
+    standalone_tower_peak: u64,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -251,6 +261,13 @@ struct AotChipContribution {
     chip_index: u32,
     cost_row_byte_offset: u32,
     instance_delta: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+#[repr(C)]
+struct AotAdditiveCost {
+    trace_cells: u64,
+    main_peak: u64,
 }
 
 #[derive(Debug)]
@@ -484,6 +501,9 @@ impl AotProgram {
         let mut preflight_last_kind = std::ptr::null_mut();
         let mut preflight_current_shard_start = std::ptr::null();
         let mut preflight_planner_cur_cells = std::ptr::null_mut();
+        let mut preflight_planner_cur_trace_cells = std::ptr::null_mut();
+        let mut preflight_planner_cur_main_peak = std::ptr::null_mut();
+        let mut preflight_planner_cur_tower_peak = std::ptr::null_mut();
         let mut preflight_planner_cur_cycle_in_shard = std::ptr::null_mut();
         let mut preflight_planner_cur_step_count = std::ptr::null_mut();
         let mut preflight_planner_max_step_shard = std::ptr::null_mut();
@@ -554,6 +574,9 @@ impl AotProgram {
                 preflight_last_kind = state.last_kind;
                 preflight_current_shard_start = state.current_shard_start_cycle;
                 preflight_planner_cur_cells = state.planner_cur_cells;
+                preflight_planner_cur_trace_cells = state.planner_cur_trace_cells;
+                preflight_planner_cur_main_peak = state.planner_cur_main_peak;
+                preflight_planner_cur_tower_peak = state.planner_cur_tower_peak;
                 preflight_planner_cur_cycle_in_shard = state.planner_cur_cycle_in_shard;
                 preflight_planner_cur_step_count = state.planner_cur_step_count;
                 preflight_planner_max_step_shard = state.planner_max_step_shard;
@@ -582,6 +605,21 @@ impl AotProgram {
         } else {
             std::ptr::null()
         };
+        let preflight_additive_cost_table = preflight_cost_model
+            .as_ref()
+            .map(|model| {
+                model
+                    .trace_cost_table()
+                    .iter()
+                    .copied()
+                    .zip(model.main_cost_table().iter().copied())
+                    .map(|(trace_cells, main_peak)| AotAdditiveCost {
+                        trace_cells,
+                        main_peak,
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
         let mut context = AotRuntimeContext {
             vm: vm_ptr,
             registers,
@@ -649,12 +687,16 @@ impl AotProgram {
             preflight_block_cells_table,
             preflight_block_cost_descriptors: preflight_block_cost_descriptors_table,
             preflight_chip_contributions: preflight_chip_contributions.as_ptr(),
-            preflight_cost_table: preflight_cost_model
-                .as_ref()
-                .map_or(std::ptr::null(), |model| model.cost_table().as_ptr()),
+            preflight_cost_table: preflight_additive_cost_table.as_ptr(),
             preflight_num_instances: preflight_planner_num_instances,
             preflight_num_chips: preflight_planner_num_chips,
             preflight_pending_block: usize::MAX,
+            preflight_planner_cur_trace_cells,
+            preflight_planner_cur_main_peak,
+            preflight_planner_cur_tower_peak,
+            preflight_tower_cost_table: preflight_cost_model
+                .as_ref()
+                .map_or(std::ptr::null(), |model| model.tower_cost_table().as_ptr()),
         };
         let trace_fn = if trace_native_steps {
             if TypeId::of::<T>() == TypeId::of::<PreflightTracer>() {
@@ -930,7 +972,7 @@ fn write_assembly(
     writeln!(file, "    pushq %r14")?;
     writeln!(file, "    pushq %r15")?;
     writeln!(file, "    pushq %rbp")?;
-    writeln!(file, "    subq $24, %rsp")?;
+    writeln!(file, "    subq $56, %rsp")?;
     writeln!(file, "    movq %rdi, %r12")?;
     writeln!(file, "    movq %rsi, %r13")?;
     writeln!(file, "    movq %rdx, %r14")?;
@@ -1031,7 +1073,7 @@ fn write_assembly(
     writeln!(file, "    movq %rax, (%rbx)")?;
     writeln!(file, "    movl ${AOT_STATUS_ERROR}, %eax")?;
     writeln!(file, "L_return:")?;
-    writeln!(file, "    addq $24, %rsp")?;
+    writeln!(file, "    addq $56, %rsp")?;
     writeln!(file, "    popq %rbp")?;
     writeln!(file, "    popq %r15")?;
     writeln!(file, "    popq %r14")?;
@@ -1331,30 +1373,45 @@ fn build_aot_block_cost_descriptors(
 ) -> Result<(Vec<AotBlockCostDescriptor>, Vec<AotChipContribution>)> {
     let mut descriptors = Vec::with_capacity(blocks.len());
     let mut contributions = Vec::new();
+    let mut counts = vec![0u64; model.chip_count()];
     for block in blocks {
         let offset = contributions.len();
-        let mut counts = BTreeMap::<usize, u64>::new();
+        // Compilation/setup only: a dense chip-indexed array avoids sorting
+        // and guarantees stable descriptor order. Execution touches only the
+        // resulting sparse descriptor, never a map.
+        counts.fill(0);
         let mut pc = block.start_pc;
         while pc < block.end_pc {
             let insn = instruction_at(program, pc)?;
             for &chip in model.chips_for_step(insn.kind, None) {
                 let chip = chip as usize;
-                *counts.entry(chip).or_default() += 1;
+                counts[chip] = counts[chip].saturating_add(1);
             }
             pc = pc.wrapping_add(PC_STEP_SIZE as u32);
         }
-        let standalone_cost = counts.iter().fold(0u64, |total, (&chip, &count)| {
-            total.saturating_add(model.chip_cost(chip, count))
-        });
-        contributions.extend(counts.into_iter().map(|(chip, count)| AotChipContribution {
-            chip_index: chip as u32,
-            cost_row_byte_offset: (chip * SHARD_COST_BUCKETS * std::mem::size_of::<u64>()) as u32,
-            instance_delta: count,
-        }));
+        let mut standalone_trace_cells = 0u64;
+        let mut standalone_main_peak = 0u64;
+        let mut standalone_tower_peak = 0u64;
+        for (chip, &count) in counts.iter().enumerate().filter(|(_, count)| **count != 0) {
+            let cost = model.chip_cost(chip, count);
+            standalone_trace_cells = standalone_trace_cells.saturating_add(cost.trace_cells);
+            standalone_main_peak = standalone_main_peak.saturating_add(cost.main_peak);
+            standalone_tower_peak = standalone_tower_peak.max(cost.tower_peak);
+            contributions.push(AotChipContribution {
+                chip_index: chip as u32,
+                cost_row_byte_offset: (chip
+                    * SHARD_COST_BUCKETS
+                    * std::mem::size_of::<AotAdditiveCost>())
+                    as u32,
+                instance_delta: count,
+            });
+        }
         descriptors.push(AotBlockCostDescriptor {
             contribution_offset: offset as u32,
             contribution_count: (contributions.len() - offset) as u32,
-            standalone_cost,
+            standalone_trace_cells,
+            standalone_main_peak,
+            standalone_tower_peak,
         });
     }
     Ok((descriptors, contributions))
@@ -1647,10 +1704,16 @@ fn emit_preflight_adaptive_block_plan_entry(
     let descriptor_offset = block_idx * std::mem::size_of::<AotBlockCostDescriptor>();
     let has_lzcnt = std::is_x86_feature_detected!("lzcnt");
 
-    // Speculatively update all affected chip counts while accumulating the
-    // exact padded-cost delta. The only loop branch depends on descriptor size;
-    // bucket selection itself uses bsr/cmov and table loads.
-    writeln!(file, "    movq $0, 16(%rsp)")?;
+    // Speculatively update all affected chip counts while accumulating trace
+    // and main deltas and the largest absolute tower peak. The only loop
+    // branch depends on descriptor size; bucket selection and max use cmov.
+    writeln!(file, "    pxor %xmm0, %xmm0")?;
+    writeln!(
+        file,
+        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_TOWER_OFFSET}(%r12), %rax"
+    )?;
+    writeln!(file, "    movq (%rax), %rax")?;
+    writeln!(file, "    movq %rax, 32(%rsp)")?;
     writeln!(
         file,
         "    movq {AOT_CTX_PREFLIGHT_BLOCK_COST_DESCRIPTORS_OFFSET}(%r12), %r10"
@@ -1668,6 +1731,7 @@ fn emit_preflight_adaptive_block_plan_entry(
     writeln!(file, "{loop_label}:")?;
     writeln!(file, "    movl (%r10), %eax")?;
     writeln!(file, "    movl 4(%r10), %edx")?;
+    writeln!(file, "    movq %rdx, 40(%rsp)")?;
     writeln!(file, "    movq 8(%r10), %r11")?;
     writeln!(
         file,
@@ -1693,7 +1757,7 @@ fn emit_preflight_adaptive_block_plan_entry(
         writeln!(file, "    subq %rdx, %r8")?;
         writeln!(file, "    testq %r9, %r9")?;
         writeln!(file, "    cmovz %r9, %r8")?;
-        writeln!(file, "    movq (%rdi,%r8,8), %rdx")?;
+        writeln!(file, "    movq %r8, %rdx")?;
         // The candidate count is always nonzero.
         writeln!(file, "    leaq -1(%r11), %r9")?;
         writeln!(file, "    lzcntq %r9, %r9")?;
@@ -1712,7 +1776,6 @@ fn emit_preflight_adaptive_block_plan_entry(
         writeln!(file, "    xorq %r8, %r8")?;
         writeln!(file, "    testq %r9, %r9")?;
         writeln!(file, "    cmovz %r8, %rdx")?;
-        writeln!(file, "    movq (%rdi,%rdx,8), %rdx")?;
         writeln!(file, "    movq %r11, %r9")?;
         writeln!(file, "    decq %r9")?;
         writeln!(file, "    orq $1, %r9")?;
@@ -1722,19 +1785,54 @@ fn emit_preflight_adaptive_block_plan_entry(
         writeln!(file, "    movq $1, %r8")?;
         writeln!(file, "    cmovbe %r8, %r9")?;
     }
-    writeln!(file, "    movq (%rdi,%r9,8), %r9")?;
-    writeln!(file, "    subq %rdx, %r9")?;
-    writeln!(file, "    addq %r9, 16(%rsp)")?;
+    // Trace and main are adjacent table lanes. Accumulate both deltas in one
+    // SIMD register, avoiding four scalar loads and stack updates per chip.
+    writeln!(file, "    movq %rdx, %r8")?;
+    writeln!(file, "    shlq $4, %r8")?;
+    writeln!(file, "    movq %r9, %rax")?;
+    writeln!(file, "    shlq $4, %rax")?;
+    writeln!(file, "    movdqu (%rdi,%r8), %xmm1")?;
+    writeln!(file, "    movdqu (%rdi,%rax), %xmm2")?;
+    writeln!(file, "    psubq %xmm1, %xmm2")?;
+    writeln!(file, "    paddq %xmm2, %xmm0")?;
+    // Tower tasks do not coexist across chips: retain only the largest new
+    // absolute per-chip peak, rather than summing tower deltas.
+    writeln!(
+        file,
+        "    movq {AOT_CTX_PREFLIGHT_TOWER_COST_TABLE_OFFSET}(%r12), %rdi"
+    )?;
+    writeln!(file, "    movq 40(%rsp), %r8")?;
+    writeln!(file, "    shrq $1, %r8")?;
+    writeln!(file, "    addq %r8, %rdi")?;
+    writeln!(file, "    movq (%rdi,%r9,8), %rax")?;
+    writeln!(file, "    movq 32(%rsp), %r8")?;
+    writeln!(file, "    cmpq %r8, %rax")?;
+    writeln!(file, "    cmovaq %rax, %r8")?;
+    writeln!(file, "    movq %r8, 32(%rsp)")?;
     writeln!(file, "    addq $16, %r10")?;
     writeln!(file, "    decl %ecx")?;
     writeln!(file, "    jne {loop_label}")?;
     writeln!(file, "{loop_done_label}:")?;
+    writeln!(file, "    movdqu %xmm0, 16(%rsp)")?;
+    // candidate = trace_total + max(main_total, tower_peak)
     writeln!(
         file,
-        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_CELLS_OFFSET}(%r12), %rax"
+        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_TRACE_OFFSET}(%r12), %rax"
     )?;
     writeln!(file, "    movq (%rax), %r9")?;
     writeln!(file, "    addq 16(%rsp), %r9")?;
+    writeln!(file, "    movq %r9, 16(%rsp)")?;
+    writeln!(
+        file,
+        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_MAIN_OFFSET}(%r12), %rax"
+    )?;
+    writeln!(file, "    movq (%rax), %r11")?;
+    writeln!(file, "    addq 24(%rsp), %r11")?;
+    writeln!(file, "    movq %r11, 24(%rsp)")?;
+    writeln!(file, "    movq 32(%rsp), %r8")?;
+    writeln!(file, "    cmpq %r8, %r11")?;
+    writeln!(file, "    cmovbq %r8, %r11")?;
+    writeln!(file, "    addq %r11, %r9")?;
     writeln!(
         file,
         "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_STEP_COUNT_OFFSET}(%r12), %r10"
@@ -1772,7 +1870,29 @@ fn emit_preflight_adaptive_block_plan_entry(
     )?;
     writeln!(file, "    jae {split_label}")?;
     writeln!(file, "{accept_label}:")?;
+    writeln!(
+        file,
+        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_CELLS_OFFSET}(%r12), %rax"
+    )?;
     writeln!(file, "    movq %r9, (%rax)")?;
+    writeln!(
+        file,
+        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_TRACE_OFFSET}(%r12), %rax"
+    )?;
+    writeln!(file, "    movq 16(%rsp), %r8")?;
+    writeln!(file, "    movq %r8, (%rax)")?;
+    writeln!(
+        file,
+        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_MAIN_OFFSET}(%r12), %rax"
+    )?;
+    writeln!(file, "    movq 24(%rsp), %r8")?;
+    writeln!(file, "    movq %r8, (%rax)")?;
+    writeln!(
+        file,
+        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_TOWER_OFFSET}(%r12), %rax"
+    )?;
+    writeln!(file, "    movq 32(%rsp), %r8")?;
+    writeln!(file, "    movq %r8, (%rax)")?;
     writeln!(file, "    jmp {done_label}")?;
     writeln!(file, "{split_label}:")?;
     writeln!(
@@ -3442,7 +3562,15 @@ unsafe extern "C" fn aot_preflight_direct_helper(context: *mut AotRuntimeContext
                     counts[contribution.chip_index as usize] = contribution.instance_delta;
                 }
                 unsafe {
-                    *context.preflight_planner_cur_cells = descriptor.standalone_cost;
+                    *context.preflight_planner_cur_trace_cells = descriptor.standalone_trace_cells;
+                    *context.preflight_planner_cur_main_peak = descriptor.standalone_main_peak;
+                    *context.preflight_planner_cur_tower_peak = descriptor.standalone_tower_peak;
+                    *context.preflight_planner_cur_cells =
+                        descriptor.standalone_trace_cells.saturating_add(
+                            descriptor
+                                .standalone_main_peak
+                                .max(descriptor.standalone_tower_peak),
+                        );
                 }
                 context.preflight_pending_block = usize::MAX;
             }
@@ -3619,6 +3747,22 @@ mod tests {
             std::mem::offset_of!(AotRuntimeContext, preflight_pending_block),
             AOT_CTX_PREFLIGHT_PENDING_BLOCK_OFFSET
         );
+        assert_eq!(
+            std::mem::offset_of!(AotRuntimeContext, preflight_planner_cur_trace_cells),
+            AOT_CTX_PREFLIGHT_PLANNER_CUR_TRACE_OFFSET
+        );
+        assert_eq!(
+            std::mem::offset_of!(AotRuntimeContext, preflight_planner_cur_main_peak),
+            AOT_CTX_PREFLIGHT_PLANNER_CUR_MAIN_OFFSET
+        );
+        assert_eq!(
+            std::mem::offset_of!(AotRuntimeContext, preflight_planner_cur_tower_peak),
+            AOT_CTX_PREFLIGHT_PLANNER_CUR_TOWER_OFFSET
+        );
+        assert_eq!(
+            std::mem::offset_of!(AotRuntimeContext, preflight_tower_cost_table),
+            AOT_CTX_PREFLIGHT_TOWER_COST_TABLE_OFFSET
+        );
     }
 
     #[test]
@@ -3756,21 +3900,25 @@ mod tests {
                         rotation: 0,
                         trace_cells_per_row: 1,
                         tower_peak_cells_per_row: 0,
+                        tower_peak_cells_by_bucket: None,
                     },
                     ChipCostSpec {
                         rotation: 0,
                         trace_cells_per_row: 1,
                         tower_peak_cells_per_row: 8,
+                        tower_peak_cells_by_bucket: None,
                     },
                     ChipCostSpec {
                         rotation: 0,
                         trace_cells_per_row: 1,
                         tower_peak_cells_per_row: 0,
+                        tower_peak_cells_by_bucket: None,
                     },
                     ChipCostSpec {
                         rotation: 0,
                         trace_cells_per_row: 1,
                         tower_peak_cells_per_row: 0,
+                        tower_peak_cells_by_bucket: None,
                     },
                 ],
                 4,
@@ -3818,7 +3966,7 @@ mod tests {
         aot.run_to_halt(&mut vm, 100).unwrap();
         let (plan, _) = vm.take_tracer().into_shard_plan();
         assert_eq!(plan.shard_cycle_boundaries(), &[4, 16, 28, 32]);
-        assert_eq!(plan.predicted_shard_costs(), &[15, 23, 5]);
+        assert_eq!(plan.predicted_shard_costs(), &[15, 19, 5]);
     }
 
     #[test]
@@ -3837,7 +3985,7 @@ mod tests {
         aot.run_to_halt(&mut vm, 100).unwrap();
         let (plan, _) = vm.take_tracer().into_shard_plan();
         assert_eq!(plan.shard_cycle_boundaries(), &[4, 16, 28, 32]);
-        assert_eq!(plan.predicted_shard_costs(), &[15, 23, 5]);
+        assert_eq!(plan.predicted_shard_costs(), &[15, 19, 5]);
     }
 
     #[test]

--- a/ceno_emul/src/aot.rs
+++ b/ceno_emul/src/aot.rs
@@ -3706,7 +3706,7 @@ mod tests {
         let program = adaptive_test_program();
         // The first block exactly fills the limit and must be accepted. The
         // second block is oversized on an empty shard and must also run once.
-        let config = crate::PreflightTracerConfig::new(true, 15, Cycle::MAX)
+        let config = crate::PreflightTracerConfig::new(true, 7, Cycle::MAX)
             .with_step_cell_extractor(Arc::new(AdaptiveTestCost::new()));
         let aot =
             AotProgram::compile_preflight_direct_with_extra_roots(program.clone(), Vec::new())
@@ -3719,7 +3719,7 @@ mod tests {
         aot.run_to_halt(&mut vm, 100).unwrap();
         let (plan, _) = vm.take_tracer().into_shard_plan();
         assert_eq!(plan.shard_cycle_boundaries(), &[4, 16, 28, 32]);
-        assert_eq!(plan.predicted_shard_costs(), &[15, 19, 5]);
+        assert_eq!(plan.predicted_shard_costs(), &[7, 19, 1]);
     }
 
     #[test]
@@ -3738,7 +3738,7 @@ mod tests {
         aot.run_to_halt(&mut vm, 100).unwrap();
         let (plan, _) = vm.take_tracer().into_shard_plan();
         assert_eq!(plan.shard_cycle_boundaries(), &[4, 16, 28, 32]);
-        assert_eq!(plan.predicted_shard_costs(), &[15, 19, 5]);
+        assert_eq!(plan.predicted_shard_costs(), &[7, 19, 1]);
     }
 
     #[test]

--- a/ceno_emul/src/aot.rs
+++ b/ceno_emul/src/aot.rs
@@ -134,6 +134,7 @@ const AOT_CTX_PREFLIGHT_STACK_MAX_OFFSET: usize = 352;
 const AOT_CTX_PREFLIGHT_HINTS_MIN_OFFSET: usize = 360;
 const AOT_CTX_PREFLIGHT_HINTS_MAX_OFFSET: usize = 368;
 const AOT_CTX_FALLBACK_STEPS_OFFSET: usize = 376;
+#[cfg(test)]
 const AOT_CTX_PREFLIGHT_BLOCK_CELLS_TABLE_OFFSET: usize = 384;
 const AOT_CTX_PREFLIGHT_BLOCK_COST_DESCRIPTORS_OFFSET: usize = 392;
 const AOT_CTX_PREFLIGHT_CHIP_CONTRIBUTIONS_OFFSET: usize = 400;
@@ -520,40 +521,28 @@ impl AotProgram {
         let mut preflight_stack_max = std::ptr::null_mut();
         let mut preflight_hints_min = std::ptr::null_mut();
         let mut preflight_hints_max = std::ptr::null_mut();
-        let mut preflight_block_cells = Vec::new();
         let mut preflight_block_cost_descriptors = Vec::new();
         let mut preflight_chip_contributions = Vec::new();
         let mut preflight_cost_model = None;
         if trace_native_steps && TypeId::of::<T>() == TypeId::of::<PreflightTracer>() {
             let preflight_vm = unsafe { &mut *(vm_ptr as *mut VMState<PreflightTracer>) };
             if preflight_vm.tracer().supports_direct_native_trace() {
-                preflight_step_cells = self
-                    .program
-                    .instructions
-                    .iter()
-                    .map(|insn| preflight_vm.tracer().native_step_cells_for_kind(insn.kind))
-                    .collect();
                 if self.trace_style == AssemblyTraceStyle::PreflightDirectBlockPlan {
-                    preflight_block_cells = self
-                        .blocks
+                    let model = preflight_vm.tracer().shard_cost_model().ok_or_else(|| {
+                        anyhow!("preflight block AOT requires a shard cost model")
+                    })?;
+                    (
+                        preflight_block_cost_descriptors,
+                        preflight_chip_contributions,
+                    ) = build_aot_block_cost_descriptors(&self.program, &self.blocks, &model)?;
+                    preflight_cost_model = Some(model);
+                } else {
+                    preflight_step_cells = self
+                        .program
+                        .instructions
                         .iter()
-                        .map(|block| {
-                            let start = ((block.start_pc - self.program.base_address)
-                                / PC_STEP_SIZE as u32)
-                                as usize;
-                            let end = ((block.end_pc - self.program.base_address)
-                                / PC_STEP_SIZE as u32)
-                                as usize;
-                            preflight_step_cells[start..end].iter().copied().sum()
-                        })
+                        .map(|insn| preflight_vm.tracer().native_step_cells_for_kind(insn.kind))
                         .collect();
-                    preflight_cost_model = preflight_vm.tracer().shard_cost_model();
-                    if let Some(model) = &preflight_cost_model {
-                        (
-                            preflight_block_cost_descriptors,
-                            preflight_chip_contributions,
-                        ) = build_aot_block_cost_descriptors(&self.program, &self.blocks, model)?;
-                    }
                 }
                 (preflight_heap_min, preflight_heap_max) = preflight_vm
                     .tracer_mut()
@@ -593,18 +582,13 @@ impl AotProgram {
         } else {
             std::ptr::null()
         };
-        let preflight_block_cells_table = if trace_mode == AOT_TRACE_MODE_PREFLIGHT_DIRECT
-            && self.trace_style == AssemblyTraceStyle::PreflightDirectBlockPlan
-        {
-            preflight_block_cells.as_ptr()
-        } else {
-            std::ptr::null()
-        };
-        let preflight_block_cost_descriptors_table = if preflight_cost_model.is_some() {
-            preflight_block_cost_descriptors.as_ptr()
-        } else {
-            std::ptr::null()
-        };
+        let preflight_block_cells_table = std::ptr::null();
+        let preflight_block_cost_descriptors_table =
+            if self.trace_style == AssemblyTraceStyle::PreflightDirectBlockPlan {
+                preflight_block_cost_descriptors.as_ptr()
+            } else {
+                std::ptr::null()
+            };
         let preflight_additive_cost_table = preflight_cost_model
             .as_ref()
             .map(|model| {
@@ -1001,29 +985,18 @@ fn write_assembly(
             && !adaptive_exact_access_plan
             && trace_style == AssemblyTraceStyle::PreflightDirectBlockPlan
         {
-            writeln!(
-                file,
-                "    cmpq $0, {AOT_CTX_PREFLIGHT_BLOCK_COST_DESCRIPTORS_OFFSET}(%r12)"
-            )?;
-            writeln!(file, "    jne L_dynamic")?;
+            writeln!(file, "    jmp L_dynamic")?;
         }
         if adaptive_exact_access_plan {
-            let no_adaptive_plan_label = format!(".L_no_adaptive_exact_plan_{block_idx}");
-            writeln!(
-                file,
-                "    cmpq $0, {AOT_CTX_PREFLIGHT_BLOCK_COST_DESCRIPTORS_OFFSET}(%r12)"
-            )?;
-            writeln!(file, "    je {no_adaptive_plan_label}")?;
             emit_preflight_direct_block_budget_guard(&mut file, block)?;
             emit_preflight_adaptive_block_plan_entry(&mut file, block_idx, block)?;
-            writeln!(file, "{no_adaptive_plan_label}:")?;
         }
         if block_plan.is_some() {
             emit_preflight_direct_block_budget_guard(&mut file, block)?;
             if matches!(block_plan, Some(PreflightBlockPlanKind::MemoryExactAccess)) {
                 emit_preflight_direct_block_memory_fast_path_guard(&mut file, program, block)?;
             }
-            emit_preflight_direct_block_plan_entry(&mut file, block_idx, block)?;
+            emit_preflight_adaptive_block_plan_entry(&mut file, block_idx, block)?;
             if matches!(block_plan, Some(PreflightBlockPlanKind::RegisterOnly)) {
                 emit_preflight_direct_block_access_entry(&mut file, program, block_idx, block)?;
             }
@@ -1034,7 +1007,9 @@ fn write_assembly(
             let step_trace_style =
                 if matches!(block_plan, Some(PreflightBlockPlanKind::RegisterOnly)) {
                     AssemblyTraceStyle::PreflightDirectBlockPlan
-                } else if matches!(block_plan, Some(PreflightBlockPlanKind::MemoryExactAccess)) {
+                } else if matches!(block_plan, Some(PreflightBlockPlanKind::MemoryExactAccess))
+                    || adaptive_exact_access_plan
+                {
                     AssemblyTraceStyle::PreflightDirectBlockPlanExactAccess
                 } else if trace_style == AssemblyTraceStyle::PreflightDirectBlockPlan {
                     AssemblyTraceStyle::PreflightDirect
@@ -1047,10 +1022,11 @@ fn write_assembly(
         if let Some(prev_pc) = pc.checked_sub(PC_STEP_SIZE as u32) {
             let insn = instruction_at(program, prev_pc)?;
             if block_plan.is_some() {
-                emit_preflight_direct_block_plan_exit(&mut file, block_idx, block)?;
+                emit_preflight_direct_block_plan_exit(&mut file, block)?;
                 emit_preflight_direct_busy_loop_guard(&mut file, prev_pc)?;
             } else if adaptive_exact_access_plan {
                 emit_preflight_adaptive_exact_access_plan_exit(&mut file, block)?;
+                emit_preflight_direct_busy_loop_guard(&mut file, prev_pc)?;
             }
             emit_successor_jump(&mut file, program, &labels, prev_pc, insn)?;
         }
@@ -1170,9 +1146,7 @@ fn emit_after_native_step(
         emit_preflight_direct_step_static(
             &mut file,
             pc,
-            program,
             insn,
-            trace_style == AssemblyTraceStyle::PreflightDirect,
             preflight_memory_bounds_updated,
             if trace_style == AssemblyTraceStyle::PreflightDirectBlockPlan {
                 PreflightAccessMode::BlockAtomic
@@ -1211,9 +1185,7 @@ fn emit_after_native_step(
     emit_preflight_direct_step_static(
         &mut file,
         pc,
-        program,
         insn,
-        true,
         false,
         PreflightAccessMode::Exact,
         true,
@@ -1578,116 +1550,6 @@ fn emit_preflight_direct_block_access_entry(
     Ok(())
 }
 
-fn emit_load_preflight_block_cells(
-    mut file: impl Write,
-    block_idx: usize,
-    label_suffix: &str,
-    dst_reg: &str,
-) -> Result<()> {
-    let zero_label = format!(".L_preflight_block_cells_zero_{block_idx}_{label_suffix}");
-    let done_label = format!(".L_preflight_block_cells_done_{block_idx}_{label_suffix}");
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_BLOCK_CELLS_TABLE_OFFSET}(%r12), {dst_reg}"
-    )?;
-    writeln!(file, "    testq {dst_reg}, {dst_reg}")?;
-    writeln!(file, "    je {zero_label}")?;
-    writeln!(file, "    movq {}({dst_reg}), {dst_reg}", block_idx * 8)?;
-    writeln!(file, "    jmp {done_label}")?;
-    writeln!(file, "{zero_label}:")?;
-    writeln!(file, "    xorq {dst_reg}, {dst_reg}")?;
-    writeln!(file, "{done_label}:")?;
-    Ok(())
-}
-
-fn emit_preflight_direct_block_plan_entry(
-    mut file: impl Write,
-    block_idx: usize,
-    block: &BasicBlock,
-) -> Result<()> {
-    let legacy_label = format!(".L_preflight_block_legacy_cost_{block_idx}");
-    let done_label = format!(".L_preflight_block_cost_entry_done_{block_idx}");
-    writeln!(
-        file,
-        "    cmpq $0, {AOT_CTX_PREFLIGHT_BLOCK_COST_DESCRIPTORS_OFFSET}(%r12)"
-    )?;
-    writeln!(file, "    je {legacy_label}")?;
-    emit_preflight_adaptive_block_plan_entry(&mut file, block_idx, block)?;
-    writeln!(file, "    jmp {done_label}")?;
-    writeln!(file, "{legacy_label}:")?;
-    emit_preflight_legacy_block_plan_entry(&mut file, block_idx, block)?;
-    writeln!(file, "{done_label}:")?;
-    Ok(())
-}
-
-fn emit_preflight_legacy_block_plan_entry(
-    mut file: impl Write,
-    block_idx: usize,
-    block: &BasicBlock,
-) -> Result<()> {
-    let no_split_label = format!(".L_preflight_block_no_split_{block_idx}");
-    let first_shard_label = format!(".L_preflight_block_first_shard_{block_idx}");
-    let target_done_label = format!(".L_preflight_block_target_done_{block_idx}");
-    let split_label = format!(".L_preflight_block_split_{block_idx}");
-    let block_cycles = block_instruction_count(block) * PC_STEP_SIZE as u64;
-
-    emit_load_preflight_block_cells(&mut file, block_idx, "entry", "%r8")?;
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_STEP_COUNT_OFFSET}(%r12), %rax"
-    )?;
-    writeln!(file, "    cmpq $0, (%rax)")?;
-    writeln!(file, "    je {no_split_label}")?;
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_PLANNER_SHARD_ID_OFFSET}(%r12), %rax"
-    )?;
-    writeln!(file, "    cmpq $0, (%rax)")?;
-    writeln!(file, "    je {first_shard_label}")?;
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_MAX_CELL_PER_SHARD_OFFSET}(%r12), %r10"
-    )?;
-    writeln!(file, "    jmp {target_done_label}")?;
-    writeln!(file, "{first_shard_label}:")?;
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_TARGET_CELL_FIRST_SHARD_OFFSET}(%r12), %r10"
-    )?;
-    writeln!(file, "{target_done_label}:")?;
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_CELLS_OFFSET}(%r12), %rax"
-    )?;
-    writeln!(file, "    movq (%rax), %r9")?;
-    writeln!(file, "    addq %r8, %r9")?;
-    writeln!(file, "    cmpq %r10, %r9")?;
-    writeln!(file, "    ja {split_label}")?;
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_CYCLE_OFFSET}(%r12), %rax"
-    )?;
-    writeln!(file, "    movq (%rax), %r9")?;
-    writeln!(file, "    addq ${block_cycles}, %r9")?;
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_MAX_CYCLE_PER_SHARD_OFFSET}(%r12), %r10"
-    )?;
-    writeln!(file, "    cmpq %r10, %r9")?;
-    writeln!(file, "    jb {no_split_label}")?;
-    writeln!(file, "{split_label}:")?;
-    writeln!(
-        file,
-        "    movl ${AOT_PREFLIGHT_HELPER_SHARD_SPLIT}, {AOT_CTX_PREFLIGHT_HELPER_KIND_OFFSET}(%r12)"
-    )?;
-    writeln!(file, "    movq %r12, %rdi")?;
-    writeln!(file, "    call *%r14")?;
-    writeln!(file, "    cmpl ${AOT_STATUS_ERROR}, %eax")?;
-    writeln!(file, "    je L_error")?;
-    writeln!(file, "{no_split_label}:")?;
-    Ok(())
-}
-
 fn emit_preflight_adaptive_block_plan_entry(
     mut file: impl Write,
     block_idx: usize,
@@ -1911,26 +1773,9 @@ fn emit_preflight_adaptive_block_plan_entry(
     Ok(())
 }
 
-fn emit_preflight_direct_block_plan_exit(
-    mut file: impl Write,
-    block_idx: usize,
-    block: &BasicBlock,
-) -> Result<()> {
-    let cost_done_label = format!(".L_preflight_block_cost_exit_done_{block_idx}");
+fn emit_preflight_direct_block_plan_exit(mut file: impl Write, block: &BasicBlock) -> Result<()> {
     let block_steps = block_instruction_count(block);
     let block_cycles = block_steps * PC_STEP_SIZE as u64;
-    writeln!(
-        file,
-        "    cmpq $0, {AOT_CTX_PREFLIGHT_BLOCK_COST_DESCRIPTORS_OFFSET}(%r12)"
-    )?;
-    writeln!(file, "    jne {cost_done_label}")?;
-    emit_load_preflight_block_cells(&mut file, block_idx, "exit", "%r8")?;
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_CELLS_OFFSET}(%r12), %rax"
-    )?;
-    writeln!(file, "    addq %r8, (%rax)")?;
-    writeln!(file, "{cost_done_label}:")?;
     writeln!(
         file,
         "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_CYCLE_OFFSET}(%r12), %rax"
@@ -1948,14 +1793,8 @@ fn emit_preflight_adaptive_exact_access_plan_exit(
     mut file: impl Write,
     block: &BasicBlock,
 ) -> Result<()> {
-    let done_label = format!(".L_adaptive_exact_exit_done_{:x}", block.start_pc);
     let block_steps = block_instruction_count(block);
     let block_cycles = block_steps * PC_STEP_SIZE as u64;
-    writeln!(
-        file,
-        "    cmpq $0, {AOT_CTX_PREFLIGHT_BLOCK_COST_DESCRIPTORS_OFFSET}(%r12)"
-    )?;
-    writeln!(file, "    je {done_label}")?;
     writeln!(
         file,
         "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_CYCLE_OFFSET}(%r12), %rax"
@@ -1966,16 +1805,13 @@ fn emit_preflight_adaptive_exact_access_plan_exit(
         "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_STEP_COUNT_OFFSET}(%r12), %rax"
     )?;
     writeln!(file, "    addq ${block_steps}, (%rax)")?;
-    writeln!(file, "{done_label}:")?;
     Ok(())
 }
 
 fn emit_preflight_direct_step_static(
     mut file: impl Write,
     pc: u32,
-    program: &Program,
     insn: Instruction,
-    update_planner: bool,
     preflight_memory_bounds_updated: bool,
     access_mode: PreflightAccessMode,
     check_busy_loop: bool,
@@ -2059,9 +1895,6 @@ fn emit_preflight_direct_step_static(
         file,
         "    incq {AOT_CTX_PREFLIGHT_PENDING_STEPS_OFFSET}(%r12)"
     )?;
-    if update_planner {
-        emit_preflight_direct_planner_step_static(&mut file, program, pc)?;
-    }
     if check_busy_loop {
         emit_preflight_direct_busy_loop_guard(&mut file, pc)?;
     }
@@ -2170,104 +2003,6 @@ fn emit_preflight_direct_memory_bound_known_region(
     writeln!(file, "    leal 1({addr_reg}), %ecx")?;
     writeln!(file, "    movl %ecx, (%rax)")?;
     writeln!(file, "2:")?;
-    Ok(())
-}
-
-fn emit_preflight_direct_planner_step_static(
-    mut file: impl Write,
-    program: &Program,
-    pc: u32,
-) -> Result<()> {
-    let insn_idx = (pc.wrapping_sub(program.base_address) / PC_STEP_SIZE as u32) as usize;
-    let no_step_cells_label = format!(".L_preflight_no_step_cells_{pc:x}");
-    let step_cells_done_label = format!(".L_preflight_step_cells_done_{pc:x}");
-    let no_split_label = format!(".L_preflight_no_split_{pc:x}");
-    let split_done_label = format!(".L_preflight_split_done_{pc:x}");
-    let adaptive_done_label = format!(".L_preflight_adaptive_step_done_{pc:x}");
-
-    // Adaptive native blocks account for their complete opcode mix at block
-    // entry. Their exact-access steps still update cycles and access records,
-    // but must not also apply the legacy scalar planner update here.
-    writeln!(
-        file,
-        "    cmpq $0, {AOT_CTX_PREFLIGHT_BLOCK_COST_DESCRIPTORS_OFFSET}(%r12)"
-    )?;
-    writeln!(file, "    jne {adaptive_done_label}")?;
-
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_STEP_CELLS_TABLE_OFFSET}(%r12), %rcx"
-    )?;
-    writeln!(file, "    testq %rcx, %rcx")?;
-    writeln!(file, "    je {no_step_cells_label}")?;
-    writeln!(file, "    movq {}(%rcx), %rcx", insn_idx * 8)?;
-    writeln!(file, "    jmp {step_cells_done_label}")?;
-    writeln!(file, "{no_step_cells_label}:")?;
-    writeln!(file, "    xorq %rcx, %rcx")?;
-    writeln!(file, "{step_cells_done_label}:")?;
-
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_CELLS_OFFSET}(%r12), %rax"
-    )?;
-    writeln!(file, "    addq %rcx, (%rax)")?;
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_CYCLE_OFFSET}(%r12), %rax"
-    )?;
-    writeln!(file, "    addq $4, (%rax)")?;
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_STEP_COUNT_OFFSET}(%r12), %rax"
-    )?;
-    writeln!(file, "    incq (%rax)")?;
-
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_PLANNER_SHARD_ID_OFFSET}(%r12), %rax"
-    )?;
-    writeln!(file, "    cmpq $0, (%rax)")?;
-    writeln!(file, "    jne 1f")?;
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_TARGET_CELL_FIRST_SHARD_OFFSET}(%r12), %rcx"
-    )?;
-    writeln!(file, "    jmp 2f")?;
-    writeln!(file, "1:")?;
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_MAX_CELL_PER_SHARD_OFFSET}(%r12), %rcx"
-    )?;
-    writeln!(file, "2:")?;
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_CELLS_OFFSET}(%r12), %rax"
-    )?;
-    writeln!(file, "    cmpq %rcx, (%rax)")?;
-    writeln!(file, "    jae 3f")?;
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_CYCLE_OFFSET}(%r12), %rax"
-    )?;
-    writeln!(
-        file,
-        "    movq {AOT_CTX_PREFLIGHT_MAX_CYCLE_PER_SHARD_OFFSET}(%r12), %rcx"
-    )?;
-    writeln!(file, "    cmpq %rcx, (%rax)")?;
-    writeln!(file, "    jb {no_split_label}")?;
-    writeln!(file, "3:")?;
-    writeln!(
-        file,
-        "    movl ${AOT_PREFLIGHT_HELPER_SHARD_SPLIT}, {AOT_CTX_PREFLIGHT_HELPER_KIND_OFFSET}(%r12)"
-    )?;
-    writeln!(file, "    movq %r12, %rdi")?;
-    writeln!(file, "    call *%r14")?;
-    writeln!(file, "    cmpl ${AOT_STATUS_ERROR}, %eax")?;
-    writeln!(file, "    je L_error")?;
-    writeln!(file, "    jmp {split_done_label}")?;
-    writeln!(file, "{no_split_label}:")?;
-    writeln!(file, "{split_done_label}:")?;
-    writeln!(file, "{adaptive_done_label}:")?;
     Ok(())
 }
 
@@ -3879,6 +3614,24 @@ mod tests {
                 0
             }
         }
+
+        fn shard_cost_model(&self) -> Option<Arc<ShardCostModel>> {
+            let mut opcodes = vec![vec![0]; InsnKind::COUNT];
+            opcodes[InsnKind::ECALL as usize].clear();
+            let mut ecalls = BTreeMap::new();
+            ecalls.insert(Platform::ecall_halt(), vec![0]);
+            Some(Arc::new(ShardCostModel::new(
+                opcodes,
+                ecalls,
+                vec![ChipCostSpec {
+                    rotation: 0,
+                    trace_cells_per_row: 1,
+                    tower_peak_cells_per_row: 0,
+                    tower_peak_cells_by_bucket: None,
+                }],
+                1,
+            )))
+        }
     }
 
     #[derive(Debug)]
@@ -3986,6 +3739,19 @@ mod tests {
         let (plan, _) = vm.take_tracer().into_shard_plan();
         assert_eq!(plan.shard_cycle_boundaries(), &[4, 16, 28, 32]);
         assert_eq!(plan.predicted_shard_costs(), &[15, 19, 5]);
+    }
+
+    #[test]
+    fn preflight_block_aot_requires_shard_cost_model() {
+        let program = Arc::new(program(vec![encode_rv32(InsnKind::ADDI, 0, 0, 1, 1)]));
+        let aot =
+            AotProgram::compile_preflight_direct_with_extra_roots(program.clone(), Vec::new())
+                .unwrap();
+        let mut vm =
+            VMState::<crate::PreflightTracer>::new_with_tracer(CENO_PLATFORM.clone(), program);
+
+        let err = aot.run_to_halt(&mut vm, 10).unwrap_err().to_string();
+        assert!(err.contains("preflight block AOT requires a shard cost model"));
     }
 
     #[test]
@@ -4166,8 +3932,13 @@ mod tests {
         let aot =
             AotProgram::compile_preflight_direct_with_extra_roots(program.clone(), Vec::new())
                 .unwrap();
-        let mut aot_vm =
-            VMState::<crate::PreflightTracer>::new_with_tracer(CENO_PLATFORM.clone(), program);
+        let config = crate::PreflightTracerConfig::new(true, u64::MAX, Cycle::MAX)
+            .with_step_cell_extractor(Arc::new(OneCellPerNativeStep));
+        let mut aot_vm = VMState::<crate::PreflightTracer>::new_with_tracer_config(
+            CENO_PLATFORM.clone(),
+            program,
+            config,
+        );
         aot_vm.init_register_unsafe(20, base);
 
         let err = aot.run_to_halt(&mut aot_vm, 10).unwrap_err().to_string();

--- a/ceno_emul/src/aot.rs
+++ b/ceno_emul/src/aot.rs
@@ -9,7 +9,7 @@
 
 use crate::{
     Change, EmuContext, InsnKind, Instruction, PC_STEP_SIZE, Platform, PreflightTracer,
-    PreflightTracerConfig, Program, Tracer, VMState,
+    PreflightTracerConfig, Program, SHARD_COST_BUCKETS, ShardCostModel, Tracer, VMState,
     addr::{ByteAddr, Cycle, RegIdx, WORD_SIZE, Word, WordAddr},
     rv32im::TrapCause,
     tracer::{
@@ -135,6 +135,13 @@ const AOT_CTX_PREFLIGHT_HINTS_MIN_OFFSET: usize = 360;
 const AOT_CTX_PREFLIGHT_HINTS_MAX_OFFSET: usize = 368;
 const AOT_CTX_FALLBACK_STEPS_OFFSET: usize = 376;
 const AOT_CTX_PREFLIGHT_BLOCK_CELLS_TABLE_OFFSET: usize = 384;
+const AOT_CTX_PREFLIGHT_BLOCK_COST_DESCRIPTORS_OFFSET: usize = 392;
+const AOT_CTX_PREFLIGHT_CHIP_CONTRIBUTIONS_OFFSET: usize = 400;
+const AOT_CTX_PREFLIGHT_COST_TABLE_OFFSET: usize = 408;
+const AOT_CTX_PREFLIGHT_NUM_INSTANCES_OFFSET: usize = 416;
+#[allow(dead_code)]
+const AOT_CTX_PREFLIGHT_NUM_CHIPS_OFFSET: usize = 424;
+const AOT_CTX_PREFLIGHT_PENDING_BLOCK_OFFSET: usize = 432;
 
 const AOT_TRACE_MODE_NONE: u32 = 0;
 const AOT_TRACE_MODE_CALLBACK: u32 = 1;
@@ -222,6 +229,28 @@ struct AotRuntimeContext {
     preflight_hints_max: *mut WordAddr,
     fallback_steps: u64,
     preflight_block_cells_table: *const u64,
+    preflight_block_cost_descriptors: *const AotBlockCostDescriptor,
+    preflight_chip_contributions: *const AotChipContribution,
+    preflight_cost_table: *const u64,
+    preflight_num_instances: *mut u64,
+    preflight_num_chips: usize,
+    preflight_pending_block: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+#[repr(C)]
+struct AotBlockCostDescriptor {
+    contribution_offset: u32,
+    contribution_count: u32,
+    standalone_cost: u64,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+#[repr(C)]
+struct AotChipContribution {
+    chip_index: u32,
+    cost_row_byte_offset: u32,
+    instance_delta: u64,
 }
 
 #[derive(Debug)]
@@ -409,6 +438,27 @@ impl AotProgram {
         }
 
         let started = Instant::now();
+        // Generic callback tracing cannot move a shard boundary ahead of a
+        // native step after that step has already mutated access state. Keep
+        // generic Preflight execution on the exact Rust path; production AOT
+        // preflight uses the dedicated direct/block-planned style below.
+        if trace_native_steps
+            && TypeId::of::<T>() == TypeId::of::<PreflightTracer>()
+            && self.trace_style == AssemblyTraceStyle::Generic
+        {
+            let mut executed_steps = 0;
+            while executed_steps < max_steps && !vm.halted() {
+                if vm.next_step_record()?.is_none() {
+                    break;
+                }
+                executed_steps += 1;
+            }
+            return Ok(AotRunReport {
+                executed_steps,
+                fallback_steps: executed_steps,
+                execute_time: started.elapsed(),
+            });
+        }
         LAST_AOT_ERROR.with(|slot| *slot.borrow_mut() = None);
         let mut executed_steps = 0u64;
         let memory_base_word = vm.memory_base_word().0;
@@ -438,6 +488,8 @@ impl AotProgram {
         let mut preflight_planner_cur_step_count = std::ptr::null_mut();
         let mut preflight_planner_max_step_shard = std::ptr::null_mut();
         let mut preflight_planner_shard_id = std::ptr::null_mut();
+        let mut preflight_planner_num_instances = std::ptr::null_mut();
+        let mut preflight_planner_num_chips = 0;
         let mut preflight_max_cell_per_shard = u64::MAX;
         let mut preflight_target_cell_first_shard = u64::MAX;
         let mut preflight_max_cycle_per_shard = Cycle::MAX;
@@ -449,6 +501,9 @@ impl AotProgram {
         let mut preflight_hints_min = std::ptr::null_mut();
         let mut preflight_hints_max = std::ptr::null_mut();
         let mut preflight_block_cells = Vec::new();
+        let mut preflight_block_cost_descriptors = Vec::new();
+        let mut preflight_chip_contributions = Vec::new();
+        let mut preflight_cost_model = None;
         if trace_native_steps && TypeId::of::<T>() == TypeId::of::<PreflightTracer>() {
             let preflight_vm = unsafe { &mut *(vm_ptr as *mut VMState<PreflightTracer>) };
             if preflight_vm.tracer().supports_direct_native_trace() {
@@ -472,6 +527,13 @@ impl AotProgram {
                             preflight_step_cells[start..end].iter().copied().sum()
                         })
                         .collect();
+                    preflight_cost_model = preflight_vm.tracer().shard_cost_model();
+                    if let Some(model) = &preflight_cost_model {
+                        (
+                            preflight_block_cost_descriptors,
+                            preflight_chip_contributions,
+                        ) = build_aot_block_cost_descriptors(&self.program, &self.blocks, model)?;
+                    }
                 }
                 (preflight_heap_min, preflight_heap_max) = preflight_vm
                     .tracer_mut()
@@ -496,6 +558,8 @@ impl AotProgram {
                 preflight_planner_cur_step_count = state.planner_cur_step_count;
                 preflight_planner_max_step_shard = state.planner_max_step_shard;
                 preflight_planner_shard_id = state.planner_shard_id;
+                preflight_planner_num_instances = state.planner_num_instances;
+                preflight_planner_num_chips = state.planner_num_chips;
                 preflight_max_cell_per_shard = state.planner_max_cell_per_shard;
                 preflight_target_cell_first_shard = state.planner_target_cell_first_shard;
                 preflight_max_cycle_per_shard = state.planner_max_cycle_per_shard;
@@ -510,6 +574,11 @@ impl AotProgram {
             && self.trace_style == AssemblyTraceStyle::PreflightDirectBlockPlan
         {
             preflight_block_cells.as_ptr()
+        } else {
+            std::ptr::null()
+        };
+        let preflight_block_cost_descriptors_table = if preflight_cost_model.is_some() {
+            preflight_block_cost_descriptors.as_ptr()
         } else {
             std::ptr::null()
         };
@@ -578,6 +647,14 @@ impl AotProgram {
             preflight_hints_max,
             fallback_steps: 0,
             preflight_block_cells_table,
+            preflight_block_cost_descriptors: preflight_block_cost_descriptors_table,
+            preflight_chip_contributions: preflight_chip_contributions.as_ptr(),
+            preflight_cost_table: preflight_cost_model
+                .as_ref()
+                .map_or(std::ptr::null(), |model| model.cost_table().as_ptr()),
+            preflight_num_instances: preflight_planner_num_instances,
+            preflight_num_chips: preflight_planner_num_chips,
+            preflight_pending_block: usize::MAX,
         };
         let trace_fn = if trace_native_steps {
             if TypeId::of::<T>() == TypeId::of::<PreflightTracer>() {
@@ -875,6 +952,30 @@ fn write_assembly(
         } else {
             None
         };
+        let adaptive_exact_access_plan = block_plan.is_none()
+            && trace_style == AssemblyTraceStyle::PreflightDirectBlockPlan
+            && block_supports_adaptive_cost_plan(program, block)?;
+        if block_plan.is_none()
+            && !adaptive_exact_access_plan
+            && trace_style == AssemblyTraceStyle::PreflightDirectBlockPlan
+        {
+            writeln!(
+                file,
+                "    cmpq $0, {AOT_CTX_PREFLIGHT_BLOCK_COST_DESCRIPTORS_OFFSET}(%r12)"
+            )?;
+            writeln!(file, "    jne L_dynamic")?;
+        }
+        if adaptive_exact_access_plan {
+            let no_adaptive_plan_label = format!(".L_no_adaptive_exact_plan_{block_idx}");
+            writeln!(
+                file,
+                "    cmpq $0, {AOT_CTX_PREFLIGHT_BLOCK_COST_DESCRIPTORS_OFFSET}(%r12)"
+            )?;
+            writeln!(file, "    je {no_adaptive_plan_label}")?;
+            emit_preflight_direct_block_budget_guard(&mut file, block)?;
+            emit_preflight_adaptive_block_plan_entry(&mut file, block_idx, block)?;
+            writeln!(file, "{no_adaptive_plan_label}:")?;
+        }
         if block_plan.is_some() {
             emit_preflight_direct_block_budget_guard(&mut file, block)?;
             if matches!(block_plan, Some(PreflightBlockPlanKind::MemoryExactAccess)) {
@@ -906,6 +1007,8 @@ fn write_assembly(
             if block_plan.is_some() {
                 emit_preflight_direct_block_plan_exit(&mut file, block_idx, block)?;
                 emit_preflight_direct_busy_loop_guard(&mut file, prev_pc)?;
+            } else if adaptive_exact_access_plan {
+                emit_preflight_adaptive_exact_access_plan_exit(&mut file, block)?;
             }
             emit_successor_jump(&mut file, program, &labels, prev_pc, insn)?;
         }
@@ -1167,6 +1270,23 @@ fn preflight_block_plan_kind(
     }))
 }
 
+/// Adaptive costing depends only on the statically known opcode mix. Blocks
+/// whose memory address is computed inside the block can therefore retain
+/// exact per-step access tracking while still using a block-entry cost guard.
+/// Truly dynamic control flow and unsupported instructions stay on the Rust
+/// fallback path.
+fn block_supports_adaptive_cost_plan(program: &Program, block: &BasicBlock) -> Result<bool> {
+    let mut pc = block.start_pc;
+    while pc < block.end_pc {
+        let insn = instruction_at(program, pc)?;
+        if native_opcode_family(insn.kind).is_none() {
+            return Ok(false);
+        }
+        pc = pc.wrapping_add(PC_STEP_SIZE as u32);
+    }
+    Ok(true)
+}
+
 fn preflight_static_register_accesses(insn: Instruction) -> Vec<(u32, PreflightSubcycle)> {
     let mut accesses = Vec::new();
     if native_step_reads_rs1(insn.kind) {
@@ -1202,6 +1322,42 @@ fn preflight_block_first_accesses(
         .into_iter()
         .map(|(addr, cycle_offset)| PreflightBlockAccess { addr, cycle_offset })
         .collect())
+}
+
+fn build_aot_block_cost_descriptors(
+    program: &Program,
+    blocks: &[BasicBlock],
+    model: &ShardCostModel,
+) -> Result<(Vec<AotBlockCostDescriptor>, Vec<AotChipContribution>)> {
+    let mut descriptors = Vec::with_capacity(blocks.len());
+    let mut contributions = Vec::new();
+    for block in blocks {
+        let offset = contributions.len();
+        let mut counts = BTreeMap::<usize, u64>::new();
+        let mut pc = block.start_pc;
+        while pc < block.end_pc {
+            let insn = instruction_at(program, pc)?;
+            for &chip in model.chips_for_step(insn.kind, None) {
+                let chip = chip as usize;
+                *counts.entry(chip).or_default() += 1;
+            }
+            pc = pc.wrapping_add(PC_STEP_SIZE as u32);
+        }
+        let standalone_cost = counts.iter().fold(0u64, |total, (&chip, &count)| {
+            total.saturating_add(model.chip_cost(chip, count))
+        });
+        contributions.extend(counts.into_iter().map(|(chip, count)| AotChipContribution {
+            chip_index: chip as u32,
+            cost_row_byte_offset: (chip * SHARD_COST_BUCKETS * std::mem::size_of::<u64>()) as u32,
+            instance_delta: count,
+        }));
+        descriptors.push(AotBlockCostDescriptor {
+            contribution_offset: offset as u32,
+            contribution_count: (contributions.len() - offset) as u32,
+            standalone_cost,
+        });
+    }
+    Ok((descriptors, contributions))
 }
 
 fn emit_preflight_direct_block_budget_guard(
@@ -1392,6 +1548,26 @@ fn emit_preflight_direct_block_plan_entry(
     block_idx: usize,
     block: &BasicBlock,
 ) -> Result<()> {
+    let legacy_label = format!(".L_preflight_block_legacy_cost_{block_idx}");
+    let done_label = format!(".L_preflight_block_cost_entry_done_{block_idx}");
+    writeln!(
+        file,
+        "    cmpq $0, {AOT_CTX_PREFLIGHT_BLOCK_COST_DESCRIPTORS_OFFSET}(%r12)"
+    )?;
+    writeln!(file, "    je {legacy_label}")?;
+    emit_preflight_adaptive_block_plan_entry(&mut file, block_idx, block)?;
+    writeln!(file, "    jmp {done_label}")?;
+    writeln!(file, "{legacy_label}:")?;
+    emit_preflight_legacy_block_plan_entry(&mut file, block_idx, block)?;
+    writeln!(file, "{done_label}:")?;
+    Ok(())
+}
+
+fn emit_preflight_legacy_block_plan_entry(
+    mut file: impl Write,
+    block_idx: usize,
+    block: &BasicBlock,
+) -> Result<()> {
     let no_split_label = format!(".L_preflight_block_no_split_{block_idx}");
     let first_shard_label = format!(".L_preflight_block_first_shard_{block_idx}");
     let target_done_label = format!(".L_preflight_block_target_done_{block_idx}");
@@ -1455,19 +1631,186 @@ fn emit_preflight_direct_block_plan_entry(
     Ok(())
 }
 
+fn emit_preflight_adaptive_block_plan_entry(
+    mut file: impl Write,
+    block_idx: usize,
+    block: &BasicBlock,
+) -> Result<()> {
+    let loop_label = format!(".L_preflight_cost_loop_{block_idx}");
+    let loop_done_label = format!(".L_preflight_cost_loop_done_{block_idx}");
+    let accept_label = format!(".L_preflight_cost_accept_{block_idx}");
+    let first_shard_label = format!(".L_preflight_cost_first_shard_{block_idx}");
+    let target_done_label = format!(".L_preflight_cost_target_done_{block_idx}");
+    let split_label = format!(".L_preflight_cost_split_{block_idx}");
+    let done_label = format!(".L_preflight_cost_done_{block_idx}");
+    let block_cycles = block_instruction_count(block) * PC_STEP_SIZE as u64;
+    let descriptor_offset = block_idx * std::mem::size_of::<AotBlockCostDescriptor>();
+    let has_lzcnt = std::is_x86_feature_detected!("lzcnt");
+
+    // Speculatively update all affected chip counts while accumulating the
+    // exact padded-cost delta. The only loop branch depends on descriptor size;
+    // bucket selection itself uses bsr/cmov and table loads.
+    writeln!(file, "    movq $0, 16(%rsp)")?;
+    writeln!(
+        file,
+        "    movq {AOT_CTX_PREFLIGHT_BLOCK_COST_DESCRIPTORS_OFFSET}(%r12), %r10"
+    )?;
+    writeln!(file, "    movl {descriptor_offset}(%r10), %eax")?;
+    writeln!(file, "    movl {}(%r10), %ecx", descriptor_offset + 4)?;
+    writeln!(file, "    shlq $4, %rax")?;
+    writeln!(
+        file,
+        "    addq {AOT_CTX_PREFLIGHT_CHIP_CONTRIBUTIONS_OFFSET}(%r12), %rax"
+    )?;
+    writeln!(file, "    movq %rax, %r10")?;
+    writeln!(file, "    testl %ecx, %ecx")?;
+    writeln!(file, "    je {loop_done_label}")?;
+    writeln!(file, "{loop_label}:")?;
+    writeln!(file, "    movl (%r10), %eax")?;
+    writeln!(file, "    movl 4(%r10), %edx")?;
+    writeln!(file, "    movq 8(%r10), %r11")?;
+    writeln!(
+        file,
+        "    movq {AOT_CTX_PREFLIGHT_NUM_INSTANCES_OFFSET}(%r12), %rdi"
+    )?;
+    writeln!(file, "    leaq (%rdi,%rax,8), %rsi")?;
+    writeln!(file, "    movq (%rsi), %r9")?;
+    writeln!(file, "    addq %r9, %r11")?;
+    writeln!(file, "    movq %r11, (%rsi)")?;
+    // Point at this chip's precomputed cost-table row. Keeping the row
+    // offset in the descriptor avoids two serialized multiplies per chip.
+    writeln!(
+        file,
+        "    movq {AOT_CTX_PREFLIGHT_COST_TABLE_OFFSET}(%r12), %rdi"
+    )?;
+    writeln!(file, "    addq %rdx, %rdi")?;
+    if has_lzcnt {
+        // bucket(n) = 0 for n=0, otherwise 65-lzcnt(n-1). The zero
+        // correction is a cmov, so chip costing remains branch-free.
+        writeln!(file, "    leaq -1(%r9), %rdx")?;
+        writeln!(file, "    lzcntq %rdx, %rdx")?;
+        writeln!(file, "    movq $65, %r8")?;
+        writeln!(file, "    subq %rdx, %r8")?;
+        writeln!(file, "    testq %r9, %r9")?;
+        writeln!(file, "    cmovz %r9, %r8")?;
+        writeln!(file, "    movq (%rdi,%r8,8), %rdx")?;
+        // The candidate count is always nonzero.
+        writeln!(file, "    leaq -1(%r11), %r9")?;
+        writeln!(file, "    lzcntq %r9, %r9")?;
+        writeln!(file, "    negq %r9")?;
+        writeln!(file, "    addq $65, %r9")?;
+    } else {
+        // Portable x86-64 fallback for hosts without LZCNT.
+        writeln!(file, "    movq %r9, %rdx")?;
+        writeln!(file, "    decq %rdx")?;
+        writeln!(file, "    orq $1, %rdx")?;
+        writeln!(file, "    bsrq %rdx, %rdx")?;
+        writeln!(file, "    addq $2, %rdx")?;
+        writeln!(file, "    movq $1, %r8")?;
+        writeln!(file, "    cmpq $1, %r9")?;
+        writeln!(file, "    cmovbe %r8, %rdx")?;
+        writeln!(file, "    xorq %r8, %r8")?;
+        writeln!(file, "    testq %r9, %r9")?;
+        writeln!(file, "    cmovz %r8, %rdx")?;
+        writeln!(file, "    movq (%rdi,%rdx,8), %rdx")?;
+        writeln!(file, "    movq %r11, %r9")?;
+        writeln!(file, "    decq %r9")?;
+        writeln!(file, "    orq $1, %r9")?;
+        writeln!(file, "    bsrq %r9, %r9")?;
+        writeln!(file, "    addq $2, %r9")?;
+        writeln!(file, "    cmpq $1, %r11")?;
+        writeln!(file, "    movq $1, %r8")?;
+        writeln!(file, "    cmovbe %r8, %r9")?;
+    }
+    writeln!(file, "    movq (%rdi,%r9,8), %r9")?;
+    writeln!(file, "    subq %rdx, %r9")?;
+    writeln!(file, "    addq %r9, 16(%rsp)")?;
+    writeln!(file, "    addq $16, %r10")?;
+    writeln!(file, "    decl %ecx")?;
+    writeln!(file, "    jne {loop_label}")?;
+    writeln!(file, "{loop_done_label}:")?;
+    writeln!(
+        file,
+        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_CELLS_OFFSET}(%r12), %rax"
+    )?;
+    writeln!(file, "    movq (%rax), %r9")?;
+    writeln!(file, "    addq 16(%rsp), %r9")?;
+    writeln!(
+        file,
+        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_STEP_COUNT_OFFSET}(%r12), %r10"
+    )?;
+    writeln!(file, "    cmpq $0, (%r10)")?;
+    writeln!(file, "    je {accept_label}")?;
+    writeln!(
+        file,
+        "    movq {AOT_CTX_PREFLIGHT_PLANNER_SHARD_ID_OFFSET}(%r12), %r10"
+    )?;
+    writeln!(file, "    cmpq $0, (%r10)")?;
+    writeln!(file, "    je {first_shard_label}")?;
+    writeln!(
+        file,
+        "    movq {AOT_CTX_PREFLIGHT_MAX_CELL_PER_SHARD_OFFSET}(%r12), %r10"
+    )?;
+    writeln!(file, "    jmp {target_done_label}")?;
+    writeln!(file, "{first_shard_label}:")?;
+    writeln!(
+        file,
+        "    movq {AOT_CTX_PREFLIGHT_TARGET_CELL_FIRST_SHARD_OFFSET}(%r12), %r10"
+    )?;
+    writeln!(file, "{target_done_label}:")?;
+    writeln!(file, "    cmpq %r10, %r9")?;
+    writeln!(file, "    ja {split_label}")?;
+    writeln!(
+        file,
+        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_CYCLE_OFFSET}(%r12), %r10"
+    )?;
+    writeln!(file, "    movq (%r10), %r11")?;
+    writeln!(file, "    addq ${block_cycles}, %r11")?;
+    writeln!(
+        file,
+        "    cmpq {AOT_CTX_PREFLIGHT_MAX_CYCLE_PER_SHARD_OFFSET}(%r12), %r11"
+    )?;
+    writeln!(file, "    jae {split_label}")?;
+    writeln!(file, "{accept_label}:")?;
+    writeln!(file, "    movq %r9, (%rax)")?;
+    writeln!(file, "    jmp {done_label}")?;
+    writeln!(file, "{split_label}:")?;
+    writeln!(
+        file,
+        "    movq ${block_idx}, {AOT_CTX_PREFLIGHT_PENDING_BLOCK_OFFSET}(%r12)"
+    )?;
+    writeln!(
+        file,
+        "    movl ${AOT_PREFLIGHT_HELPER_SHARD_SPLIT}, {AOT_CTX_PREFLIGHT_HELPER_KIND_OFFSET}(%r12)"
+    )?;
+    writeln!(file, "    movq %r12, %rdi")?;
+    writeln!(file, "    call *%r14")?;
+    writeln!(file, "    cmpl ${AOT_STATUS_ERROR}, %eax")?;
+    writeln!(file, "    je L_error")?;
+    writeln!(file, "{done_label}:")?;
+    Ok(())
+}
+
 fn emit_preflight_direct_block_plan_exit(
     mut file: impl Write,
     block_idx: usize,
     block: &BasicBlock,
 ) -> Result<()> {
+    let cost_done_label = format!(".L_preflight_block_cost_exit_done_{block_idx}");
     let block_steps = block_instruction_count(block);
     let block_cycles = block_steps * PC_STEP_SIZE as u64;
+    writeln!(
+        file,
+        "    cmpq $0, {AOT_CTX_PREFLIGHT_BLOCK_COST_DESCRIPTORS_OFFSET}(%r12)"
+    )?;
+    writeln!(file, "    jne {cost_done_label}")?;
     emit_load_preflight_block_cells(&mut file, block_idx, "exit", "%r8")?;
     writeln!(
         file,
         "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_CELLS_OFFSET}(%r12), %rax"
     )?;
     writeln!(file, "    addq %r8, (%rax)")?;
+    writeln!(file, "{cost_done_label}:")?;
     writeln!(
         file,
         "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_CYCLE_OFFSET}(%r12), %rax"
@@ -1478,6 +1821,32 @@ fn emit_preflight_direct_block_plan_exit(
         "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_STEP_COUNT_OFFSET}(%r12), %rax"
     )?;
     writeln!(file, "    addq ${block_steps}, (%rax)")?;
+    Ok(())
+}
+
+fn emit_preflight_adaptive_exact_access_plan_exit(
+    mut file: impl Write,
+    block: &BasicBlock,
+) -> Result<()> {
+    let done_label = format!(".L_adaptive_exact_exit_done_{:x}", block.start_pc);
+    let block_steps = block_instruction_count(block);
+    let block_cycles = block_steps * PC_STEP_SIZE as u64;
+    writeln!(
+        file,
+        "    cmpq $0, {AOT_CTX_PREFLIGHT_BLOCK_COST_DESCRIPTORS_OFFSET}(%r12)"
+    )?;
+    writeln!(file, "    je {done_label}")?;
+    writeln!(
+        file,
+        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_CYCLE_OFFSET}(%r12), %rax"
+    )?;
+    writeln!(file, "    addq ${block_cycles}, (%rax)")?;
+    writeln!(
+        file,
+        "    movq {AOT_CTX_PREFLIGHT_PLANNER_CUR_STEP_COUNT_OFFSET}(%r12), %rax"
+    )?;
+    writeln!(file, "    addq ${block_steps}, (%rax)")?;
+    writeln!(file, "{done_label}:")?;
     Ok(())
 }
 
@@ -1694,6 +2063,16 @@ fn emit_preflight_direct_planner_step_static(
     let step_cells_done_label = format!(".L_preflight_step_cells_done_{pc:x}");
     let no_split_label = format!(".L_preflight_no_split_{pc:x}");
     let split_done_label = format!(".L_preflight_split_done_{pc:x}");
+    let adaptive_done_label = format!(".L_preflight_adaptive_step_done_{pc:x}");
+
+    // Adaptive native blocks account for their complete opcode mix at block
+    // entry. Their exact-access steps still update cycles and access records,
+    // but must not also apply the legacy scalar planner update here.
+    writeln!(
+        file,
+        "    cmpq $0, {AOT_CTX_PREFLIGHT_BLOCK_COST_DESCRIPTORS_OFFSET}(%r12)"
+    )?;
+    writeln!(file, "    jne {adaptive_done_label}")?;
 
     writeln!(
         file,
@@ -1768,6 +2147,7 @@ fn emit_preflight_direct_planner_step_static(
     writeln!(file, "    jmp {split_done_label}")?;
     writeln!(file, "{no_split_label}:")?;
     writeln!(file, "{split_done_label}:")?;
+    writeln!(file, "{adaptive_done_label}:")?;
     Ok(())
 }
 
@@ -3012,7 +3392,60 @@ unsafe extern "C" fn aot_preflight_direct_helper(context: *mut AotRuntimeContext
             unsafe { aot_trace_native_preflight(context as *mut AotRuntimeContext) }
         }
         AOT_PREFLIGHT_HELPER_SHARD_SPLIT => {
+            let adaptive_descriptor = (!context.preflight_block_cost_descriptors.is_null()
+                && context.preflight_pending_block != usize::MAX)
+                .then(|| unsafe {
+                    *context
+                        .preflight_block_cost_descriptors
+                        .add(context.preflight_pending_block)
+                });
+            if let Some(descriptor) = adaptive_descriptor {
+                // Restore the accepted shard's counts before finalizing it;
+                // the native entry speculatively stored this block's candidate.
+                let counts = unsafe {
+                    std::slice::from_raw_parts_mut(
+                        context.preflight_num_instances,
+                        context.preflight_num_chips,
+                    )
+                };
+                let contributions = unsafe {
+                    std::slice::from_raw_parts(
+                        context
+                            .preflight_chip_contributions
+                            .add(descriptor.contribution_offset as usize),
+                        descriptor.contribution_count as usize,
+                    )
+                };
+                for contribution in contributions {
+                    counts[contribution.chip_index as usize] = counts
+                        [contribution.chip_index as usize]
+                        .saturating_sub(contribution.instance_delta);
+                }
+            }
             vm.tracer_mut().record_native_shard_split();
+            if let Some(descriptor) = adaptive_descriptor {
+                let counts = unsafe {
+                    std::slice::from_raw_parts_mut(
+                        context.preflight_num_instances,
+                        context.preflight_num_chips,
+                    )
+                };
+                let contributions = unsafe {
+                    std::slice::from_raw_parts(
+                        context
+                            .preflight_chip_contributions
+                            .add(descriptor.contribution_offset as usize),
+                        descriptor.contribution_count as usize,
+                    )
+                };
+                for contribution in contributions {
+                    counts[contribution.chip_index as usize] = contribution.instance_delta;
+                }
+                unsafe {
+                    *context.preflight_planner_cur_cells = descriptor.standalone_cost;
+                }
+                context.preflight_pending_block = usize::MAX;
+            }
             AOT_STATUS_CONTINUE
         }
         other => {
@@ -3027,8 +3460,9 @@ unsafe extern "C" fn aot_preflight_direct_helper(context: *mut AotRuntimeContext
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CENO_PLATFORM, EmuContext, encode_rv32};
+    use crate::{CENO_PLATFORM, ChipCostSpec, EmuContext, ShardCostModel, encode_rv32};
     use std::sync::Arc;
+    use strum::EnumCount;
 
     fn program(instructions: Vec<Instruction>) -> Program {
         Program::new(
@@ -3161,6 +3595,30 @@ mod tests {
             std::mem::offset_of!(AotRuntimeContext, preflight_block_cells_table),
             AOT_CTX_PREFLIGHT_BLOCK_CELLS_TABLE_OFFSET
         );
+        assert_eq!(
+            std::mem::offset_of!(AotRuntimeContext, preflight_block_cost_descriptors),
+            AOT_CTX_PREFLIGHT_BLOCK_COST_DESCRIPTORS_OFFSET
+        );
+        assert_eq!(
+            std::mem::offset_of!(AotRuntimeContext, preflight_chip_contributions),
+            AOT_CTX_PREFLIGHT_CHIP_CONTRIBUTIONS_OFFSET
+        );
+        assert_eq!(
+            std::mem::offset_of!(AotRuntimeContext, preflight_cost_table),
+            AOT_CTX_PREFLIGHT_COST_TABLE_OFFSET
+        );
+        assert_eq!(
+            std::mem::offset_of!(AotRuntimeContext, preflight_num_instances),
+            AOT_CTX_PREFLIGHT_NUM_INSTANCES_OFFSET
+        );
+        assert_eq!(
+            std::mem::offset_of!(AotRuntimeContext, preflight_num_chips),
+            AOT_CTX_PREFLIGHT_NUM_CHIPS_OFFSET
+        );
+        assert_eq!(
+            std::mem::offset_of!(AotRuntimeContext, preflight_pending_block),
+            AOT_CTX_PREFLIGHT_PENDING_BLOCK_OFFSET
+        );
     }
 
     #[test]
@@ -3277,6 +3735,109 @@ mod tests {
                 0
             }
         }
+    }
+
+    #[derive(Debug)]
+    struct AdaptiveTestCost(Arc<ShardCostModel>);
+
+    impl AdaptiveTestCost {
+        fn new() -> Self {
+            let mut opcodes = vec![Vec::new(); InsnKind::COUNT];
+            opcodes[InsnKind::ADDI as usize] = vec![0];
+            opcodes[InsnKind::ADD as usize] = vec![1];
+            opcodes[InsnKind::JAL as usize] = vec![2];
+            let mut ecalls = BTreeMap::new();
+            ecalls.insert(Platform::ecall_halt(), vec![3]);
+            Self(Arc::new(ShardCostModel::new(
+                opcodes,
+                ecalls,
+                vec![
+                    ChipCostSpec {
+                        rotation: 0,
+                        trace_cells_per_row: 1,
+                        tower_peak_cells_per_row: 0,
+                    },
+                    ChipCostSpec {
+                        rotation: 0,
+                        trace_cells_per_row: 1,
+                        tower_peak_cells_per_row: 8,
+                    },
+                    ChipCostSpec {
+                        rotation: 0,
+                        trace_cells_per_row: 1,
+                        tower_peak_cells_per_row: 0,
+                    },
+                    ChipCostSpec {
+                        rotation: 0,
+                        trace_cells_per_row: 1,
+                        tower_peak_cells_per_row: 0,
+                    },
+                ],
+                4,
+            )))
+        }
+    }
+
+    impl crate::StepCellExtractor for AdaptiveTestCost {
+        fn cells_for_kind(&self, _kind: InsnKind, _rs1_value: Option<Word>) -> u64 {
+            0
+        }
+
+        fn shard_cost_model(&self) -> Option<Arc<ShardCostModel>> {
+            Some(self.0.clone())
+        }
+    }
+
+    fn adaptive_test_program() -> Arc<Program> {
+        Arc::new(program(vec![
+            encode_rv32(InsnKind::ADDI, 0, 0, 1, 1),
+            encode_rv32(InsnKind::ADDI, 0, 0, 2, 2),
+            encode_rv32(InsnKind::JAL, 0, 0, 0, 4),
+            encode_rv32(InsnKind::ADD, 1, 2, 3, 0),
+            encode_rv32(InsnKind::ADD, 2, 3, 4, 0),
+            encode_rv32(InsnKind::JAL, 0, 0, 0, 4),
+            encode_rv32(InsnKind::ECALL, 0, 0, 0, 0),
+        ]))
+    }
+
+    #[test]
+    fn aot_adaptive_cost_splits_before_blocks_and_reinitializes_rejected_block() {
+        let program = adaptive_test_program();
+        // The first block exactly fills the limit and must be accepted. The
+        // second block is oversized on an empty shard and must also run once.
+        let config = crate::PreflightTracerConfig::new(true, 15, Cycle::MAX)
+            .with_step_cell_extractor(Arc::new(AdaptiveTestCost::new()));
+        let aot =
+            AotProgram::compile_preflight_direct_with_extra_roots(program.clone(), Vec::new())
+                .unwrap();
+        let mut vm = VMState::<crate::PreflightTracer>::new_with_tracer_config(
+            CENO_PLATFORM.clone(),
+            program,
+            config,
+        );
+        aot.run_to_halt(&mut vm, 100).unwrap();
+        let (plan, _) = vm.take_tracer().into_shard_plan();
+        assert_eq!(plan.shard_cycle_boundaries(), &[4, 16, 28, 32]);
+        assert_eq!(plan.predicted_shard_costs(), &[15, 23, 5]);
+    }
+
+    #[test]
+    fn aot_adaptive_cost_honors_cycle_limit_at_block_boundaries() {
+        let program = adaptive_test_program();
+        let config = crate::PreflightTracerConfig::new(true, u64::MAX, 16)
+            .with_step_cell_extractor(Arc::new(AdaptiveTestCost::new()));
+        let aot =
+            AotProgram::compile_preflight_direct_with_extra_roots(program.clone(), Vec::new())
+                .unwrap();
+        let mut vm = VMState::<crate::PreflightTracer>::new_with_tracer_config(
+            CENO_PLATFORM.clone(),
+            program,
+            config,
+        );
+        aot.run_to_halt(&mut vm, 100).unwrap();
+        let (plan, _) = vm.take_tracer().into_shard_plan();
+        assert_eq!(plan.shard_cycle_boundaries(), &[4, 16, 28, 32]);
+        assert_eq!(plan.predicted_shard_costs(), &[15, 23, 5]);
     }
 
     #[test]

--- a/ceno_emul/src/lib.rs
+++ b/ceno_emul/src/lib.rs
@@ -10,9 +10,9 @@ pub use platform::{CENO_PLATFORM, Platform};
 
 mod tracer;
 pub use tracer::{
-    Change, FullTracer, FullTracerConfig, LatestAccesses, MemOp, NextAccessPair, NextCycleAccess,
-    PreflightTracer, PreflightTracerConfig, ReadOp, ShardPlanBuilder, StepCellExtractor, StepIndex,
-    StepRecord, Tracer, WriteOp,
+    Change, ChipCostSpec, FullTracer, FullTracerConfig, LatestAccesses, MemOp, NextAccessPair,
+    NextCycleAccess, PreflightTracer, PreflightTracerConfig, ReadOp, SHARD_COST_BUCKETS,
+    ShardCostModel, ShardPlanBuilder, StepCellExtractor, StepIndex, StepRecord, Tracer, WriteOp,
 };
 
 mod vm_state;

--- a/ceno_emul/src/tracer.rs
+++ b/ceno_emul/src/tracer.rs
@@ -10,6 +10,7 @@ use rayon::prelude::*;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use std::{collections::BTreeMap, fmt, sync::Arc};
+use strum::EnumCount;
 
 /// An instruction and its context in an execution trace. That is concrete values of registers and memory.
 ///
@@ -77,9 +78,124 @@ pub type StepIndex = usize;
 pub trait StepCellExtractor {
     fn cells_for_kind(&self, kind: InsnKind, rs1_value: Option<Word>) -> u64;
 
+    fn shard_cost_model(&self) -> Option<Arc<ShardCostModel>> {
+        None
+    }
+
     #[inline(always)]
     fn extract_cells(&self, step: &StepRecord) -> u64 {
         self.cells_for_kind(step.insn().kind, step.rs1().map(|op| op.value))
+    }
+}
+
+pub const SHARD_COST_BUCKETS: usize = u64::BITS as usize + 2;
+const NO_CHIP: u32 = u32::MAX;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChipCostSpec {
+    pub rotation: u8,
+    pub trace_cells_per_row: u64,
+    pub tower_peak_cells_per_row: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct ShardCostModel {
+    opcode_chips: Vec<Vec<u32>>,
+    ecall_chips: BTreeMap<Word, Vec<u32>>,
+    chip_specs: Vec<ChipCostSpec>,
+    cost_table: Vec<u64>,
+    extension_field_degree: u64,
+}
+
+impl ShardCostModel {
+    pub fn new(
+        opcode_chips: Vec<Vec<usize>>,
+        ecall_chips: BTreeMap<Word, Vec<usize>>,
+        chip_specs: Vec<ChipCostSpec>,
+        extension_field_degree: usize,
+    ) -> Self {
+        assert_eq!(opcode_chips.len(), InsnKind::COUNT);
+        assert!(extension_field_degree > 0);
+        assert!(chip_specs.len() < NO_CHIP as usize);
+        assert!(
+            opcode_chips
+                .iter()
+                .flatten()
+                .chain(ecall_chips.values().flatten())
+                .all(|&chip| chip < chip_specs.len()),
+            "shard cost mapping references an unknown chip"
+        );
+        let opcode_chips = opcode_chips
+            .into_iter()
+            .map(|chips| chips.into_iter().map(|chip| chip as u32).collect())
+            .collect();
+        let ecall_chips = ecall_chips
+            .into_iter()
+            .map(|(code, chips)| (code, chips.into_iter().map(|chip| chip as u32).collect()))
+            .collect();
+        let extension_field_degree = extension_field_degree as u64;
+        let mut cost_table = Vec::with_capacity(chip_specs.len() * SHARD_COST_BUCKETS);
+        for spec in &chip_specs {
+            for bucket in 0..SHARD_COST_BUCKETS {
+                let padded_instances = match bucket {
+                    0 => 0,
+                    bucket if bucket == SHARD_COST_BUCKETS - 1 => u64::MAX,
+                    bucket => 1u64 << (bucket - 1),
+                };
+                let rotation_size = 1u64.checked_shl(spec.rotation.into()).unwrap_or(u64::MAX);
+                let domain_rows = padded_instances
+                    .checked_mul(rotation_size)
+                    .unwrap_or(u64::MAX);
+                let trace_cells = domain_rows.saturating_mul(spec.trace_cells_per_row);
+                let tower_peak = domain_rows.saturating_mul(spec.tower_peak_cells_per_row);
+                let main_peak = domain_rows.saturating_mul(extension_field_degree);
+                cost_table.push(trace_cells.saturating_add(tower_peak.max(main_peak)));
+            }
+        }
+        Self {
+            opcode_chips,
+            ecall_chips,
+            chip_specs,
+            cost_table,
+            extension_field_degree,
+        }
+    }
+
+    pub fn chip_count(&self) -> usize {
+        self.chip_specs.len()
+    }
+
+    pub fn chips_for_step(&self, kind: InsnKind, ecall_code: Option<Word>) -> &[u32] {
+        if kind == InsnKind::ECALL {
+            ecall_code
+                .and_then(|code| self.ecall_chips.get(&code))
+                .map_or(&[], Vec::as_slice)
+        } else {
+            self.opcode_chips
+                .get(kind as usize)
+                .map_or(&[], Vec::as_slice)
+        }
+    }
+
+    pub fn chip_cost(&self, chip: usize, num_instances: u64) -> u64 {
+        self.cost_table[chip * SHARD_COST_BUCKETS + padded_size_bucket(num_instances)]
+    }
+
+    pub fn cost_table(&self) -> &[u64] {
+        &self.cost_table
+    }
+
+    pub fn extension_field_degree(&self) -> u64 {
+        self.extension_field_degree
+    }
+}
+
+#[inline(always)]
+fn padded_size_bucket(num_instances: u64) -> usize {
+    if num_instances == 0 {
+        0
+    } else {
+        (u64::BITS - num_instances.saturating_sub(1).leading_zeros() + 1) as usize
     }
 }
 
@@ -314,11 +430,14 @@ impl LatestAccesses {
 #[derive(Clone, Debug)]
 pub struct ShardPlanBuilder {
     shard_cycle_boundaries: Vec<Cycle>,
+    predicted_shard_costs: Vec<u64>,
     max_cell_per_shard: u64,
     target_cell_first_shard: u64,
     max_cycle_per_shard: Cycle,
     current_shard_start_cycle: Cycle,
     cur_cells: u64,
+    cost_model: Option<Arc<ShardCostModel>>,
+    num_instances: Vec<u64>,
     cur_ecall_counts: BTreeMap<Word, u64>,
     cur_ecall_peak_cells: BTreeMap<Word, u64>,
     cur_cycle_in_shard: Cycle,
@@ -330,14 +449,26 @@ pub struct ShardPlanBuilder {
 
 impl ShardPlanBuilder {
     pub fn new(max_cell_per_shard: u64, max_cycle_per_shard: Cycle) -> Self {
+        Self::new_with_cost_model(max_cell_per_shard, max_cycle_per_shard, None)
+    }
+
+    pub fn new_with_cost_model(
+        max_cell_per_shard: u64,
+        max_cycle_per_shard: Cycle,
+        cost_model: Option<Arc<ShardCostModel>>,
+    ) -> Self {
         let initial_cycle = FullTracer::SUBCYCLES_PER_INSN;
+        let num_instances = vec![0; cost_model.as_ref().map_or(0, |model| model.chip_count())];
         ShardPlanBuilder {
             shard_cycle_boundaries: vec![initial_cycle],
+            predicted_shard_costs: Vec::new(),
             max_cell_per_shard,
             target_cell_first_shard: max_cell_per_shard,
             max_cycle_per_shard,
             current_shard_start_cycle: initial_cycle,
             cur_cells: 0,
+            cost_model,
+            num_instances,
             cur_ecall_counts: BTreeMap::new(),
             cur_ecall_peak_cells: BTreeMap::new(),
             cur_cycle_in_shard: 0,
@@ -368,6 +499,10 @@ impl ShardPlanBuilder {
         self.max_step_shard
     }
 
+    pub fn predicted_shard_costs(&self) -> &[u64] {
+        &self.predicted_shard_costs
+    }
+
     pub fn into_cycle_boundaries(self) -> Vec<Cycle> {
         assert!(self.finalized, "shard plan not finalized yet");
         self.shard_cycle_boundaries
@@ -385,6 +520,48 @@ impl ShardPlanBuilder {
             self.ecall_step_delta(ecall_code, base_cells),
             |planner| planner.add_ecall_step(ecall_code, base_cells),
         );
+    }
+
+    fn observe_modeled_step(
+        &mut self,
+        step_cycle: Cycle,
+        kind: InsnKind,
+        ecall_code: Option<Word>,
+    ) {
+        let chips = self
+            .cost_model
+            .as_ref()
+            .map(|model| {
+                model
+                    .chips_for_step(kind, ecall_code)
+                    .iter()
+                    .map(|&chip| chip as usize)
+                    .collect::<SmallVec<[_; 2]>>()
+            })
+            .unwrap_or_default();
+        let delta = chips.iter().fold(0u64, |delta, &chip| {
+            delta.saturating_add(self.modeled_step_delta(chip))
+        });
+        self.observe_step_with_delta(step_cycle, delta, |planner| {
+            for chip in chips {
+                planner.add_modeled_step(chip);
+            }
+        });
+    }
+
+    fn modeled_step_delta(&self, chip: usize) -> u64 {
+        let model = self.cost_model.as_ref().expect("cost model missing");
+        let old_count = self.num_instances[chip];
+        model
+            .chip_cost(chip, old_count.saturating_add(1))
+            .saturating_sub(model.chip_cost(chip, old_count))
+    }
+
+    fn add_modeled_step(&mut self, chip: usize) {
+        let delta = self.modeled_step_delta(chip);
+        self.num_instances[chip] = self.num_instances[chip].saturating_add(1);
+        self.cur_cells = self.cur_cells.saturating_add(delta);
+        self.debug_assert_cost_invariant();
     }
 
     fn observe_step_with_delta(
@@ -426,10 +603,12 @@ impl ShardPlanBuilder {
             self.cur_cells > 0 || self.cur_cycle_in_shard > 0,
             "shard split before accumulating any steps"
         );
+        self.record_predicted_shard_cost();
         self.push_boundary(next_shard_cycle);
         self.shard_id += 1;
         self.current_shard_start_cycle = next_shard_cycle;
         self.cur_cells = 0;
+        self.num_instances.fill(0);
         self.cur_ecall_counts.clear();
         self.cur_ecall_peak_cells.clear();
         self.cur_cycle_in_shard = 0;
@@ -509,8 +688,37 @@ impl ShardPlanBuilder {
     }
 
     fn reset_after_native_shard_split(&mut self) {
+        self.num_instances.fill(0);
         self.cur_ecall_counts.clear();
         self.cur_ecall_peak_cells.clear();
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    fn debug_assert_cost_invariant(&self) {
+        if let Some(model) = &self.cost_model {
+            let recomputed = self
+                .num_instances
+                .iter()
+                .enumerate()
+                .fold(0u64, |total, (chip, &count)| {
+                    total.saturating_add(model.chip_cost(chip, count))
+                });
+            debug_assert_eq!(self.cur_cells, recomputed, "shard cost accounting drift");
+        }
+    }
+
+    #[cfg(not(any(test, debug_assertions)))]
+    #[inline(always)]
+    fn debug_assert_cost_invariant(&self) {}
+
+    fn record_predicted_shard_cost(&mut self) {
+        self.debug_assert_cost_invariant();
+        tracing::debug!(
+            shard_id = self.shard_id,
+            predicted_cost = self.cur_cells,
+            "finalized adaptive shard cost"
+        );
+        self.predicted_shard_costs.push(self.cur_cells);
     }
 
     fn padded_ecall_count(count: u64) -> u64 {
@@ -527,6 +735,7 @@ impl ShardPlanBuilder {
             "shard plan cannot be finalized multiple times"
         );
         self.max_step_shard = self.max_step_shard.max(self.cur_step_count);
+        self.record_predicted_shard_cost();
         self.cur_step_count = 0;
         self.push_boundary(max_cycle);
         self.finalized = true;
@@ -1272,6 +1481,8 @@ pub(crate) struct PreflightNativeTraceState {
     pub planner_max_cell_per_shard: u64,
     pub planner_target_cell_first_shard: u64,
     pub planner_max_cycle_per_shard: Cycle,
+    pub planner_num_instances: *mut u64,
+    pub planner_num_chips: usize,
 }
 
 #[derive(Clone)]
@@ -1381,6 +1592,10 @@ impl PreflightTracer {
             planner_cycle_limit = planner_cycle_limit.saturating_sub(Self::SUBCYCLES_PER_INSN);
         }
         let max_cell_per_shard = config.max_cell_per_shard();
+        let cost_model = config
+            .step_cell_extractor
+            .as_ref()
+            .and_then(|extractor| extractor.shard_cost_model());
         let mut tracer = PreflightTracer {
             cycle: <Self as Tracer>::SUBCYCLES_PER_INSN,
             pc: Default::default(),
@@ -1390,9 +1605,10 @@ impl PreflightTracer {
             latest_accesses: LatestAccesses::new(platform),
             next_accesses: FxHashMap::default(),
             register_reads_tracked: 0,
-            planner: Some(ShardPlanBuilder::new(
+            planner: Some(ShardPlanBuilder::new_with_cost_model(
                 max_cell_per_shard,
                 planner_cycle_limit,
+                cost_model,
             )),
             current_shard_start_cycle: <Self as Tracer>::SUBCYCLES_PER_INSN,
             config,
@@ -1426,6 +1642,10 @@ impl PreflightTracer {
     pub(crate) fn native_trace_state(&mut self) -> PreflightNativeTraceState {
         debug_assert!(self.supports_direct_native_trace());
         let planner = self.planner.as_mut().expect("shard planner missing");
+        let planner_num_chips = planner
+            .cost_model
+            .as_ref()
+            .map_or(0, |model| model.chip_count());
         PreflightNativeTraceState {
             latest_cells: self.latest_accesses.cells_mut_ptr(),
             latest_base: self.latest_accesses.base(),
@@ -1442,6 +1662,8 @@ impl PreflightTracer {
             planner_max_cell_per_shard: planner.max_cell_per_shard,
             planner_target_cell_first_shard: planner.target_cell_first_shard,
             planner_max_cycle_per_shard: planner.max_cycle_per_shard,
+            planner_num_instances: planner.num_instances.as_mut_ptr(),
+            planner_num_chips,
         }
     }
 
@@ -1457,9 +1679,20 @@ impl PreflightTracer {
             .unwrap_or(0)
     }
 
+    pub(crate) fn shard_cost_model(&self) -> Option<Arc<ShardCostModel>> {
+        self.planner
+            .as_ref()
+            .and_then(|planner| planner.cost_model.clone())
+    }
+
     #[inline(always)]
     fn observe_current_step(&mut self, ecall_code: Option<Word>) {
         if let Some(planner) = self.planner.as_mut() {
+            if planner.cost_model.is_some() {
+                planner.observe_modeled_step(self.cycle, self.last_kind, ecall_code);
+                self.current_shard_start_cycle = planner.current_shard_start_cycle();
+                return;
+            }
             let step_cells = self
                 .config
                 .step_cell_extractor
@@ -1530,6 +1763,7 @@ impl PreflightTracer {
     pub(crate) fn record_native_shard_split(&mut self) {
         let planner = self.planner.as_mut().expect("shard planner missing");
         let next_shard_cycle = self.cycle;
+        planner.record_predicted_shard_cost();
         planner.push_boundary(next_shard_cycle);
         planner.shard_id += 1;
         planner.current_shard_start_cycle = next_shard_cycle;
@@ -1852,6 +2086,62 @@ impl<T: fmt::Debug> fmt::Debug for Change<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn cost_model(specs: Vec<ChipCostSpec>) -> Arc<ShardCostModel> {
+        let mut opcodes = vec![Vec::new(); InsnKind::COUNT];
+        opcodes[InsnKind::ADD as usize] = vec![0];
+        let mut ecalls = BTreeMap::new();
+        ecalls.insert(7, vec![0]);
+        Arc::new(ShardCostModel::new(opcodes, ecalls, specs, 4))
+    }
+
+    #[test]
+    fn shard_cost_model_padding_rotation_and_extension_degree() {
+        let model = cost_model(vec![ChipCostSpec {
+            rotation: 1,
+            trace_cells_per_row: 2,
+            tower_peak_cells_per_row: 3,
+        }]);
+        assert_eq!(model.extension_field_degree(), 4);
+        assert_eq!(model.chip_cost(0, 0), 0);
+        assert_eq!(model.chip_cost(0, 1), 12);
+        assert_eq!(model.chip_cost(0, 2), 24);
+        assert_eq!(model.chip_cost(0, 3), 48);
+        assert_eq!(model.chip_cost(0, 4), 48);
+        assert_eq!(model.chip_cost(0, 5), 96);
+    }
+
+    #[test]
+    fn shard_cost_model_selects_tower_or_main_peak() {
+        let model = cost_model(vec![
+            ChipCostSpec {
+                rotation: 0,
+                trace_cells_per_row: 2,
+                tower_peak_cells_per_row: 9,
+            },
+            ChipCostSpec {
+                rotation: 0,
+                trace_cells_per_row: 2,
+                tower_peak_cells_per_row: 1,
+            },
+        ]);
+        assert_eq!(model.chip_cost(0, 1), 11);
+        assert_eq!(model.chip_cost(1, 1), 6);
+    }
+
+    #[test]
+    fn modeled_native_and_ecall_steps_share_chip_counts() {
+        let model = cost_model(vec![ChipCostSpec {
+            rotation: 0,
+            trace_cells_per_row: 1,
+            tower_peak_cells_per_row: 1,
+        }]);
+        let mut planner = ShardPlanBuilder::new_with_cost_model(100, Cycle::MAX, Some(model));
+        planner.observe_modeled_step(4, InsnKind::ADD, None);
+        planner.observe_modeled_step(8, InsnKind::ECALL, Some(7));
+        assert_eq!(planner.num_instances, vec![2]);
+        assert_eq!(planner.cur_cells(), 10);
+    }
 
     #[derive(Debug)]
     struct OneCellPerStep;

--- a/ceno_emul/src/tracer.rs
+++ b/ceno_emul/src/tracer.rs
@@ -91,11 +91,23 @@ pub trait StepCellExtractor {
 pub const SHARD_COST_BUCKETS: usize = u64::BITS as usize + 2;
 const NO_CHIP: u32 = u32::MAX;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ChipCostSpec {
     pub rotation: u8,
     pub trace_cells_per_row: u64,
     pub tower_peak_cells_per_row: u64,
+    /// Optional scheduler-derived tower peak for every padded-size bucket.
+    /// When absent, tests and compatibility callers use the linear per-row
+    /// estimate above.
+    pub tower_peak_cells_by_bucket: Option<Vec<u64>>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(C)]
+pub struct ChipCost {
+    pub trace_cells: u64,
+    pub main_peak: u64,
+    pub tower_peak: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -103,7 +115,9 @@ pub struct ShardCostModel {
     opcode_chips: Vec<Vec<u32>>,
     ecall_chips: BTreeMap<Word, Vec<u32>>,
     chip_specs: Vec<ChipCostSpec>,
-    cost_table: Vec<u64>,
+    trace_cost_table: Vec<u64>,
+    main_cost_table: Vec<u64>,
+    tower_cost_table: Vec<u64>,
     extension_field_degree: u64,
 }
 
@@ -134,8 +148,14 @@ impl ShardCostModel {
             .map(|(code, chips)| (code, chips.into_iter().map(|chip| chip as u32).collect()))
             .collect();
         let extension_field_degree = extension_field_degree as u64;
-        let mut cost_table = Vec::with_capacity(chip_specs.len() * SHARD_COST_BUCKETS);
+        let table_len = chip_specs.len() * SHARD_COST_BUCKETS;
+        let mut trace_cost_table = Vec::with_capacity(table_len);
+        let mut main_cost_table = Vec::with_capacity(table_len);
+        let mut tower_cost_table = Vec::with_capacity(table_len);
         for spec in &chip_specs {
+            if let Some(tower_costs) = &spec.tower_peak_cells_by_bucket {
+                assert_eq!(tower_costs.len(), SHARD_COST_BUCKETS);
+            }
             for bucket in 0..SHARD_COST_BUCKETS {
                 let padded_instances = match bucket {
                     0 => 0,
@@ -147,16 +167,23 @@ impl ShardCostModel {
                     .checked_mul(rotation_size)
                     .unwrap_or(u64::MAX);
                 let trace_cells = domain_rows.saturating_mul(spec.trace_cells_per_row);
-                let tower_peak = domain_rows.saturating_mul(spec.tower_peak_cells_per_row);
                 let main_peak = domain_rows.saturating_mul(extension_field_degree);
-                cost_table.push(trace_cells.saturating_add(tower_peak.max(main_peak)));
+                let tower_peak = spec.tower_peak_cells_by_bucket.as_ref().map_or_else(
+                    || domain_rows.saturating_mul(spec.tower_peak_cells_per_row),
+                    |tower_costs| tower_costs[bucket],
+                );
+                trace_cost_table.push(trace_cells);
+                main_cost_table.push(main_peak);
+                tower_cost_table.push(tower_peak);
             }
         }
         Self {
             opcode_chips,
             ecall_chips,
             chip_specs,
-            cost_table,
+            trace_cost_table,
+            main_cost_table,
+            tower_cost_table,
             extension_field_degree,
         }
     }
@@ -177,12 +204,41 @@ impl ShardCostModel {
         }
     }
 
-    pub fn chip_cost(&self, chip: usize, num_instances: u64) -> u64 {
-        self.cost_table[chip * SHARD_COST_BUCKETS + padded_size_bucket(num_instances)]
+    pub fn chip_cost(&self, chip: usize, num_instances: u64) -> ChipCost {
+        let index = chip * SHARD_COST_BUCKETS + padded_size_bucket(num_instances);
+        ChipCost {
+            trace_cells: self.trace_cost_table[index],
+            main_peak: self.main_cost_table[index],
+            tower_peak: self.tower_cost_table[index],
+        }
     }
 
-    pub fn cost_table(&self) -> &[u64] {
-        &self.cost_table
+    pub fn trace_cost_table(&self) -> &[u64] {
+        &self.trace_cost_table
+    }
+
+    pub fn main_cost_table(&self) -> &[u64] {
+        &self.main_cost_table
+    }
+
+    pub fn tower_cost_table(&self) -> &[u64] {
+        &self.tower_cost_table
+    }
+
+    pub fn shard_cost(&self, num_instances: &[u64]) -> u64 {
+        assert_eq!(num_instances.len(), self.chip_count());
+        let (trace_total, main_total, tower_peak) = num_instances.iter().enumerate().fold(
+            (0u64, 0u64, 0u64),
+            |(trace, main, tower), (chip, &count)| {
+                let cost = self.chip_cost(chip, count);
+                (
+                    trace.saturating_add(cost.trace_cells),
+                    main.saturating_add(cost.main_peak),
+                    tower.max(cost.tower_peak),
+                )
+            },
+        );
+        trace_total.saturating_add(main_total.max(tower_peak))
     }
 
     pub fn extension_field_degree(&self) -> u64 {
@@ -436,6 +492,9 @@ pub struct ShardPlanBuilder {
     max_cycle_per_shard: Cycle,
     current_shard_start_cycle: Cycle,
     cur_cells: u64,
+    cur_trace_cells: u64,
+    cur_main_peak: u64,
+    cur_tower_peak: u64,
     cost_model: Option<Arc<ShardCostModel>>,
     num_instances: Vec<u64>,
     cur_ecall_counts: BTreeMap<Word, u64>,
@@ -467,6 +526,9 @@ impl ShardPlanBuilder {
             max_cycle_per_shard,
             current_shard_start_cycle: initial_cycle,
             cur_cells: 0,
+            cur_trace_cells: 0,
+            cur_main_peak: 0,
+            cur_tower_peak: 0,
             cost_model,
             num_instances,
             cur_ecall_counts: BTreeMap::new(),
@@ -539,29 +601,45 @@ impl ShardPlanBuilder {
                     .collect::<SmallVec<[_; 2]>>()
             })
             .unwrap_or_default();
-        let delta = chips.iter().fold(0u64, |delta, &chip| {
-            delta.saturating_add(self.modeled_step_delta(chip))
-        });
-        self.observe_step_with_delta(step_cycle, delta, |planner| {
-            for chip in chips {
-                planner.add_modeled_step(chip);
-            }
-        });
-    }
-
-    fn modeled_step_delta(&self, chip: usize) -> u64 {
-        let model = self.cost_model.as_ref().expect("cost model missing");
-        let old_count = self.num_instances[chip];
-        model
-            .chip_cost(chip, old_count.saturating_add(1))
-            .saturating_sub(model.chip_cost(chip, old_count))
-    }
-
-    fn add_modeled_step(&mut self, chip: usize) {
-        let delta = self.modeled_step_delta(chip);
-        self.num_instances[chip] = self.num_instances[chip].saturating_add(1);
-        self.cur_cells = self.cur_cells.saturating_add(delta);
+        assert!(
+            !self.finalized,
+            "shard plan cannot be extended after finalization"
+        );
+        let mut candidate = self.preview_modeled_chips(&chips);
+        if self.cur_step_count > 0 && self.candidate_would_exceed_shard(candidate.3) {
+            self.finish_current_shard(step_cycle);
+            candidate = self.preview_modeled_chips(&chips);
+        }
+        for chip in chips {
+            self.num_instances[chip] = self.num_instances[chip].saturating_add(1);
+        }
+        (
+            self.cur_trace_cells,
+            self.cur_main_peak,
+            self.cur_tower_peak,
+            self.cur_cells,
+        ) = candidate;
+        self.cur_cycle_in_shard = self
+            .cur_cycle_in_shard
+            .saturating_add(FullTracer::SUBCYCLES_PER_INSN);
+        self.cur_step_count = self.cur_step_count.saturating_add(1);
         self.debug_assert_cost_invariant();
+    }
+
+    fn preview_modeled_chips(&self, chips: &[usize]) -> (u64, u64, u64, u64) {
+        let model = self.cost_model.as_ref().expect("cost model missing");
+        let mut trace = self.cur_trace_cells;
+        let mut main = self.cur_main_peak;
+        let mut tower = self.cur_tower_peak;
+        for &chip in chips {
+            let old = model.chip_cost(chip, self.num_instances[chip]);
+            let new = model.chip_cost(chip, self.num_instances[chip].saturating_add(1));
+            trace = trace.saturating_add(new.trace_cells.saturating_sub(old.trace_cells));
+            main = main.saturating_add(new.main_peak.saturating_sub(old.main_peak));
+            tower = tower.max(new.tower_peak);
+        }
+        let total = trace.saturating_add(main.max(tower));
+        (trace, main, tower, total)
     }
 
     fn observe_step_with_delta(
@@ -586,12 +664,16 @@ impl ShardPlanBuilder {
     }
 
     fn step_would_exceed_shard(&self, step_delta: u64) -> bool {
+        self.candidate_would_exceed_shard(self.cur_cells.saturating_add(step_delta))
+    }
+
+    fn candidate_would_exceed_shard(&self, candidate_cost: u64) -> bool {
         let target = if self.shard_id == 0 {
             self.target_cell_first_shard
         } else {
             self.max_cell_per_shard
         };
-        self.cur_cells.saturating_add(step_delta) > target
+        candidate_cost > target
             || self
                 .cur_cycle_in_shard
                 .saturating_add(FullTracer::SUBCYCLES_PER_INSN)
@@ -608,6 +690,9 @@ impl ShardPlanBuilder {
         self.shard_id += 1;
         self.current_shard_start_cycle = next_shard_cycle;
         self.cur_cells = 0;
+        self.cur_trace_cells = 0;
+        self.cur_main_peak = 0;
+        self.cur_tower_peak = 0;
         self.num_instances.fill(0);
         self.cur_ecall_counts.clear();
         self.cur_ecall_peak_cells.clear();
@@ -689,6 +774,9 @@ impl ShardPlanBuilder {
 
     fn reset_after_native_shard_split(&mut self) {
         self.num_instances.fill(0);
+        self.cur_trace_cells = 0;
+        self.cur_main_peak = 0;
+        self.cur_tower_peak = 0;
         self.cur_ecall_counts.clear();
         self.cur_ecall_peak_cells.clear();
     }
@@ -696,13 +784,21 @@ impl ShardPlanBuilder {
     #[cfg(any(test, debug_assertions))]
     fn debug_assert_cost_invariant(&self) {
         if let Some(model) = &self.cost_model {
-            let recomputed = self
-                .num_instances
-                .iter()
-                .enumerate()
-                .fold(0u64, |total, (chip, &count)| {
-                    total.saturating_add(model.chip_cost(chip, count))
-                });
+            let (trace, main, tower) = self.num_instances.iter().enumerate().fold(
+                (0u64, 0u64, 0u64),
+                |(trace, main, tower), (chip, &count)| {
+                    let cost = model.chip_cost(chip, count);
+                    (
+                        trace.saturating_add(cost.trace_cells),
+                        main.saturating_add(cost.main_peak),
+                        tower.max(cost.tower_peak),
+                    )
+                },
+            );
+            let recomputed = trace.saturating_add(main.max(tower));
+            debug_assert_eq!(self.cur_trace_cells, trace, "trace cost accounting drift");
+            debug_assert_eq!(self.cur_main_peak, main, "main peak accounting drift");
+            debug_assert_eq!(self.cur_tower_peak, tower, "tower peak accounting drift");
             debug_assert_eq!(self.cur_cells, recomputed, "shard cost accounting drift");
         }
     }
@@ -1474,6 +1570,9 @@ pub(crate) struct PreflightNativeTraceState {
     pub last_kind: *mut InsnKind,
     pub current_shard_start_cycle: *const Cycle,
     pub planner_cur_cells: *mut u64,
+    pub planner_cur_trace_cells: *mut u64,
+    pub planner_cur_main_peak: *mut u64,
+    pub planner_cur_tower_peak: *mut u64,
     pub planner_cur_cycle_in_shard: *mut Cycle,
     pub planner_cur_step_count: *mut usize,
     pub planner_max_step_shard: *mut usize,
@@ -1655,6 +1754,9 @@ impl PreflightTracer {
             last_kind: &mut self.last_kind,
             current_shard_start_cycle: &self.current_shard_start_cycle,
             planner_cur_cells: &mut planner.cur_cells,
+            planner_cur_trace_cells: &mut planner.cur_trace_cells,
+            planner_cur_main_peak: &mut planner.cur_main_peak,
+            planner_cur_tower_peak: &mut planner.cur_tower_peak,
             planner_cur_cycle_in_shard: &mut planner.cur_cycle_in_shard,
             planner_cur_step_count: &mut planner.cur_step_count,
             planner_max_step_shard: &mut planner.max_step_shard,
@@ -2101,14 +2203,15 @@ mod tests {
             rotation: 1,
             trace_cells_per_row: 2,
             tower_peak_cells_per_row: 3,
+            tower_peak_cells_by_bucket: None,
         }]);
         assert_eq!(model.extension_field_degree(), 4);
-        assert_eq!(model.chip_cost(0, 0), 0);
-        assert_eq!(model.chip_cost(0, 1), 12);
-        assert_eq!(model.chip_cost(0, 2), 24);
-        assert_eq!(model.chip_cost(0, 3), 48);
-        assert_eq!(model.chip_cost(0, 4), 48);
-        assert_eq!(model.chip_cost(0, 5), 96);
+        assert_eq!(model.chip_cost(0, 0), ChipCost::default());
+        assert_eq!(model.shard_cost(&[1]), 12);
+        assert_eq!(model.shard_cost(&[2]), 24);
+        assert_eq!(model.shard_cost(&[3]), 48);
+        assert_eq!(model.shard_cost(&[4]), 48);
+        assert_eq!(model.shard_cost(&[5]), 96);
     }
 
     #[test]
@@ -2118,15 +2221,54 @@ mod tests {
                 rotation: 0,
                 trace_cells_per_row: 2,
                 tower_peak_cells_per_row: 9,
+                tower_peak_cells_by_bucket: None,
             },
             ChipCostSpec {
                 rotation: 0,
                 trace_cells_per_row: 2,
                 tower_peak_cells_per_row: 1,
+                tower_peak_cells_by_bucket: None,
             },
         ]);
-        assert_eq!(model.chip_cost(0, 1), 11);
-        assert_eq!(model.chip_cost(1, 1), 6);
+        assert_eq!(model.shard_cost(&[1, 0]), 11);
+        assert_eq!(model.shard_cost(&[0, 1]), 6);
+        // Trace and main coexist across chips, while tower is the dominant
+        // single-chip task rather than the sum of both tower peaks.
+        assert_eq!(model.shard_cost(&[1, 1]), 13);
+
+        let main_dominant = cost_model(vec![
+            ChipCostSpec {
+                rotation: 0,
+                trace_cells_per_row: 0,
+                tower_peak_cells_per_row: 5,
+                tower_peak_cells_by_bucket: None,
+            },
+            ChipCostSpec {
+                rotation: 0,
+                trace_cells_per_row: 0,
+                tower_peak_cells_per_row: 5,
+                tower_peak_cells_by_bucket: None,
+            },
+        ]);
+        assert_eq!(main_dominant.shard_cost(&[1, 1]), 8);
+    }
+
+    #[test]
+    fn shard_cost_model_uses_scheduler_tower_bucket_table() {
+        let mut tower = vec![0; SHARD_COST_BUCKETS];
+        tower[1] = 7;
+        tower[2] = 11;
+        tower[3] = 29;
+        let model = cost_model(vec![ChipCostSpec {
+            rotation: 0,
+            trace_cells_per_row: 0,
+            tower_peak_cells_per_row: u64::MAX,
+            tower_peak_cells_by_bucket: Some(tower),
+        }]);
+        assert_eq!(model.shard_cost(&[1]), 7);
+        assert_eq!(model.shard_cost(&[2]), 11);
+        assert_eq!(model.shard_cost(&[3]), 29);
+        assert_eq!(model.shard_cost(&[4]), 29);
     }
 
     #[test]
@@ -2135,6 +2277,7 @@ mod tests {
             rotation: 0,
             trace_cells_per_row: 1,
             tower_peak_cells_per_row: 1,
+            tower_peak_cells_by_bucket: None,
         }]);
         let mut planner = ShardPlanBuilder::new_with_cost_model(100, Cycle::MAX, Some(model));
         planner.observe_modeled_step(4, InsnKind::ADD, None);

--- a/ceno_emul/src/tracer.rs
+++ b/ceno_emul/src/tracer.rs
@@ -167,7 +167,12 @@ impl ShardCostModel {
                     .checked_mul(rotation_size)
                     .unwrap_or(u64::MAX);
                 let trace_cells = domain_rows.saturating_mul(spec.trace_cells_per_row);
-                let main_peak = domain_rows.saturating_mul(extension_field_degree);
+                // Batched main sumcheck keeps one half-domain extension-field
+                // fold buffer for every witness, structural-witness, and fixed
+                // MLE. `trace_cells_per_row` is exactly that MLE count.
+                let main_peak = (domain_rows / 2)
+                    .saturating_mul(spec.trace_cells_per_row)
+                    .saturating_mul(extension_field_degree);
                 let tower_peak = spec.tower_peak_cells_by_bucket.as_ref().map_or_else(
                     || domain_rows.saturating_mul(spec.tower_peak_cells_per_row),
                     |tower_costs| tower_costs[bucket],
@@ -2219,6 +2224,24 @@ mod tests {
     }
 
     #[test]
+    fn shard_cost_model_counts_every_batched_main_fold_mle() {
+        let model = cost_model(vec![ChipCostSpec {
+            rotation: 0,
+            trace_cells_per_row: 9,
+            tower_peak_cells_per_row: 0,
+            tower_peak_cells_by_bucket: None,
+        }]);
+
+        assert_eq!(model.chip_cost(0, 0).main_peak, 0);
+        assert_eq!(model.chip_cost(0, 1).main_peak, 0);
+        // Nine MLEs each allocate a half-domain Ext4 fold buffer.
+        assert_eq!(model.chip_cost(0, 2).main_peak, 9 * 1 * 4);
+        assert_eq!(model.chip_cost(0, 3).main_peak, 9 * 2 * 4);
+        assert_eq!(model.chip_cost(0, 4).main_peak, 9 * 2 * 4);
+        assert_eq!(model.chip_cost(0, 5).main_peak, 9 * 4 * 4);
+    }
+
+    #[test]
     fn shard_cost_model_selects_tower_or_main_peak() {
         let model = cost_model(vec![
             ChipCostSpec {
@@ -2234,27 +2257,27 @@ mod tests {
                 tower_peak_cells_by_bucket: None,
             },
         ]);
-        assert_eq!(model.shard_cost(&[1, 0]), 11);
-        assert_eq!(model.shard_cost(&[0, 1]), 6);
+        assert_eq!(model.shard_cost(&[2, 0]), 22);
+        assert_eq!(model.shard_cost(&[0, 2]), 12);
         // Trace and main coexist across chips, while tower is the dominant
         // single-chip task rather than the sum of both tower peaks.
-        assert_eq!(model.shard_cost(&[1, 1]), 13);
+        assert_eq!(model.shard_cost(&[2, 2]), 26);
 
         let main_dominant = cost_model(vec![
             ChipCostSpec {
                 rotation: 0,
-                trace_cells_per_row: 0,
+                trace_cells_per_row: 2,
                 tower_peak_cells_per_row: 5,
                 tower_peak_cells_by_bucket: None,
             },
             ChipCostSpec {
                 rotation: 0,
-                trace_cells_per_row: 0,
+                trace_cells_per_row: 2,
                 tower_peak_cells_per_row: 5,
                 tower_peak_cells_by_bucket: None,
             },
         ]);
-        assert_eq!(main_dominant.shard_cost(&[1, 1]), 8);
+        assert_eq!(main_dominant.shard_cost(&[2, 2]), 24);
     }
 
     #[test]
@@ -2287,7 +2310,7 @@ mod tests {
         planner.observe_modeled_step(4, InsnKind::ADD, None);
         planner.observe_modeled_step(8, InsnKind::ECALL, Some(7));
         assert_eq!(planner.num_instances, vec![2]);
-        assert_eq!(planner.cur_cells(), 10);
+        assert_eq!(planner.cur_cells(), 6);
     }
 
     #[derive(Debug)]

--- a/ceno_emul/src/tracer.rs
+++ b/ceno_emul/src/tracer.rs
@@ -163,9 +163,7 @@ impl ShardCostModel {
                     bucket => 1u64 << (bucket - 1),
                 };
                 let rotation_size = 1u64.checked_shl(spec.rotation.into()).unwrap_or(u64::MAX);
-                let domain_rows = padded_instances
-                    .checked_mul(rotation_size)
-                    .unwrap_or(u64::MAX);
+                let domain_rows = padded_instances.saturating_mul(rotation_size);
                 let trace_cells = domain_rows.saturating_mul(spec.trace_cells_per_row);
                 // Batched main sumcheck keeps one half-domain extension-field
                 // fold buffer for every witness, structural-witness, and fixed
@@ -2235,7 +2233,7 @@ mod tests {
         assert_eq!(model.chip_cost(0, 0).main_peak, 0);
         assert_eq!(model.chip_cost(0, 1).main_peak, 0);
         // Nine MLEs each allocate a half-domain Ext4 fold buffer.
-        assert_eq!(model.chip_cost(0, 2).main_peak, 9 * 1 * 4);
+        assert_eq!(model.chip_cost(0, 2).main_peak, 9 * 4);
         assert_eq!(model.chip_cost(0, 3).main_peak, 9 * 2 * 4);
         assert_eq!(model.chip_cost(0, 4).main_peak, 9 * 2 * 4);
         assert_eq!(model.chip_cost(0, 5).main_peak, 9 * 4 * 4);

--- a/ceno_emul/src/tracer.rs
+++ b/ceno_emul/src/tracer.rs
@@ -1781,6 +1781,10 @@ impl PreflightTracer {
             .unwrap_or(0)
     }
 
+    #[cfg_attr(
+        not(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux")),
+        allow(dead_code)
+    )]
     pub(crate) fn shard_cost_model(&self) -> Option<Arc<ShardCostModel>> {
         self.planner
             .as_ref()

--- a/ceno_zkvm/src/instructions/riscv/rv32im.rs
+++ b/ceno_zkvm/src/instructions/riscv/rv32im.rs
@@ -45,12 +45,12 @@ use crate::{
 };
 use ceno_emul::{
     Bn254AddSpec, Bn254DoubleSpec, Bn254Fp2AddSpec, Bn254Fp2MulSpec, Bn254FpAddSpec,
-    Bn254FpMulSpec,
+    Bn254FpMulSpec, ChipCostSpec,
     InsnKind::{self, *},
     KeccakSpec, LogPcCycleSpec, Platform, PubIoCommitSpec, STATE_CONTINUATION, Secp256k1AddSpec,
     Secp256k1DecompressSpec, Secp256k1DoubleSpec, Secp256k1ScalarInvertSpec, Secp256r1AddSpec,
-    Secp256r1DoubleSpec, Secp256r1ScalarInvertSpec, Sha256ExtendSpec, StepCellExtractor, StepIndex,
-    StepRecord, SyscallSpec, Uint256MulSpec, Word,
+    Secp256r1DoubleSpec, Secp256r1ScalarInvertSpec, Sha256ExtendSpec, ShardCostModel,
+    StepCellExtractor, StepIndex, StepRecord, SyscallSpec, Uint256MulSpec, Word,
 };
 use dummy::LargeEcallDummy;
 use ff_ext::ExtensionField;
@@ -69,6 +69,7 @@ use std::{
     any::{TypeId, type_name},
     cmp::Reverse,
     collections::{BTreeMap, HashMap},
+    sync::Arc,
 };
 use strum::{EnumCount, IntoEnumIterator};
 use tracing::info_span;
@@ -188,6 +189,7 @@ pub struct Rv32imConfig<E: ExtensionField> {
     // record opcode name -> cells
     // serve ecall/table for no InsnKind
     pub ecall_cells_map: HashMap<String, u64>,
+    pub shard_cost_model: Arc<ShardCostModel>,
 }
 
 #[derive(Clone)]
@@ -252,6 +254,10 @@ impl<E: ExtensionField> Rv32imConfig<E> {
     ) -> (Self, InstructionDispatchBuilder) {
         let mut inst_cells_map = vec![0; InsnKind::COUNT];
         let mut ecall_cells_map = HashMap::new();
+        let mut opcode_chips = vec![Vec::new(); InsnKind::COUNT];
+        let mut ecall_chips = BTreeMap::new();
+        let mut chip_specs = Vec::new();
+        let mut ecall_name_to_chips = HashMap::new();
 
         let mut inst_dispatch_builder = InstructionDispatchBuilder::new();
 
@@ -261,10 +267,10 @@ impl<E: ExtensionField> Rv32imConfig<E> {
                     <$instruction as Instruction<E>>::inst_kinds(),
                 );
                 let config = cs.register_opcode_circuit::<$instruction>();
+                let circuit_cs = cs.get_cs(&<$instruction>::name());
 
                 // update estimated cell
-                $inst_cells_map[$insn_kind as usize] = cs
-                    .get_cs(&<$instruction>::name())
+                $inst_cells_map[$insn_kind as usize] = circuit_cs
                     .as_ref()
                     .map(|cs| {
                         (cs.zkvm_v1_css.num_witin as u64
@@ -273,6 +279,27 @@ impl<E: ExtensionField> Rv32imConfig<E> {
                             * (1 << cs.rotation_vars().unwrap_or(0))
                     })
                     .unwrap_or_default();
+                let chip = chip_specs.len();
+                let spec = circuit_cs.as_ref().map_or(
+                    ChipCostSpec {
+                        rotation: 0,
+                        trace_cells_per_row: 0,
+                        tower_peak_cells_per_row: 0,
+                    },
+                    |circuit_cs| ChipCostSpec {
+                        rotation: circuit_cs.rotation_vars().unwrap_or(0) as u8,
+                        trace_cells_per_row: (circuit_cs.zkvm_v1_css.num_witin as u64
+                            + circuit_cs.zkvm_v1_css.num_structural_witin as u64
+                            + circuit_cs.zkvm_v1_css.num_fixed as u64),
+                        tower_peak_cells_per_row: (circuit_cs.zkvm_v1_css.num_witin as u64
+                            + circuit_cs.zkvm_v1_css.num_structural_witin as u64
+                            + circuit_cs.zkvm_v1_css.num_fixed as u64),
+                    },
+                );
+                chip_specs.push(spec);
+                for &kind in <$instruction as Instruction<E>>::inst_kinds() {
+                    opcode_chips[kind as usize] = vec![chip];
+                }
 
                 config
             }};
@@ -339,13 +366,14 @@ impl<E: ExtensionField> Rv32imConfig<E> {
         macro_rules! register_ecall_circuit {
             ($instruction:ty, $ecall_cells_map:ident) => {{
                 let config = cs.register_opcode_circuit::<$instruction>();
+                let circuit_cs = cs.get_cs(&<$instruction>::name());
 
                 // update estimated cell
                 assert!(
                     $ecall_cells_map
                         .insert(
                             <$instruction>::name(),
-                            cs.get_cs(&<$instruction>::name())
+                            circuit_cs
                                 .as_ref()
                                 .map(|cs| {
                                     (cs.zkvm_v1_css.num_witin as u64
@@ -357,6 +385,25 @@ impl<E: ExtensionField> Rv32imConfig<E> {
                         )
                         .is_none()
                 );
+                let chip = chip_specs.len();
+                chip_specs.push(circuit_cs.as_ref().map_or(
+                    ChipCostSpec {
+                        rotation: 0,
+                        trace_cells_per_row: 0,
+                        tower_peak_cells_per_row: 0,
+                    },
+                    |circuit_cs| {
+                        let width = circuit_cs.zkvm_v1_css.num_witin as u64
+                            + circuit_cs.zkvm_v1_css.num_structural_witin as u64
+                            + circuit_cs.zkvm_v1_css.num_fixed as u64;
+                        ChipCostSpec {
+                            rotation: circuit_cs.rotation_vars().unwrap_or(0) as u8,
+                            trace_cells_per_row: width,
+                            tower_peak_cells_per_row: width,
+                        }
+                    },
+                ));
+                ecall_name_to_chips.insert(<$instruction>::name(), vec![chip]);
 
                 config
             }};
@@ -392,6 +439,23 @@ impl<E: ExtensionField> Rv32imConfig<E> {
                 )
                 .is_none()
         );
+        let mut keccak_chips = Vec::new();
+        for name in [
+            <KeccakEcallInstruction<E>>::name(),
+            <KeccakCoreInstruction<E>>::name(),
+        ] {
+            let circuit_cs = cs.get_cs(&name).expect("keccak circuit missing");
+            let width = circuit_cs.zkvm_v1_css.num_witin as u64
+                + circuit_cs.zkvm_v1_css.num_structural_witin as u64
+                + circuit_cs.zkvm_v1_css.num_fixed as u64;
+            keccak_chips.push(chip_specs.len());
+            chip_specs.push(ChipCostSpec {
+                rotation: circuit_cs.rotation_vars().unwrap_or(0) as u8,
+                trace_cells_per_row: width,
+                tower_peak_cells_per_row: width,
+            });
+        }
+        ecall_name_to_chips.insert(<KeccakCoreInstruction<E>>::name(), keccak_chips);
         let bn254_add_config = register_ecall_circuit!(WeierstrassAddAssignInstruction<E, SwCurve<Bn254>>, ecall_cells_map);
         let sha_extend_config = register_ecall_circuit!(ShaExtendInstruction<E>, ecall_cells_map);
         let bn254_double_config = register_ecall_circuit!(WeierstrassDoubleAssignInstruction<E, SwCurve<Bn254>>, ecall_cells_map);
@@ -413,6 +477,78 @@ impl<E: ExtensionField> Rv32imConfig<E> {
         let secp256r1_scalar_invert =
             register_ecall_circuit!(Secp256r1InvInstruction<E>, ecall_cells_map);
         let uint256_mul_config = register_ecall_circuit!(Uint256MulInstruction<E>, ecall_cells_map);
+
+        let mut map_ecall = |code, name: String| {
+            let chips = ecall_name_to_chips
+                .get(&name)
+                .unwrap_or_else(|| panic!("missing shard cost chip for {name}"))
+                .clone();
+            assert!(ecall_chips.insert(code, chips).is_none());
+        };
+        map_ecall(ECALL_HALT, HaltInstruction::<E>::name());
+        map_ecall(ECALL_PUB_IO_COMMIT, PubIoCommitInstruction::<E>::name());
+        map_ecall(STATE_CONTINUATION, GlobalState::<E>::name());
+        map_ecall(KeccakSpec::CODE, KeccakCoreInstruction::<E>::name());
+        map_ecall(
+            Bn254AddSpec::CODE,
+            WeierstrassAddAssignInstruction::<E, SwCurve<Bn254>>::name(),
+        );
+        map_ecall(
+            Bn254DoubleSpec::CODE,
+            WeierstrassDoubleAssignInstruction::<E, SwCurve<Bn254>>::name(),
+        );
+        map_ecall(
+            Bn254FpAddSpec::CODE,
+            FpAddInstruction::<E, Bn254BaseField>::name(),
+        );
+        map_ecall(
+            Bn254FpMulSpec::CODE,
+            FpMulInstruction::<E, Bn254BaseField>::name(),
+        );
+        map_ecall(
+            Bn254Fp2AddSpec::CODE,
+            Fp2AddInstruction::<E, Bn254BaseField>::name(),
+        );
+        map_ecall(
+            Bn254Fp2MulSpec::CODE,
+            Fp2MulInstruction::<E, Bn254BaseField>::name(),
+        );
+        map_ecall(
+            Secp256k1AddSpec::CODE,
+            WeierstrassAddAssignInstruction::<E, SwCurve<Secp256k1>>::name(),
+        );
+        map_ecall(
+            Secp256k1DoubleSpec::CODE,
+            WeierstrassDoubleAssignInstruction::<E, SwCurve<Secp256k1>>::name(),
+        );
+        map_ecall(
+            Secp256k1ScalarInvertSpec::CODE,
+            Secp256k1InvInstruction::<E>::name(),
+        );
+        map_ecall(
+            Secp256k1DecompressSpec::CODE,
+            WeierstrassDecompressInstruction::<E, SwCurve<Secp256k1>>::name(),
+        );
+        map_ecall(
+            Secp256r1AddSpec::CODE,
+            WeierstrassAddAssignInstruction::<E, SwCurve<Secp256r1>>::name(),
+        );
+        map_ecall(
+            Secp256r1DoubleSpec::CODE,
+            WeierstrassDoubleAssignInstruction::<E, SwCurve<Secp256r1>>::name(),
+        );
+        map_ecall(
+            Secp256r1ScalarInvertSpec::CODE,
+            Secp256r1InvInstruction::<E>::name(),
+        );
+        map_ecall(Uint256MulSpec::CODE, Uint256MulInstruction::<E>::name());
+        map_ecall(Sha256ExtendSpec::CODE, ShaExtendInstruction::<E>::name());
+        let shard_cost_model = Arc::new(ShardCostModel::new(
+            opcode_chips,
+            ecall_chips,
+            chip_specs,
+            E::DEGREE,
+        ));
 
         // tables
         let dynamic_range_config =
@@ -510,6 +646,7 @@ impl<E: ExtensionField> Rv32imConfig<E> {
             pow_config,
             inst_cells_map,
             ecall_cells_map,
+            shard_cost_model,
         };
 
         (config, inst_dispatch_builder)
@@ -1175,11 +1312,19 @@ impl<E: ExtensionField> StepCellExtractor for &Rv32imConfig<E> {
     fn cells_for_kind(&self, kind: InsnKind, rs1_value: Option<Word>) -> u64 {
         self.cells_for(kind, rs1_value)
     }
+
+    fn shard_cost_model(&self) -> Option<Arc<ShardCostModel>> {
+        Some(self.shard_cost_model.clone())
+    }
 }
 
 impl<E: ExtensionField> StepCellExtractor for Rv32imConfig<E> {
     #[inline(always)]
     fn cells_for_kind(&self, kind: InsnKind, rs1_value: Option<Word>) -> u64 {
         self.cells_for(kind, rs1_value)
+    }
+
+    fn shard_cost_model(&self) -> Option<Arc<ShardCostModel>> {
+        Some(self.shard_cost_model.clone())
     }
 }

--- a/ceno_zkvm/src/instructions/riscv/rv32im.rs
+++ b/ceno_zkvm/src/instructions/riscv/rv32im.rs
@@ -37,7 +37,7 @@ use crate::{
     },
     scheme::constants::DYNAMIC_RANGE_MAX_BITS,
     state::GlobalState,
-    structs::{ZKVMConstraintSystem, ZKVMFixedTraces, ZKVMWitnesses},
+    structs::{ComposedConstrainSystem, ZKVMConstraintSystem, ZKVMFixedTraces, ZKVMWitnesses},
     tables::{
         AndTableCircuit, DoubleU8TableCircuit, DynamicRangeTableCircuit, LtuTableCircuit,
         OrTableCircuit, TableCircuit, XorTableCircuit,
@@ -78,6 +78,46 @@ pub mod mmu;
 
 const ECALL_HALT: u32 = Platform::ecall_halt();
 const ECALL_PUB_IO_COMMIT: u32 = PubIoCommitSpec::CODE;
+
+fn chip_cost_spec<E: ExtensionField>(circuit_cs: &ComposedConstrainSystem<E>) -> ChipCostSpec {
+    let cs = &circuit_cs.zkvm_v1_css;
+    let trace_cells_per_row =
+        cs.num_witin as u64 + cs.num_structural_witin as u64 + cs.num_fixed as u64;
+    let rotation = circuit_cs.rotation_vars().unwrap_or(0) as u8;
+
+    #[cfg(feature = "gpu")]
+    let tower_peak_cells_by_bucket = Some(
+        (0..ceno_emul::SHARD_COST_BUCKETS)
+            .map(|bucket| match bucket {
+                0 => 0,
+                bucket if bucket == ceno_emul::SHARD_COST_BUCKETS - 1 => u64::MAX,
+                bucket => {
+                    let padded_instances = 1u64 << (bucket - 1);
+                    padded_instances
+                        .checked_shl(rotation.into())
+                        .and_then(|rows| usize::try_from(rows).ok())
+                        // The final sentinel buckets are unreachable for a VM
+                        // trace and can exceed the estimator's shift domain.
+                        .filter(|&rows| rows <= (usize::MAX >> 16))
+                        .map_or(u64::MAX, |rows| {
+                            crate::scheme::gpu::estimate_tower_peak_cells_for_rows(circuit_cs, rows)
+                        })
+                }
+            })
+            .collect(),
+    );
+    #[cfg(not(feature = "gpu"))]
+    let tower_peak_cells_by_bucket = None;
+
+    ChipCostSpec {
+        rotation,
+        trace_cells_per_row,
+        // GPU builds use the scheduler's exact bucket table. Keep the old
+        // linear estimate only as a feature-independent compatibility fallback.
+        tower_peak_cells_per_row: trace_cells_per_row,
+        tower_peak_cells_by_bucket,
+    }
+}
 
 pub struct Rv32imConfig<E: ExtensionField> {
     // ALU Opcodes.
@@ -285,16 +325,9 @@ impl<E: ExtensionField> Rv32imConfig<E> {
                         rotation: 0,
                         trace_cells_per_row: 0,
                         tower_peak_cells_per_row: 0,
+                        tower_peak_cells_by_bucket: None,
                     },
-                    |circuit_cs| ChipCostSpec {
-                        rotation: circuit_cs.rotation_vars().unwrap_or(0) as u8,
-                        trace_cells_per_row: (circuit_cs.zkvm_v1_css.num_witin as u64
-                            + circuit_cs.zkvm_v1_css.num_structural_witin as u64
-                            + circuit_cs.zkvm_v1_css.num_fixed as u64),
-                        tower_peak_cells_per_row: (circuit_cs.zkvm_v1_css.num_witin as u64
-                            + circuit_cs.zkvm_v1_css.num_structural_witin as u64
-                            + circuit_cs.zkvm_v1_css.num_fixed as u64),
-                    },
+                    |circuit_cs| chip_cost_spec(circuit_cs),
                 );
                 chip_specs.push(spec);
                 for &kind in <$instruction as Instruction<E>>::inst_kinds() {
@@ -391,17 +424,9 @@ impl<E: ExtensionField> Rv32imConfig<E> {
                         rotation: 0,
                         trace_cells_per_row: 0,
                         tower_peak_cells_per_row: 0,
+                        tower_peak_cells_by_bucket: None,
                     },
-                    |circuit_cs| {
-                        let width = circuit_cs.zkvm_v1_css.num_witin as u64
-                            + circuit_cs.zkvm_v1_css.num_structural_witin as u64
-                            + circuit_cs.zkvm_v1_css.num_fixed as u64;
-                        ChipCostSpec {
-                            rotation: circuit_cs.rotation_vars().unwrap_or(0) as u8,
-                            trace_cells_per_row: width,
-                            tower_peak_cells_per_row: width,
-                        }
-                    },
+                    |circuit_cs| chip_cost_spec(circuit_cs),
                 ));
                 ecall_name_to_chips.insert(<$instruction>::name(), vec![chip]);
 
@@ -445,15 +470,8 @@ impl<E: ExtensionField> Rv32imConfig<E> {
             <KeccakCoreInstruction<E>>::name(),
         ] {
             let circuit_cs = cs.get_cs(&name).expect("keccak circuit missing");
-            let width = circuit_cs.zkvm_v1_css.num_witin as u64
-                + circuit_cs.zkvm_v1_css.num_structural_witin as u64
-                + circuit_cs.zkvm_v1_css.num_fixed as u64;
             keccak_chips.push(chip_specs.len());
-            chip_specs.push(ChipCostSpec {
-                rotation: circuit_cs.rotation_vars().unwrap_or(0) as u8,
-                trace_cells_per_row: width,
-                tower_peak_cells_per_row: width,
-            });
+            chip_specs.push(chip_cost_spec(circuit_cs));
         }
         ecall_name_to_chips.insert(<KeccakCoreInstruction<E>>::name(), keccak_chips);
         let bn254_add_config = register_ecall_circuit!(WeierstrassAddAssignInstruction<E, SwCurve<Bn254>>, ecall_cells_map);

--- a/ceno_zkvm/src/scheme/gpu/memory.rs
+++ b/ceno_zkvm/src/scheme/gpu/memory.rs
@@ -834,16 +834,22 @@ fn estimate_tower_stage_components<E: ExtensionField, PCS: PolynomialCommitmentS
     input: &ProofInput<'_, GpuBackend<E, PCS>>,
     occupied_rows_override: Option<usize>,
 ) -> (usize, usize, usize, usize) {
-    let cs = &composed_cs.zkvm_v1_css;
-    let elem_size = std::mem::size_of::<BB31Ext>();
-    let has_logup_numerator = composed_cs.is_with_lk_table();
-
     let occupied_rows = input
         .witness
         .first()
         .map(|mle| mle.evaluations_len())
         .or(occupied_rows_override)
         .unwrap_or_else(|| input.num_instances() << composed_cs.rotation_vars().unwrap_or(0));
+    estimate_tower_stage_components_for_rows(composed_cs, occupied_rows)
+}
+
+fn estimate_tower_stage_components_for_rows<E: ExtensionField>(
+    composed_cs: &ComposedConstrainSystem<E>,
+    occupied_rows: usize,
+) -> (usize, usize, usize, usize) {
+    let cs = &composed_cs.zkvm_v1_css;
+    let elem_size = std::mem::size_of::<BB31Ext>();
+    let has_logup_numerator = composed_cs.is_with_lk_table();
     let num_reads = cs.r_expressions.len() + cs.r_table_expressions.len();
     let num_writes = cs.w_expressions.len() + cs.w_table_expressions.len();
     let num_lk_numerators = cs.lk_table_expressions.len();
@@ -969,6 +975,29 @@ fn estimate_tower_stage_components<E: ExtensionField, PCS: PolynomialCommitmentS
         tower_input_live_bytes,
         borrowed_input_bytes,
     )
+}
+
+/// Scheduler-equivalent tower peak for a chip at an already padded trace-row
+/// count, expressed in base-field cells. Read, write, and lookup operation
+/// bits are included by the virtual tower group construction above.
+pub(crate) fn estimate_tower_peak_cells_for_rows<E: ExtensionField>(
+    composed_cs: &ComposedConstrainSystem<E>,
+    occupied_rows: usize,
+) -> u64 {
+    if occupied_rows == 0 {
+        return 0;
+    }
+    let (build_bytes, prove_local_bytes, tower_input_live_bytes, borrowed_input_bytes) =
+        estimate_tower_stage_components_for_rows(composed_cs, occupied_rows);
+    let prove_bytes = tower_input_live_bytes
+        .saturating_sub(borrowed_input_bytes)
+        .saturating_add(prove_local_bytes);
+    let cell_bytes = std::mem::size_of::<E::BaseField>().max(1);
+    build_bytes
+        .max(prove_bytes)
+        .div_ceil(cell_bytes)
+        .try_into()
+        .unwrap_or(u64::MAX)
 }
 
 fn estimate_virtual_interleaved_tower_metadata_bytes<E: ExtensionField>(

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -177,7 +177,8 @@ mod util;
 pub(crate) use memory::{
     check_gpu_mem_estimation, check_gpu_mem_estimation_with_context,
     check_gpu_tower_prove_mem_estimation_with_context, estimate_chip_proof_memory,
-    estimate_main_witness_bytes, estimate_tower_bytes, init_gpu_mem_tracker,
+    estimate_main_witness_bytes, estimate_tower_bytes, estimate_tower_peak_cells_for_rows,
+    init_gpu_mem_tracker,
 };
 use memory::{
     estimate_ecc_quark_bytes_from_num_vars, estimate_main_constraints_bytes,


### PR DESCRIPTION
## Problem

Flat per-opcode estimates omit padded trace domains and peak batched-main/tower buffers. They can therefore underprice a shard and permit GPU workloads larger than the configured memory budget.

## Design rationale

Shard cost is derived from registered circuits instead of hand-maintained opcode constants. Opcodes and ecalls map to their contributing chips; per-chip costs are bucketed by padded instance count and circuit rotation. Total cost is trace storage plus the larger of batched-main and tower peak memory because those peak buffers are not live concurrently.

Interpreter and AOT planning use the same model. AOT precomputes basic-block chip contributions while preserving exact access tracking and fallback behavior. GPU tower costs reuse the scheduler memory estimator. Construction assertions and focused tests guard incomplete opcode/ecall registration.

## Changes

- Add padded trace, batched-main, and tower cost tables per chip.
- Register RV32IM and ecall circuit contributions, including composite Keccak.
- Use modeled costs for shard boundaries and adaptive AOT block planning.
- Expose predicted shard costs and scheduler-equivalent tower estimates.

## Benchmark

CPU AOT preflight, cached mainnet input, three executions with one precompiled AOT program, median elapsed time, `CENO_MAX_CELL_PER_SHARD=805306368`:

| Block | Base `eb195ea1` | PR `3307a6e0` | Elapsed change | Shards |
|---:|---:|---:|---:|---:|
| 23587691 | 0.491 s | 0.571 s | +16.4% (0.86x) | 2 -> 5 |
| 23817600 | 6.603 s | 6.141 s | -7.0% (1.08x faster) | 16 -> 57 |

The larger-block preflight is **1.08x faster**. The higher shard counts are expected: the prior estimator undercounted padded and peak memory and produced oversized shards. Current head `7f089576` adds only Clippy cleanup after the benchmarked PR revision.

```sh
RUSTFLAGS='-C target-feature=+avx2' CENO_EMULATOR_BACKEND=aot \
CENO_MAX_CELL_PER_SHARD=805306368 cargo run --release \
  --features 'jemalloc,aot' --bin ceno-reth-benchmark-bin -- \
  --block-number $BLOCK --chain-id 1 --cache-dir block_data --mode execute
```

Environment: AMD Ryzen 9 5900XT, 16 cores/32 threads, `rustc 1.93.0-nightly`. No proving or verification was run.

Both revisions used the same benchmark-only `setup_program` + `emulate_program` adapter because the benchmark checkout's `Sdk::execute` wrapper postdates the base revision.

## Testing

- Shard cost-model tests: 5 passed.
- Adaptive AOT cost-planning tests: 2 passed.
- Cached Reth AOT preflight comparison above.

## Copilot Reviewer Directive (keep this section)

When Copilot reviews this PR, apply `.github/copilot-instructions.md` strictly.
