### PR TITLE
perf(gpu): overlap replay with shard proving

### DIFF
--- a/ceno_emul/src/tracer.rs
+++ b/ceno_emul/src/tracer.rs
@@ -3589,6 +3589,76 @@ mod tests {
         assert_eq!(fingerprint(tracer.recyclable.as_ref().unwrap()), second);
     }
 
+    #[test]
+    fn retained_shard_mode_supports_more_than_two_owned_ranges() {
+        let descriptors = Arc::new(
+            (0..3)
+                .map(|sequence| crate::GpuReplayRangeDescriptor {
+                    shard_id: 0,
+                    sequence,
+                    range_start: sequence,
+                    range_len: 1,
+                    family_counts: [0; InsnKind::COUNT],
+                    fallback_count: 1,
+                    unsupported_count: 0,
+                })
+                .collect(),
+        );
+        let mut tracer = GpuReplayTracer::new(&CENO_PLATFORM, GpuReplayTracerConfig::default());
+        tracer.install_range_descriptors(descriptors);
+        tracer.enable_retained_shard_mode();
+
+        let mut retained = Vec::new();
+        for sequence in 0..3 {
+            tracer.current.fallback.push(GpuReplayFallbackRecord {
+                ordinal: sequence,
+                record: StepRecord::default(),
+            });
+            tracer.finish_chunks();
+            retained.extend(tracer.take_sealed_chunks());
+        }
+        assert_eq!(retained.len(), 3);
+        assert!(tracer.current.typed.is_empty());
+
+        for chunk in retained {
+            tracer.recycle_range(crate::GpuReplayTypedRange {
+                sequence: chunk.sequence,
+                typed: chunk.typed,
+                fallback: chunk.fallback,
+            });
+        }
+        assert_eq!(tracer.current.typed.len(), InsnKind::COUNT);
+        assert!(tracer.recyclable.is_some());
+    }
+
+    #[test]
+    fn default_replay_mode_keeps_two_owner_limit() {
+        let descriptors = Arc::new(
+            (0..3)
+                .map(|sequence| crate::GpuReplayRangeDescriptor {
+                    shard_id: 0,
+                    sequence,
+                    range_start: sequence,
+                    range_len: 1,
+                    family_counts: [0; InsnKind::COUNT],
+                    fallback_count: 1,
+                    unsupported_count: 0,
+                })
+                .collect(),
+        );
+        let mut tracer = GpuReplayTracer::new(&CENO_PLATFORM, GpuReplayTracerConfig::default());
+        tracer.install_range_descriptors(descriptors);
+        for sequence in 0..2 {
+            tracer.current.fallback.push(GpuReplayFallbackRecord {
+                ordinal: sequence,
+                record: StepRecord::default(),
+            });
+            tracer.finish_chunks();
+            tracer.take_sealed_chunks();
+        }
+        assert!(tracer.current.typed.is_empty());
+    }
+
     #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
     #[test]
     fn deferred_mmio_bounds_rebuild_from_first_access_events() {

--- a/ceno_emul/src/tracer/gpu_replay_tracer.rs
+++ b/ceno_emul/src/tracer/gpu_replay_tracer.rs
@@ -134,6 +134,7 @@ pub struct GpuReplayTracer {
     pub(super) current: GpuReplayChunk,
     sealed: Vec<GpuReplayChunk>,
     pub(super) recyclable: Option<GpuReplayChunk>,
+    retain_complete_shard: bool,
     range_descriptors: Arc<Vec<crate::GpuReplayRangeDescriptor>>,
     pub(super) next_range_descriptor: usize,
     ordinal: usize,
@@ -168,6 +169,7 @@ impl GpuReplayTracer {
             current: GpuReplayChunk::empty(0, shard_start_cycle),
             sealed: Vec::new(),
             recyclable: None,
+            retain_complete_shard: false,
             range_descriptors: Arc::new(Vec::new()),
             next_range_descriptor: 0,
             ordinal: 0,
@@ -284,7 +286,22 @@ impl GpuReplayTracer {
         self.next_range_descriptor += 1;
         let next_descriptor = self.range_descriptors.get(self.next_range_descriptor);
         let next = self.recyclable.take().map_or_else(
-            || GpuReplayChunk::empty(sequence + 1, self.shard_start_cycle),
+            || {
+                next_descriptor
+                    .filter(|next| self.retain_complete_shard && next.shard_id == shard_id)
+                    .map_or_else(
+                        || GpuReplayChunk::empty(sequence + 1, self.shard_start_cycle),
+                        |descriptor| {
+                            let mut next = GpuReplayChunk::warmed(
+                                descriptor.family_counts,
+                                descriptor.fallback_count,
+                                self.shard_start_cycle,
+                            );
+                            next.reset_from_descriptor(descriptor, self.shard_start_cycle);
+                            next
+                        },
+                    )
+            },
             |mut next| {
                 if let Some(descriptor) = next_descriptor.filter(|next| next.shard_id == shard_id) {
                     next.reset_from_descriptor(descriptor, self.shard_start_cycle);
@@ -356,6 +373,16 @@ impl GpuReplayTracer {
         }
     }
 
+    /// Permit CPU replay to retain every range in one prepared shard while GPU
+    /// assignment of that shard remains gated by the preceding proof.
+    pub fn enable_retained_shard_mode(&mut self) {
+        assert_eq!(
+            self.ordinal, 0,
+            "retained shard mode enabled after replay started"
+        );
+        self.retain_complete_shard = true;
+    }
+
     pub fn finish_chunks(&mut self) {
         self.seal_current();
     }
@@ -408,9 +435,16 @@ impl GpuReplayTracer {
                 recycled.reset_empty(self.shard_start_cycle);
             }
             self.current = recycled;
-        } else {
-            assert!(self.recyclable.is_none(), "GPU replay range recycled twice");
+        } else if self.recyclable.is_none() {
             self.recyclable = Some(recycled);
+        } else {
+            assert!(
+                self.retain_complete_shard,
+                "GPU replay range recycled twice"
+            );
+            // Retained mode may allocate one owner per range while a full
+            // CPU-prepared shard waits for GPU assignment. Keep the two
+            // globally warmed owners and release the extras after use.
         }
     }
 

--- a/ceno_emul/src/tracer/gpu_replay_tracer.rs
+++ b/ceno_emul/src/tracer/gpu_replay_tracer.rs
@@ -288,9 +288,20 @@ impl GpuReplayTracer {
                 next_descriptor.map_or_else(
                     || GpuReplayChunk::empty(sequence + 1, self.shard_start_cycle),
                     |descriptor| {
+                        let mut family_capacities = [0usize; InsnKind::COUNT];
+                        let mut fallback_capacity = 0usize;
+                        for descriptor in self.range_descriptors.iter() {
+                            for (capacity, required) in
+                                family_capacities.iter_mut().zip(descriptor.family_counts)
+                            {
+                                *capacity = (*capacity).max(required as usize);
+                            }
+                            fallback_capacity =
+                                fallback_capacity.max(descriptor.fallback_count as usize);
+                        }
                         let mut next = GpuReplayChunk::warmed(
-                            descriptor.family_counts.map(|count| count as usize),
-                            descriptor.fallback_count as usize,
+                            family_capacities,
+                            fallback_capacity,
                             self.shard_start_cycle,
                         );
                         next.reset_from_descriptor(descriptor, self.shard_start_cycle);

--- a/ceno_emul/src/tracer/gpu_replay_tracer.rs
+++ b/ceno_emul/src/tracer/gpu_replay_tracer.rs
@@ -282,14 +282,24 @@ impl GpuReplayTracer {
         }
         assert_eq!(self.current.fallback.len(), descriptor.fallback_count);
         self.next_range_descriptor += 1;
+        let next_descriptor = self.range_descriptors.get(self.next_range_descriptor);
         let next = self.recyclable.take().map_or_else(
-            || GpuReplayChunk::empty(sequence + 1, self.shard_start_cycle),
+            || {
+                next_descriptor.map_or_else(
+                    || GpuReplayChunk::empty(sequence + 1, self.shard_start_cycle),
+                    |descriptor| {
+                        let mut next = GpuReplayChunk::warmed(
+                            descriptor.family_counts.map(|count| count as usize),
+                            descriptor.fallback_count as usize,
+                            self.shard_start_cycle,
+                        );
+                        next.reset_from_descriptor(descriptor, self.shard_start_cycle);
+                        next
+                    },
+                )
+            },
             |mut next| {
-                if let Some(descriptor) = self
-                    .range_descriptors
-                    .get(self.next_range_descriptor)
-                    .filter(|next| next.shard_id == shard_id)
-                {
+                if let Some(descriptor) = next_descriptor.filter(|next| next.shard_id == shard_id) {
                     next.reset_from_descriptor(descriptor, self.shard_start_cycle);
                 }
                 next

--- a/ceno_emul/src/tracer/gpu_replay_tracer.rs
+++ b/ceno_emul/src/tracer/gpu_replay_tracer.rs
@@ -284,31 +284,7 @@ impl GpuReplayTracer {
         self.next_range_descriptor += 1;
         let next_descriptor = self.range_descriptors.get(self.next_range_descriptor);
         let next = self.recyclable.take().map_or_else(
-            || {
-                next_descriptor.map_or_else(
-                    || GpuReplayChunk::empty(sequence + 1, self.shard_start_cycle),
-                    |descriptor| {
-                        let mut family_capacities = [0usize; InsnKind::COUNT];
-                        let mut fallback_capacity = 0usize;
-                        for descriptor in self.range_descriptors.iter() {
-                            for (capacity, required) in
-                                family_capacities.iter_mut().zip(descriptor.family_counts)
-                            {
-                                *capacity = (*capacity).max(required as usize);
-                            }
-                            fallback_capacity =
-                                fallback_capacity.max(descriptor.fallback_count as usize);
-                        }
-                        let mut next = GpuReplayChunk::warmed(
-                            family_capacities,
-                            fallback_capacity,
-                            self.shard_start_cycle,
-                        );
-                        next.reset_from_descriptor(descriptor, self.shard_start_cycle);
-                        next
-                    },
-                )
-            },
+            || GpuReplayChunk::empty(sequence + 1, self.shard_start_cycle),
             |mut next| {
                 if let Some(descriptor) = next_descriptor.filter(|next| next.shard_id == shard_id) {
                     next.reset_from_descriptor(descriptor, self.shard_start_cycle);
@@ -636,9 +612,6 @@ impl Tracer for GpuReplayTracer {
                 .expect("GPU replay typed cursor overflow");
         }
         self.ordinal += 1;
-        if self.current.len() == self.config.chunk_capacity {
-            self.seal_current();
-        }
         let cycle = self.shard_start_cycle + self.ordinal as Cycle * FullTracer::SUBCYCLES_PER_INSN;
         self.pending = StepRecord {
             cycle,

--- a/ceno_emul/src/tracer/gpu_replay_tracer.rs
+++ b/ceno_emul/src/tracer/gpu_replay_tracer.rs
@@ -70,6 +70,11 @@ impl GpuReplayChunk {
         descriptor: &crate::GpuReplayRangeDescriptor,
         shard_start_cycle: Cycle,
     ) {
+        assert_eq!(
+            self.typed.len(),
+            InsnKind::COUNT,
+            "warmed range has an invalid family vector"
+        );
         self.sequence = descriptor.sequence;
         self.shard_start_cycle = shard_start_cycle;
         for ((kind, arena), required) in InsnKind::iter()
@@ -396,15 +401,23 @@ impl GpuReplayTracer {
         self.syscall_witnesses.clear();
         let descriptor = &self.range_descriptors[self.next_range_descriptor];
         assert_eq!(descriptor.sequence, 0);
-        assert_eq!(
-            self.current.typed.len(),
-            InsnKind::COUNT,
-            "GPU replay shard transition lost a warmed CPU owner"
-        );
-        assert!(
-            self.recyclable.is_some(),
-            "GPU replay shard transition did not recover both warmed CPU owners"
-        );
+        if self.current.typed.len() != InsnKind::COUNT {
+            assert!(
+                self.retain_complete_shard,
+                "GPU replay shard transition lost a warmed CPU owner"
+            );
+            self.current = GpuReplayChunk::warmed(
+                descriptor.family_counts,
+                descriptor.fallback_count,
+                self.shard_start_cycle,
+            );
+        }
+        if !self.retain_complete_shard {
+            assert!(
+                self.recyclable.is_some(),
+                "GPU replay shard transition did not recover both warmed CPU owners"
+            );
+        }
         self.current
             .reset_from_descriptor(descriptor, self.shard_start_cycle);
     }
@@ -429,7 +442,14 @@ impl GpuReplayTracer {
             if let Some(descriptor) = next_descriptor.filter(|descriptor| {
                 self.retain_complete_shard || Some(descriptor.shard_id) == current_shard_id
             }) {
-                recycled.reset_from_descriptor(descriptor, self.shard_start_cycle);
+                if recycled.typed.len() == InsnKind::COUNT {
+                    recycled.reset_from_descriptor(descriptor, self.shard_start_cycle);
+                } else {
+                    assert!(
+                        self.retain_complete_shard,
+                        "recycled GPU replay owner has an invalid family vector"
+                    );
+                }
             } else {
                 recycled.reset_empty(self.shard_start_cycle);
             }
@@ -563,8 +583,7 @@ impl GpuReplayTracer {
 mod tests {
     use super::*;
 
-    #[test]
-    fn retained_recycling_warms_first_owner_across_shards() {
+    fn retained_cross_shard_tracer() -> GpuReplayTracer {
         let mut counts = [0; InsnKind::COUNT];
         counts[InsnKind::ADDI as usize] = 1;
         let descriptors = Arc::new(vec![
@@ -590,28 +609,60 @@ mod tests {
         let mut tracer = GpuReplayTracer::new(&CENO_PLATFORM, GpuReplayTracerConfig::default());
         tracer.install_range_descriptors(descriptors);
         tracer.enable_retained_shard_mode();
-
-        let first = std::mem::replace(
-            &mut tracer.current,
-            GpuReplayChunk::empty(1, tracer.shard_start_cycle),
-        );
-        let second = tracer.recyclable.take().unwrap();
         tracer.next_range_descriptor = 1;
+        tracer
+    }
+
+    #[test]
+    fn retained_start_shard_recovers_without_terminal_owner() {
+        let mut tracer = retained_cross_shard_tracer();
+        tracer.current = GpuReplayChunk::empty(1, tracer.shard_start_cycle);
+        tracer.recyclable = None;
+
+        tracer.start_shard();
+        assert_eq!(tracer.current.sequence, 0);
+        assert_eq!(tracer.current.typed.len(), InsnKind::COUNT);
+        assert!(tracer.recyclable.is_none());
+    }
+
+    #[test]
+    fn retained_start_shard_recovers_from_empty_terminal_owner() {
+        let mut tracer = retained_cross_shard_tracer();
+        tracer.current = GpuReplayChunk::empty(1, tracer.shard_start_cycle);
+        tracer.recyclable = None;
         tracer.recycle_range(crate::GpuReplayTypedRange {
-            sequence: first.sequence,
-            typed: first.typed,
-            fallback: first.fallback,
-        });
-        tracer.recycle_range(crate::GpuReplayTypedRange {
-            sequence: second.sequence,
-            typed: second.typed,
-            fallback: second.fallback,
+            sequence: 0,
+            typed: Vec::new(),
+            fallback: Vec::new(),
         });
 
         tracer.start_shard();
         assert_eq!(tracer.current.sequence, 0);
         assert_eq!(tracer.current.typed.len(), InsnKind::COUNT);
-        assert!(tracer.recyclable.is_some());
+        assert!(tracer.recyclable.is_none());
+    }
+
+    #[test]
+    fn retained_start_shard_reuses_one_valid_terminal_owner() {
+        let mut tracer = retained_cross_shard_tracer();
+        let first = std::mem::replace(
+            &mut tracer.current,
+            GpuReplayChunk::empty(1, tracer.shard_start_cycle),
+        );
+        tracer.recyclable = None;
+        let typed_ptr = first.typed.as_ptr();
+
+        tracer.recycle_range(crate::GpuReplayTypedRange {
+            sequence: first.sequence,
+            typed: first.typed,
+            fallback: first.fallback,
+        });
+
+        tracer.start_shard();
+        assert_eq!(tracer.current.sequence, 0);
+        assert_eq!(tracer.current.typed.len(), InsnKind::COUNT);
+        assert_eq!(tracer.current.typed.as_ptr(), typed_ptr);
+        assert!(tracer.recyclable.is_none());
     }
 }
 

--- a/ceno_emul/src/tracer/gpu_replay_tracer.rs
+++ b/ceno_emul/src/tracer/gpu_replay_tracer.rs
@@ -421,15 +421,14 @@ impl GpuReplayTracer {
             fallback: range.fallback,
         };
         if self.current.typed.is_empty() {
+            let next_descriptor = self.range_descriptors.get(self.next_range_descriptor);
             let current_shard_id = self
                 .next_range_descriptor
                 .checked_sub(1)
                 .map(|index| self.range_descriptors[index].shard_id);
-            if let Some(descriptor) = self
-                .range_descriptors
-                .get(self.next_range_descriptor)
-                .filter(|descriptor| Some(descriptor.shard_id) == current_shard_id)
-            {
+            if let Some(descriptor) = next_descriptor.filter(|descriptor| {
+                self.retain_complete_shard || Some(descriptor.shard_id) == current_shard_id
+            }) {
                 recycled.reset_from_descriptor(descriptor, self.shard_start_cycle);
             } else {
                 recycled.reset_empty(self.shard_start_cycle);
@@ -557,6 +556,62 @@ impl GpuReplayTracer {
         } else if start_addr.baddr().0 == self.platform.hints.start {
             self.max_hint_addr_access = self.max_hint_addr_access.max(access_end);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retained_recycling_warms_first_owner_across_shards() {
+        let mut counts = [0; InsnKind::COUNT];
+        counts[InsnKind::ADDI as usize] = 1;
+        let descriptors = Arc::new(vec![
+            crate::GpuReplayRangeDescriptor {
+                shard_id: 0,
+                sequence: 0,
+                range_start: 0,
+                range_len: 1,
+                family_counts: counts,
+                fallback_count: 0,
+                unsupported_count: 0,
+            },
+            crate::GpuReplayRangeDescriptor {
+                shard_id: 1,
+                sequence: 0,
+                range_start: 1,
+                range_len: 1,
+                family_counts: counts,
+                fallback_count: 0,
+                unsupported_count: 0,
+            },
+        ]);
+        let mut tracer = GpuReplayTracer::new(&CENO_PLATFORM, GpuReplayTracerConfig::default());
+        tracer.install_range_descriptors(descriptors);
+        tracer.enable_retained_shard_mode();
+
+        let first = std::mem::replace(
+            &mut tracer.current,
+            GpuReplayChunk::empty(1, tracer.shard_start_cycle),
+        );
+        let second = tracer.recyclable.take().unwrap();
+        tracer.next_range_descriptor = 1;
+        tracer.recycle_range(crate::GpuReplayTypedRange {
+            sequence: first.sequence,
+            typed: first.typed,
+            fallback: first.fallback,
+        });
+        tracer.recycle_range(crate::GpuReplayTypedRange {
+            sequence: second.sequence,
+            typed: second.typed,
+            fallback: second.fallback,
+        });
+
+        tracer.start_shard();
+        assert_eq!(tracer.current.sequence, 0);
+        assert_eq!(tracer.current.typed.len(), InsnKind::COUNT);
+        assert!(tracer.recyclable.is_some());
     }
 }
 

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1215,9 +1215,21 @@ fn spawn_compact_replay_pipeline(mut replay: CompactStepReplay) -> CompactReplay
                         replay.vm.tracer_mut().recycle_range(range);
                     }
                 }
+                tracing::info!(
+                    target: "ceno_pipeline",
+                    shard_id,
+                    phase = "cpu_replay_start",
+                    "compact replay pipeline event"
+                );
                 let shard = replay
                     .next_shard(false, Some)
                     .expect("compact replay ended before its shard plan");
+                tracing::info!(
+                    target: "ceno_pipeline",
+                    shard_id,
+                    phase = "cpu_replay_ready",
+                    "compact replay pipeline event"
+                );
                 if ready_tx.send(shard).is_err() {
                     return;
                 }
@@ -2308,6 +2320,12 @@ pub fn generate_witness<'a, E: ExtensionField>(
                 let mut compact_shard = info_span!("position_compact_shard").in_scope(|| {
                     #[cfg(feature = "gpu")]
                     {
+                        tracing::info!(
+                            target: "ceno_pipeline",
+                            shard_id = shard_ctx_builder.cur_shard_id,
+                            phase = "gpu_assignment_wait",
+                            "compact replay pipeline event"
+                        );
                         compact_pipeline
                             .as_ref()
                             .expect("compact replay pipeline missing")
@@ -2322,6 +2340,13 @@ pub fn generate_witness<'a, E: ExtensionField>(
                         })
                     }
                 })?;
+                #[cfg(feature = "gpu")]
+                tracing::info!(
+                    target: "ceno_pipeline",
+                    shard_id = shard_ctx_builder.cur_shard_id,
+                    phase = "gpu_assignment_start",
+                    "compact replay pipeline event"
+                );
                 for range in &compact_shard.arenas.ranges {
                     for (kind, arena) in InsnKind::iter().zip(&range.typed) {
                         if let Some(arena) = arena {
@@ -3833,6 +3858,12 @@ fn create_proofs_streaming<
 
                     let transcript = Transcript::new(b"riscv");
                     let start = std::time::Instant::now();
+                    tracing::info!(
+                        target: "ceno_pipeline",
+                        shard_id = shard_ctx.shard_id,
+                        phase = "proof_start",
+                        "compact replay pipeline event"
+                    );
                     let zkvm_proof =
                         match prover.create_proof(&shard_ctx, zkvm_witness, pi, transcript) {
                             Ok(proof) => proof,
@@ -3845,6 +3876,13 @@ fn create_proofs_streaming<
                                 std::process::exit(1);
                             }
                         };
+                    tracing::info!(
+                        target: "ceno_pipeline",
+                        shard_id = shard_ctx.shard_id,
+                        phase = "proof_end",
+                        elapsed_ms = start.elapsed().as_millis(),
+                        "compact replay pipeline event"
+                    );
                     tracing::debug!(
                         "{}th shard proof created in {:?}",
                         shard_ctx.shard_id,

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1183,11 +1183,18 @@ struct CompactStepReplay {
     aot: Arc<ceno_emul::aot::AotProgram>,
 }
 
-// `GpuReplayTracer` caches raw pointers into allocations it exclusively owns.
-// Moving the complete replay state to one worker thread does not alias those
-// allocations; the state is never accessed again by the spawning thread.
 #[cfg(feature = "gpu")]
-unsafe impl Send for CompactStepReplay {}
+struct CompactReplayPipelineInput {
+    platform: Platform,
+    program: Arc<Program>,
+    init_mem_state: InitMemState,
+    next_accesses: Arc<NextCycleAccess>,
+    shard_cycle_boundaries: Arc<Vec<Cycle>>,
+    range_descriptors: Arc<Vec<ceno_emul::GpuReplayRangeDescriptor>>,
+    chunk_capacity: usize,
+    #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+    aot: Arc<ceno_emul::aot::AotProgram>,
+}
 
 #[cfg(feature = "gpu")]
 struct CompactReplayPipeline {
@@ -1196,7 +1203,7 @@ struct CompactReplayPipeline {
 }
 
 #[cfg(feature = "gpu")]
-fn spawn_compact_replay_pipeline(mut replay: CompactStepReplay) -> CompactReplayPipeline {
+fn spawn_compact_replay_pipeline(input: CompactReplayPipelineInput) -> CompactReplayPipeline {
     // One prepared shard may wait while the current shard is proving. The
     // producer must recover the previous shard's arenas before replaying the
     // next one, which bounds retained CPU storage and preserves tracer reuse.
@@ -1205,6 +1212,20 @@ fn spawn_compact_replay_pipeline(mut replay: CompactStepReplay) -> CompactReplay
     std::thread::Builder::new()
         .name("ceno-compact-replay".to_string())
         .spawn(move || {
+            // Construct the VM and native replay state at their final address
+            // on the producer thread. The AOT replay path contains native
+            // pointers into that state and must not be moved after setup.
+            let mut replay = CompactStepReplay::new(
+                input.platform,
+                input.program,
+                &input.init_mem_state,
+                input.next_accesses,
+                input.shard_cycle_boundaries,
+                input.range_descriptors,
+                input.chunk_capacity,
+                #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+                input.aot,
+            );
             let shard_count = replay.shard_step_counts.len();
             for shard_id in 0..shard_count {
                 if shard_id != 0 {
@@ -2157,6 +2178,7 @@ pub fn generate_witness<'a, E: ExtensionField>(
             emul_result.replay_aot_program.clone(),
         )
     });
+    #[cfg(not(feature = "gpu"))]
     let mut compact_iter = use_compact_replay.then(|| {
         CompactStepReplay::new(
             platform.clone(),
@@ -2171,7 +2193,19 @@ pub fn generate_witness<'a, E: ExtensionField>(
         )
     });
     #[cfg(feature = "gpu")]
-    let compact_pipeline = compact_iter.take().map(spawn_compact_replay_pipeline);
+    let compact_pipeline = use_compact_replay.then(|| {
+        spawn_compact_replay_pipeline(CompactReplayPipelineInput {
+            platform: platform.clone(),
+            program: program.clone(),
+            init_mem_state: init_mem_state.clone(),
+            next_accesses: shard_ctx_builder.next_accesses(),
+            shard_cycle_boundaries: emul_result.shard_cycle_boundaries.clone(),
+            range_descriptors: emul_result.replay_range_descriptors.clone(),
+            chunk_capacity: emul_result.replay_range_capacity,
+            #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+            aot: emul_result.replay_aot_program.clone(),
+        })
+    });
     let mut current_compact_shard: Option<CompactReplayShard> = None;
     std::iter::from_fn(move || {
         info_span!(

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -4114,9 +4114,7 @@ pub fn verify<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + serde::Ser
 
 #[cfg(test)]
 mod tests {
-    use crate::e2e::{
-        MultiProver, ShardContextBuilder, recv_compact_replay_shard, recycle_compact_replay_owners,
-    };
+    use crate::e2e::{MultiProver, ShardContextBuilder};
     use ceno_emul::{
         CENO_PLATFORM, Cycle, FullTracer, GpuReplayRangeDescriptor, InsnKind, NextCycleAccess,
         StepIndex, StepRecord, SyscallWitness,
@@ -4478,62 +4476,17 @@ mod tests {
 
     #[cfg(feature = "gpu")]
     #[test]
-    fn compact_pipeline_overlaps_cpu_replay_but_gates_next_gpu_phase() {
-        use std::sync::{
-            Arc,
-            atomic::{AtomicBool, Ordering},
-            mpsc::sync_channel,
-        };
+    fn compact_pipeline_channel_contracts() {
+        use crate::e2e::{recv_compact_replay_shard, recycle_compact_replay_owners};
 
-        // This is the production channel topology in
-        // `spawn_compact_replay_pipeline`: one prepared shard and one recycled
-        // arena batch. GPU work remains exclusively on the receiver thread.
-        let (ready_tx, ready_rx) = sync_channel(1);
-        let (recycle_tx, recycle_rx) = sync_channel(1);
-        let replay_one_started = Arc::new(AtomicBool::new(false));
-        let next_gpu_phase_started = AtomicBool::new(false);
-        let replay_one_started_worker = Arc::clone(&replay_one_started);
-        let worker = std::thread::spawn(move || {
-            ready_tx.send(0usize).unwrap();
-            recycle_rx.recv().unwrap();
-            replay_one_started_worker.store(true, Ordering::Release);
-            ready_tx.send(1usize).unwrap();
-        });
-
-        // Receiving shard 0 models assignment 0. Recycling its CPU arenas
-        // enables replay 1 while proof 0 is still active.
-        assert_eq!(ready_rx.recv().unwrap(), 0);
-        recycle_tx.send(()).unwrap();
-        while !replay_one_started.load(Ordering::Acquire) {
-            std::thread::yield_now();
-        }
-
-        // The receiver has not advanced, so no assignment/H2D/kernel for shard
-        // 1 can have occurred even though its CPU replay is underway/ready.
-        assert!(!next_gpu_phase_started.load(Ordering::Relaxed));
-        assert_eq!(ready_rx.recv().unwrap(), 1);
-        next_gpu_phase_started.store(true, Ordering::Relaxed);
-        assert!(next_gpu_phase_started.load(Ordering::Relaxed));
-        worker.join().unwrap();
-    }
-
-    #[cfg(feature = "gpu")]
-    #[test]
-    fn compact_pipeline_disconnect_is_fatal() {
         let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
         drop(ready_tx);
         let result = std::panic::catch_unwind(|| recv_compact_replay_shard(&ready_rx));
         assert!(result.is_err());
-    }
 
-    #[cfg(feature = "gpu")]
-    #[test]
-    fn compact_pipeline_terminal_shard_does_not_require_recycling() {
         let (recycle_tx, recycle_rx) = std::sync::mpsc::sync_channel(1);
         drop(recycle_rx);
-
         recycle_compact_replay_owners(&recycle_tx, Vec::new(), true);
-
         let result = std::panic::catch_unwind(|| {
             recycle_compact_replay_owners(&recycle_tx, Vec::new(), false)
         });

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1183,6 +1183,50 @@ struct CompactStepReplay {
     aot: Arc<ceno_emul::aot::AotProgram>,
 }
 
+// `GpuReplayTracer` caches raw pointers into allocations it exclusively owns.
+// Moving the complete replay state to one worker thread does not alias those
+// allocations; the state is never accessed again by the spawning thread.
+#[cfg(feature = "gpu")]
+unsafe impl Send for CompactStepReplay {}
+
+#[cfg(feature = "gpu")]
+struct CompactReplayPipeline {
+    ready: std::sync::mpsc::Receiver<CompactReplayShard>,
+    recycle: std::sync::mpsc::SyncSender<Vec<ceno_emul::GpuReplayTypedRange>>,
+}
+
+#[cfg(feature = "gpu")]
+fn spawn_compact_replay_pipeline(mut replay: CompactStepReplay) -> CompactReplayPipeline {
+    // One prepared shard may wait while the current shard is proving. The
+    // producer must recover the previous shard's arenas before replaying the
+    // next one, which bounds retained CPU storage and preserves tracer reuse.
+    let (ready_tx, ready) = std::sync::mpsc::sync_channel(1);
+    let (recycle, recycle_rx) = std::sync::mpsc::sync_channel(1);
+    std::thread::Builder::new()
+        .name("ceno-compact-replay".to_string())
+        .spawn(move || {
+            let shard_count = replay.shard_step_counts.len();
+            for shard_id in 0..shard_count {
+                if shard_id != 0 {
+                    let Ok(ranges) = recycle_rx.recv() else {
+                        return;
+                    };
+                    for range in ranges {
+                        replay.vm.tracer_mut().recycle_range(range);
+                    }
+                }
+                let shard = replay
+                    .next_shard(false, Some)
+                    .expect("compact replay ended before its shard plan");
+                if ready_tx.send(shard).is_err() {
+                    return;
+                }
+            }
+        })
+        .expect("failed to spawn compact replay pipeline");
+    CompactReplayPipeline { ready, recycle }
+}
+
 #[cfg(feature = "gpu")]
 fn compact_replay_selected(debug_compare: bool, disabled_kinds: bool) -> bool {
     !debug_compare && !disabled_kinds
@@ -2114,6 +2158,8 @@ pub fn generate_witness<'a, E: ExtensionField>(
             emul_result.replay_aot_program.clone(),
         )
     });
+    #[cfg(feature = "gpu")]
+    let compact_pipeline = compact_iter.take().map(spawn_compact_replay_pipeline);
     let mut current_compact_shard: Option<CompactReplayShard> = None;
     std::iter::from_fn(move || {
         info_span!(
@@ -2142,9 +2188,12 @@ pub fn generate_witness<'a, E: ExtensionField>(
             } {
             instrunction_dispatch_ctx.begin_shard();
             }
-            let (mut shard_ctx, shard_summary) = if let Some(compact_iter) = compact_iter.as_mut() {
+            let (mut shard_ctx, shard_summary) = if use_compact_replay {
                 instrunction_dispatch_ctx.begin_compact_ingest();
-                let stream_owned_ranges = true;
+                // Replay and typed arena preparation are CPU-only and may run
+                // one shard ahead. All GPU setup and assignment below remain
+                // on this consumer thread, after the previous proof returned.
+                let stream_owned_ranges = false;
                 #[cfg(feature = "gpu")]
                 if stream_owned_ranges
                     && !{
@@ -2256,17 +2305,23 @@ pub fn generate_witness<'a, E: ExtensionField>(
                         .unwrap();
                 }
                 #[allow(unused_mut)]
-                let mut compact_shard = info_span!("position_compact_shard")
-                    .in_scope(|| {
-                        compact_iter.next_shard(stream_owned_ranges, |range| {
-                            #[cfg(feature = "gpu")]
-                            if stream_owned_ranges {
-                                return crate::instructions::gpu::dispatch::submit_provisional_fused_range(range)
-                                    .unwrap();
-                            }
-                            Some(range)
+                let mut compact_shard = info_span!("position_compact_shard").in_scope(|| {
+                    #[cfg(feature = "gpu")]
+                    {
+                        compact_pipeline
+                            .as_ref()
+                            .expect("compact replay pipeline missing")
+                            .ready
+                            .recv()
+                            .ok()
+                    }
+                    #[cfg(not(feature = "gpu"))]
+                    {
+                        compact_iter.as_mut().and_then(|compact_iter| {
+                            compact_iter.next_shard(stream_owned_ranges, Some)
                         })
-                    })?;
+                    }
+                })?;
                 for range in &compact_shard.arenas.ranges {
                     for (kind, arena) in InsnKind::iter().zip(&range.typed) {
                         if let Some(arena) = arena {
@@ -2413,12 +2468,12 @@ pub fn generate_witness<'a, E: ExtensionField>(
                     .in_scope(|| {
                         let recycled =
                             crate::instructions::gpu::dispatch::clear_compact_replay_arenas();
-                        let compact_iter = compact_iter
-                            .as_mut()
-                            .expect("compact owner recovery missing source");
-                        for range in recycled.into_iter().flatten() {
-                            compact_iter.vm.tracer_mut().recycle_range(range);
-                        }
+                        compact_pipeline
+                            .as_ref()
+                            .expect("compact replay pipeline missing")
+                            .recycle
+                            .send(recycled.into_iter().flatten().collect())
+                            .expect("compact replay pipeline stopped before owner recycling");
                     });
             }
 
@@ -3717,32 +3772,11 @@ pub fn run_e2e_proof_with_precompiled_aot<
     )
 }
 
-/// defines a lightweight CPU -> GPU pipeline for witness generation and proof creation.
-/// This enables overlapped execution such that while the GPU is proving shard `i`,
-/// the CPU is already generating the witness for shard `i+1`.
-///
-/// With `channel::bounded(0)` the pipeline behaves as a strict rendezvous:
-/// - CPU generates the next witness while GPU is proving the current one.
-/// - Once the CPU finishes generating `wN`, it blocks on `send(wN)`
-///   until the GPU finishes proving `wN–1` and calls `recv()`.
-///
-/// This ensures:
-///   - At most **one** witness on the GPU, and
-///   - At most **one** fully-generated witness waiting in CPU memory,
-///     keeping memory usage strictly bounded (2 witnesses max).
-///
-/// Timeline with bounded(0):
-///
-/// CPU gen(w1)→gen(w2)→wait→gen(w3)→wait, while GPU wait→prove(w1)→prove(w2)→prove(w3)→prove(w4).
-///
-/// CPU never runs ahead more than one witness, but CPU/GPU still overlap fully.
-///
-/// This improves total proving throughput by hiding CPU witness generation latency
-/// behind GPU proof execution.
-///
-/// in pure CPU mode, the pipeline is disabled and the prover falls back to
-/// fully sequential execution. Witness generation and proof creation run
-/// one after another with no overlap.
+/// Consume assigned witnesses and prove them sequentially. In GPU mode,
+/// `generate_witness` internally prepares one CPU replay shard ahead through a
+/// capacity-one channel. Its iterator performs all GPU assignment work before
+/// yielding, so advancing it only after the previous proof returns prevents
+/// assignment/H2D/CUDA work for shard N+1 from overlapping proof N.
 fn create_proofs_streaming<
     E: ExtensionField + LkMultiplicityKey,
     PCS: PolynomialCommitmentScheme<E> + Serialize + 'static,
@@ -4339,5 +4373,46 @@ mod tests {
             super::public_io_words_to_digest_words(&[]),
             super::KECCAK_EMPTY_WORDS
         );
+    }
+
+    #[cfg(feature = "gpu")]
+    #[test]
+    fn compact_pipeline_overlaps_cpu_replay_but_gates_next_gpu_phase() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+            mpsc::sync_channel,
+        };
+
+        // This is the production channel topology in
+        // `spawn_compact_replay_pipeline`: one prepared shard and one recycled
+        // arena batch. GPU work remains exclusively on the receiver thread.
+        let (ready_tx, ready_rx) = sync_channel(1);
+        let (recycle_tx, recycle_rx) = sync_channel(1);
+        let replay_one_started = Arc::new(AtomicBool::new(false));
+        let next_gpu_phase_started = AtomicBool::new(false);
+        let replay_one_started_worker = Arc::clone(&replay_one_started);
+        let worker = std::thread::spawn(move || {
+            ready_tx.send(0usize).unwrap();
+            recycle_rx.recv().unwrap();
+            replay_one_started_worker.store(true, Ordering::Release);
+            ready_tx.send(1usize).unwrap();
+        });
+
+        // Receiving shard 0 models assignment 0. Recycling its CPU arenas
+        // enables replay 1 while proof 0 is still active.
+        assert_eq!(ready_rx.recv().unwrap(), 0);
+        recycle_tx.send(()).unwrap();
+        while !replay_one_started.load(Ordering::Acquire) {
+            std::thread::yield_now();
+        }
+
+        // The receiver has not advanced, so no assignment/H2D/kernel for shard
+        // 1 can have occurred even though its CPU replay is underway/ready.
+        assert!(!next_gpu_phase_started.load(Ordering::Relaxed));
+        assert_eq!(ready_rx.recv().unwrap(), 1);
+        next_gpu_phase_started.store(true, Ordering::Relaxed);
+        assert!(next_gpu_phase_started.load(Ordering::Relaxed));
+        worker.join().unwrap();
     }
 }

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1226,6 +1226,7 @@ fn spawn_compact_replay_pipeline(input: CompactReplayPipelineInput) -> CompactRe
                 #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
                 input.aot,
             );
+            replay.vm.tracer_mut().enable_retained_shard_mode();
             let shard_count = replay.shard_step_counts.len();
             for shard_id in 0..shard_count {
                 if shard_id != 0 {

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1214,6 +1214,19 @@ fn recv_compact_replay_shard(
 }
 
 #[cfg(feature = "gpu")]
+fn recycle_compact_replay_owners(
+    recycle: &std::sync::mpsc::SyncSender<Vec<ceno_emul::GpuReplayTypedRange>>,
+    ranges: Vec<ceno_emul::GpuReplayTypedRange>,
+    is_last_shard: bool,
+) {
+    if !is_last_shard {
+        recycle
+            .send(ranges)
+            .expect("compact replay pipeline stopped before owner recycling");
+    }
+}
+
+#[cfg(feature = "gpu")]
 fn spawn_compact_replay_pipeline(input: CompactReplayPipelineInput) -> CompactReplayPipeline {
     // One prepared shard may wait while the current shard is proving. The
     // producer must recover the previous shard's arenas before replaying the
@@ -2539,12 +2552,14 @@ pub fn generate_witness<'a, E: ExtensionField>(
                     .in_scope(|| {
                         let recycled =
                             crate::instructions::gpu::dispatch::clear_compact_replay_arenas();
-                        compact_pipeline
-                            .as_ref()
-                            .expect("compact replay pipeline missing")
-                            .recycle
-                            .send(recycled.into_iter().flatten().collect())
-                            .expect("compact replay pipeline stopped before owner recycling");
+                        recycle_compact_replay_owners(
+                            &compact_pipeline
+                                .as_ref()
+                                .expect("compact replay pipeline missing")
+                                .recycle,
+                            recycled.into_iter().flatten().collect(),
+                            shard_ctx.is_last_shard(),
+                        );
                     });
             }
 
@@ -4099,7 +4114,9 @@ pub fn verify<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + serde::Ser
 
 #[cfg(test)]
 mod tests {
-    use crate::e2e::{MultiProver, ShardContextBuilder, recv_compact_replay_shard};
+    use crate::e2e::{
+        MultiProver, ShardContextBuilder, recv_compact_replay_shard, recycle_compact_replay_owners,
+    };
     use ceno_emul::{
         CENO_PLATFORM, Cycle, FullTracer, GpuReplayRangeDescriptor, InsnKind, NextCycleAccess,
         StepIndex, StepRecord, SyscallWitness,
@@ -4506,6 +4523,20 @@ mod tests {
         let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
         drop(ready_tx);
         let result = std::panic::catch_unwind(|| recv_compact_replay_shard(&ready_rx));
+        assert!(result.is_err());
+    }
+
+    #[cfg(feature = "gpu")]
+    #[test]
+    fn compact_pipeline_terminal_shard_does_not_require_recycling() {
+        let (recycle_tx, recycle_rx) = std::sync::mpsc::sync_channel(1);
+        drop(recycle_rx);
+
+        recycle_compact_replay_owners(&recycle_tx, Vec::new(), true);
+
+        let result = std::panic::catch_unwind(|| {
+            recycle_compact_replay_owners(&recycle_tx, Vec::new(), false)
+        });
         assert!(result.is_err());
     }
 }

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1203,6 +1203,17 @@ struct CompactReplayPipeline {
 }
 
 #[cfg(feature = "gpu")]
+fn recv_compact_replay_shard(
+    ready: &std::sync::mpsc::Receiver<CompactReplayShard>,
+) -> Option<CompactReplayShard> {
+    Some(
+        ready
+            .recv()
+            .expect("compact replay pipeline stopped before producing every planned shard"),
+    )
+}
+
+#[cfg(feature = "gpu")]
 fn spawn_compact_replay_pipeline(input: CompactReplayPipelineInput) -> CompactReplayPipeline {
     // One prepared shard may wait while the current shard is proving. The
     // producer must recover the previous shard's arenas before replaying the
@@ -2361,12 +2372,12 @@ pub fn generate_witness<'a, E: ExtensionField>(
                             phase = "gpu_assignment_wait",
                             "compact replay pipeline event"
                         );
-                        compact_pipeline
-                            .as_ref()
-                            .expect("compact replay pipeline missing")
-                            .ready
-                            .recv()
-                            .ok()
+                        recv_compact_replay_shard(
+                            &compact_pipeline
+                                .as_ref()
+                                .expect("compact replay pipeline missing")
+                                .ready,
+                        )
                     }
                     #[cfg(not(feature = "gpu"))]
                     {
@@ -4088,7 +4099,7 @@ pub fn verify<E: ExtensionField, PCS: PolynomialCommitmentScheme<E> + serde::Ser
 
 #[cfg(test)]
 mod tests {
-    use crate::e2e::{MultiProver, ShardContextBuilder};
+    use crate::e2e::{MultiProver, ShardContextBuilder, recv_compact_replay_shard};
     use ceno_emul::{
         CENO_PLATFORM, Cycle, FullTracer, GpuReplayRangeDescriptor, InsnKind, NextCycleAccess,
         StepIndex, StepRecord, SyscallWitness,
@@ -4487,5 +4498,14 @@ mod tests {
         next_gpu_phase_started.store(true, Ordering::Relaxed);
         assert!(next_gpu_phase_started.load(Ordering::Relaxed));
         worker.join().unwrap();
+    }
+
+    #[cfg(feature = "gpu")]
+    #[test]
+    fn compact_pipeline_disconnect_is_fatal() {
+        let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
+        drop(ready_tx);
+        let result = std::panic::catch_unwind(|| recv_compact_replay_shard(&ready_rx));
+        assert!(result.is_err());
     }
 }

--- a/ceno_zkvm/src/instructions/gpu/cache.rs
+++ b/ceno_zkvm/src/instructions/gpu/cache.rs
@@ -517,6 +517,14 @@ fn ensure_shard_metadata_cached_inner(
             addr_capacity as u32,
             super::config::is_debug_compare_enabled(),
         );
+        // Every buffer above is initialized on the default stream, while fused
+        // replay and some auxiliary chips launch on independent streams. Do
+        // not publish their pointers until zero-initialization and scalar H2D
+        // are visible to those consumers.
+        hal.inner.default_stream().synchronize().map_err(|e| {
+            ZKVMError::InvalidWitness(format!("shard metadata initialization sync: {e}").into())
+        })?;
+
         *cache = Some(ShardMetadataCache {
             shard_id,
             device_bufs: ShardDeviceBuffers {

--- a/ceno_zkvm/src/instructions/gpu/cache.rs
+++ b/ceno_zkvm/src/instructions/gpu/cache.rs
@@ -235,7 +235,7 @@ fn convert_compact_shard_records<E: ff_ext::ExtensionField>(
         let base = i * GPU_SHARD_RAM_RECORD_SIZE;
         let r = &raw[base..base + GPU_SHARD_RAM_RECORD_SIZE];
 
-        // Layout matches GpuShardRamRecord (112 bytes, #[repr(C)]):
+        // Layout matches GpuShardRamRecord (120 bytes, #[repr(C)]):
         //   0: addr(u32), 4: ram_type(u32), 8: value(u32), 12: _pad(u32),
         //   16: ordinal(u64), 24: shard(u64), 32: local_clk(u64),
         //   40: global_clk(u64), 48: is_to_write_set(u32), 52: nonce(u32),
@@ -415,7 +415,7 @@ fn ensure_shard_metadata_cached_inner(
         // Allocate shared EC/addr compact buffers for this shard.
         //
         // EC records: cross-shard only (sparse subset of RAM ops).
-        //   112 bytes each (28 u32s). Cap at 16M entries ≈ 1.8 GB.
+        //   120 bytes each (30 u32s). Cap at 16M entries ≈ 1.9 GB.
         // Addr records: every gpu_send() emits one (dense).
         //   4 bytes each (1 u32). Cap at 256M entries ≈ 1 GB.
         let max_ops_per_step = 52u64; // keccak worst case

--- a/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
@@ -203,6 +203,7 @@ pub(crate) fn shard_ram_record_to_gpu(rec: &crate::tables::ShardRamRecord) -> Gp
         },
         value: rec.value,
         _pad0: 0,
+        priority: 0,
         ordinal: 0,
         shard: rec.shard,
         local_clk: rec.local_clk,
@@ -1305,9 +1306,9 @@ pub(crate) fn try_gpu_assign_shared_circuit<E: ExtensionField>(
 
     let record_u32s = std::mem::size_of::<ceno_gpu::common::witgen::types::GpuShardRamRecord>() / 4;
     // GpuShardRamRecord (#[repr(C)]) layout — derived from shard_ram_record_to_gpu
-    debug_assert_eq!(record_u32s, 28, "GpuShardRamRecord layout changed");
-    const IS_TO_WRITE_SET_U32_OFFSET: usize = 12;
-    const POINT_Y6_U32_OFFSET: usize = 27;
+    debug_assert_eq!(record_u32s, 30, "GpuShardRamRecord layout changed");
+    const IS_TO_WRITE_SET_U32_OFFSET: usize = 14;
+    const POINT_Y6_U32_OFFSET: usize = 29;
 
     let host_data: Vec<u32> = if total_records == 0 {
         vec![]

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -46,12 +46,11 @@ use crate::{
 };
 
 const PACKED_PRODUCER_COUNT_BITS: u32 = 24;
-const PRODUCER_PRIORITY_ROW_BITS: u32 = 23;
 
 fn packed_producer_total(kind: InsnKind, rows: usize) -> u32 {
     let rows = u32::try_from(rows).expect("producer total exceeds u32");
     assert!(
-        rows < (1 << PRODUCER_PRIORITY_ROW_BITS),
+        rows < (1 << PACKED_PRODUCER_COUNT_BITS),
         "producer total exceeds packed priority row range"
     );
     let order = kind as u32;
@@ -2854,6 +2853,12 @@ mod tests {
         assert_eq!(add >> PACKED_PRODUCER_COUNT_BITS, InsnKind::ADD as u32);
         assert_eq!(sub >> PACKED_PRODUCER_COUNT_BITS, InsnKind::SUB as u32);
         assert_ne!(add, sub);
+    }
+
+    #[test]
+    fn packed_producer_total_accepts_full_packed_count_range() {
+        let packed = packed_producer_total(InsnKind::ADD, (1 << PACKED_PRODUCER_COUNT_BITS) - 1);
+        assert_eq!(packed & 0x00ff_ffff, 0x00ff_ffff);
     }
 
     #[test]

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -45,17 +45,14 @@ use crate::{
     witness::LkMultiplicity,
 };
 
-const PACKED_PRODUCER_COUNT_BITS: u32 = 24;
+fn producer_count(rows: usize) -> u32 {
+    u32::try_from(rows).expect("producer count exceeds u32")
+}
 
-fn packed_producer_total(kind: InsnKind, rows: usize) -> u32 {
-    let rows = u32::try_from(rows).expect("producer total exceeds u32");
-    assert!(
-        rows < (1 << PACKED_PRODUCER_COUNT_BITS),
-        "producer total exceeds packed priority row range"
-    );
+fn producer_order(kind: InsnKind) -> u32 {
     let order = kind as u32;
     assert!(order < (1 << (31 - 25)));
-    (order << PACKED_PRODUCER_COUNT_BITS) | rows
+    order
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -755,7 +752,8 @@ pub(crate) fn submit_provisional_fused_range(
                 layout: arena.layout() as u32,
                 row_count: u32::try_from(arena.len()).unwrap(),
                 producer_base: u32::try_from(producer_base).unwrap(),
-                producer_total: packed_producer_total(arena.kind(), registration.rows),
+                producer_count: producer_count(registration.rows),
+                producer_order: producer_order(arena.kind()),
                 num_cols: u32::try_from(registration.num_cols).unwrap(),
                 arg0: registration.arg0,
                 arg1: registration.arg1,
@@ -1424,7 +1422,8 @@ pub(crate) fn launch_fused_assignments(shard_ctx: &ShardContext) -> Result<(), Z
                     layout: arena.layout() as u32,
                     row_count: u32::try_from(arena.len()).expect("typed row count exceeds u32"),
                     producer_base: u32::try_from(producer_base).expect("producer base exceeds u32"),
-                    producer_total: packed_producer_total(arena.kind(), registration.rows),
+                    producer_count: producer_count(registration.rows),
+                    producer_order: producer_order(arena.kind()),
                     num_cols: u32::try_from(registration.num_cols)
                         .expect("column count exceeds u32"),
                     arg0: registration.arg0,
@@ -2845,20 +2844,11 @@ mod tests {
     }
 
     #[test]
-    fn packed_producer_total_preserves_count_and_kind_priority() {
-        let add = packed_producer_total(InsnKind::ADD, 123);
-        let sub = packed_producer_total(InsnKind::SUB, 123);
-        assert_eq!(add & 0x00ff_ffff, 123);
-        assert_eq!(sub & 0x00ff_ffff, 123);
-        assert_eq!(add >> PACKED_PRODUCER_COUNT_BITS, InsnKind::ADD as u32);
-        assert_eq!(sub >> PACKED_PRODUCER_COUNT_BITS, InsnKind::SUB as u32);
-        assert_ne!(add, sub);
-    }
-
-    #[test]
-    fn packed_producer_total_accepts_full_packed_count_range() {
-        let packed = packed_producer_total(InsnKind::ADD, (1 << PACKED_PRODUCER_COUNT_BITS) - 1);
-        assert_eq!(packed & 0x00ff_ffff, 0x00ff_ffff);
+    fn producer_metadata_preserves_count_and_kind_priority() {
+        assert_eq!(producer_count(123), 123);
+        assert_eq!(producer_order(InsnKind::ADD), InsnKind::ADD as u32);
+        assert_eq!(producer_order(InsnKind::SUB), InsnKind::SUB as u32);
+        assert_ne!(producer_order(InsnKind::ADD), producer_order(InsnKind::SUB));
     }
 
     #[test]

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -49,7 +49,7 @@ fn producer_count(rows: usize) -> u32 {
     u32::try_from(rows).expect("producer count exceeds u32")
 }
 
-fn producer_base(base: usize) -> u32 {
+fn encoded_producer_base(base: usize) -> u32 {
     let base = u32::try_from(base).expect("producer base exceeds u32");
     assert!(base < (1 << 25), "producer base exceeds device priority range");
     base
@@ -757,7 +757,7 @@ pub(crate) fn submit_provisional_fused_range(
                 tag: registration.tag,
                 layout: arena.layout() as u32,
                 row_count: u32::try_from(arena.len()).unwrap(),
-                producer_base: producer_base(producer_base),
+                producer_base: encoded_producer_base(producer_base),
                 producer_count: producer_count(registration.rows),
                 producer_order: producer_order(arena.kind()),
                 num_cols: u32::try_from(registration.num_cols).unwrap(),
@@ -1427,7 +1427,7 @@ pub(crate) fn launch_fused_assignments(shard_ctx: &ShardContext) -> Result<(), Z
                     tag: registration.tag,
                     layout: arena.layout() as u32,
                     row_count: u32::try_from(arena.len()).expect("typed row count exceeds u32"),
-                    producer_base: producer_base(producer_base),
+                    producer_base: encoded_producer_base(producer_base),
                     producer_count: producer_count(registration.rows),
                     producer_order: producer_order(arena.kind()),
                     num_cols: u32::try_from(registration.num_cols)

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -49,6 +49,12 @@ fn producer_count(rows: usize) -> u32 {
     u32::try_from(rows).expect("producer count exceeds u32")
 }
 
+fn producer_base(base: usize) -> u32 {
+    let base = u32::try_from(base).expect("producer base exceeds u32");
+    assert!(base < (1 << 25), "producer base exceeds device priority range");
+    base
+}
+
 fn producer_order(kind: InsnKind) -> u32 {
     let order = kind as u32;
     assert!(order < (1 << (31 - 25)));
@@ -751,7 +757,7 @@ pub(crate) fn submit_provisional_fused_range(
                 tag: registration.tag,
                 layout: arena.layout() as u32,
                 row_count: u32::try_from(arena.len()).unwrap(),
-                producer_base: u32::try_from(producer_base).unwrap(),
+                producer_base: producer_base(producer_base),
                 producer_count: producer_count(registration.rows),
                 producer_order: producer_order(arena.kind()),
                 num_cols: u32::try_from(registration.num_cols).unwrap(),
@@ -1421,7 +1427,7 @@ pub(crate) fn launch_fused_assignments(shard_ctx: &ShardContext) -> Result<(), Z
                     tag: registration.tag,
                     layout: arena.layout() as u32,
                     row_count: u32::try_from(arena.len()).expect("typed row count exceeds u32"),
-                    producer_base: u32::try_from(producer_base).expect("producer base exceeds u32"),
+                    producer_base: producer_base(producer_base),
                     producer_count: producer_count(registration.rows),
                     producer_order: producer_order(arena.kind()),
                     num_cols: u32::try_from(registration.num_cols)

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -45,19 +45,35 @@ use crate::{
     witness::LkMultiplicity,
 };
 
+const MAX_PRODUCER_ROWS: usize = 1 << 28;
+
 fn producer_count(rows: usize) -> u32 {
+    assert!(
+        rows <= MAX_PRODUCER_ROWS,
+        "producer count exceeds 2^28 rows"
+    );
     u32::try_from(rows).expect("producer count exceeds u32")
 }
 
-fn encoded_producer_base(base: usize) -> u32 {
-    let base = u32::try_from(base).expect("producer base exceeds u32");
-    assert!(base < (1 << 25), "producer base exceeds device priority range");
-    base
+fn checked_producer_base(base: usize, range_rows: usize, count: usize) -> u32 {
+    producer_count(count);
+    let end = base
+        .checked_add(range_rows)
+        .expect("producer range end overflow");
+    assert!(base <= count, "producer base exceeds producer count");
+    assert!(end <= count, "producer range exceeds producer count");
+    u32::try_from(base).expect("producer base exceeds u32")
 }
 
 fn producer_order(kind: InsnKind) -> u32 {
     let order = kind as u32;
-    assert!(order < (1 << (31 - 25)));
+    let max_priority =
+        (u64::from(order) << 30) | (u64::try_from(MAX_PRODUCER_ROWS - 1).unwrap() << 2) | 3;
+    assert_eq!(
+        max_priority >> 63,
+        0,
+        "producer order overlaps continuation class"
+    );
     order
 }
 
@@ -757,7 +773,7 @@ pub(crate) fn submit_provisional_fused_range(
                 tag: registration.tag,
                 layout: arena.layout() as u32,
                 row_count: u32::try_from(arena.len()).unwrap(),
-                producer_base: encoded_producer_base(producer_base),
+                producer_base: checked_producer_base(producer_base, arena.len(), registration.rows),
                 producer_count: producer_count(registration.rows),
                 producer_order: producer_order(arena.kind()),
                 num_cols: u32::try_from(registration.num_cols).unwrap(),
@@ -1427,7 +1443,11 @@ pub(crate) fn launch_fused_assignments(shard_ctx: &ShardContext) -> Result<(), Z
                     tag: registration.tag,
                     layout: arena.layout() as u32,
                     row_count: u32::try_from(arena.len()).expect("typed row count exceeds u32"),
-                    producer_base: encoded_producer_base(producer_base),
+                    producer_base: checked_producer_base(
+                        producer_base,
+                        arena.len(),
+                        registration.rows,
+                    ),
                     producer_count: producer_count(registration.rows),
                     producer_order: producer_order(arena.kind()),
                     num_cols: u32::try_from(registration.num_cols)
@@ -2855,6 +2875,28 @@ mod tests {
         assert_eq!(producer_order(InsnKind::ADD), InsnKind::ADD as u32);
         assert_eq!(producer_order(InsnKind::SUB), InsnKind::SUB as u32);
         assert_ne!(producer_order(InsnKind::ADD), producer_order(InsnKind::SUB));
+    }
+
+    #[test]
+    fn producer_domain_bounds_are_exact() {
+        assert_eq!(producer_count(1 << 28), 1 << 28);
+        assert_eq!(
+            checked_producer_base((1 << 28) - 1, 1, 1 << 28),
+            (1 << 28) - 1
+        );
+        assert_eq!(checked_producer_base(1 << 28, 0, 1 << 28), 1 << 28);
+    }
+
+    #[test]
+    #[should_panic(expected = "producer count exceeds 2^28 rows")]
+    fn producer_count_rejects_above_limit() {
+        producer_count((1 << 28) + 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "producer range exceeds producer count")]
+    fn producer_range_rejects_end_above_count() {
+        checked_producer_base((1 << 28) - 1, 2, 1 << 28);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

GPU shard proving serialized compact CPU replay with the preceding shard proof. Replay ownership also crossed shard boundaries implicitly, and the packed producer priority could not represent the full supported producer domain.

## Design Rationale

A capacity-one pipeline prepares shard N+1 on the CPU while shard N is proved. CUDA assignment remains on the proving thread and starts only after the preceding proof completes, preventing assignment kernels or transfers from overlapping sumchecks. Replay owners are retained and recycled explicitly so their storage remains valid across the boundary.

Producer base, count, and order remain separate on the host. The hot device domain contains only base and count; order is read only for terminal emission. A checked 64-bit priority preserves continuation class, instruction order, producer index, and slot through exactly `2^28` rows without changing transcript or witness order.

## Change Highlights

- `ceno_emul`: add compact replay ranges and checked producer-domain metadata.
- `ceno_zkvm`: overlap CPU replay with the preceding proof, retain/recycle owners explicitly, and gate each GPU assignment before proving its shard.
- GPU dispatch: publish initialized shard metadata across streams before dependent kernels run.

## Benchmark / Performance Impact

### Operation

| Operation | master (s) | this PR (s) | Improve (master -> this PR) |
|-----------|-----------:|------------:|----------------------------:|
| Block 23817600 total proof creation | 52.095 | 48.604 | 3.491 s (6.70%) |

### Layer

| Layer | master (s) | this PR (s) | Improve (master -> this PR) |
|-------|-----------:|------------:|----------------------------:|
| Application proving | 46.144 | 42.752 | 3.392 s (7.35%) |
| Recursion proving | 5.882 | 5.786 | 0.096 s (1.64%) |

Benchmark command:

```sh
target/release/ceno-reth-benchmark-bin --mode prove-stark --block-number 23817600 --output-dir output --cache-dir rpc-cache --chain-id 1
```

Environment: NVIDIA RTX 4090 (`CUDA_ARCH=89`), GPU + jemalloc + AOT benchmark workflow. Baseline used Ceno `436a32e2`; this PR used `6fddf6cb`.

Raw data:

- master: [run 32851091196](https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/32851091196)
- this PR: [run 32947621524](https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/32947621524)

## Testing

```sh
cargo fmt --all -- --check
cargo check -p ceno_zkvm --all-targets
RUST_MIN_STACK=33554432 cargo test --workspace --lib --bins --tests --examples --no-default-features --features goldilocks --no-run
RUSTFLAGS=-Dwarnings cargo check --workspace --all-targets
```

Both benchmark workflows completed successfully and verified block `23817600`.

## Risks and Rollout

The main risk is cross-shard lifetime or stream-ordering regression. Bounded channels, explicit owner recycling, checked domain bounds, and a publication barrier make these boundaries explicit. Reverting the PR restores serialized replay without data migration or protocol changes.

## Copilot Reviewer Directive (keep this section)

When Copilot reviews this PR, apply `.github/copilot-instructions.md` strictly.
