### PR TITLE
fix gpu replay owner handoff during AOT replay

### DIFF
--- a/ceno_emul/src/tracer/gpu_replay_tracer.rs
+++ b/ceno_emul/src/tracer/gpu_replay_tracer.rs
@@ -288,9 +288,20 @@ impl GpuReplayTracer {
                 next_descriptor.map_or_else(
                     || GpuReplayChunk::empty(sequence + 1, self.shard_start_cycle),
                     |descriptor| {
+                        let mut family_capacities = [0usize; InsnKind::COUNT];
+                        let mut fallback_capacity = 0usize;
+                        for descriptor in self.range_descriptors.iter() {
+                            for (capacity, required) in
+                                family_capacities.iter_mut().zip(descriptor.family_counts)
+                            {
+                                *capacity = (*capacity).max(required as usize);
+                            }
+                            fallback_capacity =
+                                fallback_capacity.max(descriptor.fallback_count as usize);
+                        }
                         let mut next = GpuReplayChunk::warmed(
-                            descriptor.family_counts.map(|count| count as usize),
-                            descriptor.fallback_count as usize,
+                            family_capacities,
+                            fallback_capacity,
                             self.shard_start_cycle,
                         );
                         next.reset_from_descriptor(descriptor, self.shard_start_cycle);

--- a/ceno_emul/src/tracer/gpu_replay_tracer.rs
+++ b/ceno_emul/src/tracer/gpu_replay_tracer.rs
@@ -282,14 +282,24 @@ impl GpuReplayTracer {
         }
         assert_eq!(self.current.fallback.len(), descriptor.fallback_count);
         self.next_range_descriptor += 1;
+        let next_descriptor = self.range_descriptors.get(self.next_range_descriptor);
         let next = self.recyclable.take().map_or_else(
-            || GpuReplayChunk::empty(sequence + 1, self.shard_start_cycle),
+            || {
+                next_descriptor.map_or_else(
+                    || GpuReplayChunk::empty(sequence + 1, self.shard_start_cycle),
+                    |descriptor| {
+                        let mut next = GpuReplayChunk::warmed(
+                            descriptor.family_counts.map(|count| count as usize),
+                            descriptor.fallback_count as usize,
+                            self.shard_start_cycle,
+                        );
+                        next.reset_from_descriptor(descriptor, self.shard_start_cycle);
+                        next
+                    },
+                )
+            },
             |mut next| {
-                if let Some(descriptor) = self
-                    .range_descriptors
-                    .get(self.next_range_descriptor)
-                    .filter(|next| next.shard_id == shard_id)
-                {
+                if let Some(descriptor) = next_descriptor.filter(|next| next.shard_id == shard_id) {
                     next.reset_from_descriptor(descriptor, self.shard_start_cycle);
                 }
                 next

--- a/ceno_emul/src/tracer/gpu_replay_tracer.rs
+++ b/ceno_emul/src/tracer/gpu_replay_tracer.rs
@@ -284,31 +284,7 @@ impl GpuReplayTracer {
         self.next_range_descriptor += 1;
         let next_descriptor = self.range_descriptors.get(self.next_range_descriptor);
         let next = self.recyclable.take().map_or_else(
-            || {
-                next_descriptor.map_or_else(
-                    || GpuReplayChunk::empty(sequence + 1, self.shard_start_cycle),
-                    |descriptor| {
-                        let mut family_capacities = [0usize; InsnKind::COUNT];
-                        let mut fallback_capacity = 0usize;
-                        for descriptor in self.range_descriptors.iter() {
-                            for (capacity, required) in
-                                family_capacities.iter_mut().zip(descriptor.family_counts)
-                            {
-                                *capacity = (*capacity).max(required as usize);
-                            }
-                            fallback_capacity =
-                                fallback_capacity.max(descriptor.fallback_count as usize);
-                        }
-                        let mut next = GpuReplayChunk::warmed(
-                            family_capacities,
-                            fallback_capacity,
-                            self.shard_start_cycle,
-                        );
-                        next.reset_from_descriptor(descriptor, self.shard_start_cycle);
-                        next
-                    },
-                )
-            },
+            || GpuReplayChunk::empty(sequence + 1, self.shard_start_cycle),
             |mut next| {
                 if let Some(descriptor) = next_descriptor.filter(|next| next.shard_id == shard_id) {
                     next.reset_from_descriptor(descriptor, self.shard_start_cycle);
@@ -636,9 +612,6 @@ impl Tracer for GpuReplayTracer {
                 .expect("GPU replay typed cursor overflow");
         }
         self.ordinal += 1;
-        if self.current.len() == self.config.chunk_capacity {
-            self.seal_current();
-        }
         let cycle = self.shard_start_cycle + self.ordinal as Cycle * FullTracer::SUBCYCLES_PER_INSN;
         self.pending = StepRecord {
             cycle,


### PR DESCRIPTION
## Problem

<!-- What user-facing, protocol, or developer issue does this PR solve? -->

## Design Rationale

<!-- Why this design for Ceno? Mention soundness/correctness, maintainability, and trade-offs. -->

## Change Highlights

<!-- Briefly list the key changes by crate/module (for example: ceno_zkvm, ceno_emul, ceno_recursion_v2, docs). -->

## Benchmark / Performance Impact

<!-- Required for performance-sensitive or prover/verifier-path changes. -->

### Operation

| Operation | master (s) | this PR (s) | Improve (master -> this PR) |
|-----------|------------|-------------|-----------------------------|
|           |            |             |                             |

### Layer

| Layer | master (s) | this PR (s) | Improve (master -> this PR) |
|-------|------------|-------------|-----------------------------|
|       |            |             |                             |

Benchmark command(s):

```sh
# paste exact command(s)
```

Environment (CPU/GPU, core count, rust toolchain, commit hash):

raw data:

- master:
- this PR:

## Testing

<!-- List test commands and outcomes. Include regression tests for bug fixes and edge cases. -->

```sh
# paste exact command(s), for example:
# cargo fmt --all --check
# cargo make clippy
# cargo make tests
```

## Risks and Rollout

<!-- Mention soundness/perf/compatibility risks, migration notes, and rollback plan if needed. -->

## Follow-ups (optional)

<!-- Any deferred work, TODOs, or tracking issues. -->

## Copilot Reviewer Directive (keep this section)

When Copilot reviews this PR, apply `.github/copilot-instructions.md` strictly.
