### PR TITLE
Revert "Lower production zerochecks to degree 3"

### DIFF
--- a/ceno_zkvm/src/bin/riscv_stats.rs
+++ b/ceno_zkvm/src/bin/riscv_stats.rs
@@ -1,39 +1,18 @@
-use std::{collections::BTreeMap, fs::File, io::Write};
+use std::collections::BTreeMap;
 
 use ceno_zkvm::{
-    instructions::riscv::{MmuConfig, Rv32imConfig},
-    stats::{StaticReport, TraceReport, degree_audit},
+    instructions::riscv::Rv32imConfig,
+    stats::{StaticReport, TraceReport},
     structs::ZKVMConstraintSystem,
 };
-use ff_ext::BabyBearExt4;
-type E = BabyBearExt4;
+use ff_ext::GoldilocksExt2;
+type E = GoldilocksExt2;
 fn main() {
     let mut zkvm_cs = ZKVMConstraintSystem::default();
 
     let _ = Rv32imConfig::<E>::construct_circuits(&mut zkvm_cs);
-    let _ = MmuConfig::<E>::construct_circuits(&mut zkvm_cs);
     let static_report = StaticReport::new(&zkvm_cs);
     let report = TraceReport::new(&static_report, BTreeMap::new(), "no program");
     report.save_table("riscv_stats.txt");
-
-    let mut degree_audit_file = File::create("riscv_degree_audit.csv").unwrap();
-    writeln!(
-        degree_audit_file,
-        "chip,max_constraint_degree,max_main_sumcheck_degree,cubic_constraints,witness_columns,trace_weighted_witness_cells"
-    )
-    .unwrap();
-    for row in degree_audit(&zkvm_cs, &BTreeMap::new()) {
-        writeln!(
-            degree_audit_file,
-            "{},{},{},{},{},{}",
-            row.chip,
-            row.max_constraint_degree,
-            row.max_main_sumcheck_degree,
-            row.cubic_constraints,
-            row.witness_columns,
-            row.trace_weighted_witness_cells,
-        )
-        .unwrap();
-    }
-    println!("INFO: generated riscv_stats.txt and riscv_degree_audit.csv");
+    println!("INFO: generated riscv_stats.txt");
 }

--- a/ceno_zkvm/src/gadgets/field/range.rs
+++ b/ceno_zkvm/src/gadgets/field/range.rs
@@ -212,9 +212,9 @@ impl<Expr: Clone, P: FieldParameters> FieldLtCols<Expr, P> {
             // Add the flag to the sum.
             sum_flags = sum_flags.clone() + flag.expr();
         }
-        // Exactly one flag is active when the condition is active, and none are
-        // active otherwise.
-        builder.require_equal(|| "sum_flags", sum_flags.expr(), cond.expr())?;
+        // Assert that the sum is equal to one.
+        builder.condition_require_one(|| "sum_flags", cond.expr(), sum_flags.expr())?;
+        builder.condition_require_zero(|| "sum_flags", 1 - cond.expr(), sum_flags.expr())?;
 
         // Check the less-than condition.
 
@@ -239,22 +239,22 @@ impl<Expr: Clone, P: FieldParameters> FieldLtCols<Expr, P> {
             lhs_comparison_byte = lhs_comparison_byte.expr() + lhs_byte.expr() * flag.expr();
             rhs_comparison_byte = rhs_comparison_byte.expr() + flag.expr() * rhs_byte.expr();
 
-            builder.require_zero(
+            builder.condition_require_zero(
                 || "if cond, when not inequality visited, assert lhs_byte == rhs_byte",
-                (cond.expr() - is_inequality_visited.clone())
-                    * (lhs_byte.clone() - rhs_byte.clone()),
+                cond.expr(),
+                (1 - is_inequality_visited.clone()) * (lhs_byte.clone() - rhs_byte.clone()),
             )?;
         }
 
-        builder.require_equal(
+        builder.condition_require_zero(
             || "if cond, lhs_comparison_byte == lhs_comparison_byte",
-            self.lhs_comparison_byte.expr() * cond.expr(),
-            lhs_comparison_byte,
+            cond.expr(),
+            self.lhs_comparison_byte.expr() - lhs_comparison_byte,
         )?;
-        builder.require_equal(
+        builder.condition_require_zero(
             || "if cond, rhs_comparison_byte == rhs_comparison_byte",
-            self.rhs_comparison_byte.expr() * cond.expr(),
-            rhs_comparison_byte,
+            cond.expr(),
+            self.rhs_comparison_byte.expr() - rhs_comparison_byte,
         )?;
 
         // Send the comparison interaction.

--- a/ceno_zkvm/src/gadgets/poseidon2.rs
+++ b/ceno_zkvm/src/gadgets/poseidon2.rs
@@ -78,7 +78,6 @@ pub struct Poseidon2Config<
 > {
     pub(crate) p3_cols: Vec<WitIn>, // columns in the plonky3-air
     pub(crate) post_linear_layer_cols: Vec<WitIn>, /* additional columns to hold the state after linear layers */
-    pub(crate) sbox_aux_cols: Vec<WitIn>,
     constants: RoundConstants<E::BaseField, STATE_WIDTH, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>,
 }
 
@@ -114,7 +113,6 @@ where
         sbox: &SBox<Expression<E>, SBOX_DEGREE, SBOX_REGISTERS>,
         x: &mut Expression<E>,
         cb: &mut CircuitBuilder<E>,
-        sbox_aux_cols: &mut Vec<WitIn>,
     ) -> Result<(), CircuitBuilderError> {
         *x = match (SBOX_DEGREE, SBOX_REGISTERS) {
             (3, 0) => x.cube(),
@@ -131,14 +129,8 @@ where
             }
             (7, 1) => {
                 let committed_x3: Expression<E> = sbox.0[0].clone();
-                let x2 = cb.flatten_expr(|| "x2 = x.square()", x.square())?;
-                cb.require_zero(
-                    || "x3 = x2 * x",
-                    committed_x3.clone() - x2.expr() * x.clone(),
-                )?;
-                let x6 = cb.flatten_expr(|| "x6 = x3.square()", committed_x3.square())?;
-                sbox_aux_cols.extend([x2, x6]);
-                x6.expr() * x.clone()
+                cb.require_zero(|| "x3 = x.cube()", committed_x3.clone() - x.cube())?;
+                committed_x3.square() * x.clone()
             }
             _ => panic!(
                 "Unexpected (SBOX_DEGREE, SBOX_REGISTERS) of ({}, {})",
@@ -154,11 +146,10 @@ where
         full_round: &FullRound<Expression<E>, STATE_WIDTH, SBOX_DEGREE, SBOX_REGISTERS>,
         round_constants: &[E::BaseField],
         cb: &mut CircuitBuilder<E>,
-        sbox_aux_cols: &mut Vec<WitIn>,
     ) -> Result<(), CircuitBuilderError> {
         for (i, (s, r)) in state.iter_mut().zip_eq(round_constants.iter()).enumerate() {
             *s = s.clone() + r.expr();
-            Self::eval_sbox(&full_round.sbox[i], s, cb, sbox_aux_cols)?;
+            Self::eval_sbox(&full_round.sbox[i], s, cb)?;
         }
         Self::external_linear_layer(state);
         for (state_i, post_i) in state.iter_mut().zip_eq(full_round.post.iter()) {
@@ -175,7 +166,6 @@ where
         partial_round: &PartialRound<Expression<E>, STATE_WIDTH, SBOX_DEGREE, SBOX_REGISTERS>,
         round_constant: &E::BaseField,
         cb: &mut CircuitBuilder<E>,
-        sbox_aux_cols: &mut Vec<WitIn>,
     ) -> Result<(), CircuitBuilderError> {
         cb.require_equal(
             || "post_linear_layer[0] = state[0]",
@@ -184,7 +174,7 @@ where
         )?;
         state[0] = post_linear_layer.expr();
 
-        Self::eval_sbox(&partial_round.sbox, &mut state[0], cb, sbox_aux_cols)?;
+        Self::eval_sbox(&partial_round.sbox, &mut state[0], cb)?;
 
         cb.require_zero(
             || "state[0] = post_sbox",
@@ -271,7 +261,6 @@ where
             HALF_FULL_ROUNDS,
             PARTIAL_ROUNDS,
         > = col_exprs.as_mut_slice().borrow_mut();
-        let mut sbox_aux_cols = Vec::new();
 
         // external linear layer
         Self::external_linear_layer(&mut poseidon2_cols.inputs);
@@ -300,7 +289,6 @@ where
                 &poseidon2_cols.beginning_full_rounds[round],
                 &round_constants.beginning_full_round_constants[round],
                 cb,
-                &mut sbox_aux_cols,
             )
             .unwrap();
         }
@@ -313,7 +301,6 @@ where
                 &poseidon2_cols.partial_rounds[round],
                 &round_constants.partial_round_constants[round],
                 cb,
-                &mut sbox_aux_cols,
             )
             .unwrap();
         }
@@ -339,7 +326,6 @@ where
                 &poseidon2_cols.ending_full_rounds[round],
                 &round_constants.ending_full_round_constants[round],
                 cb,
-                &mut sbox_aux_cols,
             )
             .unwrap();
         }
@@ -347,7 +333,6 @@ where
         Poseidon2Config {
             p3_cols,
             post_linear_layer_cols,
-            sbox_aux_cols,
             constants: round_constants,
         }
     }
@@ -391,7 +376,7 @@ where
     }
 
     pub fn num_cols(&self) -> usize {
-        self.p3_cols.len() + self.post_linear_layer_cols.len() + self.sbox_aux_cols.len()
+        self.p3_cols.len() + self.post_linear_layer_cols.len()
     }
 
     pub fn assign_instance(
@@ -399,10 +384,7 @@ where
         instance: &mut [E::BaseField],
         state: [E::BaseField; STATE_WIDTH],
     ) {
-        let (p3_cols, remaining_cols) = instance.split_at_mut(self.num_p3_cols());
-        let (post_linear_layer_cols, remaining_cols) =
-            remaining_cols.split_at_mut(self.post_linear_layer_cols.len());
-        let (sbox_aux_cols, _) = remaining_cols.split_at_mut(self.sbox_aux_cols.len());
+        let (p3_cols, post_linear_layer_cols) = instance.split_at_mut(self.num_p3_cols());
 
         let poseidon2_cols: &mut Poseidon2Cols<
             E::BaseField,
@@ -424,7 +406,6 @@ where
         >(
             poseidon2_cols,
             post_linear_layer_cols,
-            sbox_aux_cols,
             state,
             &self.constants,
         );
@@ -452,11 +433,9 @@ fn generate_trace_rows_for_perm<
         PARTIAL_ROUNDS,
     >,
     post_linear_layers: &mut [F],
-    sbox_aux_cols: &mut [F],
     mut state: [F; WIDTH],
     constants: &RoundConstants<F, WIDTH, HALF_FULL_ROUNDS, PARTIAL_ROUNDS>,
 ) {
-    let mut sbox_aux_idx = 0;
     perm.export = F::ONE;
     perm.inputs
         .iter_mut()
@@ -482,11 +461,7 @@ fn generate_trace_rows_for_perm<
         .zip(&constants.beginning_full_round_constants)
     {
         generate_full_round::<F, LinearLayers, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>(
-            &mut state,
-            full_round,
-            constants,
-            sbox_aux_cols,
-            &mut sbox_aux_idx,
+            &mut state, full_round, constants,
         );
     }
 
@@ -501,8 +476,6 @@ fn generate_trace_rows_for_perm<
             &mut post_linear_layers[WIDTH + i],
             partial_round,
             *constant,
-            sbox_aux_cols,
-            &mut sbox_aux_idx,
         );
     }
 
@@ -521,14 +494,9 @@ fn generate_trace_rows_for_perm<
         .zip(&constants.ending_full_round_constants)
     {
         generate_full_round::<F, LinearLayers, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>(
-            &mut state,
-            full_round,
-            constants,
-            sbox_aux_cols,
-            &mut sbox_aux_idx,
+            &mut state, full_round, constants,
         );
     }
-    debug_assert_eq!(sbox_aux_idx, sbox_aux_cols.len());
 }
 
 #[inline]
@@ -542,14 +510,12 @@ fn generate_full_round<
     state: &mut [F; WIDTH],
     full_round: &mut FullRound<F, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>,
     round_constants: &[F; WIDTH],
-    sbox_aux_cols: &mut [F],
-    sbox_aux_idx: &mut usize,
 ) {
     for (state_i, const_i) in state.iter_mut().zip(round_constants) {
         *state_i += *const_i;
     }
     for (state_i, sbox_i) in state.iter_mut().zip(full_round.sbox.iter_mut()) {
-        generate_sbox(sbox_i, state_i, sbox_aux_cols, sbox_aux_idx);
+        generate_sbox(sbox_i, state_i);
     }
     LinearLayers::external_linear_layer(state);
     full_round
@@ -573,17 +539,10 @@ fn generate_partial_round<
     post_linear_layer: &mut F,
     partial_round: &mut PartialRound<F, WIDTH, SBOX_DEGREE, SBOX_REGISTERS>,
     round_constant: F,
-    sbox_aux_cols: &mut [F],
-    sbox_aux_idx: &mut usize,
 ) {
     state[0] += round_constant;
     *post_linear_layer = state[0];
-    generate_sbox(
-        &mut partial_round.sbox,
-        &mut state[0],
-        sbox_aux_cols,
-        sbox_aux_idx,
-    );
+    generate_sbox(&mut partial_round.sbox, &mut state[0]);
     partial_round.post_sbox = state[0];
     LinearLayers::internal_linear_layer(state);
 }
@@ -592,8 +551,6 @@ fn generate_partial_round<
 fn generate_sbox<F: PrimeField, const DEGREE: u64, const REGISTERS: usize>(
     sbox: &mut SBox<F, DEGREE, REGISTERS>,
     x: &mut F,
-    sbox_aux_cols: &mut [F],
-    sbox_aux_idx: &mut usize,
 ) {
     *x = match (DEGREE, REGISTERS) {
         (3, 0) => x.cube(),
@@ -606,12 +563,8 @@ fn generate_sbox<F: PrimeField, const DEGREE: u64, const REGISTERS: usize>(
             x3 * x2
         }
         (7, 1) => {
-            let x2 = x.square();
             let x3 = x.cube();
             sbox.0[0] = x3;
-            sbox_aux_cols[*sbox_aux_idx] = x2;
-            sbox_aux_cols[*sbox_aux_idx + 1] = x3.square();
-            *sbox_aux_idx += 2;
             x3 * x3 * *x
         }
         (11, 2) => {

--- a/ceno_zkvm/src/gadgets/signed_limbs.rs
+++ b/ceno_zkvm/src/gadgets/signed_limbs.rs
@@ -28,10 +28,6 @@ pub struct UIntLimbsLTConfig<E: ExtensionField> {
     pub diff_marker: [WitIn; UINT_LIMBS],
     pub diff_val: WitIn,
 
-    // Oriented limb differences. Materializing these products keeps the
-    // marker-gated comparison constraints quadratic.
-    pub oriented_diff: [WitIn; UINT_LIMBS],
-
     // 1 if a < b, 0 otherwise.
     pub cmp_lt: WitIn,
     phantom: PhantomData<E>,
@@ -68,8 +64,6 @@ impl<E: ExtensionField> UIntLimbsLT<E> {
                 .expect("create_bit_error")
         });
         let diff_val = circuit_builder.create_witin(|| "diff_val");
-        let oriented_diff =
-            array::from_fn(|i| circuit_builder.create_witin(|| format!("oriented_diff_{i}")));
 
         // Check if a_msb_f and b_msb_f are signed values of a[NUM_LIMBS - 1] and b[NUM_LIMBS - 1] in prime field F.
         let a_diff = a_expr[UINT_LIMBS - 1].expr() - a_msb_f.expr();
@@ -87,18 +81,12 @@ impl<E: ExtensionField> UIntLimbsLT<E> {
         let mut prefix_sum = Expression::ZERO;
 
         for i in (0..UINT_LIMBS).rev() {
-            let raw_diff = if i == UINT_LIMBS - 1 {
+            let diff = (if i == UINT_LIMBS - 1 {
                 b_msb_f.expr() - a_msb_f.expr()
             } else {
                 b_expr[i].expr() - a_expr[i].expr()
-            };
-            circuit_builder.require_equal(
-                || format!("oriented_diff_{i}"),
-                oriented_diff[i].expr(),
-                raw_diff
-                    * (E::BaseField::from_u8(2).expr() * cmp_lt.expr() - E::BaseField::ONE.expr()),
-            )?;
-            let diff = oriented_diff[i].expr();
+            }) * (E::BaseField::from_u8(2).expr() * cmp_lt.expr()
+                - E::BaseField::ONE.expr());
             prefix_sum += diff_marker[i].expr();
             circuit_builder.require_zero(
                 || format!("prefix_diff_zero_{i}"),
@@ -154,7 +142,6 @@ impl<E: ExtensionField> UIntLimbsLT<E> {
             b_msb_f,
             diff_marker,
             diff_val,
-            oriented_diff,
             cmp_lt,
             phantom: PhantomData,
         })
@@ -221,20 +208,6 @@ impl<E: ExtensionField> UIntLimbsLT<E> {
             a[diff_idx] - b[diff_idx]
         };
         set_val!(instance, config.diff_val, diff_val as u64);
-        for (i, witin) in config.oriented_diff.iter().enumerate() {
-            let oriented_diff = if i == UINT_LIMBS - 1 {
-                if cmp_lt {
-                    b_msb_f - a_msb_f
-                } else {
-                    a_msb_f - b_msb_f
-                }
-            } else if cmp_lt {
-                E::BaseField::from_u16(b[i]) - E::BaseField::from_u16(a[i])
-            } else {
-                E::BaseField::from_u16(a[i]) - E::BaseField::from_u16(b[i])
-            };
-            set_val!(instance, witin, oriented_diff);
-        }
 
         if diff_idx != UINT_LIMBS {
             lkm.assert_ux::<LIMB_BITS>((diff_val - 1) as u64);

--- a/ceno_zkvm/src/instructions/riscv/div/div_circuit_v2.rs
+++ b/ceno_zkvm/src/instructions/riscv/div/div_circuit_v2.rs
@@ -48,11 +48,6 @@ pub struct DivRemConfig<E: ExtensionField> {
     pub(crate) remainder_prime: UInt<E>, // r'
     pub(crate) lt_marker: [WitIn; UINT_LIMBS],
     pub(crate) lt_diff: WitIn,
-    pub(crate) quotient_nonzero_sum: WitIn,
-    pub(crate) quotient_sign_mismatch_nonzero: WitIn,
-    pub(crate) carry_bit_product: [WitIn; UINT_LIMBS],
-    pub(crate) signed_carry_active: [WitIn; UINT_LIMBS],
-    pub(crate) oriented_lt_diff: [WitIn; UINT_LIMBS],
 }
 
 pub struct ArithInstruction<E, I>(PhantomData<(E, I)>);
@@ -196,10 +191,10 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ArithInstruction<E
             .iter()
             .fold(E::BaseField::ZERO.expr(), |acc, d| acc + d.clone());
         let divisor_not_zero: Expression<E> = E::BaseField::ONE.expr() - divisor_zero.expr();
-        cb.require_equal(
+        cb.condition_require_one(
             || "check_divisor_sum_inv",
-            divisor_sum * divisor_sum_inv.expr(),
             divisor_not_zero.clone(),
+            divisor_sum.clone() * divisor_sum_inv.expr(),
         )?;
 
         for (i, remainder_expr) in remainder_expr.iter().enumerate() {
@@ -215,10 +210,10 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ArithInstruction<E
             .fold(E::BaseField::ZERO.expr(), |acc, r| acc + r.clone());
         let divisor_remainder_not_zero: Expression<E> =
             E::BaseField::ONE.expr() - divisor_zero.expr() - remainder_zero.expr();
-        cb.require_equal(
+        cb.condition_require_one(
             || "check_remainder_sum_inv",
-            remainder_sum * remainder_sum_inv.expr(),
             divisor_remainder_not_zero,
+            remainder_sum.clone() * remainder_sum_inv.expr(),
         )?;
 
         // TODO: can directly define sign_xor as expr?
@@ -236,22 +231,14 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ArithInstruction<E
         let quotient_sum: Expression<E> = quotient_expr
             .iter()
             .fold(E::BaseField::ZERO.expr(), |acc, q| acc + q.clone());
-        let quotient_nonzero_sum = cb.flatten_expr(
-            || "quotient_nonzero_sum",
-            quotient_sum * divisor_not_zero.clone(),
-        )?;
         cb.condition_require_zero(
             || "check_quotient_sign_eq_xor",
-            quotient_nonzero_sum.expr(),
+            quotient_sum * divisor_not_zero.clone(),
             quotient_sign.expr() - sign_xor.expr(),
-        )?;
-        let quotient_sign_mismatch_nonzero = cb.flatten_expr(
-            || "quotient_sign_mismatch_nonzero",
-            (quotient_sign.expr() - sign_xor.expr()) * divisor_not_zero.clone(),
         )?;
         cb.condition_require_zero(
             || "check_quotient_sign_zero_when_not_eq_xor",
-            quotient_sign_mismatch_nonzero.expr(),
+            (quotient_sign.expr() - sign_xor.expr()) * divisor_not_zero.clone(),
             quotient_sign.expr(),
         )?;
 
@@ -263,10 +250,6 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ArithInstruction<E
             array::from_fn(|_| E::BaseField::ZERO.expr());
         let remainder_inv: [_; UINT_LIMBS] =
             array::from_fn(|i| cb.create_witin(|| format!("remainder_inv_{i}")));
-        let carry_bit_product: [_; UINT_LIMBS] =
-            array::from_fn(|i| cb.create_witin(|| format!("carry_bit_product_{i}")));
-        let signed_carry_active: [_; UINT_LIMBS] =
-            array::from_fn(|i| cb.create_witin(|| format!("signed_carry_active_{i}")));
 
         for i in 0..UINT_LIMBS {
             // When the signs of remainer (i.e., dividend) and divisor are the same, r_prime = r.
@@ -289,31 +272,22 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ArithInstruction<E
             carry_lt[i] =
                 (last_carry.clone() + remainder_expr[i].clone() + remainder_prime_expr[i].clone())
                     * carry_divide.expr();
-            cb.require_equal(
-                || "carry_bit_product",
-                carry_bit_product[i].expr(),
+            cb.condition_require_zero(
+                || "check_carry_lt",
+                sign_xor.expr(),
                 (carry_lt[i].clone() - last_carry.clone())
                     * (carry_lt[i].clone() - E::BaseField::ONE.expr()),
             )?;
             cb.condition_require_zero(
-                || "check_carry_lt",
-                sign_xor.expr(),
-                carry_bit_product[i].expr(),
-            )?;
-            cb.require_equal(
                 || "check_remainder_prime_not_max",
-                (remainder_prime_expr[i].clone() - E::BaseField::from_u32(1 << LIMB_BITS).expr())
-                    * remainder_inv[i].expr(),
                 sign_xor.expr(),
-            )?;
-            cb.require_equal(
-                || "signed_carry_active",
-                signed_carry_active[i].expr(),
-                sign_xor.expr() * (E::BaseField::ONE.expr() - carry_lt[i].clone()),
+                (remainder_prime_expr[i].clone() - E::BaseField::from_u32(1 << LIMB_BITS).expr())
+                    * remainder_inv[i].expr()
+                    - E::BaseField::ONE.expr(),
             )?;
             cb.condition_require_zero(
                 || "check_remainder_prime_zero",
-                signed_carry_active[i].expr(),
+                sign_xor.expr() * (E::BaseField::ONE.expr() - carry_lt[i].clone()),
                 remainder_prime_expr[i].clone(),
             )?;
         }
@@ -324,18 +298,14 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ArithInstruction<E
         });
         let mut prefix_sum: Expression<E> = divisor_zero.expr() + remainder_zero.expr();
         let lt_diff = cb.create_witin(|| "lt_diff");
-        let oriented_lt_diff: [_; UINT_LIMBS] =
-            array::from_fn(|i| cb.create_witin(|| format!("oriented_lt_diff_{i}")));
 
         for i in (0..UINT_LIMBS).rev() {
-            let raw_diff = remainder_prime_expr[i].clone()
+            let diff = remainder_prime_expr[i].clone()
                 * (E::BaseField::from_u8(2).expr() * divisor_sign.expr()
                     - E::BaseField::ONE.expr())
                 + divisor_expr[i].clone()
                     * (E::BaseField::ONE.expr()
                         - E::BaseField::from_u8(2).expr() * divisor_sign.expr());
-            cb.require_equal(|| "oriented_lt_diff", oriented_lt_diff[i].expr(), raw_diff)?;
-            let diff = oriented_lt_diff[i].expr();
             prefix_sum += lt_marker[i].expr();
             cb.require_zero(
                 || "prefix_sum_not_zero_or_diff_zero",
@@ -407,11 +377,6 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ArithInstruction<E
             remainder_prime,
             lt_marker,
             lt_diff,
-            quotient_nonzero_sum,
-            quotient_sign_mismatch_nonzero,
-            carry_bit_product,
-            signed_carry_active,
-            oriented_lt_diff,
         })
     }
 
@@ -528,11 +493,7 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ArithInstruction<E
         let remainder_sum_f = remainder.iter().fold(E::BaseField::ZERO, |acc, r| {
             acc + E::BaseField::from_u32(*r)
         });
-        let remainder_sum_inv_f = if case == DivRemCoreSpecialCase::None && !remainder_zero {
-            remainder_sum_f.inverse()
-        } else {
-            E::BaseField::ZERO
-        };
+        let remainder_sum_inv_f = remainder_sum_f.try_inverse().unwrap_or(E::BaseField::ZERO);
 
         let (lt_diff_idx, lt_diff_val) = if case == DivRemCoreSpecialCase::None && !remainder_zero {
             let idx = run_sltu_diff_idx(&u32_to_limbs(&divisor), &remainder_prime, divisor_sign);
@@ -552,54 +513,13 @@ impl<E: ExtensionField, I: RIVInstruction> Instruction<E> for ArithInstruction<E
 
         set_val!(instance, config.divisor_sum_inv, divisor_sum_inv_f);
         set_val!(instance, config.remainder_sum_inv, remainder_sum_inv_f);
-        let divisor_not_zero_f =
-            E::BaseField::from_bool(case != DivRemCoreSpecialCase::ZeroDivisor);
-        let quotient_sum_f = quotient.iter().fold(E::BaseField::ZERO, |acc, q| {
-            acc + E::BaseField::from_u32(*q)
-        });
-        set_val!(
-            instance,
-            config.quotient_nonzero_sum,
-            quotient_sum_f * divisor_not_zero_f
-        );
-        set_val!(
-            instance,
-            config.quotient_sign_mismatch_nonzero,
-            (E::BaseField::from_bool(quotient_sign) - E::BaseField::from_bool(sign_xor))
-                * divisor_not_zero_f
-        );
-        let carry_divide = E::BaseField::from_u32(1 << LIMB_BITS).inverse();
-        let mut last_carry = E::BaseField::ZERO;
         for i in 0..UINT_LIMBS {
-            let carry = (last_carry + E::BaseField::from_u32(remainder[i]) + remainder_prime_f[i])
-                * carry_divide;
             set_val!(
                 instance,
                 config.remainder_inv[i],
-                if sign_xor {
-                    (remainder_prime_f[i] - E::BaseField::from_u32(1 << LIMB_BITS)).inverse()
-                } else {
-                    E::BaseField::ZERO
-                }
+                (remainder_prime_f[i] - E::BaseField::from_u32(1 << LIMB_BITS)).inverse()
             );
-            set_val!(
-                instance,
-                config.carry_bit_product[i],
-                (carry - last_carry) * (carry - E::BaseField::ONE)
-            );
-            set_val!(
-                instance,
-                config.signed_carry_active[i],
-                E::BaseField::from_bool(sign_xor) * (E::BaseField::ONE - carry)
-            );
-            let oriented_diff = if divisor_sign {
-                remainder_prime_f[i] - E::BaseField::from_u16(divisor_limbs[i])
-            } else {
-                E::BaseField::from_u16(divisor_limbs[i]) - remainder_prime_f[i]
-            };
-            set_val!(instance, config.oriented_lt_diff[i], oriented_diff);
             set_val!(instance, config.lt_marker[i], (i == lt_diff_idx) as u64);
-            last_carry = carry;
         }
         set_val!(instance, config.sign_xor, sign_xor as u64);
         config.remainder_prime.assign_limbs(

--- a/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp.rs
+++ b/ceno_zkvm/src/instructions/riscv/ecall/fptower_fp.rs
@@ -97,7 +97,7 @@ impl<E: ExtensionField, P: FpOpField + FpAddSpec + NumWords> Instruction<E>
         cb: &mut CircuitBuilder<E>,
         _param: &ProgramParams,
     ) -> Result<(Self::InstructionConfig, GKRCircuit<E>), ZKVMError> {
-        build_fp_op_circuit::<E, P>(cb, P::SYSCALL_CODE, "fp_add", FieldOperation::Add)
+        build_fp_op_circuit::<E, P>(cb, P::SYSCALL_CODE, "fp_add")
     }
 
     fn generate_fixed_traces(
@@ -167,7 +167,7 @@ impl<E: ExtensionField, P: FpOpField + FpMulSpec + NumWords> Instruction<E>
         cb: &mut CircuitBuilder<E>,
         _param: &ProgramParams,
     ) -> Result<(Self::InstructionConfig, GKRCircuit<E>), ZKVMError> {
-        build_fp_op_circuit::<E, P>(cb, P::SYSCALL_CODE, "fp_mul", FieldOperation::Mul)
+        build_fp_op_circuit::<E, P>(cb, P::SYSCALL_CODE, "fp_mul")
     }
 
     fn generate_fixed_traces(
@@ -214,7 +214,6 @@ fn build_fp_op_circuit<E: ExtensionField, P: FpOpField + NumWords>(
     cb: &mut CircuitBuilder<E>,
     syscall_code: u32,
     layer_name: &str,
-    op: FieldOperation,
 ) -> Result<(EcallFpOpConfig<E, P>, GKRCircuit<E>), ZKVMError> {
     let vm_state = StateInOut::construct_circuit(cb, false)?;
 
@@ -254,7 +253,7 @@ fn build_fp_op_circuit<E: ExtensionField, P: FpOpField + NumWords>(
         0.into(),
     ))?;
 
-    let mut layout = FpOpLayout::<E, P>::build_fixed_op(cb, op)?;
+    let mut layout = <FpOpLayout<E, P> as ProtocolBuilder<E>>::build_layer_logic(cb, ())?;
 
     let mut mem_rw = izip!(&layout.input32_exprs[0], &layout.output32_exprs)
         .enumerate()

--- a/ceno_zkvm/src/instructions/riscv/shift/shift_circuit_v2.rs
+++ b/ceno_zkvm/src/instructions/riscv/shift/shift_circuit_v2.rs
@@ -37,12 +37,6 @@ pub struct ShiftBaseConfig<E: ExtensionField, const NUM_LIMBS: usize, const LIMB
 
     // Part of each x[i] that gets bit shifted to the next limb
     pub bit_shift_carry: [WitIn; NUM_LIMBS],
-
-    // Products reused under limb-selection markers. For left shifts this is
-    // b[i] * bit_multiplier_left; for right shifts it is
-    // a[i] * bit_multiplier_right.
-    pub scaled_limbs: [WitIn; NUM_LIMBS],
-    pub sign_fill: Option<WitIn>,
     pub phantom: PhantomData<E>,
 }
 
@@ -65,30 +59,6 @@ impl<E: ExtensionField, const NUM_LIMBS: usize, const LIMB_BITS: usize>
         let b_sign = circuit_builder.create_bit(|| "b_sign")?;
         let bit_shift_carry =
             array::from_fn(|i| circuit_builder.create_witin(|| format!("bit_shift_carry_{}", i)));
-        let scaled_limbs =
-            array::from_fn(|i| circuit_builder.create_witin(|| format!("scaled_shift_limb_{i}")));
-        for i in 0..NUM_LIMBS {
-            let product = match kind {
-                InsnKind::SLL | InsnKind::SLLI => b[i].expr() * bit_multiplier_left.expr(),
-                InsnKind::SRL | InsnKind::SRLI | InsnKind::SRA | InsnKind::SRAI => {
-                    a[i].expr() * bit_multiplier_right.expr()
-                }
-                _ => unreachable!(),
-            };
-            circuit_builder.require_equal(
-                || format!("scaled_shift_limb_{i}"),
-                scaled_limbs[i].expr(),
-                product,
-            )?;
-        }
-        let sign_fill = if matches!(kind, InsnKind::SRA | InsnKind::SRAI) {
-            Some(circuit_builder.flatten_expr(
-                || "sign_fill",
-                b_sign.expr() * (bit_multiplier_right.expr() - Expression::ONE),
-            )?)
-        } else {
-            None
-        };
 
         // Constrain that bit_shift, bit_multiplier are correct, i.e. that bit_multiplier =
         // 1 << bit_shift. Because the sum of all bit_shift_marker[i] is constrained to be
@@ -150,7 +120,7 @@ impl<E: ExtensionField, const NUM_LIMBS: usize, const LIMB_BITS: usize>
                                 Expression::ZERO
                             } else {
                                 bit_shift_carry[j - i - 1].expr()
-                            } + scaled_limbs[j - i].expr()
+                            } + b[j - i].expr() * bit_multiplier_left.expr()
                                 - E::BaseField::from_usize(1 << LIMB_BITS).expr()
                                     * bit_shift_carry[j - i].expr();
                             circuit_builder.condition_require_zero(
@@ -172,7 +142,7 @@ impl<E: ExtensionField, const NUM_LIMBS: usize, const LIMB_BITS: usize>
                             )?;
                         } else {
                             let expected_a_right = if j + i == NUM_LIMBS - 1 {
-                                sign_fill.map_or(Expression::ZERO, |wit| wit.expr())
+                                b_sign.expr() * (bit_multiplier_right.expr() - Expression::ONE)
                             } else {
                                 bit_shift_carry[j + i + 1].expr()
                             } * E::BaseField::from_usize(1 << LIMB_BITS)
@@ -182,7 +152,7 @@ impl<E: ExtensionField, const NUM_LIMBS: usize, const LIMB_BITS: usize>
                             circuit_builder.condition_require_zero(
                                 || format!("limb_shift_marker_a_expected_a_right_{i}_{j}",),
                                 limb_shift_marker[i].expr(),
-                                scaled_limbs[j].expr() - expected_a_right,
+                                a[j].expr() * bit_multiplier_right.expr() - expected_a_right,
                             )?;
                         }
                     }
@@ -229,8 +199,6 @@ impl<E: ExtensionField, const NUM_LIMBS: usize, const LIMB_BITS: usize>
             bit_multiplier_right,
             limb_shift_marker,
             bit_shift_carry,
-            scaled_limbs,
-            sign_fill,
             b_sign,
             phantom: PhantomData,
         })
@@ -281,7 +249,7 @@ impl<E: ExtensionField, const NUM_LIMBS: usize, const LIMB_BITS: usize>
     ) {
         let b: [u32; NUM_LIMBS] = split_to_limb::<u32, LIMB_BITS>(b).try_into().unwrap();
         let c: [u32; NUM_LIMBS] = split_to_limb::<u32, LIMB_BITS>(c).try_into().unwrap();
-        let (a, limb_shift, bit_shift) = run_shift::<NUM_LIMBS, LIMB_BITS>(kind, &b, &c);
+        let (_, limb_shift, bit_shift) = run_shift::<NUM_LIMBS, LIMB_BITS>(kind, &b, &c);
 
         match kind {
             InsnKind::SLL | InsnKind::SLLI => set_val!(
@@ -295,16 +263,6 @@ impl<E: ExtensionField, const NUM_LIMBS: usize, const LIMB_BITS: usize>
                 E::BaseField::from_usize(1 << bit_shift)
             ),
         };
-
-        let multiplier = E::BaseField::from_usize(1 << bit_shift);
-        for (i, witin) in self.scaled_limbs.iter().enumerate() {
-            let limb = if matches!(kind, InsnKind::SLL | InsnKind::SLLI) {
-                b[i]
-            } else {
-                a[i]
-            };
-            set_val!(instance, witin, E::BaseField::from_u32(limb) * multiplier);
-        }
 
         let bit_shift_carry: [u32; NUM_LIMBS] = array::from_fn(|i| match kind {
             InsnKind::SLL | InsnKind::SLLI => b[i] >> (LIMB_BITS - bit_shift),
@@ -332,13 +290,6 @@ impl<E: ExtensionField, const NUM_LIMBS: usize, const LIMB_BITS: usize>
             lk_multiplicity.lookup_xor_byte(b[NUM_LIMBS - 1] as u64, 1 << (LIMB_BITS - 1));
         }
         set_val!(instance, self.b_sign, E::BaseField::from_bool(b_sign != 0));
-        if let Some(sign_fill) = self.sign_fill {
-            set_val!(
-                instance,
-                sign_fill,
-                E::BaseField::from_u32(b_sign) * (multiplier - E::BaseField::ONE)
-            );
-        }
     }
 }
 

--- a/ceno_zkvm/src/precompiles/fptower/fp.rs
+++ b/ceno_zkvm/src/precompiles/fptower/fp.rs
@@ -171,17 +171,14 @@ impl<E: ExtensionField, P: FpOpField> FpOpLayout<E, P> {
         cols.output_range_check
             .populate(lk_multiplicity, &output, &modulus);
     }
+}
 
-    pub fn build_fixed_op(
-        cb: &mut CircuitBuilder<E>,
-        op: FieldOperation,
-    ) -> Result<Self, CircuitBuilderError> {
-        Self::build_with_op(cb, Some(op))
-    }
+impl<E: ExtensionField, P: FpOpField> ProtocolBuilder<E> for FpOpLayout<E, P> {
+    type Params = ();
 
-    fn build_with_op(
+    fn build_layer_logic(
         cb: &mut CircuitBuilder<E>,
-        op: Option<FieldOperation>,
+        _params: Self::Params,
     ) -> Result<Self, CircuitBuilderError> {
         let mut layout = FpOpLayout::new(cb);
         let wits = &layout.layer_exprs.wits;
@@ -195,36 +192,18 @@ impl<E: ExtensionField, P: FpOpField> FpOpLayout<E, P> {
         )?;
 
         let modulus: Polynomial<Expression<E>> = P::to_limbs_expr::<E>(&P::modulus()).into();
-        if let Some(op) = op {
-            cb.require_equal(
-                || "fp_op_fixed_add",
-                wits.is_add.expr(),
-                E::BaseField::from_bool(op == FieldOperation::Add).expr(),
-            )?;
-            cb.require_equal(
-                || "fp_op_fixed_sub",
-                wits.is_sub.expr(),
-                E::BaseField::from_bool(op == FieldOperation::Sub).expr(),
-            )?;
-            cb.require_equal(
-                || "fp_op_fixed_mul",
-                wits.is_mul.expr(),
-                E::BaseField::from_bool(op == FieldOperation::Mul).expr(),
-            )?;
-            wits.output
-                .eval_with_modulus(cb, &wits.x_limbs, &wits.y_limbs, &modulus, op)?;
-        } else {
-            wits.output.eval_variable(
-                cb,
-                &wits.x_limbs,
-                &wits.y_limbs,
-                &modulus,
-                wits.is_add.expr(),
-                wits.is_sub.expr(),
-                wits.is_mul.expr(),
-                E::BaseField::ZERO.expr(),
-            )?;
-        }
+        let zero = E::BaseField::ZERO.expr();
+
+        wits.output.eval_variable(
+            cb,
+            &wits.x_limbs,
+            &wits.y_limbs,
+            &modulus,
+            wits.is_add.expr(),
+            wits.is_sub.expr(),
+            wits.is_mul.expr(),
+            zero,
+        )?;
         wits.output_range_check
             .eval(cb, &wits.output.result, &modulus)?;
 
@@ -244,17 +223,6 @@ impl<E: ExtensionField, P: FpOpField> FpOpLayout<E, P> {
         layout.output32_exprs = output32;
 
         Ok(layout)
-    }
-}
-
-impl<E: ExtensionField, P: FpOpField> ProtocolBuilder<E> for FpOpLayout<E, P> {
-    type Params = ();
-
-    fn build_layer_logic(
-        cb: &mut CircuitBuilder<E>,
-        _params: Self::Params,
-    ) -> Result<Self, CircuitBuilderError> {
-        Self::build_with_op(cb, None)
     }
 
     fn finalize(&mut self, name: String, cb: &mut CircuitBuilder<E>) -> Chip<E> {

--- a/ceno_zkvm/src/precompiles/uint256.rs
+++ b/ceno_zkvm/src/precompiles/uint256.rs
@@ -233,15 +233,13 @@ impl<E: ExtensionField> ProtocolBuilder<E> for Uint256MulLayout<E> {
         coeff_2_256.push(Expression::ONE);
         let modulus_polynomial: Polynomial<Expression<E>> = (*modulus_limbs).into();
         let modulus_is_zero_expr = modulus_is_zero.expr();
-        // modulus_is_zero is constrained iff every modulus limb is zero, so
-        // adding 2^256 in that case is equivalent to conditionally selecting
-        // between modulus and 2^256 without multiplying every modulus limb by
-        // the selector.
-        let p_modulus: Polynomial<Expression<E>> = modulus_polynomial
-            + poly_scale_expr(
-                &Polynomial::from_coefficients(&coeff_2_256),
-                modulus_is_zero_expr.clone(),
-            );
+        let p_modulus: Polynomial<Expression<E>> = poly_scale_expr(
+            &modulus_polynomial,
+            Expression::ONE - modulus_is_zero_expr.clone(),
+        ) + poly_scale_expr(
+            &Polynomial::from_coefficients(&coeff_2_256),
+            modulus_is_zero_expr.clone(),
+        );
 
         // Evaluate the uint256 multiplication
         wits.output

--- a/ceno_zkvm/src/precompiles/weierstrass/weierstrass_decompress.rs
+++ b/ceno_zkvm/src/precompiles/weierstrass/weierstrass_decompress.rs
@@ -95,7 +95,6 @@ use p3::field::PrimeCharacteristicRing;
 #[repr(C)]
 pub struct WeierstrassDecompressWitCols<WitT, P: FieldParameters + NumLimbs + NumWords> {
     pub sign_bit: WitT,
-    pub sign_matches_lsb: WitT,
     pub(crate) x_limbs: Limbs<WitT, P::Limbs>,
     pub(crate) y_limbs: Limbs<WitT, P::Limbs>,
     pub(crate) old_output32: GenericArray<[WitT; UINT_LIMBS], P::WordsFieldElement>,
@@ -113,7 +112,6 @@ pub struct WeierstrassDecompressWitCols<WitT, P: FieldParameters + NumLimbs + Nu
 #[repr(C)]
 pub struct CompactSecp256k1DecompressWitCols<WitT, P: FieldParameters + NumLimbs + NumWords> {
     pub sign_bit: WitT,
-    pub sign_matches_lsb: WitT,
     pub(crate) x_limbs: Limbs<WitT, P::Limbs>,
     pub(crate) y_limbs: Limbs<WitT, P::Limbs>,
     pub(crate) old_output32: GenericArray<[WitT; UINT_LIMBS], P::WordsFieldElement>,
@@ -170,7 +168,6 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters>
             CurveType::Secp256k1 => {
                 WeierstrassDecompressLayer::CompactSecp256k1(CompactSecp256k1DecompressWitCols {
                     sign_bit: cb.create_bit(|| "sign_bit").unwrap(),
-                    sign_matches_lsb: cb.create_witin(|| "sign_matches_lsb"),
                     x_limbs: Limbs(GenericArray::generate(|_| cb.create_witin(|| "x"))),
                     y_limbs: Limbs(GenericArray::generate(|_| cb.create_witin(|| "y"))),
                     old_output32: GenericArray::generate(|i| {
@@ -189,7 +186,6 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters>
             CurveType::Secp256r1 => {
                 WeierstrassDecompressLayer::Generic(WeierstrassDecompressWitCols {
                     sign_bit: cb.create_bit(|| "sign_bit").unwrap(),
-                    sign_matches_lsb: cb.create_witin(|| "sign_matches_lsb"),
                     x_limbs: Limbs(GenericArray::generate(|_| cb.create_witin(|| "x"))),
                     y_limbs: Limbs(GenericArray::generate(|_| cb.create_witin(|| "y"))),
                     old_output32: GenericArray::generate(|i| {
@@ -279,8 +275,6 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters>
         };
 
         let y = cols.pos_y.populate(record, &x_3_plus_b_plus_ax, sqrt_fn);
-        cols.sign_matches_lsb =
-            E::BaseField::from_bool(cols.pos_y.lsb.to_canonical_u64() == instance.sign_bit as u64);
 
         let zero = BigUint::zero();
         let neg_y = cols.neg_y.populate(record, &zero, &y, FieldOperation::Sub);
@@ -342,8 +336,6 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters>
         );
 
         let y = cols.pos_y.populate(record, &rhs, secp256k1_sqrt);
-        cols.sign_matches_lsb =
-            E::BaseField::from_bool(cols.pos_y.lsb.to_canonical_u64() == instance.sign_bit as u64);
 
         let zero = BigUint::zero();
         let neg_y = cols.neg_y.populate(record, &zero, &y, FieldOperation::Sub);
@@ -409,12 +401,9 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> ProtocolBuild
                 wits.pos_y
                     .eval(cb, &wits.x_3_plus_b_plus_ax.result, wits.pos_y.lsb)?;
 
-                cb.require_equal(
-                    || "sign_matches_lsb",
-                    wits.sign_matches_lsb.expr(),
-                    1 - (wits.pos_y.lsb.expr() + wits.sign_bit.expr()
-                        - 2 * wits.pos_y.lsb.expr() * wits.sign_bit.expr()),
-                )?;
+                let cond: Expression<E> = 1
+                    - (wits.pos_y.lsb.expr() + wits.sign_bit.expr()
+                        - 2 * wits.pos_y.lsb.expr() * wits.sign_bit.expr());
                 for (y, sqrt_y, neg_sqrt_y) in izip!(
                     wits.y_limbs.0.iter(),
                     wits.pos_y.multiplication.result.0.iter(),
@@ -422,7 +411,7 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> ProtocolBuild
                 ) {
                     cb.condition_require_equal(
                         || "when lsb == sign_bit, y_limbs = sqrt(y), otherwise y_limbs = -sqrt(y)",
-                        wits.sign_matches_lsb.expr(),
+                        cond.expr(),
                         y.expr(),
                         sqrt_y.expr(),
                         neg_sqrt_y.expr(),
@@ -464,12 +453,9 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> ProtocolBuild
 
                 wits.pos_y.eval(cb, &wits.rhs, wits.pos_y.lsb)?;
 
-                cb.require_equal(
-                    || "sign_matches_lsb",
-                    wits.sign_matches_lsb.expr(),
-                    1 - (wits.pos_y.lsb.expr() + wits.sign_bit.expr()
-                        - 2 * wits.pos_y.lsb.expr() * wits.sign_bit.expr()),
-                )?;
+                let cond: Expression<E> = 1
+                    - (wits.pos_y.lsb.expr() + wits.sign_bit.expr()
+                        - 2 * wits.pos_y.lsb.expr() * wits.sign_bit.expr());
                 for (y, sqrt_y, neg_sqrt_y) in izip!(
                     wits.y_limbs.0.iter(),
                     wits.pos_y.multiplication.result.0.iter(),
@@ -477,7 +463,7 @@ impl<E: ExtensionField, EC: EllipticCurve + WeierstrassParameters> ProtocolBuild
                 ) {
                     cb.condition_require_equal(
                         || "when lsb == sign_bit, y_limbs = sqrt(y), otherwise y_limbs = -sqrt(y)",
-                        wits.sign_matches_lsb.expr(),
+                        cond.expr(),
                         y.expr(),
                         sqrt_y.expr(),
                         neg_sqrt_y.expr(),

--- a/ceno_zkvm/src/stats.rs
+++ b/ceno_zkvm/src/stats.rs
@@ -148,83 +148,6 @@ where
 }
 pub type StaticReport = Report<CircuitStats>;
 
-#[derive(Clone, Debug, serde::Serialize)]
-pub struct DegreeAuditStats {
-    pub chip: String,
-    pub max_constraint_degree: usize,
-    pub max_main_sumcheck_degree: usize,
-    pub cubic_constraints: usize,
-    pub witness_columns: usize,
-    pub trace_weighted_witness_cells: usize,
-}
-
-pub fn degree_audit<E: ExtensionField>(
-    zkvm_system: &ZKVMConstraintSystem<E>,
-    num_instances: &BTreeMap<String, usize>,
-) -> Vec<DegreeAuditStats> {
-    zkvm_system
-        .get_css()
-        .iter()
-        .map(|(name, composed)| {
-            let cs = &composed.zkvm_v1_css;
-            let constraints = cs
-                .assert_zero_expressions
-                .iter()
-                .chain(&cs.assert_zero_sumcheck_expressions);
-            let max_constraint_degree = constraints
-                .clone()
-                .map(Expression::degree)
-                .max()
-                .unwrap_or(0);
-            let cubic_constraints = constraints.filter(|expr| expr.degree() == 3).count();
-            let selected_degree = |expressions: &[Expression<E>], has_selector: bool| {
-                expressions
-                    .iter()
-                    .map(Expression::degree)
-                    .max()
-                    .unwrap_or(0)
-                    + usize::from(has_selector && !expressions.is_empty())
-            };
-            let zero_expressions = cs
-                .assert_zero_expressions
-                .iter()
-                .chain(&cs.assert_zero_sumcheck_expressions)
-                .cloned()
-                .collect_vec();
-            let selector_gated_degree = [
-                selected_degree(&cs.r_expressions, cs.r_selector.is_some()),
-                selected_degree(&cs.w_expressions, cs.w_selector.is_some()),
-                selected_degree(&cs.lk_expressions, cs.lk_selector.is_some()),
-                selected_degree(&zero_expressions, cs.zero_selector.is_some()),
-            ]
-            .into_iter()
-            .max()
-            .unwrap_or(0);
-            let max_main_sumcheck_degree = composed
-                .gkr_circuit
-                .as_ref()
-                .and_then(|gkr| {
-                    gkr.layers
-                        .iter()
-                        .map(|layer| layer.max_expr_degree + 1)
-                        .max()
-                })
-                .map(|gkr_degree| gkr_degree.max(selector_gated_degree))
-                .unwrap_or(selector_gated_degree);
-            let witness_columns = cs.num_witin as usize;
-            DegreeAuditStats {
-                chip: name.clone(),
-                max_constraint_degree,
-                max_main_sumcheck_degree,
-                cubic_constraints,
-                witness_columns,
-                trace_weighted_witness_cells: witness_columns
-                    * num_instances.get(name).copied().unwrap_or(0),
-            }
-        })
-        .collect()
-}
-
 impl Report<CircuitStats> {
     pub fn new<E: ExtensionField>(zkvm_system: &ZKVMConstraintSystem<E>) -> Self {
         Report {
@@ -359,40 +282,5 @@ impl Report<CircuitStatsTrace> {
         let mut file = File::create(filename).expect("Unable to create file");
         _ = opcodes_table.print(&mut file);
         _ = tables_table.print(&mut file);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::instructions::riscv::{MmuConfig, Rv32imConfig};
-    use ff_ext::BabyBearExt4;
-
-    #[test]
-    fn production_riscv_constraints_are_at_most_quadratic() {
-        let audit = std::thread::Builder::new()
-            .stack_size(64 * 1024 * 1024)
-            .spawn(|| {
-                let mut zkvm_cs = ZKVMConstraintSystem::<BabyBearExt4>::default();
-                Rv32imConfig::<BabyBearExt4>::construct_circuits(&mut zkvm_cs);
-                MmuConfig::<BabyBearExt4>::construct_circuits(&mut zkvm_cs);
-                degree_audit(&zkvm_cs, &BTreeMap::new())
-            })
-            .unwrap()
-            .join()
-            .unwrap();
-        let offenders = audit
-            .iter()
-            .filter(|row| {
-                row.max_constraint_degree > 2
-                    || row.max_main_sumcheck_degree > 3
-                    || row.cubic_constraints != 0
-            })
-            .collect_vec();
-
-        assert!(
-            offenders.is_empty(),
-            "degree audit found non-quadratic constraints: {offenders:?}"
-        );
     }
 }


### PR DESCRIPTION
It was accidently included in previous PR https://github.com/scroll-tech/ceno/pull/1394

Benchmark shows although It bring benefit to main sumcheck univariate evaluation,  however a side effect is performance regressed due to the new resident column bring more overhead to GPU vram which reduce the multi-tower concurrency scheduling. 