### PR TITLE
feat: multi-GPU proving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,9 +1691,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
+name = "cuda-config"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee74643f7430213a1a78320f88649de309b20b80818325575e393f848f79f5d"
+dependencies = [
+ "glob",
+]
+
+[[package]]
+name = "cuda-runtime-sys"
+version = "0.3.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d070b301187fee3c611e75a425cf12247b7c75c09729dbdef95cb9cb64e8c39"
+dependencies = [
+ "cuda-config",
+]
+
+[[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/ceno-gpu-mock.git?branch=main#fe8f7923b7d3a3823c27949fab0aab8e31011aa9"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fmulti_gpu#b75f3be0c37ea28eb393ce2ed174c7fc5f5c9aec"
+dependencies = [
+ "anyhow",
+ "cuda-runtime-sys",
+ "cudarc",
+ "downcast-rs",
+ "either",
+ "ff_ext",
+ "itertools 0.13.0",
+ "mpcs",
+ "multilinear_extensions",
+ "p3",
+ "rand 0.8.5",
+ "rayon",
+ "sha2",
+ "sppark",
+ "sppark_plug",
+ "sumcheck",
+ "thiserror 1.0.69",
+ "tracing",
+ "transcript",
+ "witness",
+]
 
 [[package]]
 name = "cudarc"
@@ -2737,6 +2777,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.1",
+]
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3195,6 +3244,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5213,6 +5268,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
@@ -5220,7 +5288,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -5636,6 +5704,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sppark"
+version = "0.1.11"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fmulti_gpu#b75f3be0c37ea28eb393ce2ed174c7fc5f5c9aec"
+dependencies = [
+ "cc",
+ "which",
+]
+
+[[package]]
+name = "sppark_plug"
+version = "0.1.0"
+source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fmulti_gpu#b75f3be0c37ea28eb393ce2ed174c7fc5f5c9aec"
+dependencies = [
+ "cc",
+ "ff_ext",
+ "itertools 0.13.0",
+ "p3",
+ "sppark",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5844,7 +5933,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -6454,6 +6543,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "whir"
 version = "0.1.0"
 source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.36#b85adae2bf13f5ded83c2f6eb84f7b9e0ef3f21b"
@@ -6582,6 +6683,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.4",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,49 +1691,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
-name = "cuda-config"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee74643f7430213a1a78320f88649de309b20b80818325575e393f848f79f5d"
-dependencies = [
- "glob",
-]
-
-[[package]]
-name = "cuda-runtime-sys"
-version = "0.3.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d070b301187fee3c611e75a425cf12247b7c75c09729dbdef95cb9cb64e8c39"
-dependencies = [
- "cuda-config",
-]
-
-[[package]]
 name = "cuda_hal"
 version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fmulti_gpu#b75f3be0c37ea28eb393ce2ed174c7fc5f5c9aec"
-dependencies = [
- "anyhow",
- "cuda-runtime-sys",
- "cudarc",
- "downcast-rs",
- "either",
- "ff_ext",
- "itertools 0.13.0",
- "mpcs",
- "multilinear_extensions",
- "p3",
- "rand 0.8.5",
- "rayon",
- "sha2",
- "sppark",
- "sppark_plug",
- "sumcheck",
- "thiserror 1.0.69",
- "tracing",
- "transcript",
- "witness",
-]
+source = "git+https://github.com/scroll-tech/ceno-gpu-mock.git?branch=main#fe8f7923b7d3a3823c27949fab0aab8e31011aa9"
 
 [[package]]
 name = "cudarc"
@@ -2777,15 +2737,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.1",
-]
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3244,12 +3195,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5268,19 +5213,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
@@ -5288,7 +5220,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
 
@@ -5704,27 +5636,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sppark"
-version = "0.1.11"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fmulti_gpu#b75f3be0c37ea28eb393ce2ed174c7fc5f5c9aec"
-dependencies = [
- "cc",
- "which",
-]
-
-[[package]]
-name = "sppark_plug"
-version = "0.1.0"
-source = "git+ssh://git@github.com/scroll-tech/ceno-gpu.git?branch=feat%2Fmulti_gpu#b75f3be0c37ea28eb393ce2ed174c7fc5f5c9aec"
-dependencies = [
- "cc",
- "ff_ext",
- "itertools 0.13.0",
- "p3",
- "sppark",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5933,7 +5844,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.7",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -6543,18 +6454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "whir"
 version = "0.1.0"
 source = "git+https://github.com/scroll-tech/gkr-backend.git?tag=v1.0.0-alpha.36#b85adae2bf13f5ded83c2f6eb84f7b9e0ef3f21b"
@@ -6683,15 +6582,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.4",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3712,7 +3712,7 @@ dependencies = [
 [[package]]
 name = "openvm-codec-derive"
 version = "2.0.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#f57f0f025e9b250a5bb6a56cb077548a5cb5f913"
+source = "git+https://github.com/hero78119/stark-backend.git?rev=4abbf1d4987f1861a825dc87c2023da0acd15341#4abbf1d4987f1861a825dc87c2023da0acd15341"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "openvm-cpu-backend"
 version = "2.0.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#f57f0f025e9b250a5bb6a56cb077548a5cb5f913"
+source = "git+https://github.com/hero78119/stark-backend.git?rev=4abbf1d4987f1861a825dc87c2023da0acd15341#4abbf1d4987f1861a825dc87c2023da0acd15341"
 dependencies = [
  "cfg-if",
  "derive-new 0.7.0",
@@ -3773,7 +3773,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-backend"
 version = "2.0.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#f57f0f025e9b250a5bb6a56cb077548a5cb5f913"
+source = "git+https://github.com/hero78119/stark-backend.git?rev=4abbf1d4987f1861a825dc87c2023da0acd15341#4abbf1d4987f1861a825dc87c2023da0acd15341"
 dependencies = [
  "derive-new 0.7.0",
  "getset",
@@ -3800,7 +3800,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-builder"
 version = "2.0.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#f57f0f025e9b250a5bb6a56cb077548a5cb5f913"
+source = "git+https://github.com/hero78119/stark-backend.git?rev=4abbf1d4987f1861a825dc87c2023da0acd15341#4abbf1d4987f1861a825dc87c2023da0acd15341"
 dependencies = [
  "cc",
  "glob",
@@ -3809,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-common"
 version = "2.0.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#f57f0f025e9b250a5bb6a56cb077548a5cb5f913"
+source = "git+https://github.com/hero78119/stark-backend.git?rev=4abbf1d4987f1861a825dc87c2023da0acd15341#4abbf1d4987f1861a825dc87c2023da0acd15341"
 dependencies = [
  "bytesize",
  "ctor",
@@ -3933,7 +3933,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "2.0.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#f57f0f025e9b250a5bb6a56cb077548a5cb5f913"
+source = "git+https://github.com/hero78119/stark-backend.git?rev=4abbf1d4987f1861a825dc87c2023da0acd15341#4abbf1d4987f1861a825dc87c2023da0acd15341"
 dependencies = [
  "cfg-if",
  "derivative",
@@ -3965,7 +3965,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "2.0.0"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#f57f0f025e9b250a5bb6a56cb077548a5cb5f913"
+source = "git+https://github.com/hero78119/stark-backend.git?rev=4abbf1d4987f1861a825dc87c2023da0acd15341#4abbf1d4987f1861a825dc87c2023da0acd15341"
 dependencies = [
  "dashmap",
  "derive-new 0.7.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,6 +1273,7 @@ dependencies = [
  "gkr_iop",
  "glob",
  "itertools 0.13.0",
+ "libc",
  "metrics",
  "mpcs",
  "multilinear_extensions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,8 +137,8 @@ openvm-stark-sdk = { git = "https://github.com/hero78119/stark-backend.git", rev
 #ceno_crypto_primitives = { path = "../ceno-patch/crypto-primitives", package = "ceno_crypto_primitives" }
 #ceno_syscall = { path = "../ceno-patch/syscall", package = "ceno_syscall" }
 
-#[patch."https://github.com/scroll-tech/ceno-gpu-mock.git"]
-#ceno_gpu = { path = "../ceno-gpu/cuda_hal", package = "cuda_hal" }
+[patch."https://github.com/scroll-tech/ceno-gpu-mock.git"]
+ceno_gpu = { git = "ssh://git@github.com/scroll-tech/ceno-gpu.git", package = "cuda_hal", branch = "feat/multi_gpu" }
 #
 #[patch."https://github.com/scroll-tech/gkr-backend.git"]
 #ff_ext = { path = "../gkr-backend/crates/ff_ext", package = "ff_ext" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,8 +137,8 @@ openvm-stark-sdk = { git = "https://github.com/hero78119/stark-backend.git", rev
 #ceno_crypto_primitives = { path = "../ceno-patch/crypto-primitives", package = "ceno_crypto_primitives" }
 #ceno_syscall = { path = "../ceno-patch/syscall", package = "ceno_syscall" }
 
-[patch."https://github.com/scroll-tech/ceno-gpu-mock.git"]
-ceno_gpu = { git = "ssh://git@github.com/scroll-tech/ceno-gpu.git", package = "cuda_hal", branch = "feat/multi_gpu" }
+#[patch."https://github.com/scroll-tech/ceno-gpu-mock.git"]
+#ceno_gpu = { path = "../ceno-gpu/cuda_hal", package = "cuda_hal" }
 #
 #[patch."https://github.com/scroll-tech/gkr-backend.git"]
 #ff_ext = { path = "../gkr-backend/crates/ff_ext", package = "ff_ext" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,15 @@ opt-level = 3
 [profile.release]
 lto = "thin"
 
+[patch."https://github.com/openvm-org/stark-backend.git"]
+openvm-codec-derive = { git = "https://github.com/hero78119/stark-backend.git", rev = "4abbf1d4987f1861a825dc87c2023da0acd15341" }
+openvm-cpu-backend = { git = "https://github.com/hero78119/stark-backend.git", rev = "4abbf1d4987f1861a825dc87c2023da0acd15341" }
+openvm-cuda-backend = { git = "https://github.com/hero78119/stark-backend.git", rev = "4abbf1d4987f1861a825dc87c2023da0acd15341" }
+openvm-cuda-builder = { git = "https://github.com/hero78119/stark-backend.git", rev = "4abbf1d4987f1861a825dc87c2023da0acd15341" }
+openvm-cuda-common = { git = "https://github.com/hero78119/stark-backend.git", rev = "4abbf1d4987f1861a825dc87c2023da0acd15341" }
+openvm-stark-backend = { git = "https://github.com/hero78119/stark-backend.git", rev = "4abbf1d4987f1861a825dc87c2023da0acd15341" }
+openvm-stark-sdk = { git = "https://github.com/hero78119/stark-backend.git", rev = "4abbf1d4987f1861a825dc87c2023da0acd15341" }
+
 #[patch."https://github.com/scroll-tech/elliptic-curves"]
 #k256 = { path = "../elliptic-curves/k256", default-features = false, features = ["std", "ecdsa"] }
 #

--- a/ceno_cli/Cargo.toml
+++ b/ceno_cli/Cargo.toml
@@ -40,7 +40,12 @@ vergen-git2 = { version = "9.1.0", features = ["build", "cargo", "rustc", "emit_
 
 [features]
 aot-x86_64 = ["ceno_zkvm/aot-x86_64"]
-gpu = ["gkr_iop/gpu", "ceno_zkvm/gpu", "ceno_recursion_v2/cuda"]
+gpu = [
+  "aot-x86_64",
+  "gkr_iop/gpu",
+  "ceno_zkvm/gpu",
+  "ceno_recursion_v2/cuda",
+]
 jemalloc = ["dep:tikv-jemallocator", "ceno_zkvm/jemalloc"]
 jemalloc-prof = ["jemalloc", "tikv-jemallocator?/profiling"]
 nightly-features = [

--- a/ceno_cli/src/commands/common_args/ceno.rs
+++ b/ceno_cli/src/commands/common_args/ceno.rs
@@ -7,11 +7,15 @@ use ceno_recursion_v2::{
     continuation::prover::{AggProver, AggregationOptions},
     system::{utils::test_system_params_zero_pow, warm_child_vk_digest_cache},
 };
+#[cfg(feature = "gpu")]
+use ceno_zkvm::multi_gpu::{MultiGpuConfig, select_device_ids};
+#[cfg(not(feature = "gpu"))]
+use ceno_zkvm::scheme::create_prover;
 use ceno_zkvm::{
     e2e::*,
     scheme::{
-        constants::MAX_NUM_VARIABLES, create_backend, create_prover,
-        mock_prover::LkMultiplicityKey, verifier::ZKVMVerifier,
+        constants::MAX_NUM_VARIABLES, create_backend, mock_prover::LkMultiplicityKey,
+        verifier::ZKVMVerifier,
     },
 };
 use clap::Args;
@@ -100,6 +104,21 @@ pub struct CenoOptions {
     // => 2^30 * 16 / 4 / 2
     #[arg(long, default_value = "2147483648")]
     max_cell_per_shard: u64,
+
+    /// Comma-separated logical CUDA device ordinals. Takes precedence over --gpu-count.
+    #[cfg(feature = "gpu")]
+    #[arg(long, value_delimiter = ',')]
+    gpu_devices: Option<Vec<usize>>,
+
+    /// Select logical CUDA devices 0 through count-1.
+    #[cfg(feature = "gpu")]
+    #[arg(long)]
+    gpu_count: Option<usize>,
+
+    /// Logical CUDA device used by recursion after base proving.
+    #[cfg(feature = "gpu")]
+    #[arg(long)]
+    recursion_gpu_device: Option<usize>,
 
     /// Profiling granularity.
     /// Setting any value restricts logs to profiling information
@@ -396,13 +415,21 @@ fn run_elf_inner<
     compilation_options: &CompilationOptions,
     elf_path: P,
     checkpoint: Checkpoint,
-) -> anyhow::Result<E2ECheckpointResult<E, PCS>> {
+) -> anyhow::Result<E2ECheckpointResult<E, PCS>>
+where
+    PCS::ProverParam: Send + Sync,
+    PCS::VerifierParam: Send + Sync,
+    PCS::Commitment: Send + Sync,
+    PCS::CommitmentWithWitness: Send + Sync,
+    PCS::Proof: Send,
+{
     let elf_path = elf_path.as_ref();
     let elf_bytes =
         std::fs::read(elf_path).context(format!("failed to read {}", elf_path.display()))?;
     let program = Program::load_elf(&elf_bytes, u32::MAX).context("failed to load elf")?;
     print_cargo_message("Loaded", format_args!("{}", elf_path.display()));
-    let multi_prover = MultiProver::new(
+    #[allow(unused_mut)]
+    let mut multi_prover = MultiProver::new(
         options.prover_id as usize,
         options.num_provers as usize,
         options.max_cell_per_shard,
@@ -443,8 +470,90 @@ fn run_elf_inner<
     );
 
     let backend = create_backend(options.max_num_variables, options.security_level);
+    #[cfg(feature = "gpu")]
+    let (device, multi_gpu) = {
+        let available = ceno_zkvm::multi_gpu::discover_cuda_devices()
+            .context("failed to discover CUDA devices")?
+            .len();
+        let device_ids =
+            select_device_ids(options.gpu_devices.as_deref(), options.gpu_count, available)
+                .map_err(anyhow::Error::msg)?;
+        let mut config = MultiGpuConfig::new(device_ids).map_err(anyhow::Error::msg)?;
+        if let Some(recursion_device) = options.recursion_gpu_device {
+            config = config
+                .with_recursion_device(recursion_device)
+                .map_err(anyhow::Error::msg)?;
+        }
+        let prepared = config
+            .prepare(options.max_cell_per_shard)
+            .map_err(anyhow::Error::msg)?;
+        multi_prover.max_cell_per_shard = prepared.max_cell_per_shard;
+        tracing::info!(
+            devices = ?config.device_ids,
+            recursion_device = config.recursion_device,
+            max_cell_per_shard = prepared.max_cell_per_shard,
+            "validated Stage 1 multi-GPU configuration"
+        );
+        let device = gkr_iop::gpu::GpuProver::new(backend.clone(), prepared.workers[0].hal.clone());
+        let multi_gpu = (config.device_ids.len() > 1).then_some((config, prepared));
+        (device, multi_gpu)
+    };
+    #[cfg(not(feature = "gpu"))]
+    let device = create_prover(backend.clone());
+    #[cfg(feature = "gpu")]
+    if let Some((config, prepared)) = multi_gpu {
+        if !matches!(checkpoint, Checkpoint::PrepWitnessGen) {
+            let ctx = setup_program::<E>(program, platform, multi_prover);
+            let (pk, vk) = ctx.keygen_with_pb(backend.as_ref());
+            let pk = Arc::new(pk);
+            let init_full_mem = pk.program_ctx.as_ref().unwrap().setup_init_mem(&hints);
+            let max_steps = options.max_steps;
+            #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+            let preflight_aot = pk
+                .program_ctx
+                .as_ref()
+                .unwrap()
+                .preflight_aot_program
+                .clone();
+            #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+            let fulltracer_aot = pk
+                .program_ctx
+                .as_ref()
+                .unwrap()
+                .fulltracer_aot_program
+                .clone();
+            let run = move || {
+                run_e2e_multi_gpu_proof_with_precompiled_aot(
+                    pk,
+                    backend,
+                    &prepared,
+                    &config,
+                    &init_full_mem,
+                    public_io_digest,
+                    max_steps,
+                    #[cfg(all(
+                        feature = "aot-x86_64",
+                        target_arch = "x86_64",
+                        target_os = "linux"
+                    ))]
+                    preflight_aot,
+                    #[cfg(all(
+                        feature = "aot-x86_64",
+                        target_arch = "x86_64",
+                        target_os = "linux"
+                    ))]
+                    fulltracer_aot,
+                )
+                .unwrap_or_else(|error| panic!("multi-GPU proving failed: {error}"))
+            };
+            if matches!(checkpoint, Checkpoint::PrepE2EProving) {
+                return Ok(E2ECheckpointResult::deferred(vk, move || _ = run()));
+            }
+            return Ok(E2ECheckpointResult::completed(run(), vk));
+        }
+    }
     Ok(run_e2e_with_checkpoint::<E, PCS, _, _>(
-        create_prover(backend.clone()),
+        device,
         program,
         platform,
         multi_prover,
@@ -464,7 +573,14 @@ fn keygen_inner<
     args: &CenoOptions,
     compilation_options: &CompilationOptions,
     elf_path: P,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<()>
+where
+    PCS::ProverParam: Send + Sync,
+    PCS::VerifierParam: Send + Sync,
+    PCS::Commitment: Send + Sync,
+    PCS::CommitmentWithWitness: Send + Sync,
+    PCS::Proof: Send,
+{
     let result = run_elf_inner::<E, PCS, P>(
         args,
         compilation_options,
@@ -491,7 +607,14 @@ fn prove_inner<
     compilation_options: &CompilationOptions,
     elf_path: P,
     checkpoint: Checkpoint,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<()>
+where
+    PCS::ProverParam: Send + Sync,
+    PCS::VerifierParam: Send + Sync,
+    PCS::Commitment: Send + Sync,
+    PCS::CommitmentWithWitness: Send + Sync,
+    PCS::Proof: Send,
+{
     let result = run_elf_inner::<E, PCS, P>(args, compilation_options, elf_path, checkpoint)?;
     let zkvm_proofs = result.proofs.expect("PrepSanityCheck should yield proof.");
     let vk = result.vk.expect("PrepSanityCheck should yield vk.");

--- a/ceno_cli/src/commands/common_args/ceno.rs
+++ b/ceno_cli/src/commands/common_args/ceno.rs
@@ -11,6 +11,8 @@ use ceno_recursion_v2::{
 use ceno_zkvm::multi_gpu::{MultiGpuConfig, select_device_ids};
 #[cfg(not(feature = "gpu"))]
 use ceno_zkvm::scheme::create_prover;
+#[cfg(feature = "gpu")]
+use ceno_zkvm::scheme::prover::ZKVMProver;
 use ceno_zkvm::{
     e2e::*,
     scheme::{
@@ -507,6 +509,7 @@ where
             let (pk, vk) = ctx.keygen_with_pb(backend.as_ref());
             let pk = Arc::new(pk);
             let init_full_mem = pk.program_ctx.as_ref().unwrap().setup_init_mem(&hints);
+            let prover = ZKVMProver::new(pk.clone(), device);
             let max_steps = options.max_steps;
             #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
             let preflight_aot = pk
@@ -524,8 +527,7 @@ where
                 .clone();
             let run = move || {
                 run_e2e_multi_gpu_proof_with_precompiled_aot(
-                    pk,
-                    backend,
+                    &prover,
                     &prepared,
                     &config,
                     &init_full_mem,

--- a/ceno_cli/src/commands/common_args/ceno.rs
+++ b/ceno_cli/src/commands/common_args/ceno.rs
@@ -478,7 +478,7 @@ where
 
     let backend = create_backend(options.max_num_variables, options.security_level);
     #[cfg(feature = "gpu")]
-    let (device, multi_gpu) = {
+    let (device, multi_gpu_config, prepared_multi_gpu) = {
         let available = ceno_zkvm::multi_gpu::discover_cuda_devices()
             .context("failed to discover CUDA devices")?
             .len();
@@ -509,62 +509,51 @@ where
             "validated Stage 1 multi-GPU configuration"
         );
         let device = gkr_iop::gpu::GpuProver::new(backend.clone(), prepared.workers[0].hal.clone());
-        let multi_gpu = (config.device_ids.len() > 1).then_some((config, prepared));
-        (device, multi_gpu)
+        (device, config, prepared)
     };
     #[cfg(not(feature = "gpu"))]
     let device = create_prover(backend.clone());
     #[cfg(feature = "gpu")]
-    if let Some((config, prepared)) = multi_gpu {
-        if !matches!(checkpoint, Checkpoint::PrepWitnessGen) {
-            let ctx = setup_program::<E>(program, platform, multi_prover);
-            let (pk, vk) = ctx.keygen_with_pb(backend.as_ref());
-            let pk = Arc::new(pk);
-            let init_full_mem = pk.program_ctx.as_ref().unwrap().setup_init_mem(&hints);
-            let prover = ZKVMProver::new(pk.clone(), device);
-            let max_steps = options.max_steps;
-            #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
-            let preflight_aot = pk
-                .program_ctx
-                .as_ref()
-                .unwrap()
-                .preflight_aot_program
-                .clone();
-            #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
-            let fulltracer_aot = pk
-                .program_ctx
-                .as_ref()
-                .unwrap()
-                .fulltracer_aot_program
-                .clone();
-            let run = move || {
-                run_e2e_multi_gpu_proof_with_precompiled_aot(
-                    &prover,
-                    &prepared,
-                    &config,
-                    &init_full_mem,
-                    public_io_digest,
-                    max_steps,
-                    #[cfg(all(
-                        feature = "aot-x86_64",
-                        target_arch = "x86_64",
-                        target_os = "linux"
-                    ))]
-                    preflight_aot,
-                    #[cfg(all(
-                        feature = "aot-x86_64",
-                        target_arch = "x86_64",
-                        target_os = "linux"
-                    ))]
-                    fulltracer_aot,
-                )
-                .unwrap_or_else(|error| panic!("multi-GPU proving failed: {error}"))
-            };
-            if matches!(checkpoint, Checkpoint::PrepE2EProving) {
-                return Ok(E2ECheckpointResult::deferred(vk, move || _ = run()));
-            }
-            return Ok(E2ECheckpointResult::completed(run(), vk));
+    if !matches!(checkpoint, Checkpoint::PrepWitnessGen) {
+        let ctx = setup_program::<E>(program, platform, multi_prover);
+        let (pk, vk) = ctx.keygen_with_pb(backend.as_ref());
+        let pk = Arc::new(pk);
+        let init_full_mem = pk.program_ctx.as_ref().unwrap().setup_init_mem(&hints);
+        let prover = ZKVMProver::new(pk.clone(), device);
+        let max_steps = options.max_steps;
+        #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+        let preflight_aot = pk
+            .program_ctx
+            .as_ref()
+            .unwrap()
+            .preflight_aot_program
+            .clone();
+        #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+        let fulltracer_aot = pk
+            .program_ctx
+            .as_ref()
+            .unwrap()
+            .fulltracer_aot_program
+            .clone();
+        let run = move || {
+            run_e2e_multi_gpu_proof_with_precompiled_aot(
+                &prover,
+                &prepared_multi_gpu,
+                &multi_gpu_config,
+                &init_full_mem,
+                public_io_digest,
+                max_steps,
+                #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+                preflight_aot,
+                #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+                fulltracer_aot,
+            )
+            .unwrap_or_else(|error| panic!("multi-GPU proving failed: {error}"))
+        };
+        if matches!(checkpoint, Checkpoint::PrepE2EProving) {
+            return Ok(E2ECheckpointResult::deferred(vk, move || _ = run()));
         }
+        return Ok(E2ECheckpointResult::completed(run(), vk));
     }
     Ok(run_e2e_with_checkpoint::<E, PCS, _, _>(
         device,

--- a/ceno_cli/src/commands/common_args/ceno.rs
+++ b/ceno_cli/src/commands/common_args/ceno.rs
@@ -546,6 +546,7 @@ where
         let init_full_mem = pk.program_ctx.as_ref().unwrap().setup_init_mem(&hints);
         let prover = ZKVMProver::new(pk.clone(), device);
         let max_steps = options.max_steps;
+        let shard_id = options.shard_id.map(|value| value as usize);
         #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
         let preflight_aot = pk
             .program_ctx
@@ -568,7 +569,7 @@ where
                 &init_full_mem,
                 public_io_digest,
                 max_steps,
-                options.shard_id.map(|value| value as usize),
+                shard_id,
                 base_event_sink,
                 #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
                 preflight_aot,

--- a/ceno_cli/src/commands/common_args/ceno.rs
+++ b/ceno_cli/src/commands/common_args/ceno.rs
@@ -568,6 +568,7 @@ where
                 &init_full_mem,
                 public_io_digest,
                 max_steps,
+                options.shard_id.map(|value| value as usize),
                 base_event_sink,
                 #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
                 preflight_aot,

--- a/ceno_cli/src/commands/common_args/ceno.rs
+++ b/ceno_cli/src/commands/common_args/ceno.rs
@@ -8,7 +8,7 @@ use ceno_recursion_v2::{
     system::{utils::test_system_params_zero_pow, warm_child_vk_digest_cache},
 };
 #[cfg(feature = "gpu")]
-use ceno_zkvm::multi_gpu::{MultiGpuConfig, select_device_ids};
+use ceno_zkvm::multi_gpu::{MultiGpuConfig, parse_worker_cpu_affinity, select_device_ids};
 #[cfg(not(feature = "gpu"))]
 use ceno_zkvm::scheme::create_prover;
 #[cfg(feature = "gpu")]
@@ -121,6 +121,11 @@ pub struct CenoOptions {
     #[cfg(feature = "gpu")]
     #[arg(long)]
     recursion_gpu_device: Option<usize>,
+
+    /// Exclusive CPU set for one GPU worker. Repeat once per selected GPU.
+    #[cfg(feature = "gpu")]
+    #[arg(long)]
+    gpu_worker_cpus: Vec<String>,
 
     /// Profiling granularity.
     /// Setting any value restricts logs to profiling information
@@ -484,6 +489,13 @@ where
         if let Some(recursion_device) = options.recursion_gpu_device {
             config = config
                 .with_recursion_device(recursion_device)
+                .map_err(anyhow::Error::msg)?;
+        }
+        if let Some(affinity) =
+            parse_worker_cpu_affinity(&options.gpu_worker_cpus).map_err(anyhow::Error::msg)?
+        {
+            config = config
+                .with_worker_cpu_affinity(affinity)
                 .map_err(anyhow::Error::msg)?;
         }
         let prepared = config

--- a/ceno_cli/src/commands/common_args/ceno.rs
+++ b/ceno_cli/src/commands/common_args/ceno.rs
@@ -1,18 +1,26 @@
 use super::CompilationOptions;
 use crate::utils::*;
 use anyhow::{Context, bail};
+#[cfg(feature = "gpu")]
+use cargo_ceno::sdk::StreamingRecursionOrchestrator;
 use ceno_emul::{IterAddresses, Program, WORD_SIZE, Word};
 use ceno_host::{CenoStdin, memory_from_file};
+#[cfg(not(feature = "gpu"))]
+use ceno_recursion_v2::continuation::prover::AggProver;
+#[cfg(not(feature = "gpu"))]
+use ceno_recursion_v2::system::warm_child_vk_digest_cache;
 use ceno_recursion_v2::{
-    continuation::prover::{AggProver, AggregationOptions},
-    system::{utils::test_system_params_zero_pow, warm_child_vk_digest_cache},
+    continuation::prover::AggregationOptions, system::utils::test_system_params_zero_pow,
 };
-#[cfg(feature = "gpu")]
-use ceno_zkvm::multi_gpu::{MultiGpuConfig, parse_worker_cpu_affinity, select_device_ids};
 #[cfg(not(feature = "gpu"))]
 use ceno_zkvm::scheme::create_prover;
 #[cfg(feature = "gpu")]
 use ceno_zkvm::scheme::prover::ZKVMProver;
+#[cfg(feature = "gpu")]
+use ceno_zkvm::{
+    e2e::BaseProvingEventSink,
+    multi_gpu::{MultiGpuConfig, parse_worker_cpu_affinity, select_device_ids},
+};
 use ceno_zkvm::{
     e2e::*,
     scheme::{
@@ -116,11 +124,6 @@ pub struct CenoOptions {
     #[cfg(feature = "gpu")]
     #[arg(long)]
     gpu_count: Option<usize>,
-
-    /// Logical CUDA device used by recursion after base proving.
-    #[cfg(feature = "gpu")]
-    #[arg(long)]
-    recursion_gpu_device: Option<usize>,
 
     /// Exclusive CPU set for one GPU worker. Repeat once per selected GPU.
     #[cfg(feature = "gpu")]
@@ -430,6 +433,34 @@ where
     PCS::CommitmentWithWitness: Send + Sync,
     PCS::Proof: Send,
 {
+    run_elf_inner_with_base_sink(
+        options,
+        compilation_options,
+        elf_path,
+        checkpoint,
+        #[cfg(feature = "gpu")]
+        None,
+    )
+}
+
+fn run_elf_inner_with_base_sink<
+    E: ExtensionField + LkMultiplicityKey,
+    PCS: PolynomialCommitmentScheme<E> + Serialize + 'static,
+    P: AsRef<Path>,
+>(
+    options: &CenoOptions,
+    compilation_options: &CompilationOptions,
+    elf_path: P,
+    checkpoint: Checkpoint,
+    #[cfg(feature = "gpu")] base_event_sink: Option<Arc<dyn BaseProvingEventSink<E, PCS>>>,
+) -> anyhow::Result<E2ECheckpointResult<E, PCS>>
+where
+    PCS::ProverParam: Send + Sync,
+    PCS::VerifierParam: Send + Sync,
+    PCS::Commitment: Send + Sync,
+    PCS::CommitmentWithWitness: Send + Sync,
+    PCS::Proof: Send,
+{
     let elf_path = elf_path.as_ref();
     let elf_bytes =
         std::fs::read(elf_path).context(format!("failed to read {}", elf_path.display()))?;
@@ -486,11 +517,6 @@ where
             select_device_ids(options.gpu_devices.as_deref(), options.gpu_count, available)
                 .map_err(anyhow::Error::msg)?;
         let mut config = MultiGpuConfig::new(device_ids).map_err(anyhow::Error::msg)?;
-        if let Some(recursion_device) = options.recursion_gpu_device {
-            config = config
-                .with_recursion_device(recursion_device)
-                .map_err(anyhow::Error::msg)?;
-        }
         if let Some(affinity) =
             parse_worker_cpu_affinity(&options.gpu_worker_cpus).map_err(anyhow::Error::msg)?
         {
@@ -504,7 +530,6 @@ where
         multi_prover.max_cell_per_shard = prepared.max_cell_per_shard;
         tracing::info!(
             devices = ?config.device_ids,
-            recursion_device = config.recursion_device,
             max_cell_per_shard = prepared.max_cell_per_shard,
             "validated Stage 1 multi-GPU configuration"
         );
@@ -536,13 +561,14 @@ where
             .fulltracer_aot_program
             .clone();
         let run = move || {
-            run_e2e_multi_gpu_proof_with_precompiled_aot(
-                &prover,
+            ceno_zkvm::e2e::run_e2e_multi_gpu_proof_with_precompiled_aot_and_sink(
+                prover,
                 &prepared_multi_gpu,
                 &multi_gpu_config,
                 &init_full_mem,
                 public_io_digest,
                 max_steps,
+                base_event_sink,
                 #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
                 preflight_aot,
                 #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
@@ -657,17 +683,38 @@ fn prove_recursion_inner<P: AsRef<Path>>(
     elf_path: P,
     checkpoint: Checkpoint,
 ) -> anyhow::Result<()> {
-    let result = run_elf_inner::<BabyBearExt4, Jagged<Basefold<BabyBearExt4, BasefoldRSParams>>, P>(
+    let options = AggregationOptions::new(test_system_params_zero_pow(5, 16, 3));
+    #[cfg(feature = "gpu")]
+    let recursion = args
+        .out_root_proof
+        .as_ref()
+        .map(|_| Arc::new(StreamingRecursionOrchestrator::new(options.clone())));
+    #[cfg(feature = "gpu")]
+    let event_sink = recursion
+        .as_ref()
+        .map(|sink| sink.clone() as Arc<dyn BaseProvingEventSink<_, _>>);
+    let result = run_elf_inner_with_base_sink::<
+        BabyBearExt4,
+        Jagged<Basefold<BabyBearExt4, BasefoldRSParams>>,
+        P,
+    >(
         args,
         compilation_options,
         elf_path,
         checkpoint,
+        #[cfg(feature = "gpu")]
+        event_sink,
     )?;
+    #[cfg(feature = "gpu")]
+    if let Some(recursion) = &recursion {
+        recursion.mark_base_verified();
+    }
     let zkvm_proofs = result.proofs.expect("PrepSanityCheck should yield proof.");
     let vk = result.vk.expect("PrepSanityCheck should yield vk.");
 
     let start = std::time::Instant::now();
     let verifier = ZKVMVerifier::new(vk.clone());
+    #[cfg(not(feature = "gpu"))]
     if let Err(e) = verify(zkvm_proofs.clone(), &verifier) {
         bail!("Verification failed: {e:?}");
     }
@@ -693,17 +740,26 @@ fn prove_recursion_inner<P: AsRef<Path>>(
             .context("failed to serialize vk")?;
     }
     if let Some(out_root_proof) = args.out_root_proof.as_ref() {
-        let options = AggregationOptions::new(test_system_params_zero_pow(5, 16, 3));
-        let vk = Arc::new(vk);
-        warm_child_vk_digest_cache(&vk);
         let start = std::time::Instant::now();
-        let prover = AggProver::<2, 2>::new(vk, options);
-        let root_output = prover
-            .prove_with_root_vk(&zkvm_proofs)
-            .map_err(|err| anyhow::anyhow!("{err}"))?;
-        prover
-            .verify_root_proof(&root_output.root_vk, &root_output.root_proof)
-            .map_err(|err| anyhow::anyhow!("{err}"))?;
+        #[cfg(feature = "gpu")]
+        let root_output = recursion
+            .expect("root output requested without recursion orchestrator")
+            .finish()
+            .map_err(anyhow::Error::msg)?
+            .root_output;
+        #[cfg(not(feature = "gpu"))]
+        let root_output = {
+            let vk = Arc::new(vk);
+            warm_child_vk_digest_cache(&vk);
+            let prover = AggProver::<2, 2>::new(vk, options);
+            let root_output = prover
+                .prove_with_root_vk(&zkvm_proofs)
+                .map_err(|err| anyhow::anyhow!("{err}"))?;
+            prover
+                .verify_root_proof(&root_output.root_vk, &root_output.root_proof)
+                .map_err(|err| anyhow::anyhow!("{err}"))?;
+            root_output
+        };
         print_cargo_message(
             "Aggregated",
             format_args!("root proof in {:.2}s", start.elapsed().as_secs_f32()),

--- a/ceno_cli/src/sdk.rs
+++ b/ceno_cli/src/sdk.rs
@@ -407,10 +407,16 @@ where
             .zkvm_prover
             .as_ref()
             .expect("ZKVMProver is not initialized");
+        let init_mem_started = std::time::Instant::now();
         let init_full_mem = prover.setup_init_mem(&Vec::from(&hints));
+        tracing::info!(
+            target: "ceno_multi_gpu",
+            elapsed_ms = init_mem_started.elapsed().as_millis(),
+            phase = "sdk_init_memory",
+            "multi-GPU base setup event"
+        );
         let proofs = run_e2e_multi_gpu_proof_with_precompiled_aot(
-            prover.pk.clone(),
-            prover.device().backend.clone(),
+            prover,
             prepared,
             config,
             &init_full_mem,

--- a/ceno_cli/src/sdk.rs
+++ b/ceno_cli/src/sdk.rs
@@ -12,13 +12,19 @@ use ceno_recursion_v2::{
         warm_child_vk_digest_cache,
     },
 };
+#[cfg(feature = "gpu")]
+use ceno_zkvm::e2e::run_e2e_multi_gpu_proof_with_precompiled_aot;
 #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
 use ceno_zkvm::e2e::{prepare_fulltracer_aot_program, prepare_preflight_aot_program};
+#[cfg(feature = "gpu")]
+use ceno_zkvm::multi_gpu::{MultiGpuConfig, PreparedMultiGpu};
+#[cfg(not(feature = "gpu"))]
+use ceno_zkvm::scheme::create_prover;
 use ceno_zkvm::{
     e2e::{MultiProver, run_e2e_proof_with_precompiled_aot, setup_program},
     scheme::{
-        ZKVMProof, create_backend, create_prover, hal::ProverDevice,
-        mock_prover::LkMultiplicityKey, prover::ZKVMProver, verifier::ZKVMVerifier,
+        ZKVMProof, create_backend, hal::ProverDevice, mock_prover::LkMultiplicityKey,
+        prover::ZKVMProver, verifier::ZKVMVerifier,
     },
     structs::{ZKVMProvingKey, ZKVMVerifyingKey},
 };
@@ -76,6 +82,10 @@ where
     pub app_program: Option<Program>,
     pub platform: Option<Platform>,
     pub multi_prover: Option<MultiProver>,
+    #[cfg(feature = "gpu")]
+    pub multi_gpu_config: Option<MultiGpuConfig>,
+    #[cfg(feature = "gpu")]
+    prepared_multi_gpu: Option<PreparedMultiGpu>,
 
     pub zkvm_pk: Option<Arc<ZKVMProvingKey<E, PCS>>>,
     pub zkvm_vk: Option<ZKVMVerifyingKey<E, PCS>>,
@@ -102,6 +112,10 @@ where
             app_program: None,
             platform: None,
             multi_prover: None,
+            #[cfg(feature = "gpu")]
+            multi_gpu_config: None,
+            #[cfg(feature = "gpu")]
+            prepared_multi_gpu: None,
             zkvm_pk: None,
             zkvm_vk: None,
             zkvm_prover: None,
@@ -124,6 +138,10 @@ where
             app_program: Some(program),
             platform: Some(platform),
             multi_prover: Some(multi_prover),
+            #[cfg(feature = "gpu")]
+            multi_gpu_config: None,
+            #[cfg(feature = "gpu")]
+            prepared_multi_gpu: None,
             zkvm_pk: None,
             zkvm_vk: None,
             zkvm_prover: None,
@@ -146,6 +164,14 @@ where
 
     pub fn set_aggregation_options(&mut self, options: AggregationOptions) {
         self.aggregation_options = Some(options);
+    }
+
+    #[cfg(feature = "gpu")]
+    pub fn set_multi_gpu_config(&mut self, config: MultiGpuConfig) {
+        config
+            .validate_shape()
+            .expect("invalid multi-GPU configuration");
+        self.multi_gpu_config = Some(config);
     }
 
     pub fn aggregation_options(&self) -> AggregationOptions {
@@ -330,12 +356,83 @@ impl<E, PCS, SC, VC> CenoSDK<E, PCS, SC, VC>
 where
     E: ExtensionField + LkMultiplicityKey,
     PCS: PolynomialCommitmentScheme<E> + Serialize + 'static,
+    PCS::ProverParam: Send + Sync,
+    PCS::VerifierParam: Send + Sync,
+    PCS::Commitment: Send + Sync,
+    PCS::CommitmentWithWitness: Send + Sync,
+    PCS::Proof: Send,
 {
     pub fn init_base_prover(&mut self, max_num_variables: usize, level: SecurityLevel) {
         let backend = create_backend(max_num_variables, level);
-        let device = create_prover(backend);
+        let config = self
+            .multi_gpu_config
+            .clone()
+            .unwrap_or_else(|| MultiGpuConfig::new(vec![0]).unwrap());
+        self.multi_gpu_config = Some(config.clone());
+        let requested_max_cells = self
+            .multi_prover
+            .as_ref()
+            .map_or(u64::MAX, |prover| prover.max_cell_per_shard);
+        let prepared = config
+            .prepare(requested_max_cells)
+            .expect("multi-GPU device validation failed");
+        if let Some(multi_prover) = self.multi_prover.as_mut() {
+            multi_prover.max_cell_per_shard = prepared.max_cell_per_shard;
+        }
+        let device = GpuProver::new(backend, prepared.workers[0].hal.clone());
 
         self.set_zkvm_prover(device);
+        self.prepared_multi_gpu = Some(prepared);
+    }
+
+    pub fn generate_multi_gpu_base_proof(
+        &self,
+        hints: CenoStdin,
+        public_io_digest: [u32; 8],
+        max_steps: usize,
+        shard_id: Option<usize>,
+    ) -> Vec<ZKVMProof<E, PCS>> {
+        let config = self
+            .multi_gpu_config
+            .as_ref()
+            .expect("multi-GPU configuration was not initialized");
+        if shard_id.is_some() {
+            return self.generate_base_proof(hints, public_io_digest, max_steps, shard_id);
+        }
+        let prepared = self
+            .prepared_multi_gpu
+            .as_ref()
+            .expect("multi-GPU devices were not prepared");
+        let prover = self
+            .zkvm_prover
+            .as_ref()
+            .expect("ZKVMProver is not initialized");
+        let init_full_mem = prover.setup_init_mem(&Vec::from(&hints));
+        let proofs = run_e2e_multi_gpu_proof_with_precompiled_aot(
+            prover.pk.clone(),
+            prover.device().backend.clone(),
+            prepared,
+            config,
+            &init_full_mem,
+            public_io_digest,
+            max_steps,
+            #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+            self.preflight_aot_program.clone(),
+            #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+            self.fulltracer_aot_program.clone(),
+        )
+        .unwrap_or_else(|error| panic!("multi-GPU base proving failed: {error}"));
+        let recursion_worker = prepared
+            .workers
+            .iter()
+            .find(|worker| worker.info.logical_ordinal == config.recursion_device)
+            .expect("recursion GPU was not prepared");
+        gkr_iop::gpu::set_thread_cuda_hal(recursion_worker.hal.clone());
+        tracing::info!(
+            recursion_device = config.recursion_device,
+            "bound Stage 1 recursion GPU after base workers"
+        );
+        proofs
     }
 }
 

--- a/ceno_cli/src/sdk.rs
+++ b/ceno_cli/src/sdk.rs
@@ -14,6 +14,8 @@ use ceno_recursion_v2::{
 };
 #[cfg(feature = "gpu")]
 use ceno_zkvm::e2e::run_e2e_multi_gpu_proof_with_precompiled_aot;
+#[cfg(not(feature = "gpu"))]
+use ceno_zkvm::e2e::run_e2e_proof_with_precompiled_aot;
 #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
 use ceno_zkvm::e2e::{prepare_fulltracer_aot_program, prepare_preflight_aot_program};
 #[cfg(feature = "gpu")]
@@ -21,7 +23,7 @@ use ceno_zkvm::multi_gpu::{MultiGpuConfig, PreparedMultiGpu};
 #[cfg(not(feature = "gpu"))]
 use ceno_zkvm::scheme::create_prover;
 use ceno_zkvm::{
-    e2e::{MultiProver, run_e2e_proof_with_precompiled_aot, setup_program},
+    e2e::{MultiProver, setup_program},
     scheme::{
         ZKVMProof, create_backend, hal::ProverDevice, mock_prover::LkMultiplicityKey,
         prover::ZKVMProver, verifier::ZKVMVerifier,
@@ -231,12 +233,13 @@ where
         self.preflight_aot_program = Some(preflight_aot_program);
     }
 
+    #[cfg(not(feature = "gpu"))]
     pub fn generate_base_proof(
         &self,
         hints: CenoStdin,
         public_io_digest: [u32; 8],
         max_steps: usize,
-        shard_id: Option<usize>,
+        _shard_id: Option<usize>,
     ) -> Vec<ZKVMProof<E, PCS>> {
         if let Some(zkvm_prover) = self.zkvm_prover.as_ref() {
             let init_full_mem = zkvm_prover.setup_init_mem(&Vec::from(&hints));
@@ -246,7 +249,7 @@ where
                 public_io_digest,
                 max_steps,
                 false,
-                shard_id,
+                _shard_id,
                 #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
                 self.preflight_aot_program.clone(),
                 #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
@@ -396,9 +399,10 @@ where
             .multi_gpu_config
             .as_ref()
             .expect("multi-GPU configuration was not initialized");
-        if shard_id.is_some() {
-            return self.generate_base_proof(hints, public_io_digest, max_steps, shard_id);
-        }
+        assert!(
+            shard_id.is_none(),
+            "GPU debug shard proving is unsupported by the canonical Stage 1 coordinator"
+        );
         let prepared = self
             .prepared_multi_gpu
             .as_ref()
@@ -415,7 +419,7 @@ where
             phase = "sdk_init_memory",
             "multi-GPU base setup event"
         );
-        let proofs = run_e2e_multi_gpu_proof_with_precompiled_aot(
+        run_e2e_multi_gpu_proof_with_precompiled_aot(
             prover,
             prepared,
             config,
@@ -427,18 +431,7 @@ where
             #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
             self.fulltracer_aot_program.clone(),
         )
-        .unwrap_or_else(|error| panic!("multi-GPU base proving failed: {error}"));
-        let recursion_worker = prepared
-            .workers
-            .iter()
-            .find(|worker| worker.info.logical_ordinal == config.recursion_device)
-            .expect("recursion GPU was not prepared");
-        gkr_iop::gpu::set_thread_cuda_hal(recursion_worker.hal.clone());
-        tracing::info!(
-            recursion_device = config.recursion_device,
-            "bound Stage 1 recursion GPU after base workers"
-        );
-        proofs
+        .unwrap_or_else(|error| panic!("multi-GPU base proving failed: {error}"))
     }
 }
 

--- a/ceno_cli/src/sdk.rs
+++ b/ceno_cli/src/sdk.rs
@@ -1,10 +1,16 @@
 use std::{marker::PhantomData, sync::Arc};
+#[cfg(feature = "gpu")]
+use std::{sync::Mutex, time::Instant};
 
 use anyhow::{Context, Result};
 #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
 use ceno_emul::StepCellExtractor;
 use ceno_emul::{Platform, Program};
 use ceno_host::CenoStdin;
+#[cfg(feature = "gpu")]
+use ceno_recursion_v2::continuation::prover::{
+    GpuRecursionBatchOutput, GpuRecursionSession, RecursionWorkerMetrics, RootProvingOutput,
+};
 use ceno_recursion_v2::{
     continuation::prover::{AggProver, AggregationOptions, LeafVk, RootProof, SystemParams},
     system::{
@@ -12,10 +18,13 @@ use ceno_recursion_v2::{
         warm_child_vk_digest_cache,
     },
 };
-#[cfg(feature = "gpu")]
-use ceno_zkvm::e2e::run_e2e_multi_gpu_proof_with_precompiled_aot;
 #[cfg(not(feature = "gpu"))]
 use ceno_zkvm::e2e::run_e2e_proof_with_precompiled_aot;
+#[cfg(feature = "gpu")]
+use ceno_zkvm::e2e::{
+    BaseDeviceReleased, BaseProofReady, BaseProvingEventSink,
+    run_e2e_multi_gpu_proof_with_precompiled_aot_and_sink,
+};
 #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
 use ceno_zkvm::e2e::{prepare_fulltracer_aot_program, prepare_preflight_aot_program};
 #[cfg(feature = "gpu")]
@@ -48,6 +57,258 @@ pub const DEFAULT_RECURSION_K_WHIR: usize = 3;
 pub type CenoRecursionV2Prover = AggProver<DEFAULT_LEAF_FANIN, DEFAULT_INTERNAL_FANIN>;
 pub type CenoRecursionV2RootProof = RootProof;
 pub type CenoRecursionV2LeafVk = LeafVk;
+
+#[cfg(feature = "gpu")]
+#[derive(Clone, Debug, Default)]
+pub struct StreamingRecursionTimings {
+    pub base_proving: std::time::Duration,
+    pub recursion_streaming: std::time::Duration,
+    pub root_verification: std::time::Duration,
+    pub total: std::time::Duration,
+}
+
+#[cfg(feature = "gpu")]
+pub struct StreamingRecursionOutput {
+    pub base_proofs: Vec<RecursionProof>,
+    pub root_output: RootProvingOutput,
+    pub worker_metrics: Vec<RecursionWorkerMetrics>,
+    pub timings: StreamingRecursionTimings,
+}
+
+#[cfg(feature = "gpu")]
+struct RecursionOrchestrationState<S> {
+    session: Option<S>,
+    first_error: Option<String>,
+    proof_count: usize,
+    released_devices: usize,
+    base_verified: bool,
+}
+
+#[cfg(feature = "gpu")]
+impl<S> RecursionOrchestrationState<S> {
+    fn new() -> Self {
+        Self {
+            session: None,
+            first_error: None,
+            proof_count: 0,
+            released_devices: 0,
+            base_verified: false,
+        }
+    }
+
+    fn start(&mut self, session: S) -> Result<(), String> {
+        if self.session.is_some() {
+            return Err("base proving initialized recursion twice".to_owned());
+        }
+        self.session = Some(session);
+        Ok(())
+    }
+
+    fn accept_proof(
+        &mut self,
+        accept: impl FnOnce(&mut S) -> Result<(), String>,
+    ) -> Result<(), String> {
+        if let Some(error) = &self.first_error {
+            return Err(error.clone());
+        }
+        accept(
+            self.session
+                .as_mut()
+                .ok_or("base proof arrived before recursion initialization")?,
+        )?;
+        self.proof_count += 1;
+        Ok(())
+    }
+
+    fn release_device(
+        &mut self,
+        release: impl FnOnce(&mut S) -> Result<(), String>,
+    ) -> Result<(), String> {
+        if let Some(error) = &self.first_error {
+            return Err(error.clone());
+        }
+        release(
+            self.session
+                .as_mut()
+                .ok_or("GPU was released before recursion initialization")?,
+        )?;
+        self.released_devices += 1;
+        Ok(())
+    }
+
+    fn fail(&mut self, error: &str, cancel: impl FnOnce(&mut S)) {
+        if self.first_error.is_some() {
+            return;
+        }
+        if let Some(session) = &mut self.session {
+            cancel(session);
+        }
+        self.first_error = Some(error.to_owned());
+    }
+
+    fn mark_base_verified(&mut self) {
+        self.base_verified = true;
+    }
+
+    fn take_verified_session(&mut self) -> Result<S, String> {
+        if let Some(error) = &self.first_error {
+            return Err(error.clone());
+        }
+        if !self.base_verified {
+            return Err("canonical base verification has not completed".to_owned());
+        }
+        self.session
+            .take()
+            .ok_or("base proving never initialized recursion".to_owned())
+    }
+}
+
+#[cfg(feature = "gpu")]
+pub struct StreamingRecursionOrchestrator {
+    options: AggregationOptions,
+    state: Mutex<RecursionOrchestrationState<GpuRecursionSession<2, 2>>>,
+    started: Instant,
+}
+
+#[cfg(feature = "gpu")]
+impl StreamingRecursionOrchestrator {
+    pub fn new(options: AggregationOptions) -> Self {
+        Self {
+            options,
+            state: Mutex::new(RecursionOrchestrationState::new()),
+            started: Instant::now(),
+        }
+    }
+
+    pub fn mark_base_verified(&self) {
+        self.state
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .mark_base_verified();
+    }
+
+    pub fn finish(&self) -> Result<GpuRecursionBatchOutput, String> {
+        let (session, proof_count, released_devices) = {
+            let mut state = self.state.lock().unwrap_or_else(|err| err.into_inner());
+            (
+                state.take_verified_session()?,
+                state.proof_count,
+                state.released_devices,
+            )
+        };
+        let output = session.finish().map_err(|error| error.to_string())?;
+        log_recursion_completion(
+            &output,
+            proof_count,
+            released_devices,
+            self.started.elapsed(),
+        );
+        Ok(output)
+    }
+}
+
+#[cfg(feature = "gpu")]
+impl Drop for StreamingRecursionOrchestrator {
+    fn drop(&mut self) {
+        let state = self.state.get_mut().unwrap_or_else(|err| err.into_inner());
+        if let Some(session) = state.session.take() {
+            session.cancel("streaming recursion orchestration ended before root publication");
+            let _ = session.finish();
+        }
+    }
+}
+
+#[cfg(feature = "gpu")]
+impl BaseProvingEventSink<RecursionField, RecursionPcs> for StreamingRecursionOrchestrator {
+    fn on_started(
+        &self,
+        total_shards: usize,
+        app_vk: ceno_zkvm::structs::ZKVMVerifyingKey<RecursionField, RecursionPcs>,
+    ) -> Result<(), String> {
+        let mut state = self.state.lock().unwrap_or_else(|err| err.into_inner());
+        let app_vk = Arc::new(app_vk);
+        warm_child_vk_digest_cache(&app_vk);
+        state.start(
+            GpuRecursionSession::new(app_vk, total_shards, self.options.clone())
+                .map_err(|error| error.to_string())?,
+        )?;
+        tracing::info!(
+            target: "ceno_multi_gpu",
+            total_shards,
+            phase = "recursion_session_started",
+            "streaming recursion scheduler initialized"
+        );
+        Ok(())
+    }
+
+    fn on_proof_ready(
+        &self,
+        ready: BaseProofReady<RecursionField, RecursionPcs>,
+    ) -> Result<(), String> {
+        self.state
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .accept_proof(|session| {
+                session
+                    .accept_base_proof(ready.shard_id, ready.proof)
+                    .map_err(|error| error.to_string())
+            })
+    }
+
+    fn on_device_released(&self, released: BaseDeviceReleased) -> Result<(), String> {
+        self.state
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .release_device(|session| {
+                session
+                    .release_device(released.device_id)
+                    .map_err(|error| error.to_string())
+            })
+    }
+
+    fn on_failure(&self, error: &str) {
+        self.state
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .fail(error, |session| session.cancel(error.to_owned()));
+    }
+}
+
+#[cfg(feature = "gpu")]
+fn log_recursion_completion(
+    output: &GpuRecursionBatchOutput,
+    proof_count: usize,
+    released_devices: usize,
+    elapsed: std::time::Duration,
+) {
+    for metrics in &output.worker_metrics {
+        tracing::info!(
+            target: "ceno_multi_gpu",
+            device_id = metrics.device_id,
+            task_count = metrics.task_count,
+            leaf_tasks = metrics.leaf_tasks,
+            leaf_bridge_tasks = metrics.leaf_bridge_tasks,
+            recursive_tasks = metrics.recursive_tasks,
+            root_tasks = metrics.root_tasks,
+            asset_hydrations = metrics.asset_hydrations,
+            asset_switches = metrics.asset_switches,
+            hydration_ms = metrics.hydration_time.as_millis(),
+            proving_ms = metrics.proving_time.as_millis(),
+            total_ms = metrics.total_time.as_millis(),
+            phase = "recursion_worker_metrics",
+            "streaming recursion worker complete"
+        );
+    }
+    tracing::info!(
+        target: "ceno_multi_gpu",
+        proof_count,
+        released_devices,
+        elapsed_ms = elapsed.as_millis(),
+        root_verification_ms = output.root_verification_time.as_millis(),
+        phase = "root_publication_gate",
+        "canonical base verification succeeded; recursion root may be published"
+    );
+}
 
 pub fn recursion_system_params(l_skip: usize, n_stack: usize, k_whir: usize) -> SystemParams {
     test_system_params_zero_pow(l_skip, n_stack, k_whir)
@@ -389,28 +650,46 @@ where
     }
 
     pub fn generate_multi_gpu_base_proof(
-        &self,
+        &mut self,
         hints: CenoStdin,
         public_io_digest: [u32; 8],
         max_steps: usize,
         shard_id: Option<usize>,
     ) -> Vec<ZKVMProof<E, PCS>> {
+        self.generate_multi_gpu_base_proof_with_sink(
+            hints,
+            public_io_digest,
+            max_steps,
+            shard_id,
+            None,
+        )
+        .unwrap_or_else(|error| panic!("multi-GPU base proving failed: {error}"))
+    }
+
+    fn generate_multi_gpu_base_proof_with_sink(
+        &mut self,
+        hints: CenoStdin,
+        public_io_digest: [u32; 8],
+        max_steps: usize,
+        shard_id: Option<usize>,
+        event_sink: Option<Arc<dyn BaseProvingEventSink<E, PCS>>>,
+    ) -> Result<Vec<ZKVMProof<E, PCS>>> {
         let config = self
             .multi_gpu_config
             .as_ref()
-            .expect("multi-GPU configuration was not initialized");
-        assert!(
+            .context("multi-GPU configuration was not initialized")?;
+        anyhow::ensure!(
             shard_id.is_none(),
             "GPU debug shard proving is unsupported by the canonical Stage 1 coordinator"
         );
         let prepared = self
             .prepared_multi_gpu
             .as_ref()
-            .expect("multi-GPU devices were not prepared");
+            .context("multi-GPU devices were not prepared")?;
         let prover = self
             .zkvm_prover
             .as_ref()
-            .expect("ZKVMProver is not initialized");
+            .context("ZKVMProver is not initialized")?;
         let init_mem_started = std::time::Instant::now();
         let init_full_mem = prover.setup_init_mem(&Vec::from(&hints));
         tracing::info!(
@@ -419,19 +698,120 @@ where
             phase = "sdk_init_memory",
             "multi-GPU base setup event"
         );
-        run_e2e_multi_gpu_proof_with_precompiled_aot(
+        let prover = self
+            .zkvm_prover
+            .take()
+            .context("ZKVMProver is not initialized")?;
+        run_e2e_multi_gpu_proof_with_precompiled_aot_and_sink(
             prover,
             prepared,
             config,
             &init_full_mem,
             public_io_digest,
             max_steps,
+            event_sink,
             #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
             self.preflight_aot_program.clone(),
             #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
             self.fulltracer_aot_program.clone(),
         )
-        .unwrap_or_else(|error| panic!("multi-GPU base proving failed: {error}"))
+        .map_err(anyhow::Error::msg)
+    }
+}
+
+#[cfg(feature = "gpu")]
+impl<SC, VC> CenoSDK<RecursionField, RecursionPcs, SC, VC> {
+    pub fn generate_streaming_recursion_proof(
+        &mut self,
+        hints: CenoStdin,
+        public_io_digest: [u32; 8],
+        max_steps: usize,
+    ) -> Result<StreamingRecursionOutput> {
+        let total_started = Instant::now();
+        let recursion = Arc::new(StreamingRecursionOrchestrator::new(
+            self.aggregation_options(),
+        ));
+        let event_sink = recursion.clone() as Arc<dyn BaseProvingEventSink<_, _>>;
+        let base_started = Instant::now();
+        let base_proofs = self.generate_multi_gpu_base_proof_with_sink(
+            hints,
+            public_io_digest,
+            max_steps,
+            None,
+            Some(event_sink),
+        )?;
+        let base_proving = base_started.elapsed();
+
+        // The base call above owns the sole canonical full-trace verifier. Only its
+        // successful return opens the root-publication gate.
+        recursion.mark_base_verified();
+        let GpuRecursionBatchOutput {
+            root_output,
+            worker_metrics,
+            root_verification_time,
+        } = recursion.finish().map_err(anyhow::Error::msg)?;
+        let recursion_streaming = recursion.started.elapsed();
+
+        Ok(StreamingRecursionOutput {
+            base_proofs,
+            root_output,
+            worker_metrics,
+            timings: StreamingRecursionTimings {
+                base_proving,
+                recursion_streaming,
+                root_verification: root_verification_time,
+                total: total_started.elapsed(),
+            },
+        })
+    }
+}
+
+#[cfg(all(test, feature = "gpu"))]
+mod streaming_recursion_tests {
+    use super::RecursionOrchestrationState;
+
+    #[derive(Debug, Default)]
+    struct FakeSession {
+        events: Vec<&'static str>,
+        cancel_count: usize,
+    }
+
+    #[test]
+    fn fake_sink_routes_events_and_enforces_root_gate() {
+        let mut state = RecursionOrchestrationState::<FakeSession>::new();
+        assert!(state.accept_proof(|_| Ok(())).is_err());
+        assert!(state.release_device(|_| Ok(())).is_err());
+
+        state.start(FakeSession::default()).unwrap();
+        state
+            .accept_proof(|session| {
+                session.events.push("proof_ready");
+                Ok(())
+            })
+            .unwrap();
+        state
+            .release_device(|session| {
+                session.events.push("device_released");
+                Ok(())
+            })
+            .unwrap();
+        assert!(state.take_verified_session().is_err());
+        state.mark_base_verified();
+        let session = state.take_verified_session().unwrap();
+        assert_eq!(session.events, vec!["proof_ready", "device_released"]);
+        assert_eq!(state.proof_count, 1);
+        assert_eq!(state.released_devices, 1);
+    }
+
+    #[test]
+    fn fake_sink_preserves_first_failure_and_cancels_once() {
+        let mut state = RecursionOrchestrationState::new();
+        state.start(FakeSession::default()).unwrap();
+        state.fail("first", |session| session.cancel_count += 1);
+        state.fail("second", |session| session.cancel_count += 1);
+        assert_eq!(state.first_error.as_deref(), Some("first"));
+        assert_eq!(state.session.as_ref().unwrap().cancel_count, 1);
+        assert_eq!(state.take_verified_session().unwrap_err(), "first");
     }
 }
 

--- a/ceno_cli/src/sdk.rs
+++ b/ceno_cli/src/sdk.rs
@@ -725,10 +725,6 @@ where
             .multi_gpu_config
             .as_ref()
             .context("multi-GPU configuration was not initialized")?;
-        anyhow::ensure!(
-            shard_id.is_none(),
-            "GPU debug shard proving is unsupported by the canonical Stage 1 coordinator"
-        );
         let prepared = self
             .prepared_multi_gpu
             .as_ref()
@@ -756,6 +752,7 @@ where
             &init_full_mem,
             public_io_digest,
             max_steps,
+            shard_id,
             event_sink,
             #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
             self.preflight_aot_program.clone(),

--- a/ceno_cli/src/sdk.rs
+++ b/ceno_cli/src/sdk.rs
@@ -733,14 +733,7 @@ where
             .zkvm_prover
             .as_ref()
             .context("ZKVMProver is not initialized")?;
-        let init_mem_started = std::time::Instant::now();
         let init_full_mem = prover.setup_init_mem(&Vec::from(&hints));
-        tracing::info!(
-            target: "ceno_multi_gpu",
-            elapsed_ms = init_mem_started.elapsed().as_millis(),
-            phase = "sdk_init_memory",
-            "multi-GPU base setup event"
-        );
         let prover = self
             .zkvm_prover
             .take()
@@ -804,25 +797,13 @@ impl<SC, VC> CenoSDK<RecursionField, RecursionPcs, SC, VC> {
     ) -> Result<StreamingRecursionOutput> {
         let total_started = Instant::now();
         let options = self.aggregation_options();
-        let assets_builder = match self.recursion_assets_builder.take() {
-            Some(builder) => builder,
-            None => {
-                let prover = self
-                    .zkvm_prover
-                    .as_ref()
-                    .context("ZKVMProver is not initialized")?;
-                let app_vk = Arc::new(
-                    prover
-                        .cached_verifier()
-                        .context("initial GPU prover has no cached verifier")?
-                        .vk
-                        .clone(),
-                );
-                let app_vk_digest = prover.vk_digest();
-                RecursionHostAssetsBuilder::spawn(app_vk, app_vk_digest, options.clone())
-                    .map_err(|error| anyhow::anyhow!(error.to_string()))?
-            }
-        };
+        if self.recursion_assets_builder.is_none() {
+            self.prepare_streaming_recursion()?;
+        }
+        let assets_builder = self
+            .recursion_assets_builder
+            .take()
+            .expect("recursion host assets were just prepared");
         let recursion = Arc::new(StreamingRecursionOrchestrator::with_assets_builder(
             options,
             assets_builder,

--- a/ceno_cli/src/sdk.rs
+++ b/ceno_cli/src/sdk.rs
@@ -9,7 +9,8 @@ use ceno_emul::{Platform, Program};
 use ceno_host::CenoStdin;
 #[cfg(feature = "gpu")]
 use ceno_recursion_v2::continuation::prover::{
-    GpuRecursionBatchOutput, GpuRecursionSession, RecursionWorkerMetrics, RootProvingOutput,
+    GpuRecursionBatchOutput, GpuRecursionSession, RecursionHostAssetsBuilder,
+    RecursionWorkerMetrics, RootProvingOutput,
 };
 use ceno_recursion_v2::{
     continuation::prover::{AggProver, AggregationOptions, LeafVk, RootProof, SystemParams},
@@ -59,6 +60,9 @@ pub type CenoRecursionV2RootProof = RootProof;
 pub type CenoRecursionV2LeafVk = LeafVk;
 #[cfg(feature = "gpu")]
 type DefaultGpuRecursionSession = GpuRecursionSession<DEFAULT_LEAF_FANIN, DEFAULT_INTERNAL_FANIN>;
+#[cfg(feature = "gpu")]
+type DefaultRecursionHostAssetsBuilder =
+    RecursionHostAssetsBuilder<DEFAULT_LEAF_FANIN, DEFAULT_INTERNAL_FANIN>;
 
 #[cfg(feature = "gpu")]
 #[derive(Clone, Debug, Default)]
@@ -169,6 +173,7 @@ impl<S> RecursionOrchestrationState<S> {
 pub struct StreamingRecursionOrchestrator {
     options: AggregationOptions,
     state: Mutex<RecursionOrchestrationState<DefaultGpuRecursionSession>>,
+    assets_builder: Mutex<Option<DefaultRecursionHostAssetsBuilder>>,
     started: Instant,
 }
 
@@ -178,6 +183,19 @@ impl StreamingRecursionOrchestrator {
         Self {
             options,
             state: Mutex::new(RecursionOrchestrationState::new()),
+            assets_builder: Mutex::new(None),
+            started: Instant::now(),
+        }
+    }
+
+    fn with_assets_builder(
+        options: AggregationOptions,
+        assets_builder: DefaultRecursionHostAssetsBuilder,
+    ) -> Self {
+        Self {
+            options,
+            state: Mutex::new(RecursionOrchestrationState::new()),
+            assets_builder: Mutex::new(Some(assets_builder)),
             started: Instant::now(),
         }
     }
@@ -226,12 +244,28 @@ impl BaseProvingEventSink<RecursionField, RecursionPcs> for StreamingRecursionOr
         &self,
         total_shards: usize,
         app_vk: ceno_zkvm::structs::ZKVMVerifyingKey<RecursionField, RecursionPcs>,
+        app_vk_digest: [RecursionField; ceno_zkvm::structs::VK_DIGEST_LEN],
     ) -> Result<(), String> {
         let mut state = self.state.lock().unwrap_or_else(|err| err.into_inner());
-        let app_vk = Arc::new(app_vk);
-        warm_child_vk_digest_cache(&app_vk);
+        let assets_builder = self
+            .assets_builder
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .take()
+            .map(Ok)
+            .unwrap_or_else(|| {
+                RecursionHostAssetsBuilder::spawn(
+                    Arc::new(app_vk),
+                    app_vk_digest,
+                    self.options.clone(),
+                )
+                .map_err(|error| error.to_string())
+            })?;
+        assets_builder
+            .validate_child_vk_digest(&app_vk_digest)
+            .map_err(|error| error.to_string())?;
         state.start(
-            GpuRecursionSession::new(app_vk, total_shards, self.options.clone())
+            GpuRecursionSession::new_with_assets_builder(total_shards, assets_builder)
                 .map_err(|error| error.to_string())?,
         )?;
         tracing::info!(
@@ -361,6 +395,8 @@ where
     pub fulltracer_aot_program: Option<Arc<ceno_emul::aot::AotProgram>>,
 
     aggregation_options: Option<AggregationOptions>,
+    #[cfg(feature = "gpu")]
+    recursion_assets_builder: Option<DefaultRecursionHostAssetsBuilder>,
     _phantom: PhantomData<(SC, VC)>,
 }
 
@@ -389,6 +425,8 @@ where
             #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
             fulltracer_aot_program: None,
             aggregation_options: None,
+            #[cfg(feature = "gpu")]
+            recursion_assets_builder: None,
             _phantom: PhantomData,
         }
     }
@@ -415,6 +453,8 @@ where
             #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
             fulltracer_aot_program: None,
             aggregation_options: None,
+            #[cfg(feature = "gpu")]
+            recursion_assets_builder: None,
             _phantom: PhantomData,
         }
     }
@@ -428,6 +468,11 @@ where
     }
 
     pub fn set_aggregation_options(&mut self, options: AggregationOptions) {
+        #[cfg(feature = "gpu")]
+        assert!(
+            self.recursion_assets_builder.is_none(),
+            "aggregation options cannot change after streaming recursion preparation"
+        );
         self.aggregation_options = Some(options);
     }
 
@@ -723,6 +768,35 @@ where
 
 #[cfg(feature = "gpu")]
 impl<SC, VC> CenoSDK<RecursionField, RecursionPcs, SC, VC> {
+    pub fn prepare_streaming_recursion(&mut self) -> Result<()> {
+        anyhow::ensure!(
+            self.recursion_assets_builder.is_none(),
+            "streaming recursion host assets were already prepared"
+        );
+        let prover = self
+            .zkvm_prover
+            .as_ref()
+            .context("ZKVMProver is not initialized")?;
+        let app_vk = Arc::new(
+            prover
+                .cached_verifier()
+                .context("initial GPU prover has no cached verifier")?
+                .vk
+                .clone(),
+        );
+        let app_vk_digest = prover.vk_digest();
+        self.recursion_assets_builder = Some(
+            RecursionHostAssetsBuilder::spawn(app_vk, app_vk_digest, self.aggregation_options())
+                .map_err(|error| anyhow::anyhow!(error.to_string()))?,
+        );
+        tracing::info!(
+            target: "ceno_multi_gpu",
+            phase = "recursion_host_assets_prebuild_started",
+            "recursion host-asset template prebuild started"
+        );
+        Ok(())
+    }
+
     pub fn generate_streaming_recursion_proof(
         &mut self,
         hints: CenoStdin,
@@ -730,8 +804,29 @@ impl<SC, VC> CenoSDK<RecursionField, RecursionPcs, SC, VC> {
         max_steps: usize,
     ) -> Result<StreamingRecursionOutput> {
         let total_started = Instant::now();
-        let recursion = Arc::new(StreamingRecursionOrchestrator::new(
-            self.aggregation_options(),
+        let options = self.aggregation_options();
+        let assets_builder = match self.recursion_assets_builder.take() {
+            Some(builder) => builder,
+            None => {
+                let prover = self
+                    .zkvm_prover
+                    .as_ref()
+                    .context("ZKVMProver is not initialized")?;
+                let app_vk = Arc::new(
+                    prover
+                        .cached_verifier()
+                        .context("initial GPU prover has no cached verifier")?
+                        .vk
+                        .clone(),
+                );
+                let app_vk_digest = prover.vk_digest();
+                RecursionHostAssetsBuilder::spawn(app_vk, app_vk_digest, options.clone())
+                    .map_err(|error| anyhow::anyhow!(error.to_string()))?
+            }
+        };
+        let recursion = Arc::new(StreamingRecursionOrchestrator::with_assets_builder(
+            options,
+            assets_builder,
         ));
         let event_sink = recursion.clone() as Arc<dyn BaseProvingEventSink<_, _>>;
         let base_started = Instant::now();

--- a/ceno_cli/src/sdk.rs
+++ b/ceno_cli/src/sdk.rs
@@ -57,6 +57,8 @@ pub const DEFAULT_RECURSION_K_WHIR: usize = 3;
 pub type CenoRecursionV2Prover = AggProver<DEFAULT_LEAF_FANIN, DEFAULT_INTERNAL_FANIN>;
 pub type CenoRecursionV2RootProof = RootProof;
 pub type CenoRecursionV2LeafVk = LeafVk;
+#[cfg(feature = "gpu")]
+type DefaultGpuRecursionSession = GpuRecursionSession<DEFAULT_LEAF_FANIN, DEFAULT_INTERNAL_FANIN>;
 
 #[cfg(feature = "gpu")]
 #[derive(Clone, Debug, Default)]
@@ -166,7 +168,7 @@ impl<S> RecursionOrchestrationState<S> {
 #[cfg(feature = "gpu")]
 pub struct StreamingRecursionOrchestrator {
     options: AggregationOptions,
-    state: Mutex<RecursionOrchestrationState<GpuRecursionSession<2, 2>>>,
+    state: Mutex<RecursionOrchestrationState<DefaultGpuRecursionSession>>,
     started: Instant,
 }
 
@@ -768,7 +770,9 @@ impl<SC, VC> CenoSDK<RecursionField, RecursionPcs, SC, VC> {
 
 #[cfg(all(test, feature = "gpu"))]
 mod streaming_recursion_tests {
-    use super::RecursionOrchestrationState;
+    use ceno_recursion_v2::continuation::prover::{RecursionNodeKind, RecursionPlan};
+
+    use super::{DEFAULT_INTERNAL_FANIN, DEFAULT_LEAF_FANIN, RecursionOrchestrationState};
 
     #[derive(Debug, Default)]
     struct FakeSession {
@@ -812,6 +816,18 @@ mod streaming_recursion_tests {
         assert_eq!(state.first_error.as_deref(), Some("first"));
         assert_eq!(state.session.as_ref().unwrap().cancel_count, 1);
         assert_eq!(state.take_verified_session().unwrap_err(), "first");
+    }
+
+    #[test]
+    fn streaming_plan_uses_public_default_fanins() {
+        let plan = RecursionPlan::new(11, DEFAULT_LEAF_FANIN, DEFAULT_INTERNAL_FANIN).unwrap();
+        let count = |kind| plan.nodes.iter().filter(|node| node.kind == kind).count();
+
+        assert_eq!(count(RecursionNodeKind::Leaf), 3);
+        assert_eq!(count(RecursionNodeKind::LeafBridge), 1);
+        assert_eq!(count(RecursionNodeKind::Recursive { level: 0 }), 1);
+        assert_eq!(count(RecursionNodeKind::Root), 1);
+        assert_eq!(plan.nodes.len(), 6);
     }
 }
 

--- a/ceno_cli/src/sdk.rs
+++ b/ceno_cli/src/sdk.rs
@@ -785,6 +785,8 @@ impl<SC, VC> CenoSDK<RecursionField, RecursionPcs, SC, VC> {
                 .clone(),
         );
         let app_vk_digest = prover.vk_digest();
+        // This is the earliest exact-VK point and intentionally precedes AOT/base replay. The
+        // later shard-aware bind is cheap and occurs only after preflight reveals shard count.
         self.recursion_assets_builder = Some(
             RecursionHostAssetsBuilder::spawn(app_vk, app_vk_digest, self.aggregation_options())
                 .map_err(|error| anyhow::anyhow!(error.to_string()))?,

--- a/ceno_emul/src/aot.rs
+++ b/ceno_emul/src/aot.rs
@@ -343,6 +343,7 @@ const AOT_TRACE_MODE_CALLBACK: u32 = 1;
 const AOT_TRACE_MODE_PREFLIGHT_DIRECT: u32 = 2;
 const AOT_TRACE_MODE_FULLTRACER_DIRECT: u32 = 3;
 const AOT_TRACE_MODE_GPU_REPLAY_DIRECT: u32 = 4;
+const AOT_TRACE_MODE_GPU_REPLAY_FAST_FLIGHT: u32 = 5;
 
 const AOT_PREFLIGHT_HELPER_SYNC: u32 = 1;
 const AOT_PREFLIGHT_HELPER_BUSY_LOOP: u32 = 2;
@@ -1396,7 +1397,15 @@ impl AotProgram {
         vm: &mut VMState<T>,
         max_steps: usize,
     ) -> Result<AotRunReport> {
-        self.run_to_halt_with_trace(vm, max_steps, true)
+        self.run_to_halt_with_trace(vm, max_steps, true, false)
+    }
+
+    pub fn run_gpu_replay_fast_flight_to_halt(
+        &self,
+        vm: &mut VMState<crate::GpuReplayTracer>,
+        max_steps: usize,
+    ) -> Result<AotRunReport> {
+        self.run_to_halt_with_trace(vm, max_steps, true, true)
     }
 
     pub fn run_pure_to_halt<T: Tracer + 'static>(
@@ -1404,7 +1413,7 @@ impl AotProgram {
         vm: &mut VMState<T>,
         max_steps: usize,
     ) -> Result<AotRunReport> {
-        self.run_to_halt_with_trace(vm, max_steps, false)
+        self.run_to_halt_with_trace(vm, max_steps, false, false)
     }
 
     fn run_to_halt_with_trace<T: Tracer + 'static>(
@@ -1412,6 +1421,7 @@ impl AotProgram {
         vm: &mut VMState<T>,
         max_steps: usize,
         trace_native_steps: bool,
+        gpu_replay_fast_flight: bool,
     ) -> Result<AotRunReport> {
         let diagnostic_role = self.trace_style.cache_name();
         let diagnostic_path = self
@@ -1735,7 +1745,11 @@ impl AotProgram {
         {
             let replay_vm = unsafe { &mut *(vm_ptr as *mut VMState<crate::GpuReplayTracer>) };
             let state = replay_vm.tracer_mut().prepare_native_range();
-            trace_mode = AOT_TRACE_MODE_GPU_REPLAY_DIRECT;
+            trace_mode = if gpu_replay_fast_flight {
+                AOT_TRACE_MODE_GPU_REPLAY_FAST_FLIGHT
+            } else {
+                AOT_TRACE_MODE_GPU_REPLAY_DIRECT
+            };
             gpu_replay_kinds = state.kinds;
             gpu_replay_kind_count = state.kind_count;
             gpu_replay_ordinal = state.ordinal;
@@ -1991,7 +2005,9 @@ impl AotProgram {
         );
         let trace_fn = if matches!(
             trace_mode,
-            AOT_TRACE_MODE_FULLTRACER_DIRECT | AOT_TRACE_MODE_GPU_REPLAY_DIRECT
+            AOT_TRACE_MODE_FULLTRACER_DIRECT
+                | AOT_TRACE_MODE_GPU_REPLAY_DIRECT
+                | AOT_TRACE_MODE_GPU_REPLAY_FAST_FLIGHT
         ) {
             std::ptr::null()
         } else if trace_native_steps {
@@ -2141,7 +2157,10 @@ impl AotProgram {
                 .unwrap_or_else(|| anyhow!("AOT native step failed without error detail"));
             return Err(err);
         }
-        if trace_mode == AOT_TRACE_MODE_GPU_REPLAY_DIRECT {
+        if matches!(
+            trace_mode,
+            AOT_TRACE_MODE_GPU_REPLAY_DIRECT | AOT_TRACE_MODE_GPU_REPLAY_FAST_FLIGHT
+        ) {
             tracing::info!(
                 "GPU_REPLAY_DIRECT tracer=GpuReplayTracer native_mode=gpu-replay-direct ordinary_callbacks={} fallback_dynamic_pc={} fallback_memory_guard={} fallback_ecall={} fallback_exceptional={}",
                 context.gpu_replay_ordinary_callbacks,

--- a/ceno_emul/src/aot/assembly.rs
+++ b/ceno_emul/src/aot/assembly.rs
@@ -835,6 +835,9 @@ ceno_aot_gpu_replay_emit_step:
     movl $0, 12(%rsp)
     movl $0, 16(%rsp)
 
+    cmpl ${AOT_TRACE_MODE_GPU_REPLAY_FAST_FLIGHT}, {AOT_CTX_TRACE_MODE_OFFSET}(%r12)
+    je .L_gpu_replay_fast_flight_state
+
     movl {AOT_CTX_TRACE_KIND_OFFSET}(%r12), %eax
     cmpq {AOT_CTX_GPU_REPLAY_KIND_COUNT_OFFSET}(%r12), %rax
     jae .L_gpu_replay_bad_kind
@@ -852,6 +855,7 @@ ceno_aot_gpu_replay_emit_step:
     cmpl $7, 112(%r10)
     ja .L_gpu_replay_bad_layout
 
+.L_gpu_replay_fast_flight_state:
     movq {AOT_CTX_GPU_REPLAY_PENDING_CYCLE_OFFSET}(%r12), %r8
     movq (%r8), %rax
     movl {AOT_CTX_TRACE_FLAGS_OFFSET}(%r12), %edi
@@ -955,6 +959,9 @@ ceno_aot_gpu_replay_emit_step:
 .L_gpu_replay_events_done:
     movq {AOT_CTX_GPU_REPLAY_EVENT_CURSOR_OFFSET}(%r12), %r8
     movq %rsi, (%r8)
+
+    cmpl ${AOT_TRACE_MODE_GPU_REPLAY_FAST_FLIGHT}, {AOT_CTX_TRACE_MODE_OFFSET}(%r12)
+    je .L_gpu_replay_fast_flight_done
 
     cmpl ${gpu_compact_sentinel}, 116(%r10)
     je .L_gpu_replay_compact
@@ -1113,6 +1120,15 @@ ceno_aot_gpu_replay_emit_step:
     movl %edi, (%r8,%rcx,4)
     incl %ecx
     movl %ecx, 108(%r10)
+    movq {AOT_CTX_GPU_REPLAY_ORDINAL_OFFSET}(%r12), %r8
+    incq (%r8)
+    movq {AOT_CTX_GPU_REPLAY_PENDING_CYCLE_OFFSET}(%r12), %r8
+    addq $4, (%r8)
+    movl ${AOT_STATUS_CONTINUE}, %eax
+    addq $48, %rsp
+    ret
+
+.L_gpu_replay_fast_flight_done:
     movq {AOT_CTX_GPU_REPLAY_ORDINAL_OFFSET}(%r12), %r8
     incq (%r8)
     movq {AOT_CTX_GPU_REPLAY_PENDING_CYCLE_OFFSET}(%r12), %r8
@@ -1497,6 +1513,11 @@ pub(super) fn emit_after_native_step(
             writeln!(
                 file,
                 "    cmpl ${AOT_TRACE_MODE_GPU_REPLAY_DIRECT}, {AOT_CTX_TRACE_MODE_OFFSET}(%r12)"
+            )?;
+            writeln!(file, "    je {gpu_replay_label}")?;
+            writeln!(
+                file,
+                "    cmpl ${AOT_TRACE_MODE_GPU_REPLAY_FAST_FLIGHT}, {AOT_CTX_TRACE_MODE_OFFSET}(%r12)"
             )?;
             writeln!(file, "    je {gpu_replay_label}")?;
         }

--- a/ceno_emul/src/aot/runtime.rs
+++ b/ceno_emul/src/aot/runtime.rs
@@ -11,9 +11,14 @@ pub(super) unsafe extern "C" fn aot_exec_one<T: Tracer>(
     aot_native_callback_event(&AOT_NATIVE_CALLBACK_FALLBACK, "fallback");
     let fallback_started = Instant::now();
     let context = unsafe { &mut *(context as *mut AotRuntimeContext) };
-    if context.trace_mode == AOT_TRACE_MODE_GPU_REPLAY_DIRECT {
+    if matches!(
+        context.trace_mode,
+        AOT_TRACE_MODE_GPU_REPLAY_DIRECT | AOT_TRACE_MODE_GPU_REPLAY_FAST_FLIGHT
+    ) {
         let replay_vm = unsafe { &mut *(context.vm as *mut VMState<crate::GpuReplayTracer>) };
-        if let Err(message) = replay_vm.tracer_mut().sync_native_range() {
+        if context.trace_mode == AOT_TRACE_MODE_GPU_REPLAY_DIRECT
+            && let Err(message) = replay_vm.tracer_mut().sync_native_range()
+        {
             LAST_AOT_ERROR.with(|slot| *slot.borrow_mut() = Some(anyhow!(message)));
             return AOT_STATUS_ERROR;
         }
@@ -122,7 +127,11 @@ pub(super) unsafe extern "C" fn aot_exec_one<T: Tracer>(
             AOT_STATUS_ERROR
         }
     };
-    if context.trace_mode == AOT_TRACE_MODE_GPU_REPLAY_DIRECT && status != AOT_STATUS_ERROR {
+    if matches!(
+        context.trace_mode,
+        AOT_TRACE_MODE_GPU_REPLAY_DIRECT | AOT_TRACE_MODE_GPU_REPLAY_FAST_FLIGHT
+    ) && status != AOT_STATUS_ERROR
+    {
         let replay_vm = unsafe { &mut *(context.vm as *mut VMState<crate::GpuReplayTracer>) };
         let state = replay_vm.tracer_mut().prepare_native_range();
         context.gpu_replay_kinds = state.kinds;

--- a/ceno_emul/src/aot/tests.rs
+++ b/ceno_emul/src/aot/tests.rs
@@ -2233,6 +2233,193 @@ fn gpu_replay_direct_typed_rows_match_interpreter_without_trace_callbacks() {
 
 #[test]
 #[cfg(not(debug_assertions))]
+fn gpu_replay_fast_flight_preserves_state_and_next_compact_shard() {
+    let base = CENO_PLATFORM.heap.start;
+    let program = Arc::new(program(vec![
+        encode_rv32(InsnKind::ADDI, 0, 0, 1, 7),
+        encode_rv32(InsnKind::SW, 20, 1, 0, 0),
+        encode_rv32(InsnKind::LW, 20, 0, 2, 0),
+        encode_rv32(InsnKind::ECALL, 0, 0, 0, 0),
+        encode_rv32(
+            InsnKind::ADDI,
+            0,
+            0,
+            Platform::reg_ecall().into(),
+            Platform::ecall_halt() as i32,
+        ),
+        encode_rv32(InsnKind::ECALL, 0, 0, 0, 0),
+    ]));
+    let descriptor = |shard_id, first: InsnKind, second: Option<InsnKind>| {
+        let mut family_counts = [0usize; InsnKind::COUNT];
+        family_counts[first as usize] += 1;
+        if let Some(second) = second.filter(|kind| *kind != InsnKind::ECALL) {
+            family_counts[second as usize] += 1;
+        }
+        crate::GpuReplayRangeDescriptor {
+            shard_id,
+            sequence: 0,
+            range_start: 0,
+            range_len: 2,
+            family_counts,
+            fallback_count: usize::from(second == Some(InsnKind::ECALL)),
+            unsupported_count: 0,
+        }
+    };
+    let descriptors = Arc::new(vec![
+        descriptor(0, InsnKind::ADDI, Some(InsnKind::SW)),
+        descriptor(1, InsnKind::LW, Some(InsnKind::ECALL)),
+        descriptor(2, InsnKind::ADDI, Some(InsnKind::ECALL)),
+    ]);
+    let aot = AotProgram::compile_with_extra_roots_and_trace_style(
+        program.clone(),
+        vec![program.base_address + 16],
+        AssemblyTraceStyle::GpuReplayDirect,
+    )
+    .unwrap();
+    let make_vm = || {
+        let mut vm = VMState::<crate::GpuReplayTracer>::new_with_tracer_config(
+            CENO_PLATFORM.clone(),
+            program.clone(),
+            crate::GpuReplayTracerConfig { chunk_capacity: 2 },
+        );
+        vm.tracer_mut()
+            .install_range_descriptors(descriptors.clone());
+        vm.tracer_mut().enable_retained_shard_mode();
+        vm.init_register_unsafe(20, base);
+        vm.init_register_unsafe(Platform::reg_ecall(), crate::syscalls::PHANTOM_LOG_PC_CYCLE);
+        vm.init_memory(ByteAddr(base).waddr(), 0);
+        vm
+    };
+
+    let mut all_compact = make_vm();
+    let mut expected_last = None;
+    for shard in 0..3 {
+        if shard != 0 {
+            all_compact.tracer_mut().start_shard();
+        }
+        assert_eq!(
+            aot.run_to_halt(&mut all_compact, 2).unwrap().executed_steps,
+            2
+        );
+        all_compact.tracer_mut().finish_chunks();
+        let chunk = all_compact.tracer_mut().take_sealed_chunks().remove(0);
+        if shard == 2 {
+            expected_last = Some(chunk);
+        }
+    }
+
+    let mut mixed = make_vm();
+    assert_eq!(aot.run_to_halt(&mut mixed, 2).unwrap().executed_steps, 2);
+    mixed.tracer_mut().finish_chunks();
+    assert_eq!(mixed.tracer_mut().take_sealed_chunks().len(), 1);
+    mixed.tracer_mut().start_shard_with_capture(false);
+    assert_eq!(
+        aot.run_gpu_replay_fast_flight_to_halt(&mut mixed, 2)
+            .unwrap()
+            .executed_steps,
+        2
+    );
+    assert!(mixed.tracer_mut().take_sealed_chunks().is_empty());
+    assert!(mixed.tracer().syscall_witnesses().is_empty());
+    mixed.tracer_mut().finish_fast_flight_ranges(1);
+    mixed.tracer_mut().start_shard();
+    assert_eq!(aot.run_to_halt(&mut mixed, 2).unwrap().executed_steps, 2);
+    mixed.tracer_mut().finish_chunks();
+    let actual_last = mixed.tracer_mut().take_sealed_chunks().remove(0);
+
+    assert_eq!(mixed.peek_register(2), all_compact.peek_register(2));
+    assert_eq!(
+        mixed.peek_memory(ByteAddr(base).waddr()),
+        all_compact.peek_memory(ByteAddr(base).waddr())
+    );
+    assert_eq!(mixed.get_pc(), all_compact.get_pc());
+    assert_eq!(mixed.tracer().cycle(), all_compact.tracer().cycle());
+    let expected_last = expected_last.unwrap();
+    assert_eq!(actual_last.fallback, expected_last.fallback);
+    for (kind, (actual, expected)) in
+        InsnKind::iter().zip(actual_last.typed.iter().zip(&expected_last.typed))
+    {
+        assert_eq!(
+            actual
+                .as_ref()
+                .map_or(&[][..], |arena| arena.payload_bytes()),
+            expected
+                .as_ref()
+                .map_or(&[][..], |arena| arena.payload_bytes()),
+            "next owned shard payload differs for {kind:?}"
+        );
+    }
+
+    // Fast flight may retain empty warmed allocation capacity from a prior
+    // owned shard, but it must not initialize or seal any compact payload.
+    let mut leading_fast = make_vm();
+    leading_fast.tracer_mut().set_first_shard_capture(false);
+    for shard in 0..2 {
+        if shard != 0 {
+            leading_fast.tracer_mut().start_shard_with_capture(false);
+        }
+        assert_eq!(
+            aot.run_gpu_replay_fast_flight_to_halt(&mut leading_fast, 2)
+                .unwrap()
+                .executed_steps,
+            2
+        );
+        assert!(leading_fast.tracer_mut().take_sealed_chunks().is_empty());
+        assert!(leading_fast.tracer().syscall_witnesses().is_empty());
+        leading_fast.tracer_mut().finish_fast_flight_ranges(1);
+    }
+    leading_fast.tracer_mut().start_shard();
+    assert_eq!(
+        aot.run_to_halt(&mut leading_fast, 2)
+            .unwrap()
+            .executed_steps,
+        2
+    );
+    leading_fast.tracer_mut().finish_chunks();
+    let leading_fast_last = leading_fast.tracer_mut().take_sealed_chunks().remove(0);
+    assert_eq!(leading_fast.peek_register(2), all_compact.peek_register(2));
+    assert_eq!(leading_fast.get_pc(), all_compact.get_pc());
+    for (actual, expected) in leading_fast_last.typed.iter().zip(&expected_last.typed) {
+        assert_eq!(
+            actual
+                .as_ref()
+                .map_or(&[][..], |arena| arena.payload_bytes()),
+            expected
+                .as_ref()
+                .map_or(&[][..], |arena| arena.payload_bytes())
+        );
+    }
+
+    let mut trailing_fast = make_vm();
+    for shard in 0..2 {
+        if shard != 0 {
+            trailing_fast.tracer_mut().start_shard();
+        }
+        assert_eq!(
+            aot.run_to_halt(&mut trailing_fast, 2)
+                .unwrap()
+                .executed_steps,
+            2
+        );
+        trailing_fast.tracer_mut().finish_chunks();
+        assert_eq!(trailing_fast.tracer_mut().take_sealed_chunks().len(), 1);
+    }
+    trailing_fast.tracer_mut().start_shard_with_capture(false);
+    assert_eq!(
+        aot.run_gpu_replay_fast_flight_to_halt(&mut trailing_fast, 2)
+            .unwrap()
+            .executed_steps,
+        2
+    );
+    assert!(trailing_fast.tracer_mut().take_sealed_chunks().is_empty());
+    assert!(trailing_fast.tracer().syscall_witnesses().is_empty());
+    trailing_fast.tracer_mut().finish_fast_flight_ranges(1);
+    assert_eq!(trailing_fast.peek_register(2), all_compact.peek_register(2));
+    assert_eq!(trailing_fast.get_pc(), all_compact.get_pc());
+}
+
+#[test]
+#[cfg(not(debug_assertions))]
 fn gpu_replay_direct_preserves_cycles_past_27_bits() {
     let program = Arc::new(program(vec![encode_rv32(InsnKind::OR, 1, 2, 3, 0)]));
     let mut family_counts = [0usize; InsnKind::COUNT];

--- a/ceno_emul/src/aot/tests.rs
+++ b/ceno_emul/src/aot/tests.rs
@@ -2270,6 +2270,29 @@ fn gpu_replay_fast_flight_preserves_state_and_next_compact_shard() {
         descriptor(1, InsnKind::LW, Some(InsnKind::ECALL)),
         descriptor(2, InsnKind::ADDI, Some(InsnKind::ECALL)),
     ]);
+    // Exercise the source-ordered tape on both sides of the fast-flight shard.
+    // A worker that owns alternating shards must consume the skipped shard's
+    // events without losing the cursor needed to annotate its next owned shard.
+    let tape = Arc::new(NextCycleAccess::from_unsorted(vec![
+        NextAccessEvent::new(8, 12, Platform::register_vma(20).into()),
+        NextAccessEvent::new(9, 15, Platform::register_vma(1).into()),
+        NextAccessEvent::new(12, 24, Platform::register_vma(20).into()),
+        NextAccessEvent::new(14, 28, Platform::register_vma(2).into()),
+        NextAccessEvent::new(15, 31, ByteAddr(base).waddr()),
+        NextAccessEvent::new(16, 24, Platform::register_vma(Platform::reg_ecall()).into()),
+        NextAccessEvent::new(18, 26, Platform::register_vma(Platform::reg_arg0()).into()),
+        NextAccessEvent::new(19, 35, ByteAddr(base).waddr()),
+        NextAccessEvent::new(19, 35, ByteAddr(base).waddr() + 1usize),
+        NextAccessEvent::new(19, 35, ByteAddr(base).waddr() + 2usize),
+        NextAccessEvent::new(19, 35, ByteAddr(base).waddr() + 3usize),
+        NextAccessEvent::new(19, 35, ByteAddr(base).waddr() + 4usize),
+        NextAccessEvent::new(19, 35, ByteAddr(base).waddr() + 5usize),
+        NextAccessEvent::new(19, 35, ByteAddr(base).waddr() + 6usize),
+        NextAccessEvent::new(19, 35, ByteAddr(base).waddr() + 7usize),
+        NextAccessEvent::new(22, 24, Platform::register_vma(Platform::reg_ecall()).into()),
+        NextAccessEvent::new(24, 32, Platform::register_vma(Platform::reg_ecall()).into()),
+        NextAccessEvent::new(25, 33, Platform::register_vma(Platform::reg_arg0()).into()),
+    ]));
     let aot = AotProgram::compile_with_extra_roots_and_trace_style(
         program.clone(),
         vec![program.base_address + 16],
@@ -2277,17 +2300,21 @@ fn gpu_replay_fast_flight_preserves_state_and_next_compact_shard() {
     )
     .unwrap();
     let make_vm = || {
-        let mut vm = VMState::<crate::GpuReplayTracer>::new_with_tracer_config(
+        let mut vm = VMState::<crate::GpuReplayTracer>::new_with_tracer_config_and_next_accesses(
             CENO_PLATFORM.clone(),
             program.clone(),
             crate::GpuReplayTracerConfig { chunk_capacity: 2 },
+            Some(tape.clone()),
         );
         vm.tracer_mut()
             .install_range_descriptors(descriptors.clone());
         vm.tracer_mut().enable_retained_shard_mode();
         vm.init_register_unsafe(20, base);
-        vm.init_register_unsafe(Platform::reg_ecall(), crate::syscalls::PHANTOM_LOG_PC_CYCLE);
-        vm.init_memory(ByteAddr(base).waddr(), 0);
+        vm.init_register_unsafe(Platform::reg_arg0(), base);
+        vm.init_register_unsafe(Platform::reg_ecall(), crate::syscalls::PUB_IO_COMMIT);
+        for offset in 0usize..8 {
+            vm.init_memory(ByteAddr(base).waddr() + offset, offset as u32);
+        }
         vm
     };
 
@@ -2334,6 +2361,17 @@ fn gpu_replay_fast_flight_preserves_state_and_next_compact_shard() {
     );
     assert_eq!(mixed.get_pc(), all_compact.get_pc());
     assert_eq!(mixed.tracer().cycle(), all_compact.tracer().cycle());
+    assert_eq!(
+        mixed.committed_public_io(),
+        all_compact.committed_public_io()
+    );
+    for offset in 0usize..8 {
+        let address = ByteAddr(base).waddr() + offset;
+        assert_eq!(
+            mixed.final_access_cycle(address),
+            all_compact.final_access_cycle(address)
+        );
+    }
     let expected_last = expected_last.unwrap();
     assert_eq!(actual_last.fallback, expected_last.fallback);
     for (kind, (actual, expected)) in

--- a/ceno_emul/src/aot/tests.rs
+++ b/ceno_emul/src/aot/tests.rs
@@ -2273,7 +2273,7 @@ fn gpu_replay_fast_flight_preserves_state_and_next_compact_shard() {
     // Exercise the source-ordered tape on both sides of the fast-flight shard.
     // A worker that owns alternating shards must consume the skipped shard's
     // events without losing the cursor needed to annotate its next owned shard.
-    let tape = Arc::new(NextCycleAccess::from_unsorted(vec![
+    let mut next_access_events = vec![
         NextAccessEvent::new(8, 12, Platform::register_vma(20).into()),
         NextAccessEvent::new(9, 15, Platform::register_vma(1).into()),
         NextAccessEvent::new(12, 24, Platform::register_vma(20).into()),
@@ -2281,18 +2281,14 @@ fn gpu_replay_fast_flight_preserves_state_and_next_compact_shard() {
         NextAccessEvent::new(15, 31, ByteAddr(base).waddr()),
         NextAccessEvent::new(16, 24, Platform::register_vma(Platform::reg_ecall()).into()),
         NextAccessEvent::new(18, 26, Platform::register_vma(Platform::reg_arg0()).into()),
-        NextAccessEvent::new(19, 35, ByteAddr(base).waddr()),
-        NextAccessEvent::new(19, 35, ByteAddr(base).waddr() + 1usize),
-        NextAccessEvent::new(19, 35, ByteAddr(base).waddr() + 2usize),
-        NextAccessEvent::new(19, 35, ByteAddr(base).waddr() + 3usize),
-        NextAccessEvent::new(19, 35, ByteAddr(base).waddr() + 4usize),
-        NextAccessEvent::new(19, 35, ByteAddr(base).waddr() + 5usize),
-        NextAccessEvent::new(19, 35, ByteAddr(base).waddr() + 6usize),
-        NextAccessEvent::new(19, 35, ByteAddr(base).waddr() + 7usize),
         NextAccessEvent::new(22, 24, Platform::register_vma(Platform::reg_ecall()).into()),
         NextAccessEvent::new(24, 32, Platform::register_vma(Platform::reg_ecall()).into()),
         NextAccessEvent::new(25, 33, Platform::register_vma(Platform::reg_arg0()).into()),
-    ]));
+    ];
+    next_access_events.extend(
+        (0usize..50).map(|offset| NextAccessEvent::new(19, 35, ByteAddr(base).waddr() + offset)),
+    );
+    let tape = Arc::new(NextCycleAccess::from_unsorted(next_access_events));
     let aot = AotProgram::compile_with_extra_roots_and_trace_style(
         program.clone(),
         vec![program.base_address + 16],
@@ -2311,8 +2307,10 @@ fn gpu_replay_fast_flight_preserves_state_and_next_compact_shard() {
         vm.tracer_mut().enable_retained_shard_mode();
         vm.init_register_unsafe(20, base);
         vm.init_register_unsafe(Platform::reg_arg0(), base);
-        vm.init_register_unsafe(Platform::reg_ecall(), crate::syscalls::PUB_IO_COMMIT);
-        for offset in 0usize..8 {
+        // Keccak mutates 50 words and exercises the effectful syscall fallback
+        // while shard 1 is skipped by the alternating worker.
+        vm.init_register_unsafe(Platform::reg_ecall(), crate::syscalls::KECCAK_PERMUTE);
+        for offset in 0usize..50 {
             vm.init_memory(ByteAddr(base).waddr() + offset, offset as u32);
         }
         vm
@@ -2365,11 +2363,43 @@ fn gpu_replay_fast_flight_preserves_state_and_next_compact_shard() {
         mixed.committed_public_io(),
         all_compact.committed_public_io()
     );
-    for offset in 0usize..8 {
-        let address = ByteAddr(base).waddr() + offset;
+    assert_eq!(
+        mixed.replay_state_audit_digest(),
+        all_compact.replay_state_audit_digest(),
+        "audit must agree after equivalent compact and fast-flight replay"
+    );
+    let register_addresses = (0..VMState::<crate::GpuReplayTracer>::REG_COUNT)
+        .map(|index| Platform::register_vma(index as u8).into())
+        .collect::<Vec<WordAddr>>();
+    for (index, address) in register_addresses.iter().copied().enumerate() {
+        assert_eq!(
+            mixed.peek_register(index as u8),
+            all_compact.peek_register(index as u8),
+            "register value differs at x{index}"
+        );
         assert_eq!(
             mixed.final_access_cycle(address),
-            all_compact.final_access_cycle(address)
+            all_compact.final_access_cycle(address),
+            "register access cycle differs at x{index}"
+        );
+    }
+    let mut accessed = mixed.final_access_addresses();
+    accessed.extend(all_compact.final_access_addresses());
+    accessed.sort_unstable();
+    accessed.dedup();
+    for address in accessed
+        .into_iter()
+        .filter(|address| !register_addresses.contains(address))
+    {
+        assert_eq!(
+            mixed.peek_memory(address),
+            all_compact.peek_memory(address),
+            "memory value differs at {address:?}"
+        );
+        assert_eq!(
+            mixed.final_access_cycle(address),
+            all_compact.final_access_cycle(address),
+            "memory access cycle differs at {address:?}"
         );
     }
     let expected_last = expected_last.unwrap();

--- a/ceno_emul/src/dense_addr_space.rs
+++ b/ceno_emul/src/dense_addr_space.rs
@@ -195,6 +195,7 @@ impl PackedMemory {
         self.store.end()
     }
 
+    #[cfg(all(test, feature = "aot-x86_64", not(debug_assertions)))]
     pub(crate) fn raw_cells(&self) -> &[u64] {
         &self.store.cells
     }

--- a/ceno_emul/src/dense_addr_space.rs
+++ b/ceno_emul/src/dense_addr_space.rs
@@ -195,6 +195,10 @@ impl PackedMemory {
         self.store.end()
     }
 
+    pub(crate) fn raw_cells(&self) -> &[u64] {
+        &self.store.cells
+    }
+
     #[cfg(any(test, debug_assertions))]
     pub(crate) fn addresses(&self) -> impl Iterator<Item = WordAddr> + '_ {
         self.touched.iter().copied()

--- a/ceno_emul/src/tracer/gpu_replay_tracer.rs
+++ b/ceno_emul/src/tracer/gpu_replay_tracer.rs
@@ -527,9 +527,8 @@ impl GpuReplayTracer {
 
     /// Replay cursors that affect future compact witness annotation.
     ///
-    /// Exposed only so the opt-in multi-GPU state audit can distinguish equal
-    /// VM values from a fast-flight worker that consumed a different tape or
-    /// range prefix.
+    /// Distinguish equal VM values from different tape or range prefixes in tests.
+    #[cfg(all(test, feature = "aot-x86_64", not(debug_assertions)))]
     pub(crate) fn replay_audit_cursors(&self) -> (usize, usize) {
         (self.next_range_descriptor, self.next_access_cursor)
     }

--- a/ceno_emul/src/tracer/gpu_replay_tracer.rs
+++ b/ceno_emul/src/tracer/gpu_replay_tracer.rs
@@ -525,6 +525,15 @@ impl GpuReplayTracer {
         self.max_hint_addr_access
     }
 
+    /// Replay cursors that affect future compact witness annotation.
+    ///
+    /// Exposed only so the opt-in multi-GPU state audit can distinguish equal
+    /// VM values from a fast-flight worker that consumed a different tape or
+    /// range prefix.
+    pub(crate) fn replay_audit_cursors(&self) -> (usize, usize) {
+        (self.next_range_descriptor, self.next_access_cursor)
+    }
+
     pub fn remaining_chunk_capacity(&self) -> usize {
         self.config
             .chunk_capacity

--- a/ceno_emul/src/tracer/gpu_replay_tracer.rs
+++ b/ceno_emul/src/tracer/gpu_replay_tracer.rs
@@ -140,6 +140,7 @@ pub struct GpuReplayTracer {
     sealed: Vec<GpuReplayChunk>,
     pub(super) recyclable: Option<GpuReplayChunk>,
     retain_complete_shard: bool,
+    capture_compact: bool,
     range_descriptors: Arc<Vec<crate::GpuReplayRangeDescriptor>>,
     pub(super) next_range_descriptor: usize,
     ordinal: usize,
@@ -175,6 +176,7 @@ impl GpuReplayTracer {
             sealed: Vec::new(),
             recyclable: None,
             retain_complete_shard: false,
+            capture_compact: true,
             range_descriptors: Arc::new(Vec::new()),
             next_range_descriptor: 0,
             ordinal: 0,
@@ -202,10 +204,14 @@ impl GpuReplayTracer {
             "GPU replay native range exceeds 262144 rows"
         );
         self.native_error = 0;
-        for (index, slot) in self.native_kinds.iter_mut().enumerate() {
-            *slot = self.current.typed[index]
-                .as_mut()
-                .map_or_else(Default::default, crate::GpuTypedSoaArena::native_state);
+        if self.capture_compact {
+            for (index, slot) in self.native_kinds.iter_mut().enumerate() {
+                *slot = self.current.typed[index]
+                    .as_mut()
+                    .map_or_else(Default::default, crate::GpuTypedSoaArena::native_state);
+            }
+        } else {
+            self.native_kinds.fill(Default::default());
         }
         let events = self.next_accesses.events();
         GpuReplayNativeTraceState {
@@ -395,10 +401,19 @@ impl GpuReplayTracer {
     /// Seal the previous shard and start a new ordinal domain while retaining
     /// predecessor state and the next-access cursor.
     pub fn start_shard(&mut self) {
+        self.start_shard_with_capture(true);
+    }
+
+    pub fn start_shard_with_capture(&mut self, capture_compact: bool) {
         self.finish_chunks();
         self.shard_start_cycle = self.pending.cycle;
         self.ordinal = 0;
         self.syscall_witnesses.clear();
+        self.capture_compact = capture_compact;
+        if !capture_compact {
+            self.current.reset_empty(self.shard_start_cycle);
+            return;
+        }
         let descriptor = &self.range_descriptors[self.next_range_descriptor];
         assert_eq!(descriptor.sequence, 0);
         if self.current.typed.len() != InsnKind::COUNT {
@@ -420,6 +435,33 @@ impl GpuReplayTracer {
         }
         self.current
             .reset_from_descriptor(descriptor, self.shard_start_cycle);
+    }
+
+    pub fn set_first_shard_capture(&mut self, capture_compact: bool) {
+        assert_eq!(
+            self.ordinal, 0,
+            "first shard capture changed after replay started"
+        );
+        self.capture_compact = capture_compact;
+        if !capture_compact {
+            self.current.reset_empty(self.shard_start_cycle);
+        }
+    }
+
+    pub fn finish_fast_flight_ranges(&mut self, range_count: usize) {
+        assert!(
+            !self.capture_compact,
+            "compact shard cannot skip replay ranges"
+        );
+        assert!(
+            self.current.is_empty(),
+            "fast-flight shard produced compact payload"
+        );
+        self.next_range_descriptor = self
+            .next_range_descriptor
+            .checked_add(range_count)
+            .expect("GPU replay descriptor index overflow");
+        assert!(self.next_range_descriptor <= self.range_descriptors.len());
     }
 
     pub fn take_sealed_chunks(&mut self) -> Vec<GpuReplayChunk> {
@@ -539,6 +581,21 @@ impl GpuReplayTracer {
                 _ => panic!("GPU replay access/tape mismatch"),
             };
             self.pending.future_access_mask |= bit;
+            self.next_access_cursor += 1;
+        }
+    }
+
+    fn consume_fast_flight_next_accesses(&mut self) {
+        let start = self.pending.cycle;
+        let end = start + FullTracer::SUBCYCLES_PER_INSN;
+        while let Some(event) = self.next_accesses.events().get(self.next_access_cursor) {
+            assert!(
+                event.source_cycle >= start,
+                "GPU fast-flight skipped next-access event"
+            );
+            if event.source_cycle >= end {
+                break;
+            }
             self.next_access_cursor += 1;
         }
     }
@@ -703,7 +760,11 @@ impl Tracer for GpuReplayTracer {
 
     #[inline(always)]
     fn advance(&mut self) -> Self::Record {
-        self.annotate_pending();
+        if self.capture_compact {
+            self.annotate_pending();
+        } else {
+            self.consume_fast_flight_next_accesses();
+        }
         let busy_loop = self.pending.is_busy_loop();
         let ordinal = u32::try_from(self.ordinal).expect("GPU replay ordinal exceeds u32");
         #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
@@ -738,6 +799,16 @@ impl Tracer for GpuReplayTracer {
                     !self.range_descriptors.is_empty(),
                 ),
             );
+        }
+        if !self.capture_compact {
+            self.ordinal += 1;
+            let cycle =
+                self.shard_start_cycle + self.ordinal as Cycle * FullTracer::SUBCYCLES_PER_INSN;
+            self.pending = StepRecord {
+                cycle,
+                ..StepRecord::default()
+            };
+            return GpuReplayStep { ordinal, busy_loop };
         }
         if self.pending.insn.kind == InsnKind::ECALL {
             self.current.fallback.push(GpuReplayFallbackRecord {
@@ -844,6 +915,9 @@ impl Tracer for GpuReplayTracer {
     fn track_syscall(&mut self, effects: SyscallEffects) {
         let witness = effects.finalize(self);
         assert!(!self.pending.has_syscall(), "Only one syscall per step");
+        if !self.capture_compact {
+            return;
+        }
         self.pending.syscall_index = u32::try_from(self.syscall_witnesses.len())
             .expect("GPU replay syscall witness index exceeds u32");
         self.syscall_witnesses.push(witness);

--- a/ceno_emul/src/vm_state.rs
+++ b/ceno_emul/src/vm_state.rs
@@ -6,11 +6,10 @@ use crate::{
     platform::Platform,
     rv32im::{Instruction, TrapCause},
     syscalls::{SyscallEffects, handle_syscall},
-    tracer::{Change, FullTracer, GpuReplayTracer, NativeTraceStep, PreflightTracer, Tracer},
+    tracer::{Change, FullTracer, NativeTraceStep, PreflightTracer, Tracer},
 };
 use anyhow::{Result, anyhow};
 use std::{iter::from_fn, ops::Deref, sync::Arc};
-use tiny_keccak::{Hasher, Keccak};
 
 pub struct HaltState {
     pub exit_code: u32,
@@ -347,13 +346,12 @@ impl<T: Tracer> VMState<T> {
     }
 }
 
-impl VMState<GpuReplayTracer> {
+#[cfg(all(test, feature = "aot-x86_64", not(debug_assertions)))]
+impl VMState<crate::GpuReplayTracer> {
     /// Hash the complete replay-visible VM and witness-annotation cursor state.
-    ///
-    /// This scans dense memory and is intended only for an explicitly selected
-    /// multi-GPU replay audit shard, never for the normal hot path.
-    #[doc(hidden)]
-    pub fn replay_state_audit_digest(&self) -> [u8; 32] {
+    pub(crate) fn replay_state_audit_digest(&self) -> [u8; 32] {
+        use tiny_keccak::{Hasher, Keccak};
+
         let mut keccak = Keccak::v256();
         keccak.update(b"ceno-replay-vm-state-audit-v2");
         keccak.update(&self.pc.to_le_bytes());

--- a/ceno_emul/src/vm_state.rs
+++ b/ceno_emul/src/vm_state.rs
@@ -6,10 +6,11 @@ use crate::{
     platform::Platform,
     rv32im::{Instruction, TrapCause},
     syscalls::{SyscallEffects, handle_syscall},
-    tracer::{Change, FullTracer, NativeTraceStep, PreflightTracer, Tracer},
+    tracer::{Change, FullTracer, GpuReplayTracer, NativeTraceStep, PreflightTracer, Tracer},
 };
 use anyhow::{Result, anyhow};
 use std::{iter::from_fn, ops::Deref, sync::Arc};
+use tiny_keccak::{Hasher, Keccak};
 
 pub struct HaltState {
     pub exit_code: u32,
@@ -343,6 +344,42 @@ impl<T: Tracer> VMState<T> {
 
         self.tracer.track_syscall(effects);
         Ok(())
+    }
+}
+
+impl VMState<GpuReplayTracer> {
+    /// Hash the complete replay-visible VM and witness-annotation cursor state.
+    ///
+    /// This scans dense memory and is intended only for an explicitly selected
+    /// multi-GPU replay audit shard, never for the normal hot path.
+    #[doc(hidden)]
+    pub fn replay_state_audit_digest(&self) -> [u8; 32] {
+        let mut keccak = Keccak::v256();
+        keccak.update(b"ceno-replay-vm-state-audit-v2");
+        keccak.update(&self.pc.to_le_bytes());
+        for (index, value) in self.registers.iter().enumerate() {
+            keccak.update(&value.to_le_bytes());
+            let address: WordAddr = Platform::register_vma(index as RegIdx).into();
+            keccak.update(&self.final_access_cycle(address).to_le_bytes());
+        }
+        let (range_cursor, access_cursor) = self.tracer.replay_audit_cursors();
+        keccak.update(&range_cursor.to_le_bytes());
+        keccak.update(&access_cursor.to_le_bytes());
+        // Both replay workers run on one host. Hashing packed cells as bytes
+        // retains every memory value and access stamp without a per-cell copy.
+        let cells = self.memory.raw_cells();
+        let bytes = unsafe {
+            std::slice::from_raw_parts(cells.as_ptr().cast::<u8>(), std::mem::size_of_val(cells))
+        };
+        keccak.update(bytes);
+        if let Some(public_io) = self.committed_public_io {
+            for value in public_io {
+                keccak.update(&value.to_le_bytes());
+            }
+        }
+        let mut digest = [0; 32];
+        keccak.finalize(&mut digest);
+        digest
     }
 }
 

--- a/ceno_recursion_v2/src/circuit/recursive/prover.rs
+++ b/ceno_recursion_v2/src/circuit/recursive/prover.rs
@@ -99,6 +99,70 @@ where
         )
     }
 
+    pub fn from_pk(
+        child_vk: Arc<MultiStarkVerifyingKey<BabyBearPoseidon2Config>>,
+        pk: Arc<MultiStarkProvingKey<BabyBearPoseidon2Config>>,
+    ) -> Self {
+        Self::from_pk_with_child_constraint_eval_air_id(
+            child_vk,
+            pk,
+            CENO_RECURSIVE_CONSTRAINT_EVAL_AIR_ID,
+            false,
+        )
+    }
+
+    pub fn from_pk_for_ceno_leaf_child(
+        child_vk: Arc<MultiStarkVerifyingKey<BabyBearPoseidon2Config>>,
+        pk: Arc<MultiStarkProvingKey<BabyBearPoseidon2Config>>,
+    ) -> Self {
+        Self::from_pk_with_child_constraint_eval_air_id(
+            child_vk,
+            pk,
+            CENO_LEAF_CONSTRAINT_EVAL_AIR_ID,
+            true,
+        )
+    }
+
+    fn from_pk_with_child_constraint_eval_air_id(
+        child_vk: Arc<MultiStarkVerifyingKey<BabyBearPoseidon2Config>>,
+        pk: Arc<MultiStarkProvingKey<BabyBearPoseidon2Config>>,
+        child_constraint_eval_air_id: usize,
+        bridge_child_cached_commit: bool,
+    ) -> Self {
+        let engine = E::new(pk.params.clone());
+        let device_ctx = DC::from(engine.device().device_ctx().clone());
+        let verifier_circuit = S::new(
+            child_vk.clone(),
+            VerifierConfig {
+                continuations_enabled: true,
+                ..Default::default()
+            },
+        );
+        let child_vk_pcs_data = verifier_circuit.commit_child_vk(&engine, &child_vk);
+        let child_vk_commit = VkCommit {
+            cached_commit: child_vk_pcs_data.commitment,
+            vk_pre_hash: child_vk.pre_hash,
+        };
+        let circuit = Arc::new(CenoRecursiveCircuit {
+            verifier_circuit: Arc::new(verifier_circuit),
+            child_vk_commit,
+            child_constraint_eval_air_id,
+            bridge_child_cached_commit,
+        });
+        let vk = Arc::new(pk.get_vk());
+        let d_pk = engine.device().transport_pk_to_device(pk.as_ref());
+        Self {
+            pk,
+            d_pk,
+            vk,
+            child_vk,
+            child_vk_pcs_data,
+            circuit,
+            device_ctx,
+            _engine: std::marker::PhantomData,
+        }
+    }
+
     pub fn new_with_child_constraint_eval_air_id(
         child_vk: Arc<MultiStarkVerifyingKey<BabyBearPoseidon2Config>>,
         system_params: SystemParams,
@@ -204,6 +268,10 @@ where
 
     pub fn get_vk(&self) -> Arc<MultiStarkVerifyingKey<BabyBearPoseidon2Config>> {
         self.vk.clone()
+    }
+
+    pub fn get_pk(&self) -> Arc<MultiStarkProvingKey<BabyBearPoseidon2Config>> {
+        self.pk.clone()
     }
 
     fn child_vk_commit(&self) -> VkCommit<F> {

--- a/ceno_recursion_v2/src/circuit/root/prover.rs
+++ b/ceno_recursion_v2/src/circuit/root/prover.rs
@@ -117,6 +117,38 @@ where
         }
     }
 
+    pub fn from_pk(
+        child_vk: Arc<MultiStarkVerifyingKey<BabyBearPoseidon2Config>>,
+        pk: Arc<MultiStarkProvingKey<RootSC>>,
+    ) -> Self {
+        let engine = E::new(pk.params.clone());
+        let device_ctx = DC::from(engine.device().device_ctx().clone());
+        let verifier_circuit = S::new(
+            child_vk.clone(),
+            VerifierConfig {
+                continuations_enabled: true,
+                ..Default::default()
+            },
+        );
+        let child_vk_pcs_data = verifier_circuit.commit_child_vk(&engine, &child_vk);
+        let circuit = Arc::new(CenoRootCircuit {
+            verifier_circuit: Arc::new(verifier_circuit),
+            child_vk_pre_hash: child_vk.pre_hash,
+        });
+        let vk = Arc::new(pk.get_vk());
+        let d_pk = engine.device().transport_pk_to_device(pk.as_ref());
+        Self {
+            pk,
+            d_pk,
+            vk,
+            child_vk,
+            child_vk_pcs_data,
+            circuit,
+            device_ctx,
+            _engine: std::marker::PhantomData,
+        }
+    }
+
     pub fn generate_proving_ctx(
         &self,
         proof: Proof<BabyBearPoseidon2Config>,
@@ -176,6 +208,10 @@ where
 
     pub fn get_vk(&self) -> Arc<MultiStarkVerifyingKey<RootSC>> {
         self.vk.clone()
+    }
+
+    pub fn get_pk(&self) -> Arc<MultiStarkProvingKey<RootSC>> {
+        self.pk.clone()
     }
 
     pub fn get_circuit(&self) -> Arc<CenoRootCircuit<S>> {

--- a/ceno_recursion_v2/src/continuation/prover/assets.rs
+++ b/ceno_recursion_v2/src/continuation/prover/assets.rs
@@ -1,0 +1,240 @@
+use std::sync::Arc;
+
+use eyre::{Result, eyre};
+use openvm_stark_backend::keygen::types::{MultiStarkProvingKey, MultiStarkVerifyingKey};
+use openvm_stark_sdk::config::baby_bear_poseidon2::{
+    BabyBearPoseidon2Config, BabyBearPoseidon2CpuEngine, DuplexSponge,
+};
+
+#[cfg(feature = "cuda")]
+use crate::circuit::{recursive::prover::CenoRecursiveGpuProver, root::prover::CenoRootGpuProver};
+#[cfg(feature = "cuda")]
+use openvm_cuda_backend::BabyBearPoseidon2GpuEngine;
+
+use crate::{
+    circuit::{
+        recursive::prover::{CenoRecursiveCpuProver, CenoRecursiveProver},
+        root::prover::{CenoRootCpuProver, CenoRootProver},
+    },
+    system::RecursionVk,
+};
+
+use super::{
+    AggregationOptions, InnerCpuProver, RecursionNodeKind, RootSC, internal_aggregation_chunk_plan,
+};
+
+type RecursivePk = MultiStarkProvingKey<BabyBearPoseidon2Config>;
+type RecursiveVk = MultiStarkVerifyingKey<BabyBearPoseidon2Config>;
+type RootPk = MultiStarkProvingKey<RootSC>;
+type CpuEngine = BabyBearPoseidon2CpuEngine<DuplexSponge>;
+
+/// Immutable host-side proving material for one complete recursion plan.
+///
+/// Device proving keys and child-VK commitments are deliberately absent. A worker creates those
+/// only after binding its CUDA device, and drops them before switching circuit kind.
+pub struct RecursionHostAssets<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize> {
+    child_vk: Arc<RecursionVk>,
+    leaf_pk: Arc<RecursivePk>,
+    leaf_vk: Arc<RecursiveVk>,
+    leaf_bridge_pk: Arc<RecursivePk>,
+    leaf_bridge_vk: Arc<RecursiveVk>,
+    recursive_pks: Vec<Arc<RecursivePk>>,
+    recursive_vks: Vec<Arc<RecursiveVk>>,
+    root_pk: Arc<RootPk>,
+    root_vk: Arc<MultiStarkVerifyingKey<RootSC>>,
+}
+
+pub enum CpuRecursionProver<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize> {
+    Leaf(InnerCpuProver<LEAF_FANIN>),
+    LeafBridge(CenoRecursiveCpuProver<INTERNAL_FANIN>),
+    Recursive(CenoRecursiveCpuProver<INTERNAL_FANIN>),
+    Root(CenoRootCpuProver),
+}
+
+#[cfg(feature = "cuda")]
+pub enum GpuRecursionProver<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize> {
+    Leaf(super::InnerGpuProver<LEAF_FANIN>),
+    LeafBridge(CenoRecursiveGpuProver<INTERNAL_FANIN>),
+    Recursive(CenoRecursiveGpuProver<INTERNAL_FANIN>),
+    Root(CenoRootGpuProver),
+}
+
+impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
+    RecursionHostAssets<LEAF_FANIN, INTERNAL_FANIN>
+{
+    pub fn new(
+        child_vk: Arc<RecursionVk>,
+        total_shards: usize,
+        options: &AggregationOptions,
+    ) -> Result<Self> {
+        if LEAF_FANIN == 0 {
+            return Err(eyre!("leaf aggregation fanin must be non-zero"));
+        }
+        let leaf_count = total_shards.div_ceil(LEAF_FANIN);
+        let plan = internal_aggregation_chunk_plan(leaf_count, INTERNAL_FANIN)?;
+
+        let leaf = InnerCpuProver::<LEAF_FANIN>::new::<CpuEngine>(
+            child_vk.clone(),
+            options.leaf_system_params.clone(),
+            false,
+            None,
+        );
+        let leaf_pk = leaf.get_pk();
+        let leaf_vk = leaf.get_vk();
+
+        let internal_params = options.internal_system_params();
+        let leaf_bridge = CenoRecursiveCpuProver::<INTERNAL_FANIN>::new_for_ceno_leaf_child(
+            leaf_vk.clone(),
+            internal_params.clone(),
+        );
+        let leaf_bridge_pk = leaf_bridge.get_pk();
+        let leaf_bridge_vk = leaf_bridge.get_vk();
+
+        let mut recursive_pks = Vec::with_capacity(1 + plan.internal_recursive_self_layers.len());
+        let mut recursive_vks = Vec::with_capacity(recursive_pks.capacity());
+        let mut recursive = CenoRecursiveCpuProver::<INTERNAL_FANIN>::new(
+            leaf_bridge_vk.clone(),
+            internal_params.clone(),
+        );
+        recursive_pks.push(recursive.get_pk());
+        recursive_vks.push(recursive.get_vk());
+        for _ in &plan.internal_recursive_self_layers {
+            recursive = CenoRecursiveCpuProver::<INTERNAL_FANIN>::new(
+                recursive.get_vk(),
+                internal_params.clone(),
+            );
+            recursive_pks.push(recursive.get_pk());
+            recursive_vks.push(recursive.get_vk());
+        }
+
+        let final_vk = recursive_vks
+            .last()
+            .expect("the mandatory initial recursive layer always exists")
+            .clone();
+        let root = CenoRootCpuProver::new(final_vk, options.root_system_params());
+
+        Ok(Self {
+            child_vk,
+            leaf_pk,
+            leaf_vk,
+            leaf_bridge_pk,
+            leaf_bridge_vk,
+            recursive_pks,
+            recursive_vks,
+            root_pk: root.get_pk(),
+            root_vk: root.get_vk(),
+        })
+    }
+
+    pub fn leaf_vk(&self) -> Arc<RecursiveVk> {
+        self.leaf_vk.clone()
+    }
+
+    pub fn leaf_bridge_vk(&self) -> Arc<RecursiveVk> {
+        self.leaf_bridge_vk.clone()
+    }
+
+    pub fn recursive_vk(&self, level: usize) -> Option<Arc<RecursiveVk>> {
+        self.recursive_vks.get(level).cloned()
+    }
+
+    pub fn root_vk(&self) -> Arc<MultiStarkVerifyingKey<RootSC>> {
+        self.root_vk.clone()
+    }
+
+    pub fn recursive_depth_count(&self) -> usize {
+        self.recursive_pks.len()
+    }
+
+    pub fn hydrate_cpu(
+        &self,
+        kind: RecursionNodeKind,
+    ) -> Result<CpuRecursionProver<LEAF_FANIN, INTERNAL_FANIN>> {
+        Ok(match kind {
+            RecursionNodeKind::Leaf => {
+                CpuRecursionProver::Leaf(InnerCpuProver::from_pk::<CpuEngine>(
+                    self.child_vk.clone(),
+                    self.leaf_pk.clone(),
+                    false,
+                    None,
+                ))
+            }
+            RecursionNodeKind::LeafBridge => {
+                CpuRecursionProver::LeafBridge(CenoRecursiveProver::from_pk_for_ceno_leaf_child(
+                    self.leaf_vk.clone(),
+                    self.leaf_bridge_pk.clone(),
+                ))
+            }
+            RecursionNodeKind::Recursive { level } => {
+                let pk = self
+                    .recursive_pks
+                    .get(level)
+                    .ok_or_else(|| eyre!("unplanned recursive level {level}"))?
+                    .clone();
+                let child_vk = if level == 0 {
+                    self.leaf_bridge_vk.clone()
+                } else {
+                    self.recursive_vks[level - 1].clone()
+                };
+                CpuRecursionProver::Recursive(CenoRecursiveProver::from_pk(child_vk, pk))
+            }
+            RecursionNodeKind::Root => {
+                let child_vk = self
+                    .recursive_vks
+                    .last()
+                    .expect("the mandatory initial recursive layer always exists")
+                    .clone();
+                CpuRecursionProver::Root(CenoRootProver::from_pk(child_vk, self.root_pk.clone()))
+            }
+        })
+    }
+
+    /// Bind `device_id` before constructing any engine, context, commitment, or device PK.
+    #[cfg(feature = "cuda")]
+    pub fn hydrate_gpu_on(
+        &self,
+        device_id: usize,
+        kind: RecursionNodeKind,
+    ) -> Result<GpuRecursionProver<LEAF_FANIN, INTERNAL_FANIN>> {
+        let device_id = i32::try_from(device_id).map_err(|_| eyre!("invalid CUDA device ID"))?;
+        openvm_cuda_common::common::set_device_by_id(device_id)?;
+
+        Ok(match kind {
+            RecursionNodeKind::Leaf => GpuRecursionProver::Leaf(super::InnerGpuProver::from_pk::<
+                BabyBearPoseidon2GpuEngine,
+            >(
+                self.child_vk.clone(),
+                self.leaf_pk.clone(),
+                false,
+                None,
+            )),
+            RecursionNodeKind::LeafBridge => {
+                GpuRecursionProver::LeafBridge(CenoRecursiveGpuProver::from_pk_for_ceno_leaf_child(
+                    self.leaf_vk.clone(),
+                    self.leaf_bridge_pk.clone(),
+                ))
+            }
+            RecursionNodeKind::Recursive { level } => {
+                let pk = self
+                    .recursive_pks
+                    .get(level)
+                    .ok_or_else(|| eyre!("unplanned recursive level {level}"))?
+                    .clone();
+                let child_vk = if level == 0 {
+                    self.leaf_bridge_vk.clone()
+                } else {
+                    self.recursive_vks[level - 1].clone()
+                };
+                GpuRecursionProver::Recursive(CenoRecursiveGpuProver::from_pk(child_vk, pk))
+            }
+            RecursionNodeKind::Root => {
+                let child_vk = self
+                    .recursive_vks
+                    .last()
+                    .expect("the mandatory initial recursive layer always exists")
+                    .clone();
+                GpuRecursionProver::Root(CenoRootGpuProver::from_pk(child_vk, self.root_pk.clone()))
+            }
+        })
+    }
+}

--- a/ceno_recursion_v2/src/continuation/prover/assets.rs
+++ b/ceno_recursion_v2/src/continuation/prover/assets.rs
@@ -12,10 +12,7 @@ use crate::circuit::{recursive::prover::CenoRecursiveGpuProver, root::prover::Ce
 use openvm_cuda_backend::BabyBearPoseidon2GpuEngine;
 
 use crate::{
-    circuit::{
-        recursive::prover::{CenoRecursiveCpuProver, CenoRecursiveProver},
-        root::prover::{CenoRootCpuProver, CenoRootProver},
-    },
+    circuit::{recursive::prover::CenoRecursiveCpuProver, root::prover::CenoRootCpuProver},
     system::RecursionVk,
 };
 
@@ -61,6 +58,7 @@ pub struct RecursionHostAssetsTemplate<const LEAF_FANIN: usize, const INTERNAL_F
     root_params: SystemParams,
 }
 
+#[cfg(test)]
 pub enum CpuRecursionProver<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize> {
     Leaf(InnerCpuProver<LEAF_FANIN>),
     LeafBridge(CenoRecursiveCpuProver<INTERNAL_FANIN>),
@@ -171,14 +169,17 @@ impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
 impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
     RecursionHostAssets<LEAF_FANIN, INTERNAL_FANIN>
 {
+    #[cfg(test)]
     pub fn leaf_vk(&self) -> Arc<RecursiveVk> {
         self.leaf_vk.clone()
     }
 
+    #[cfg(test)]
     pub fn leaf_bridge_vk(&self) -> Arc<RecursiveVk> {
         self.leaf_bridge_vk.clone()
     }
 
+    #[cfg(test)]
     pub fn recursive_vk(&self, level: usize) -> Option<Arc<RecursiveVk>> {
         self.recursive_vks.get(level).cloned()
     }
@@ -187,14 +188,20 @@ impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
         self.root_vk.clone()
     }
 
+    #[cfg(test)]
     pub fn recursive_depth_count(&self) -> usize {
         self.recursive_pks.len()
     }
 
+    #[cfg(test)]
     pub fn hydrate_cpu(
         &self,
         kind: RecursionNodeKind,
     ) -> Result<CpuRecursionProver<LEAF_FANIN, INTERNAL_FANIN>> {
+        use crate::circuit::{
+            recursive::prover::CenoRecursiveProver, root::prover::CenoRootProver,
+        };
+
         Ok(match kind {
             RecursionNodeKind::Leaf => {
                 CpuRecursionProver::Leaf(InnerCpuProver::from_pk::<CpuEngine>(

--- a/ceno_recursion_v2/src/continuation/prover/assets.rs
+++ b/ceno_recursion_v2/src/continuation/prover/assets.rs
@@ -20,7 +20,8 @@ use crate::{
 };
 
 use super::{
-    AggregationOptions, InnerCpuProver, RecursionNodeKind, RootSC, internal_aggregation_chunk_plan,
+    AggregationOptions, InnerCpuProver, RecursionNodeKind, RootSC, SystemParams,
+    internal_aggregation_chunk_plan,
 };
 
 type RecursivePk = MultiStarkProvingKey<BabyBearPoseidon2Config>;
@@ -42,6 +43,22 @@ pub struct RecursionHostAssets<const LEAF_FANIN: usize, const INTERNAL_FANIN: us
     recursive_vks: Vec<Arc<RecursiveVk>>,
     root_pk: Arc<RootPk>,
     root_vk: Arc<MultiStarkVerifyingKey<RootSC>>,
+}
+
+/// Shard-independent host proving material that can be prepared before replay determines the
+/// exact shard count. It is bound to one child VK, aggregation configuration, and fan-in pair.
+pub struct RecursionHostAssetsTemplate<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize> {
+    child_vk: Arc<RecursionVk>,
+    leaf_pk: Arc<RecursivePk>,
+    leaf_vk: Arc<RecursiveVk>,
+    leaf_bridge_pk: Arc<RecursivePk>,
+    leaf_bridge_vk: Arc<RecursiveVk>,
+    initial_recursive_pk: Arc<RecursivePk>,
+    initial_recursive_vk: Arc<RecursiveVk>,
+    initial_root_pk: Arc<RootPk>,
+    initial_root_vk: Arc<MultiStarkVerifyingKey<RootSC>>,
+    internal_params: SystemParams,
+    root_params: SystemParams,
 }
 
 pub enum CpuRecursionProver<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize> {
@@ -67,12 +84,17 @@ impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
         total_shards: usize,
         options: &AggregationOptions,
     ) -> Result<Self> {
+        RecursionHostAssetsTemplate::new(child_vk, options)?.bind(total_shards)
+    }
+}
+
+impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
+    RecursionHostAssetsTemplate<LEAF_FANIN, INTERNAL_FANIN>
+{
+    pub fn new(child_vk: Arc<RecursionVk>, options: &AggregationOptions) -> Result<Self> {
         if LEAF_FANIN == 0 {
             return Err(eyre!("leaf aggregation fanin must be non-zero"));
         }
-        let leaf_count = total_shards.div_ceil(LEAF_FANIN);
-        let plan = internal_aggregation_chunk_plan(leaf_count, INTERNAL_FANIN)?;
-
         let leaf = InnerCpuProver::<LEAF_FANIN>::new::<CpuEngine>(
             child_vk.clone(),
             options.leaf_system_params.clone(),
@@ -90,42 +112,75 @@ impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
         let leaf_bridge_pk = leaf_bridge.get_pk();
         let leaf_bridge_vk = leaf_bridge.get_vk();
 
-        let mut recursive_pks = Vec::with_capacity(1 + plan.internal_recursive_self_layers.len());
-        let mut recursive_vks = Vec::with_capacity(recursive_pks.capacity());
-        let mut recursive = CenoRecursiveCpuProver::<INTERNAL_FANIN>::new(
+        let initial_recursive = CenoRecursiveCpuProver::<INTERNAL_FANIN>::new(
             leaf_bridge_vk.clone(),
             internal_params.clone(),
         );
-        recursive_pks.push(recursive.get_pk());
-        recursive_vks.push(recursive.get_vk());
-        for _ in &plan.internal_recursive_self_layers {
-            recursive = CenoRecursiveCpuProver::<INTERNAL_FANIN>::new(
-                recursive.get_vk(),
-                internal_params.clone(),
-            );
-            recursive_pks.push(recursive.get_pk());
-            recursive_vks.push(recursive.get_vk());
-        }
-
-        let final_vk = recursive_vks
-            .last()
-            .expect("the mandatory initial recursive layer always exists")
-            .clone();
-        let root = CenoRootCpuProver::new(final_vk, options.root_system_params());
-
+        let initial_recursive_pk = initial_recursive.get_pk();
+        let initial_recursive_vk = initial_recursive.get_vk();
+        let root_params = options.root_system_params();
+        let initial_root =
+            CenoRootCpuProver::new(initial_recursive_vk.clone(), root_params.clone());
         Ok(Self {
             child_vk,
             leaf_pk,
             leaf_vk,
             leaf_bridge_pk,
             leaf_bridge_vk,
-            recursive_pks,
-            recursive_vks,
-            root_pk: root.get_pk(),
-            root_vk: root.get_vk(),
+            initial_recursive_pk,
+            initial_recursive_vk,
+            initial_root_pk: initial_root.get_pk(),
+            initial_root_vk: initial_root.get_vk(),
+            internal_params,
+            root_params,
         })
     }
 
+    pub fn bind(
+        &self,
+        total_shards: usize,
+    ) -> Result<RecursionHostAssets<LEAF_FANIN, INTERNAL_FANIN>> {
+        let leaf_count = total_shards.div_ceil(LEAF_FANIN);
+        let plan = internal_aggregation_chunk_plan(leaf_count, INTERNAL_FANIN)?;
+        let mut recursive_pks = Vec::with_capacity(1 + plan.internal_recursive_self_layers.len());
+        let mut recursive_vks = Vec::with_capacity(recursive_pks.capacity());
+        recursive_pks.push(self.initial_recursive_pk.clone());
+        recursive_vks.push(self.initial_recursive_vk.clone());
+        let mut recursive_vk = self.initial_recursive_vk.clone();
+        for _ in &plan.internal_recursive_self_layers {
+            let recursive = CenoRecursiveCpuProver::<INTERNAL_FANIN>::new(
+                recursive_vk,
+                self.internal_params.clone(),
+            );
+            recursive_pks.push(recursive.get_pk());
+            recursive_vk = recursive.get_vk();
+            recursive_vks.push(recursive_vk.clone());
+        }
+
+        let (root_pk, root_vk) = if plan.internal_recursive_self_layers.is_empty() {
+            (self.initial_root_pk.clone(), self.initial_root_vk.clone())
+        } else {
+            let root = CenoRootCpuProver::new(recursive_vk, self.root_params.clone());
+            (root.get_pk(), root.get_vk())
+        };
+
+        Ok(RecursionHostAssets {
+            child_vk: self.child_vk.clone(),
+            leaf_pk: self.leaf_pk.clone(),
+            leaf_vk: self.leaf_vk.clone(),
+            leaf_bridge_pk: self.leaf_bridge_pk.clone(),
+            leaf_bridge_vk: self.leaf_bridge_vk.clone(),
+            recursive_pks,
+            recursive_vks,
+            root_pk,
+            root_vk,
+        })
+    }
+}
+
+impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
+    RecursionHostAssets<LEAF_FANIN, INTERNAL_FANIN>
+{
     pub fn leaf_vk(&self) -> Arc<RecursiveVk> {
         self.leaf_vk.clone()
     }

--- a/ceno_recursion_v2/src/continuation/prover/assets.rs
+++ b/ceno_recursion_v2/src/continuation/prover/assets.rs
@@ -77,18 +77,6 @@ pub enum GpuRecursionProver<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize
 }
 
 impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
-    RecursionHostAssets<LEAF_FANIN, INTERNAL_FANIN>
-{
-    pub fn new(
-        child_vk: Arc<RecursionVk>,
-        total_shards: usize,
-        options: &AggregationOptions,
-    ) -> Result<Self> {
-        RecursionHostAssetsTemplate::new(child_vk, options)?.bind(total_shards)
-    }
-}
-
-impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
     RecursionHostAssetsTemplate<LEAF_FANIN, INTERNAL_FANIN>
 {
     pub fn new(child_vk: Arc<RecursionVk>, options: &AggregationOptions) -> Result<Self> {
@@ -140,6 +128,8 @@ impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
         &self,
         total_shards: usize,
     ) -> Result<RecursionHostAssets<LEAF_FANIN, INTERNAL_FANIN>> {
+        // Shard count changes only the required recursive depth. Reuse all exact-VK material
+        // already present in the template and construct keys only for genuinely deeper layers.
         let leaf_count = total_shards.div_ceil(LEAF_FANIN);
         let plan = internal_aggregation_chunk_plan(leaf_count, INTERNAL_FANIN)?;
         let mut recursive_pks = Vec::with_capacity(1 + plan.internal_recursive_self_layers.len());

--- a/ceno_recursion_v2/src/continuation/prover/gpu_workers.rs
+++ b/ceno_recursion_v2/src/continuation/prover/gpu_workers.rs
@@ -1,0 +1,360 @@
+use std::{
+    any::Any,
+    collections::HashSet,
+    panic::{AssertUnwindSafe, catch_unwind},
+    sync::Arc,
+    thread,
+    time::Instant,
+};
+
+use eyre::{Result, eyre};
+use openvm_cuda_backend::BabyBearPoseidon2GpuEngine;
+use openvm_stark_backend::proof::Proof;
+use openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2Config;
+
+use crate::system::{RecursionProof, RecursionVk};
+
+use super::{
+    AggregationOptions, ChildVkKind, GpuRecursionProver, RecursionHostAssets, RecursionNodeKind,
+    RecursionPlan, RecursionScheduler, RecursionTask, RecursionTaskResult, RecursionWorkerError,
+    RecursionWorkerMetrics, RecursionWorkerPhase, RootProof, RootProvingOutput,
+    run_scheduler_worker, verify_root_proof,
+};
+
+type InternalProof = Proof<BabyBearPoseidon2Config>;
+type GpuScheduler = RecursionScheduler<RecursionProof, InternalProof, RootProof>;
+type GpuWorkerHandle =
+    thread::JoinHandle<std::result::Result<RecursionWorkerMetrics, RecursionWorkerError>>;
+
+pub struct GpuRecursionBatchOutput {
+    pub root_output: RootProvingOutput,
+    pub worker_metrics: Vec<RecursionWorkerMetrics>,
+    pub root_verification_time: std::time::Duration,
+}
+
+pub struct GpuRecursionSession<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize> {
+    scheduler: Arc<GpuScheduler>,
+    assets: Arc<RecursionHostAssets<LEAF_FANIN, INTERNAL_FANIN>>,
+    root_vk: super::RootVk,
+    released_devices: HashSet<usize>,
+    workers: Vec<GpuWorkerHandle>,
+}
+
+impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
+    GpuRecursionSession<LEAF_FANIN, INTERNAL_FANIN>
+{
+    pub fn new(
+        child_vk: Arc<RecursionVk>,
+        total_shards: usize,
+        options: AggregationOptions,
+    ) -> Result<Self> {
+        let assets = Arc::new(RecursionHostAssets::new(child_vk, total_shards, &options)?);
+        let root_vk = assets.root_vk().as_ref().clone();
+        Ok(Self {
+            scheduler: Arc::new(GpuScheduler::new(RecursionPlan::new(
+                total_shards,
+                LEAF_FANIN,
+                INTERNAL_FANIN,
+            )?)),
+            assets,
+            root_vk,
+            released_devices: HashSet::new(),
+            workers: Vec::new(),
+        })
+    }
+
+    pub fn accept_base_proof(&self, shard_id: usize, proof: RecursionProof) -> Result<()> {
+        self.scheduler.accept_base_proof(shard_id, proof)?;
+        tracing::info!(
+            target: "ceno_multi_gpu",
+            shard_id,
+            phase = "recursion_base_proof_queued",
+            "metadata-valid base proof entered recursion scheduler"
+        );
+        Ok(())
+    }
+
+    pub fn release_device(&mut self, device_id: usize) -> Result<()> {
+        register_released_device(&mut self.released_devices, device_id)?;
+        let scheduler = self.scheduler.clone();
+        let assets = self.assets.clone();
+        let worker = thread::Builder::new()
+            .name(format!("recursion-gpu-{device_id}"))
+            .spawn(move || {
+                match catch_unwind(AssertUnwindSafe(|| {
+                    run_gpu_worker(device_id, &scheduler, &assets)
+                })) {
+                    Ok(result) => result,
+                    Err(payload) => {
+                        let error = worker_error(
+                            device_id,
+                            RecursionWorkerPhase::Panic,
+                            panic_message(payload),
+                        );
+                        scheduler.cancel(error.to_string());
+                        Err(error)
+                    }
+                }
+            })
+            .map_err(|err| {
+                self.scheduler
+                    .cancel(format!("failed to spawn recursion GPU {device_id}: {err}"));
+                eyre!("failed to spawn recursion GPU {device_id}: {err}")
+            })?;
+        self.workers.push(worker);
+        tracing::info!(
+            target: "ceno_multi_gpu",
+            device_id,
+            active_recursion_workers = self.workers.len(),
+            phase = "device_role_transition",
+            "released base GPU started recursion work"
+        );
+        Ok(())
+    }
+
+    pub fn cancel(&self, error: impl Into<String>) {
+        self.scheduler.cancel(error);
+    }
+
+    pub fn finish(mut self) -> Result<GpuRecursionBatchOutput> {
+        if self.workers.is_empty() {
+            return Err(eyre!("no base GPU was released for recursion"));
+        }
+        let mut worker_metrics = Vec::with_capacity(self.workers.len());
+        let mut worker_errors = Vec::new();
+        for worker in self.workers.drain(..) {
+            match worker.join() {
+                Ok(Ok(metrics)) => worker_metrics.push(metrics),
+                Ok(Err(err)) => worker_errors.push(err.to_string()),
+                Err(payload) => {
+                    worker_errors.push(format!("worker join panic: {}", panic_message(payload)))
+                }
+            }
+        }
+        if let Some(error) = self.scheduler.cancellation_error() {
+            return Err(eyre!(error));
+        }
+        if !worker_errors.is_empty() {
+            return Err(eyre!(worker_errors.join("; ")));
+        }
+        let root_proof = self
+            .scheduler
+            .take_root_proof()?
+            .ok_or_else(|| eyre!("recursion workers exited without a root proof"))?;
+        drop(self.scheduler.take_base_proofs()?);
+        let first_device = *self
+            .released_devices
+            .iter()
+            .min()
+            .expect("at least one released device was checked");
+        openvm_cuda_common::common::set_device_by_id(i32::try_from(first_device)?)?;
+        let root_verification_started = Instant::now();
+        verify_root_proof(&self.root_vk, &root_proof)?;
+        let root_verification_time = root_verification_started.elapsed();
+        worker_metrics.sort_by_key(|metrics| metrics.device_id);
+        Ok(GpuRecursionBatchOutput {
+            root_output: RootProvingOutput {
+                root_vk: self.root_vk,
+                root_proof,
+            },
+            worker_metrics,
+            root_verification_time,
+        })
+    }
+}
+
+fn register_released_device(released_devices: &mut HashSet<usize>, device_id: usize) -> Result<()> {
+    if !released_devices.insert(device_id) {
+        return Err(eyre!("recursion GPU device {device_id} was released twice"));
+    }
+    Ok(())
+}
+
+pub fn prove_batch_with_gpu_workers<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>(
+    child_vk: Arc<RecursionVk>,
+    shard_proofs: Vec<RecursionProof>,
+    options: AggregationOptions,
+    device_ids: &[usize],
+) -> Result<GpuRecursionBatchOutput> {
+    if shard_proofs.is_empty() {
+        return Err(eyre!("no shard proofs to aggregate"));
+    }
+    if device_ids.is_empty() {
+        return Err(eyre!("at least one recursion GPU device is required"));
+    }
+    if device_ids.iter().copied().collect::<HashSet<_>>().len() != device_ids.len() {
+        return Err(eyre!("recursion GPU device IDs must be unique"));
+    }
+
+    let mut session = GpuRecursionSession::<LEAF_FANIN, INTERNAL_FANIN>::new(
+        child_vk,
+        shard_proofs.len(),
+        options,
+    )?;
+    for (shard_id, proof) in shard_proofs.into_iter().enumerate() {
+        session.accept_base_proof(shard_id, proof)?;
+    }
+    for &device_id in device_ids {
+        session.release_device(device_id)?;
+    }
+    session.finish()
+}
+
+fn run_gpu_worker<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>(
+    device_id: usize,
+    scheduler: &GpuScheduler,
+    assets: &RecursionHostAssets<LEAF_FANIN, INTERNAL_FANIN>,
+) -> std::result::Result<RecursionWorkerMetrics, RecursionWorkerError> {
+    let cuda_device_id = i32::try_from(device_id).map_err(|_| {
+        worker_error(
+            device_id,
+            RecursionWorkerPhase::Execute,
+            "invalid CUDA device ID".to_string(),
+        )
+    })?;
+    if let Err(err) = openvm_cuda_common::common::set_device_by_id(cuda_device_id) {
+        let error = worker_error(device_id, RecursionWorkerPhase::Execute, err.to_string());
+        scheduler.cancel(error.to_string());
+        return Err(error);
+    }
+
+    let mut active = None;
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        run_scheduler_worker(device_id, scheduler, |task, metrics| {
+            execute_gpu_task(device_id, assets, &mut active, task, metrics)
+        })
+    }));
+    let result = match result {
+        Ok(result) => result,
+        Err(payload) => {
+            let error = worker_error(
+                device_id,
+                RecursionWorkerPhase::Panic,
+                panic_message(payload),
+            );
+            scheduler.cancel(error.to_string());
+            Err(error)
+        }
+    };
+    drop(active);
+    let trim_result = u32::try_from(device_id)
+        .map_err(|_| "invalid CUDA device ID".to_string())
+        .and_then(|device_id| {
+            openvm_cuda_common::memory_manager::synchronize_and_trim_device(device_id)
+                .map_err(|err| err.to_string())
+        });
+    match (result, trim_result) {
+        (Ok(metrics), Ok(())) => Ok(metrics),
+        (Err(error), _) => Err(error),
+        (Ok(_), Err(message)) => {
+            let error = worker_error(device_id, RecursionWorkerPhase::Teardown, message);
+            scheduler.cancel(error.to_string());
+            Err(error)
+        }
+    }
+}
+
+fn execute_gpu_task<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>(
+    device_id: usize,
+    assets: &RecursionHostAssets<LEAF_FANIN, INTERNAL_FANIN>,
+    active: &mut Option<(
+        RecursionNodeKind,
+        GpuRecursionProver<LEAF_FANIN, INTERNAL_FANIN>,
+    )>,
+    task: RecursionTask<RecursionProof, InternalProof>,
+    metrics: &mut RecursionWorkerMetrics,
+) -> Result<RecursionTaskResult<RecursionProof, InternalProof, RootProof>> {
+    let kind = task.node().kind;
+    if active.as_ref().map(|(active_kind, _)| *active_kind) != Some(kind) {
+        if active.take().is_some() {
+            openvm_cuda_common::memory_manager::synchronize_and_trim_device(u32::try_from(
+                device_id,
+            )?)?;
+            metrics.asset_switches += 1;
+        }
+        let hydration_started = Instant::now();
+        *active = Some((kind, assets.hydrate_gpu_on(device_id, kind)?));
+        metrics.hydration_time += hydration_started.elapsed();
+        metrics.asset_hydrations += 1;
+    }
+    let prover = &active.as_ref().expect("active prover was just hydrated").1;
+    Ok(match (task, prover) {
+        (RecursionTask::Leaf { node, proofs }, GpuRecursionProver::Leaf(prover)) => {
+            let proof =
+                prover.agg_prove_no_def::<BabyBearPoseidon2GpuEngine>(&proofs, ChildVkKind::App)?;
+            RecursionTaskResult::Leaf {
+                node: node.id,
+                proof,
+                base_proofs: proofs,
+            }
+        }
+        (RecursionTask::Intermediate { node, proofs }, GpuRecursionProver::LeafBridge(prover))
+            if node.kind == RecursionNodeKind::LeafBridge =>
+        {
+            RecursionTaskResult::Intermediate {
+                node: node.id,
+                proof: prover.prove(&proofs)?,
+            }
+        }
+        (RecursionTask::Intermediate { node, proofs }, GpuRecursionProver::Recursive(prover))
+            if matches!(node.kind, RecursionNodeKind::Recursive { .. }) =>
+        {
+            RecursionTaskResult::Intermediate {
+                node: node.id,
+                proof: prover.prove(&proofs)?,
+            }
+        }
+        (RecursionTask::Root { node, proof }, GpuRecursionProver::Root(prover)) => {
+            RecursionTaskResult::Root {
+                node: node.id,
+                proof: RootProof {
+                    proof: prover.prove(proof)?,
+                },
+            }
+        }
+        (task, _) => {
+            return Err(eyre!(
+                "hydrated prover does not match {:?}",
+                task.node().kind
+            ));
+        }
+    })
+}
+
+fn worker_error(
+    device_id: usize,
+    phase: RecursionWorkerPhase,
+    message: String,
+) -> RecursionWorkerError {
+    RecursionWorkerError {
+        device_id,
+        node: None,
+        phase,
+        message,
+    }
+}
+
+fn panic_message(payload: Box<dyn Any + Send>) -> String {
+    payload
+        .downcast_ref::<&str>()
+        .map(|message| (*message).to_string())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "unknown panic payload".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::register_released_device;
+    use std::collections::HashSet;
+
+    #[test]
+    fn duplicate_device_release_is_rejected() {
+        let mut released = HashSet::new();
+        register_released_device(&mut released, 7).unwrap();
+        let error = register_released_device(&mut released, 7)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("released twice"));
+        assert_eq!(released, HashSet::from([7]));
+    }
+}

--- a/ceno_recursion_v2/src/continuation/prover/gpu_workers.rs
+++ b/ceno_recursion_v2/src/continuation/prover/gpu_workers.rs
@@ -210,6 +210,8 @@ impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
         let assets = self.resolve_assets().inspect_err(|error| {
             self.scheduler.cancel(error.to_string());
         })?;
+        // The base owner has already synchronized, dropped device state, and trimmed this GPU.
+        // Hydration therefore happens on the worker thread after binding the released device.
         let worker = thread::Builder::new()
             .name(format!("recursion-gpu-{device_id}"))
             .spawn(move || {
@@ -402,6 +404,8 @@ fn execute_gpu_task<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>(
     let kind = task.node().kind;
     if active.as_ref().map(|(active_kind, _)| *active_kind) != Some(kind) {
         if active.take().is_some() {
+            // Proving keys are device-local. Finish and release the previous circuit kind before
+            // hydrating the next one so allocations never cross contexts or overlap peak pools.
             openvm_cuda_common::memory_manager::synchronize_and_trim_device(u32::try_from(
                 device_id,
             )?)?;

--- a/ceno_recursion_v2/src/continuation/prover/gpu_workers.rs
+++ b/ceno_recursion_v2/src/continuation/prover/gpu_workers.rs
@@ -12,19 +12,108 @@ use openvm_cuda_backend::BabyBearPoseidon2GpuEngine;
 use openvm_stark_backend::proof::Proof;
 use openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2Config;
 
-use crate::system::{RecursionProof, RecursionVk};
+use crate::system::{RecursionProof, RecursionVk, child_vk_digest, warm_child_vk_digest_cache};
 
 use super::{
-    AggregationOptions, ChildVkKind, GpuRecursionProver, RecursionHostAssets, RecursionNodeKind,
-    RecursionPlan, RecursionScheduler, RecursionTask, RecursionTaskResult, RecursionWorkerError,
-    RecursionWorkerMetrics, RecursionWorkerPhase, RootProof, RootProvingOutput,
-    run_scheduler_worker, verify_root_proof,
+    AggregationOptions, ChildVkKind, GpuRecursionProver, RecursionHostAssets,
+    RecursionHostAssetsTemplate, RecursionNodeKind, RecursionPlan, RecursionScheduler,
+    RecursionTask, RecursionTaskResult, RecursionWorkerError, RecursionWorkerMetrics,
+    RecursionWorkerPhase, RootProof, RootProvingOutput, run_scheduler_worker, verify_root_proof,
 };
 
 type InternalProof = Proof<BabyBearPoseidon2Config>;
 type GpuScheduler = RecursionScheduler<RecursionProof, InternalProof, RootProof>;
 type GpuWorkerHandle =
     thread::JoinHandle<std::result::Result<RecursionWorkerMetrics, RecursionWorkerError>>;
+type HostAssets<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize> =
+    RecursionHostAssets<LEAF_FANIN, INTERNAL_FANIN>;
+type HostAssetsTemplate<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize> =
+    RecursionHostAssetsTemplate<LEAF_FANIN, INTERNAL_FANIN>;
+type HostAssetsBuilder<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize> = thread::JoinHandle<
+    Result<(
+        Arc<HostAssets<LEAF_FANIN, INTERNAL_FANIN>>,
+        HostAssetBuildTimings,
+    )>,
+>;
+
+#[derive(Clone, Copy)]
+struct HostAssetBuildTimings {
+    template: std::time::Duration,
+    template_wait: std::time::Duration,
+    bind: std::time::Duration,
+}
+
+pub struct RecursionHostAssetsBuilder<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize> {
+    child_vk_digest: [crate::system::RecursionField; ceno_zkvm::structs::VK_DIGEST_LEN],
+    handle: thread::JoinHandle<
+        Result<(
+            Arc<HostAssetsTemplate<LEAF_FANIN, INTERNAL_FANIN>>,
+            std::time::Duration,
+        )>,
+    >,
+}
+
+impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
+    RecursionHostAssetsBuilder<LEAF_FANIN, INTERNAL_FANIN>
+{
+    pub fn spawn(
+        child_vk: Arc<RecursionVk>,
+        child_vk_digest: [crate::system::RecursionField; ceno_zkvm::structs::VK_DIGEST_LEN],
+        options: AggregationOptions,
+    ) -> Result<Self> {
+        let handle = thread::Builder::new()
+            .name("recursion-host-template".to_owned())
+            .spawn(move || {
+                let started = Instant::now();
+                warm_child_vk_digest_cache(&child_vk);
+                let template = Arc::new(RecursionHostAssetsTemplate::new(child_vk, &options)?);
+                Ok((template, started.elapsed()))
+            })?;
+        Ok(Self {
+            child_vk_digest,
+            handle,
+        })
+    }
+
+    pub fn validate_child_vk_digest(
+        &self,
+        child_vk_digest: &[crate::system::RecursionField; ceno_zkvm::structs::VK_DIGEST_LEN],
+    ) -> Result<()> {
+        if &self.child_vk_digest != child_vk_digest {
+            return Err(eyre!(
+                "prebuilt recursion host assets do not match the proving app VK"
+            ));
+        }
+        Ok(())
+    }
+
+    fn bind(
+        self,
+        total_shards: usize,
+    ) -> Result<(
+        Arc<HostAssets<LEAF_FANIN, INTERNAL_FANIN>>,
+        HostAssetBuildTimings,
+    )> {
+        let wait_started = Instant::now();
+        let (template, template_time) = self.handle.join().map_err(|payload| {
+            eyre!(
+                "recursion host-asset template builder panicked: {}",
+                panic_message(payload)
+            )
+        })??;
+        let template_wait = wait_started.elapsed();
+        let bind_started = Instant::now();
+        let assets = Arc::new(template.bind(total_shards)?);
+        Ok((
+            assets,
+            HostAssetBuildTimings {
+                template: template_time,
+                template_wait,
+                bind: bind_started.elapsed(),
+            },
+        ))
+    }
+}
 
 pub struct GpuRecursionBatchOutput {
     pub root_output: RootProvingOutput,
@@ -34,8 +123,8 @@ pub struct GpuRecursionBatchOutput {
 
 pub struct GpuRecursionSession<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize> {
     scheduler: Arc<GpuScheduler>,
-    assets: Arc<RecursionHostAssets<LEAF_FANIN, INTERNAL_FANIN>>,
-    root_vk: super::RootVk,
+    assets: Option<Arc<HostAssets<LEAF_FANIN, INTERNAL_FANIN>>>,
+    assets_builder: Option<HostAssetsBuilder<LEAF_FANIN, INTERNAL_FANIN>>,
     released_devices: HashSet<usize>,
     workers: Vec<GpuWorkerHandle>,
 }
@@ -45,22 +134,63 @@ impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
 {
     pub fn new(
         child_vk: Arc<RecursionVk>,
+        child_vk_digest: [crate::system::RecursionField; ceno_zkvm::structs::VK_DIGEST_LEN],
         total_shards: usize,
         options: AggregationOptions,
     ) -> Result<Self> {
-        let assets = Arc::new(RecursionHostAssets::new(child_vk, total_shards, &options)?);
-        let root_vk = assets.root_vk().as_ref().clone();
+        Self::new_with_assets_builder(
+            total_shards,
+            RecursionHostAssetsBuilder::spawn(child_vk, child_vk_digest, options)?,
+        )
+    }
+
+    pub fn new_with_assets_builder(
+        total_shards: usize,
+        assets_template: RecursionHostAssetsBuilder<LEAF_FANIN, INTERNAL_FANIN>,
+    ) -> Result<Self> {
+        let scheduler = Arc::new(GpuScheduler::new(RecursionPlan::new(
+            total_shards,
+            LEAF_FANIN,
+            INTERNAL_FANIN,
+        )?));
+        let assets_builder = thread::Builder::new()
+            .name("recursion-host-assets".to_owned())
+            .spawn(move || assets_template.bind(total_shards))?;
         Ok(Self {
-            scheduler: Arc::new(GpuScheduler::new(RecursionPlan::new(
-                total_shards,
-                LEAF_FANIN,
-                INTERNAL_FANIN,
-            )?)),
-            assets,
-            root_vk,
+            scheduler,
+            assets: None,
+            assets_builder: Some(assets_builder),
             released_devices: HashSet::new(),
             workers: Vec::new(),
         })
+    }
+
+    fn resolve_assets(&mut self) -> Result<Arc<HostAssets<LEAF_FANIN, INTERNAL_FANIN>>> {
+        if let Some(assets) = &self.assets {
+            return Ok(assets.clone());
+        }
+        let wait_started = Instant::now();
+        let builder = self
+            .assets_builder
+            .take()
+            .ok_or_else(|| eyre!("recursion host-asset builder is unavailable"))?;
+        let (assets, timings) = builder.join().map_err(|payload| {
+            eyre!(
+                "recursion host-asset builder panicked: {}",
+                panic_message(payload)
+            )
+        })??;
+        tracing::info!(
+            target: "ceno_multi_gpu",
+            template_build_ms = timings.template.as_millis(),
+            template_wait_ms = timings.template_wait.as_millis(),
+            bind_ms = timings.bind.as_millis(),
+            release_wait_ms = wait_started.elapsed().as_millis(),
+            phase = "recursion_host_assets_ready",
+            "recursion host assets ready"
+        );
+        self.assets = Some(assets.clone());
+        Ok(assets)
     }
 
     pub fn accept_base_proof(&self, shard_id: usize, proof: RecursionProof) -> Result<()> {
@@ -77,7 +207,9 @@ impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
     pub fn release_device(&mut self, device_id: usize) -> Result<()> {
         register_released_device(&mut self.released_devices, device_id)?;
         let scheduler = self.scheduler.clone();
-        let assets = self.assets.clone();
+        let assets = self.resolve_assets().inspect_err(|error| {
+            self.scheduler.cancel(error.to_string());
+        })?;
         let worker = thread::Builder::new()
             .name(format!("recursion-gpu-{device_id}"))
             .spawn(move || {
@@ -117,6 +249,7 @@ impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
     }
 
     pub fn finish(mut self) -> Result<GpuRecursionBatchOutput> {
+        let assets = self.resolve_assets()?;
         if self.workers.is_empty() {
             return Err(eyre!("no base GPU was released for recursion"));
         }
@@ -142,6 +275,7 @@ impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
             .take_root_proof()?
             .ok_or_else(|| eyre!("recursion workers exited without a root proof"))?;
         drop(self.scheduler.take_base_proofs()?);
+        let root_vk = assets.root_vk().as_ref().clone();
         let first_device = *self
             .released_devices
             .iter()
@@ -149,12 +283,12 @@ impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
             .expect("at least one released device was checked");
         openvm_cuda_common::common::set_device_by_id(i32::try_from(first_device)?)?;
         let root_verification_started = Instant::now();
-        verify_root_proof(&self.root_vk, &root_proof)?;
+        verify_root_proof(&root_vk, &root_proof)?;
         let root_verification_time = root_verification_started.elapsed();
         worker_metrics.sort_by_key(|metrics| metrics.device_id);
         Ok(GpuRecursionBatchOutput {
             root_output: RootProvingOutput {
-                root_vk: self.root_vk,
+                root_vk,
                 root_proof,
             },
             worker_metrics,
@@ -187,7 +321,8 @@ pub fn prove_batch_with_gpu_workers<const LEAF_FANIN: usize, const INTERNAL_FANI
     }
 
     let mut session = GpuRecursionSession::<LEAF_FANIN, INTERNAL_FANIN>::new(
-        child_vk,
+        child_vk.clone(),
+        child_vk_digest(&child_vk),
         shard_proofs.len(),
         options,
     )?;

--- a/ceno_recursion_v2/src/continuation/prover/gpu_workers.rs
+++ b/ceno_recursion_v2/src/continuation/prover/gpu_workers.rs
@@ -12,7 +12,7 @@ use openvm_cuda_backend::BabyBearPoseidon2GpuEngine;
 use openvm_stark_backend::proof::Proof;
 use openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2Config;
 
-use crate::system::{RecursionProof, RecursionVk, child_vk_digest, warm_child_vk_digest_cache};
+use crate::system::{RecursionProof, RecursionVk, warm_child_vk_digest_cache};
 
 use super::{
     AggregationOptions, ChildVkKind, GpuRecursionProver, RecursionHostAssets,
@@ -132,18 +132,6 @@ pub struct GpuRecursionSession<const LEAF_FANIN: usize, const INTERNAL_FANIN: us
 impl<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>
     GpuRecursionSession<LEAF_FANIN, INTERNAL_FANIN>
 {
-    pub fn new(
-        child_vk: Arc<RecursionVk>,
-        child_vk_digest: [crate::system::RecursionField; ceno_zkvm::structs::VK_DIGEST_LEN],
-        total_shards: usize,
-        options: AggregationOptions,
-    ) -> Result<Self> {
-        Self::new_with_assets_builder(
-            total_shards,
-            RecursionHostAssetsBuilder::spawn(child_vk, child_vk_digest, options)?,
-        )
-    }
-
     pub fn new_with_assets_builder(
         total_shards: usize,
         assets_template: RecursionHostAssetsBuilder<LEAF_FANIN, INTERNAL_FANIN>,
@@ -306,6 +294,7 @@ fn register_released_device(released_devices: &mut HashSet<usize>, device_id: us
     Ok(())
 }
 
+#[cfg(test)]
 pub fn prove_batch_with_gpu_workers<const LEAF_FANIN: usize, const INTERNAL_FANIN: usize>(
     child_vk: Arc<RecursionVk>,
     shard_proofs: Vec<RecursionProof>,
@@ -322,11 +311,13 @@ pub fn prove_batch_with_gpu_workers<const LEAF_FANIN: usize, const INTERNAL_FANI
         return Err(eyre!("recursion GPU device IDs must be unique"));
     }
 
-    let mut session = GpuRecursionSession::<LEAF_FANIN, INTERNAL_FANIN>::new(
-        child_vk.clone(),
-        child_vk_digest(&child_vk),
+    let mut session = GpuRecursionSession::<LEAF_FANIN, INTERNAL_FANIN>::new_with_assets_builder(
         shard_proofs.len(),
-        options,
+        RecursionHostAssetsBuilder::spawn(
+            child_vk.clone(),
+            crate::system::child_vk_digest(&child_vk),
+            options,
+        )?,
     )?;
     for (shard_id, proof) in shard_proofs.into_iter().enumerate() {
         session.accept_base_proof(shard_id, proof)?;

--- a/ceno_recursion_v2/src/continuation/prover/inner/mod.rs
+++ b/ceno_recursion_v2/src/continuation/prover/inner/mod.rs
@@ -338,6 +338,10 @@ where
         self.vk.clone()
     }
 
+    pub fn get_pk(&self) -> Arc<MultiStarkProvingKey<SC>> {
+        self.pk.clone()
+    }
+
     pub fn child_vk_air_count(&self) -> usize {
         self.child_vk.circuit_vks.len()
     }

--- a/ceno_recursion_v2/src/continuation/prover/mod.rs
+++ b/ceno_recursion_v2/src/continuation/prover/mod.rs
@@ -33,16 +33,20 @@ use crate::{
     system::{RecursionProof, RecursionVk, VerifierSubCircuit, VerifierTraceGen},
 };
 
+#[cfg(any(test, feature = "cuda"))]
 mod assets;
 #[cfg(feature = "cuda")]
 mod gpu_workers;
 mod inner;
+#[cfg(any(test, feature = "cuda"))]
 mod scheduler;
 
+#[cfg(any(test, feature = "cuda"))]
 pub use assets::*;
 #[cfg(feature = "cuda")]
 pub use gpu_workers::*;
 pub use inner::*;
+#[cfg(any(test, feature = "cuda"))]
 pub use scheduler::*;
 
 pub type InnerCpuProver<const MAX_NUM_PROOFS: usize> = InnerAggregationProver<

--- a/ceno_recursion_v2/src/continuation/prover/mod.rs
+++ b/ceno_recursion_v2/src/continuation/prover/mod.rs
@@ -33,15 +33,27 @@ use crate::{
     system::{RecursionProof, RecursionVk, VerifierSubCircuit, VerifierTraceGen},
 };
 
+mod assets;
+#[cfg(feature = "cuda")]
+mod gpu_workers;
 mod inner;
+mod scheduler;
 
+pub use assets::*;
+#[cfg(feature = "cuda")]
+pub use gpu_workers::*;
 pub use inner::*;
+pub use scheduler::*;
 
 pub type InnerCpuProver<const MAX_NUM_PROOFS: usize> = InnerAggregationProver<
     CpuBackend<BabyBearPoseidon2Config>,
     VerifierSubCircuit<MAX_NUM_PROOFS>,
     InnerTraceGenImpl,
 >;
+
+#[cfg(feature = "cuda")]
+pub type InnerGpuProver<const MAX_NUM_PROOFS: usize> =
+    InnerAggregationProver<GpuBackend, VerifierSubCircuit<MAX_NUM_PROOFS>, InnerTraceGenImpl>;
 
 #[cfg(not(feature = "cuda"))]
 type DefaultInnerBackend = CpuBackend<BabyBearPoseidon2Config>;

--- a/ceno_recursion_v2/src/continuation/prover/scheduler.rs
+++ b/ceno_recursion_v2/src/continuation/prover/scheduler.rs
@@ -82,6 +82,8 @@ impl RecursionPlan {
             RecursionNodeKind::LeafBridge,
             1,
         );
+        // Preserve the verifier's mandatory bridge and initial-recursive transcript layers even
+        // when a partial tail means either layer has only one child.
         current = push_parent_layer(
             &mut nodes,
             &current,
@@ -116,10 +118,10 @@ impl RecursionPlan {
         let mut parents = vec![None; nodes.len()];
         for node in &nodes {
             for child in &node.children {
-                if let RecursionNodeInput::Node(child) = child {
-                    if parents[child.0].replace(node.id).is_some() {
-                        return Err(eyre!("recursion node {:?} has multiple parents", child));
-                    }
+                if let RecursionNodeInput::Node(child) = child
+                    && parents[child.0].replace(node.id).is_some()
+                {
+                    return Err(eyre!("recursion node {:?} has multiple parents", child));
                 }
             }
         }
@@ -241,7 +243,6 @@ struct SchedulerState<B, P, R> {
     status: Vec<NodeStatus>,
     ready: Vec<RecursionNodeId>,
     cancelled: Option<String>,
-    shutdown: bool,
 }
 
 pub struct RecursionScheduler<B, P, R> {
@@ -307,15 +308,10 @@ impl<B, P, R> RecursionScheduler<B, P, R> {
                 status: vec![NodeStatus::Pending; node_count],
                 ready: Vec::new(),
                 cancelled: None,
-                shutdown: false,
             }),
             plan,
             changed: Condvar::new(),
         }
-    }
-
-    pub fn plan(&self) -> &RecursionPlan {
-        &self.plan
     }
 
     pub fn accept_base_proof(&self, shard_id: usize, proof: B) -> Result<()> {
@@ -329,7 +325,7 @@ impl<B, P, R> RecursionScheduler<B, P, R> {
             return Err(eyre!("duplicate base proof shard {shard_id}"));
         }
         state.base_proofs[shard_id] = Some(proof);
-        decrement_and_enqueue(&self.plan, &mut state, leaf)?;
+        decrement_and_enqueue(&mut state, leaf)?;
         self.changed.notify_all();
         Ok(())
     }
@@ -343,9 +339,11 @@ impl<B, P, R> RecursionScheduler<B, P, R> {
                 state.status[id.0] = NodeStatus::Running;
                 return materialize_task(&self.plan, &mut state, id).map(Some);
             }
-            if state.shutdown || state.root_proof.is_some() {
+            if state.root_proof.is_some() {
                 return Ok(None);
             }
+            // The mutex closes the notification-before-wait race; completion/cancellation always
+            // mutates state under the same lock before waking every eligible worker.
             state = self.changed.wait(state).unwrap();
         }
     }
@@ -414,13 +412,13 @@ impl<B, P, R> RecursionScheduler<B, P, R> {
                 );
             }
         }
-        if let Some(parent) = self.plan.parent(id) {
-            if state.pending[parent.0] == 0 {
-                return self.fail_completion(
-                    &mut state,
-                    format!("recursion node {} readiness underflow", parent.0),
-                );
-            }
+        if let Some(parent) = self.plan.parent(id)
+            && state.pending[parent.0] == 0
+        {
+            return self.fail_completion(
+                &mut state,
+                format!("recursion node {} readiness underflow", parent.0),
+            );
         }
 
         match result {
@@ -439,7 +437,7 @@ impl<B, P, R> RecursionScheduler<B, P, R> {
         }
         state.status[id.0] = NodeStatus::Complete;
         if let Some(parent) = self.plan.parent(id) {
-            decrement_and_enqueue(&self.plan, &mut state, parent)?;
+            decrement_and_enqueue(&mut state, parent)?;
         }
         self.changed.notify_all();
         Ok(())
@@ -458,12 +456,6 @@ impl<B, P, R> RecursionScheduler<B, P, R> {
         if state.cancelled.is_none() {
             state.cancelled = Some(error.into());
         }
-        self.changed.notify_all();
-    }
-
-    pub fn shutdown(&self) {
-        let mut state = self.state.lock().unwrap();
-        state.shutdown = true;
         self.changed.notify_all();
     }
 
@@ -571,7 +563,6 @@ fn ensure_running<B, P, R>(state: &SchedulerState<B, P, R>) -> Result<()> {
 }
 
 fn decrement_and_enqueue<B, P, R>(
-    plan: &RecursionPlan,
     state: &mut SchedulerState<B, P, R>,
     node: RecursionNodeId,
 ) -> Result<()> {
@@ -587,11 +578,11 @@ fn decrement_and_enqueue<B, P, R>(
         state.status[node.0] = NodeStatus::Ready;
         state.ready.push(node);
     }
-    let _ = plan;
     Ok(())
 }
 
 fn select_ready_node(plan: &RecursionPlan, ready: &[RecursionNodeId]) -> Option<RecursionNodeId> {
+    // Prefer leaves, then a ready root, then the deepest intermediate; node index breaks ties.
     ready.iter().copied().min_by_key(|id| {
         let node = &plan.nodes[id.0];
         let class = match node.kind {
@@ -844,7 +835,7 @@ mod tests {
         for shard_id in 0..5 {
             scheduler.accept_base_proof(shard_id, shard_id).unwrap();
         }
-        let node_count = scheduler.plan().nodes.len();
+        let node_count = scheduler.plan.nodes.len();
         let workers = (0..2)
             .map(|device_id| {
                 let scheduler = scheduler.clone();
@@ -904,7 +895,7 @@ mod tests {
         for shard_id in 0..5 {
             scheduler.accept_base_proof(shard_id, shard_id).unwrap();
         }
-        let node_count = scheduler.plan().nodes.len();
+        let node_count = scheduler.plan.nodes.len();
         let metrics = run_scheduler_worker(0, &scheduler, |task, _| {
             let id = task.node().id;
             Ok(match task {

--- a/ceno_recursion_v2/src/continuation/prover/scheduler.rs
+++ b/ceno_recursion_v2/src/continuation/prover/scheduler.rs
@@ -1,0 +1,1001 @@
+use std::{
+    fmt,
+    ops::Range,
+    sync::{Condvar, Mutex},
+    time::{Duration, Instant},
+};
+
+use eyre::{Result, eyre};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecursionNodeKind {
+    Leaf,
+    LeafBridge,
+    Recursive { level: usize },
+    Root,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct RecursionNodeId(pub usize);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecursionNodeInput {
+    BaseShard(usize),
+    Node(RecursionNodeId),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecursionNode {
+    pub id: RecursionNodeId,
+    pub kind: RecursionNodeKind,
+    pub layer: usize,
+    pub index: usize,
+    pub shard_range: Range<usize>,
+    pub children: Vec<RecursionNodeInput>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecursionPlan {
+    pub total_shards: usize,
+    pub nodes: Vec<RecursionNode>,
+    pub root: RecursionNodeId,
+    parents: Vec<Option<RecursionNodeId>>,
+    leaf_for_shard: Vec<RecursionNodeId>,
+}
+
+impl RecursionPlan {
+    pub fn new(total_shards: usize, leaf_fanin: usize, internal_fanin: usize) -> Result<Self> {
+        if total_shards == 0 {
+            return Err(eyre!("recursion plan requires at least one base shard"));
+        }
+        if leaf_fanin == 0 {
+            return Err(eyre!("leaf aggregation fanin must be non-zero"));
+        }
+        if internal_fanin == 0 {
+            return Err(eyre!("internal aggregation fanin must be non-zero"));
+        }
+
+        let mut nodes = Vec::new();
+        let mut leaf_for_shard = Vec::with_capacity(total_shards);
+        let mut current = Vec::new();
+        for (index, start) in (0..total_shards).step_by(leaf_fanin).enumerate() {
+            let end = (start + leaf_fanin).min(total_shards);
+            let id = push_node(
+                &mut nodes,
+                RecursionNodeKind::Leaf,
+                0,
+                index,
+                start..end,
+                (start..end).map(RecursionNodeInput::BaseShard).collect(),
+            );
+            leaf_for_shard.extend(std::iter::repeat_n(id, end - start));
+            current.push(id);
+        }
+
+        current = push_parent_layer(
+            &mut nodes,
+            &current,
+            internal_fanin,
+            RecursionNodeKind::LeafBridge,
+            1,
+        );
+        current = push_parent_layer(
+            &mut nodes,
+            &current,
+            internal_fanin,
+            RecursionNodeKind::Recursive { level: 0 },
+            2,
+        );
+        let mut recursive_level = 1;
+        while current.len() > 1 {
+            current = push_parent_layer(
+                &mut nodes,
+                &current,
+                internal_fanin,
+                RecursionNodeKind::Recursive {
+                    level: recursive_level,
+                },
+                2 + recursive_level,
+            );
+            recursive_level += 1;
+        }
+
+        let child = current[0];
+        let child_range = nodes[child.0].shard_range.clone();
+        let root = push_node(
+            &mut nodes,
+            RecursionNodeKind::Root,
+            2 + recursive_level,
+            0,
+            child_range,
+            vec![RecursionNodeInput::Node(child)],
+        );
+        let mut parents = vec![None; nodes.len()];
+        for node in &nodes {
+            for child in &node.children {
+                if let RecursionNodeInput::Node(child) = child {
+                    if parents[child.0].replace(node.id).is_some() {
+                        return Err(eyre!("recursion node {:?} has multiple parents", child));
+                    }
+                }
+            }
+        }
+
+        Ok(Self {
+            total_shards,
+            nodes,
+            root,
+            parents,
+            leaf_for_shard,
+        })
+    }
+
+    pub fn parent(&self, node: RecursionNodeId) -> Option<RecursionNodeId> {
+        self.parents[node.0]
+    }
+
+    pub fn leaf_for_shard(&self, shard_id: usize) -> Option<RecursionNodeId> {
+        self.leaf_for_shard.get(shard_id).copied()
+    }
+}
+
+fn push_node(
+    nodes: &mut Vec<RecursionNode>,
+    kind: RecursionNodeKind,
+    layer: usize,
+    index: usize,
+    shard_range: Range<usize>,
+    children: Vec<RecursionNodeInput>,
+) -> RecursionNodeId {
+    let id = RecursionNodeId(nodes.len());
+    nodes.push(RecursionNode {
+        id,
+        kind,
+        layer,
+        index,
+        shard_range,
+        children,
+    });
+    id
+}
+
+fn push_parent_layer(
+    nodes: &mut Vec<RecursionNode>,
+    children: &[RecursionNodeId],
+    fanin: usize,
+    kind: RecursionNodeKind,
+    layer: usize,
+) -> Vec<RecursionNodeId> {
+    children
+        .chunks(fanin)
+        .enumerate()
+        .map(|(index, chunk)| {
+            let start = nodes[chunk[0].0].shard_range.start;
+            let end = nodes[chunk[chunk.len() - 1].0].shard_range.end;
+            push_node(
+                nodes,
+                kind,
+                layer,
+                index,
+                start..end,
+                chunk
+                    .iter()
+                    .copied()
+                    .map(RecursionNodeInput::Node)
+                    .collect(),
+            )
+        })
+        .collect()
+}
+
+#[derive(Debug)]
+pub enum RecursionTask<B, P> {
+    Leaf { node: RecursionNode, proofs: Vec<B> },
+    Intermediate { node: RecursionNode, proofs: Vec<P> },
+    Root { node: RecursionNode, proof: P },
+}
+
+impl<B, P> RecursionTask<B, P> {
+    pub fn node(&self) -> &RecursionNode {
+        match self {
+            Self::Leaf { node, .. } | Self::Intermediate { node, .. } | Self::Root { node, .. } => {
+                node
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum RecursionTaskResult<B, P, R> {
+    Leaf {
+        node: RecursionNodeId,
+        proof: P,
+        base_proofs: Vec<B>,
+    },
+    Intermediate {
+        node: RecursionNodeId,
+        proof: P,
+    },
+    Root {
+        node: RecursionNodeId,
+        proof: R,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum NodeStatus {
+    Pending,
+    Ready,
+    Running,
+    Complete,
+}
+
+struct SchedulerState<B, P, R> {
+    base_proofs: Vec<Option<B>>,
+    proofs: Vec<Option<P>>,
+    root_proof: Option<R>,
+    pending: Vec<usize>,
+    status: Vec<NodeStatus>,
+    ready: Vec<RecursionNodeId>,
+    cancelled: Option<String>,
+    shutdown: bool,
+}
+
+pub struct RecursionScheduler<B, P, R> {
+    plan: RecursionPlan,
+    state: Mutex<SchedulerState<B, P, R>>,
+    changed: Condvar,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecursionWorkerPhase {
+    Wait,
+    Execute,
+    Complete,
+    Teardown,
+    Panic,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecursionWorkerError {
+    pub device_id: usize,
+    pub node: Option<RecursionNodeId>,
+    pub phase: RecursionWorkerPhase,
+    pub message: String,
+}
+
+impl fmt::Display for RecursionWorkerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "recursion worker device {}", self.device_id)?;
+        if let Some(node) = self.node {
+            write!(f, " node {}", node.0)?;
+        }
+        write!(f, " {:?}: {}", self.phase, self.message)
+    }
+}
+
+impl std::error::Error for RecursionWorkerError {}
+
+#[derive(Clone, Debug, Default)]
+pub struct RecursionWorkerMetrics {
+    pub device_id: usize,
+    pub task_count: usize,
+    pub leaf_tasks: usize,
+    pub leaf_bridge_tasks: usize,
+    pub recursive_tasks: usize,
+    pub root_tasks: usize,
+    pub asset_hydrations: usize,
+    pub asset_switches: usize,
+    pub hydration_time: Duration,
+    pub proving_time: Duration,
+    pub total_time: Duration,
+}
+
+impl<B, P, R> RecursionScheduler<B, P, R> {
+    pub fn new(plan: RecursionPlan) -> Self {
+        let pending = plan.nodes.iter().map(|node| node.children.len()).collect();
+        let node_count = plan.nodes.len();
+        Self {
+            state: Mutex::new(SchedulerState {
+                base_proofs: (0..plan.total_shards).map(|_| None).collect(),
+                proofs: (0..node_count).map(|_| None).collect(),
+                root_proof: None,
+                pending,
+                status: vec![NodeStatus::Pending; node_count],
+                ready: Vec::new(),
+                cancelled: None,
+                shutdown: false,
+            }),
+            plan,
+            changed: Condvar::new(),
+        }
+    }
+
+    pub fn plan(&self) -> &RecursionPlan {
+        &self.plan
+    }
+
+    pub fn accept_base_proof(&self, shard_id: usize, proof: B) -> Result<()> {
+        let leaf = self
+            .plan
+            .leaf_for_shard(shard_id)
+            .ok_or_else(|| eyre!("out-of-range base proof shard {shard_id}"))?;
+        let mut state = self.state.lock().unwrap();
+        ensure_running(&state)?;
+        if state.base_proofs[shard_id].is_some() {
+            return Err(eyre!("duplicate base proof shard {shard_id}"));
+        }
+        state.base_proofs[shard_id] = Some(proof);
+        decrement_and_enqueue(&self.plan, &mut state, leaf)?;
+        self.changed.notify_all();
+        Ok(())
+    }
+
+    pub fn wait_for_task(&self) -> Result<Option<RecursionTask<B, P>>> {
+        let mut state = self.state.lock().unwrap();
+        loop {
+            ensure_running(&state)?;
+            if let Some(id) = select_ready_node(&self.plan, &state.ready) {
+                state.ready.retain(|candidate| *candidate != id);
+                state.status[id.0] = NodeStatus::Running;
+                return materialize_task(&self.plan, &mut state, id).map(Some);
+            }
+            if state.shutdown || state.root_proof.is_some() {
+                return Ok(None);
+            }
+            state = self.changed.wait(state).unwrap();
+        }
+    }
+
+    pub fn complete_task(&self, result: RecursionTaskResult<B, P, R>) -> Result<()> {
+        let id = match &result {
+            RecursionTaskResult::Leaf { node, .. }
+            | RecursionTaskResult::Intermediate { node, .. }
+            | RecursionTaskResult::Root { node, .. } => *node,
+        };
+        let mut state = self.state.lock().unwrap();
+        ensure_running(&state)?;
+        let Some(node) = self.plan.nodes.get(id.0) else {
+            return self
+                .fail_completion(&mut state, format!("out-of-range recursion node {}", id.0));
+        };
+        if state.status[id.0] != NodeStatus::Running {
+            return self.fail_completion(
+                &mut state,
+                format!("recursion node {} completed while not running", id.0),
+            );
+        }
+
+        match (&node.kind, &result) {
+            (RecursionNodeKind::Leaf, RecursionTaskResult::Leaf { base_proofs, .. }) => {
+                if base_proofs.len() != node.shard_range.len() {
+                    return self.fail_completion(
+                        &mut state,
+                        format!(
+                            "leaf node {} returned {} base proofs, expected {}",
+                            id.0,
+                            base_proofs.len(),
+                            node.shard_range.len()
+                        ),
+                    );
+                }
+                if let Some(shard_id) = node
+                    .shard_range
+                    .clone()
+                    .find(|shard_id| state.base_proofs[*shard_id].is_some())
+                {
+                    return self.fail_completion(
+                        &mut state,
+                        format!("leaf node {} returned duplicate shard {shard_id}", id.0),
+                    );
+                }
+            }
+            (RecursionNodeKind::Root, RecursionTaskResult::Root { .. }) => {}
+            (RecursionNodeKind::Leaf, _) => {
+                return self.fail_completion(
+                    &mut state,
+                    format!("leaf node {} returned the wrong result type", id.0),
+                );
+            }
+            (RecursionNodeKind::Root, _) => {
+                return self.fail_completion(
+                    &mut state,
+                    format!("root node {} returned the wrong result type", id.0),
+                );
+            }
+            (_, RecursionTaskResult::Intermediate { .. }) => {}
+            (_, _) => {
+                return self.fail_completion(
+                    &mut state,
+                    format!("intermediate node {} returned the wrong result type", id.0),
+                );
+            }
+        }
+        if let Some(parent) = self.plan.parent(id) {
+            if state.pending[parent.0] == 0 {
+                return self.fail_completion(
+                    &mut state,
+                    format!("recursion node {} readiness underflow", parent.0),
+                );
+            }
+        }
+
+        match result {
+            RecursionTaskResult::Leaf {
+                proof, base_proofs, ..
+            } => {
+                for (shard_id, proof) in node.shard_range.clone().zip(base_proofs) {
+                    state.base_proofs[shard_id] = Some(proof);
+                }
+                state.proofs[id.0] = Some(proof);
+            }
+            RecursionTaskResult::Intermediate { proof, .. } => {
+                state.proofs[id.0] = Some(proof);
+            }
+            RecursionTaskResult::Root { proof, .. } => state.root_proof = Some(proof),
+        }
+        state.status[id.0] = NodeStatus::Complete;
+        if let Some(parent) = self.plan.parent(id) {
+            decrement_and_enqueue(&self.plan, &mut state, parent)?;
+        }
+        self.changed.notify_all();
+        Ok(())
+    }
+
+    fn fail_completion(&self, state: &mut SchedulerState<B, P, R>, error: String) -> Result<()> {
+        if state.cancelled.is_none() {
+            state.cancelled = Some(error.clone());
+        }
+        self.changed.notify_all();
+        Err(eyre!(error))
+    }
+
+    pub fn cancel(&self, error: impl Into<String>) {
+        let mut state = self.state.lock().unwrap();
+        if state.cancelled.is_none() {
+            state.cancelled = Some(error.into());
+        }
+        self.changed.notify_all();
+    }
+
+    pub fn shutdown(&self) {
+        let mut state = self.state.lock().unwrap();
+        state.shutdown = true;
+        self.changed.notify_all();
+    }
+
+    pub fn cancellation_error(&self) -> Option<String> {
+        self.state.lock().unwrap().cancelled.clone()
+    }
+
+    pub fn take_root_proof(&self) -> Result<Option<R>> {
+        let mut state = self.state.lock().unwrap();
+        ensure_running(&state)?;
+        Ok(state.root_proof.take())
+    }
+
+    pub fn take_base_proofs(&self) -> Result<Vec<B>> {
+        let mut state = self.state.lock().unwrap();
+        ensure_running(&state)?;
+        state
+            .base_proofs
+            .iter_mut()
+            .enumerate()
+            .map(|(shard_id, proof)| {
+                proof
+                    .take()
+                    .ok_or_else(|| eyre!("base proof shard {shard_id} is not available"))
+            })
+            .collect()
+    }
+}
+
+#[cfg(any(test, feature = "cuda"))]
+pub(crate) fn run_scheduler_worker<B, P, R, Execute>(
+    device_id: usize,
+    scheduler: &RecursionScheduler<B, P, R>,
+    mut execute: Execute,
+) -> std::result::Result<RecursionWorkerMetrics, RecursionWorkerError>
+where
+    Execute: FnMut(
+        RecursionTask<B, P>,
+        &mut RecursionWorkerMetrics,
+    ) -> Result<RecursionTaskResult<B, P, R>>,
+{
+    let started = Instant::now();
+    let mut metrics = RecursionWorkerMetrics {
+        device_id,
+        ..Default::default()
+    };
+    loop {
+        let task = match scheduler.wait_for_task() {
+            Ok(Some(task)) => task,
+            Ok(None) => {
+                metrics.total_time = started.elapsed();
+                return Ok(metrics);
+            }
+            Err(err) => {
+                return Err(RecursionWorkerError {
+                    device_id,
+                    node: None,
+                    phase: RecursionWorkerPhase::Wait,
+                    message: err.to_string(),
+                });
+            }
+        };
+        let node = task.node().id;
+        let kind = task.node().kind;
+        let prove_started = Instant::now();
+        let result = execute(task, &mut metrics).map_err(|err| RecursionWorkerError {
+            device_id,
+            node: Some(node),
+            phase: RecursionWorkerPhase::Execute,
+            message: err.to_string(),
+        });
+        metrics.proving_time += prove_started.elapsed();
+        let result = match result {
+            Ok(result) => result,
+            Err(err) => {
+                scheduler.cancel(err.to_string());
+                return Err(err);
+            }
+        };
+        if let Err(err) = scheduler.complete_task(result) {
+            let err = RecursionWorkerError {
+                device_id,
+                node: Some(node),
+                phase: RecursionWorkerPhase::Complete,
+                message: err.to_string(),
+            };
+            scheduler.cancel(err.to_string());
+            return Err(err);
+        }
+        metrics.task_count += 1;
+        match kind {
+            RecursionNodeKind::Leaf => metrics.leaf_tasks += 1,
+            RecursionNodeKind::LeafBridge => metrics.leaf_bridge_tasks += 1,
+            RecursionNodeKind::Recursive { .. } => metrics.recursive_tasks += 1,
+            RecursionNodeKind::Root => metrics.root_tasks += 1,
+        }
+    }
+}
+
+fn ensure_running<B, P, R>(state: &SchedulerState<B, P, R>) -> Result<()> {
+    match &state.cancelled {
+        Some(error) => Err(eyre!(error.clone())),
+        None => Ok(()),
+    }
+}
+
+fn decrement_and_enqueue<B, P, R>(
+    plan: &RecursionPlan,
+    state: &mut SchedulerState<B, P, R>,
+    node: RecursionNodeId,
+) -> Result<()> {
+    let pending = state
+        .pending
+        .get_mut(node.0)
+        .ok_or_else(|| eyre!("out-of-range recursion node {}", node.0))?;
+    if *pending == 0 {
+        return Err(eyre!("recursion node {} readiness underflow", node.0));
+    }
+    *pending -= 1;
+    if *pending == 0 {
+        state.status[node.0] = NodeStatus::Ready;
+        state.ready.push(node);
+    }
+    let _ = plan;
+    Ok(())
+}
+
+fn select_ready_node(plan: &RecursionPlan, ready: &[RecursionNodeId]) -> Option<RecursionNodeId> {
+    ready.iter().copied().min_by_key(|id| {
+        let node = &plan.nodes[id.0];
+        let class = match node.kind {
+            RecursionNodeKind::Leaf => 0,
+            RecursionNodeKind::Root => 1,
+            _ => 2,
+        };
+        (class, usize::MAX - node.layer, node.index)
+    })
+}
+
+fn materialize_task<B, P, R>(
+    plan: &RecursionPlan,
+    state: &mut SchedulerState<B, P, R>,
+    id: RecursionNodeId,
+) -> Result<RecursionTask<B, P>> {
+    let node = plan.nodes[id.0].clone();
+    match node.kind {
+        RecursionNodeKind::Leaf => {
+            let proofs = node
+                .shard_range
+                .clone()
+                .map(|shard_id| {
+                    state.base_proofs[shard_id]
+                        .take()
+                        .ok_or_else(|| eyre!("leaf node {} missing shard {shard_id}", id.0))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(RecursionTask::Leaf { node, proofs })
+        }
+        RecursionNodeKind::Root => {
+            let [RecursionNodeInput::Node(child)] = node.children.as_slice() else {
+                return Err(eyre!("root node {} must have one node child", id.0));
+            };
+            let proof = state.proofs[child.0]
+                .take()
+                .ok_or_else(|| eyre!("root node {} missing child {}", id.0, child.0))?;
+            Ok(RecursionTask::Root { node, proof })
+        }
+        _ => {
+            let proofs = node
+                .children
+                .iter()
+                .map(|child| match child {
+                    RecursionNodeInput::Node(child) => state.proofs[child.0]
+                        .take()
+                        .ok_or_else(|| eyre!("node {} missing child {}", id.0, child.0)),
+                    RecursionNodeInput::BaseShard(shard_id) => Err(eyre!(
+                        "intermediate node {} has base-shard child {shard_id}",
+                        id.0
+                    )),
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(RecursionTask::Intermediate { node, proofs })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, Barrier, mpsc},
+        thread,
+        time::Duration,
+    };
+
+    use super::*;
+
+    fn finish_usize_task(
+        scheduler: &RecursionScheduler<usize, usize, usize>,
+        task: RecursionTask<usize, usize>,
+    ) -> RecursionNodeKind {
+        let kind = task.node().kind;
+        let id = task.node().id;
+        let result = match task {
+            RecursionTask::Leaf { proofs, .. } => RecursionTaskResult::Leaf {
+                node: id,
+                proof: id.0,
+                base_proofs: proofs,
+            },
+            RecursionTask::Intermediate { .. } => RecursionTaskResult::Intermediate {
+                node: id,
+                proof: id.0,
+            },
+            RecursionTask::Root { .. } => RecursionTaskResult::Root {
+                node: id,
+                proof: id.0,
+            },
+        };
+        scheduler.complete_task(result).unwrap();
+        kind
+    }
+
+    #[test]
+    fn plan_preserves_mandatory_bridge_and_initial_recursive_layers() {
+        let plan = RecursionPlan::new(1, 4, 4).unwrap();
+        assert_eq!(plan.nodes.len(), 4);
+        assert_eq!(plan.nodes[0].kind, RecursionNodeKind::Leaf);
+        assert_eq!(plan.nodes[1].kind, RecursionNodeKind::LeafBridge);
+        assert_eq!(
+            plan.nodes[2].kind,
+            RecursionNodeKind::Recursive { level: 0 }
+        );
+        assert_eq!(plan.nodes[3].kind, RecursionNodeKind::Root);
+        assert_eq!(plan.nodes[3].shard_range, 0..1);
+    }
+
+    #[test]
+    fn plan_keeps_partial_tails_and_consecutive_ranges() {
+        let plan = RecursionPlan::new(11, 4, 4).unwrap();
+        let leaves = plan
+            .nodes
+            .iter()
+            .filter(|node| node.kind == RecursionNodeKind::Leaf)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            leaves
+                .iter()
+                .map(|node| node.shard_range.clone())
+                .collect::<Vec<_>>(),
+            vec![0..4, 4..8, 8..11]
+        );
+        assert_eq!(plan.nodes[plan.root.0].shard_range, 0..11);
+    }
+
+    #[test]
+    fn invalid_plan_shapes_are_rejected() {
+        assert!(RecursionPlan::new(0, 4, 4).is_err());
+        assert!(RecursionPlan::new(1, 0, 4).is_err());
+        assert!(RecursionPlan::new(1, 4, 0).is_err());
+    }
+
+    #[test]
+    fn out_of_order_base_arrival_unlocks_only_complete_consecutive_leaf() {
+        let scheduler =
+            RecursionScheduler::<usize, usize, usize>::new(RecursionPlan::new(5, 2, 2).unwrap());
+        scheduler.accept_base_proof(1, 1).unwrap();
+        scheduler.accept_base_proof(2, 2).unwrap();
+        scheduler.accept_base_proof(3, 3).unwrap();
+        let task = scheduler.wait_for_task().unwrap().unwrap();
+        assert_eq!(task.node().shard_range, 2..4);
+        finish_usize_task(&scheduler, task);
+        scheduler.accept_base_proof(0, 0).unwrap();
+        let task = scheduler.wait_for_task().unwrap().unwrap();
+        assert_eq!(task.node().shard_range, 0..2);
+    }
+
+    #[test]
+    fn leaf_priority_is_non_preemptive_and_work_conserving() {
+        let scheduler =
+            RecursionScheduler::<usize, usize, usize>::new(RecursionPlan::new(3, 1, 2).unwrap());
+        scheduler.accept_base_proof(0, 0).unwrap();
+        let first = scheduler.wait_for_task().unwrap().unwrap();
+        finish_usize_task(&scheduler, first);
+        scheduler.accept_base_proof(1, 1).unwrap();
+        let second = scheduler.wait_for_task().unwrap().unwrap();
+        finish_usize_task(&scheduler, second);
+        let bridge = scheduler.wait_for_task().unwrap().unwrap();
+        assert_eq!(bridge.node().kind, RecursionNodeKind::LeafBridge);
+        scheduler.accept_base_proof(2, 2).unwrap();
+        finish_usize_task(&scheduler, bridge);
+        let next = scheduler.wait_for_task().unwrap().unwrap();
+        assert_eq!(next.node().kind, RecursionNodeKind::Leaf);
+        assert_eq!(next.node().index, 2);
+    }
+
+    #[test]
+    fn completion_immediately_unlocks_parent_and_reaches_root() {
+        let scheduler =
+            RecursionScheduler::<usize, usize, usize>::new(RecursionPlan::new(5, 2, 2).unwrap());
+        for shard_id in 0..5 {
+            scheduler.accept_base_proof(shard_id, shard_id).unwrap();
+        }
+        while scheduler.take_root_proof().unwrap().is_none() {
+            let task = scheduler.wait_for_task().unwrap().unwrap();
+            finish_usize_task(&scheduler, task);
+        }
+        assert_eq!(
+            scheduler.take_base_proofs().unwrap(),
+            (0..5).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn cancellation_wakes_a_blocked_worker_without_polling() {
+        let scheduler = Arc::new(RecursionScheduler::<usize, usize, usize>::new(
+            RecursionPlan::new(1, 1, 1).unwrap(),
+        ));
+        let worker = {
+            let scheduler = scheduler.clone();
+            thread::spawn(move || scheduler.wait_for_task().unwrap_err().to_string())
+        };
+        thread::sleep(Duration::from_millis(10));
+        scheduler.cancel("forced failure");
+        assert!(worker.join().unwrap().contains("forced failure"));
+    }
+
+    #[test]
+    fn ready_notification_before_wait_is_not_lost() {
+        let scheduler = Arc::new(RecursionScheduler::<usize, usize, usize>::new(
+            RecursionPlan::new(1, 1, 1).unwrap(),
+        ));
+        scheduler.accept_base_proof(0, 7).unwrap();
+        let (tx, rx) = mpsc::channel();
+        let worker = {
+            let scheduler = scheduler.clone();
+            thread::spawn(move || {
+                tx.send(scheduler.wait_for_task().unwrap().unwrap())
+                    .unwrap()
+            })
+        };
+        let task = rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert_eq!(task.node().kind, RecursionNodeKind::Leaf);
+        worker.join().unwrap();
+    }
+
+    #[test]
+    fn concurrent_workers_checkout_each_ready_task_exactly_once() {
+        let scheduler = Arc::new(RecursionScheduler::<usize, usize, usize>::new(
+            RecursionPlan::new(2, 1, 2).unwrap(),
+        ));
+        scheduler.accept_base_proof(0, 0).unwrap();
+        scheduler.accept_base_proof(1, 1).unwrap();
+        let barrier = Arc::new(Barrier::new(3));
+        let workers = (0..2)
+            .map(|_| {
+                let scheduler = scheduler.clone();
+                let barrier = barrier.clone();
+                thread::spawn(move || {
+                    barrier.wait();
+                    scheduler.wait_for_task().unwrap().unwrap().node().id
+                })
+            })
+            .collect::<Vec<_>>();
+        barrier.wait();
+        let mut checked_out = workers
+            .into_iter()
+            .map(|worker| worker.join().unwrap())
+            .collect::<Vec<_>>();
+        checked_out.sort_by_key(|id| id.0);
+        checked_out.dedup();
+        assert_eq!(checked_out.len(), 2);
+    }
+
+    #[test]
+    fn fake_workers_complete_plan_and_report_structured_metrics() {
+        let scheduler = Arc::new(RecursionScheduler::<usize, usize, usize>::new(
+            RecursionPlan::new(5, 2, 2).unwrap(),
+        ));
+        for shard_id in 0..5 {
+            scheduler.accept_base_proof(shard_id, shard_id).unwrap();
+        }
+        let node_count = scheduler.plan().nodes.len();
+        let workers = (0..2)
+            .map(|device_id| {
+                let scheduler = scheduler.clone();
+                thread::spawn(move || {
+                    run_scheduler_worker(device_id, &scheduler, |task, _| {
+                        let id = task.node().id;
+                        Ok(match task {
+                            RecursionTask::Leaf { proofs, .. } => RecursionTaskResult::Leaf {
+                                node: id,
+                                proof: id.0,
+                                base_proofs: proofs,
+                            },
+                            RecursionTask::Intermediate { .. } => {
+                                RecursionTaskResult::Intermediate {
+                                    node: id,
+                                    proof: id.0,
+                                }
+                            }
+                            RecursionTask::Root { .. } => RecursionTaskResult::Root {
+                                node: id,
+                                proof: id.0,
+                            },
+                        })
+                    })
+                })
+            })
+            .collect::<Vec<_>>();
+        let metrics = workers
+            .into_iter()
+            .map(|worker| worker.join().unwrap().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            metrics
+                .iter()
+                .map(|metrics| metrics.task_count)
+                .sum::<usize>(),
+            node_count
+        );
+        assert_eq!(
+            metrics
+                .iter()
+                .map(|metrics| metrics.root_tasks)
+                .sum::<usize>(),
+            1
+        );
+        assert!(scheduler.take_root_proof().unwrap().is_some());
+        assert_eq!(
+            scheduler.take_base_proofs().unwrap(),
+            (0..5).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn one_fake_worker_uses_the_same_scheduler_to_completion() {
+        let scheduler =
+            RecursionScheduler::<usize, usize, usize>::new(RecursionPlan::new(5, 2, 2).unwrap());
+        for shard_id in 0..5 {
+            scheduler.accept_base_proof(shard_id, shard_id).unwrap();
+        }
+        let node_count = scheduler.plan().nodes.len();
+        let metrics = run_scheduler_worker(0, &scheduler, |task, _| {
+            let id = task.node().id;
+            Ok(match task {
+                RecursionTask::Leaf { proofs, .. } => RecursionTaskResult::Leaf {
+                    node: id,
+                    proof: id.0,
+                    base_proofs: proofs,
+                },
+                RecursionTask::Intermediate { .. } => RecursionTaskResult::Intermediate {
+                    node: id,
+                    proof: id.0,
+                },
+                RecursionTask::Root { .. } => RecursionTaskResult::Root {
+                    node: id,
+                    proof: id.0,
+                },
+            })
+        })
+        .unwrap();
+        assert_eq!(metrics.device_id, 0);
+        assert_eq!(metrics.task_count, node_count);
+        assert_eq!(metrics.root_tasks, 1);
+        assert!(scheduler.take_root_proof().unwrap().is_some());
+        assert_eq!(
+            scheduler.take_base_proofs().unwrap(),
+            (0..5).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn fake_worker_failure_cancels_and_wakes_peer() {
+        let scheduler = Arc::new(RecursionScheduler::<usize, usize, usize>::new(
+            RecursionPlan::new(1, 1, 1).unwrap(),
+        ));
+        scheduler.accept_base_proof(0, 0).unwrap();
+        let barrier = Arc::new(Barrier::new(2));
+        let (checked_out_tx, checked_out_rx) = mpsc::channel();
+        let failing = {
+            let scheduler = scheduler.clone();
+            let barrier = barrier.clone();
+            thread::spawn(move || {
+                run_scheduler_worker(0, &scheduler, |_, _| {
+                    checked_out_tx.send(()).unwrap();
+                    barrier.wait();
+                    Err(eyre!("injected failure"))
+                })
+            })
+        };
+        checked_out_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        let waiting = {
+            let scheduler = scheduler.clone();
+            thread::spawn(move || run_scheduler_worker(1, &scheduler, |_, _| unreachable!()))
+        };
+        barrier.wait();
+        let errors = [waiting.join().unwrap(), failing.join().unwrap()]
+            .into_iter()
+            .map(|result| result.unwrap_err().to_string())
+            .collect::<Vec<_>>();
+        assert!(
+            scheduler
+                .cancellation_error()
+                .unwrap()
+                .contains("injected failure")
+        );
+        assert!(
+            errors
+                .iter()
+                .all(|error| error.contains("injected failure"))
+        );
+    }
+
+    #[test]
+    fn duplicates_and_wrong_results_are_rejected() {
+        let scheduler =
+            RecursionScheduler::<usize, usize, usize>::new(RecursionPlan::new(1, 1, 1).unwrap());
+        scheduler.accept_base_proof(0, 0).unwrap();
+        assert!(scheduler.accept_base_proof(0, 1).is_err());
+        let task = scheduler.wait_for_task().unwrap().unwrap();
+        let RecursionTask::Leaf { proofs, .. } = &task else {
+            panic!("expected leaf task");
+        };
+        assert_eq!(proofs, &[0]);
+        let id = task.node().id;
+        let error = scheduler
+            .complete_task(RecursionTaskResult::Intermediate { node: id, proof: 0 })
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("wrong result type"));
+        assert!(
+            scheduler
+                .wait_for_task()
+                .unwrap_err()
+                .to_string()
+                .contains(&error)
+        );
+    }
+}

--- a/ceno_recursion_v2/src/continuation/prover/scheduler.rs
+++ b/ceno_recursion_v2/src/continuation/prover/scheduler.rs
@@ -2,8 +2,11 @@ use std::{
     fmt,
     ops::Range,
     sync::{Condvar, Mutex},
-    time::{Duration, Instant},
+    time::Duration,
 };
+
+#[cfg(any(test, feature = "cuda"))]
+use std::time::Instant;
 
 use eyre::{Result, eyre};
 

--- a/ceno_recursion_v2/src/continuation/tests/mod.rs
+++ b/ceno_recursion_v2/src/continuation/tests/mod.rs
@@ -4,8 +4,8 @@ mod prover_integration {
         circuit::{Circuit, root::CenoRootCircuit},
         continuation::prover::{
             AggProver, AggregationOptions, ChildVkKind, CpuRecursionProver, InnerCpuProver,
-            RecursionHostAssets, RecursionNodeKind, internal_aggregation_chunk_plan,
-            verify_root_proof,
+            RecursionHostAssets, RecursionHostAssetsTemplate, RecursionNodeKind,
+            internal_aggregation_chunk_plan, verify_root_proof,
         },
         system::{
             AggregationSubCircuit, RecursionField, RecursionProof, RecursionVk, VerifierSubCircuit,
@@ -255,7 +255,8 @@ mod prover_integration {
             return Ok(());
         };
         let options = AggregationOptions::new(test_system_params_zero_pow(5, 16, 3));
-        let assets = RecursionHostAssets::<2, 2>::new(Arc::new(child_vk), 17, &options)?;
+        let template = RecursionHostAssetsTemplate::<2, 2>::new(Arc::new(child_vk), &options)?;
+        let assets = template.bind(17)?;
         assert_eq!(assets.recursive_depth_count(), 3);
 
         let CpuRecursionProver::Leaf(leaf) = assets.hydrate_cpu(RecursionNodeKind::Leaf)? else {
@@ -301,6 +302,17 @@ mod prover_integration {
                     level: assets.recursive_depth_count(),
                 })
                 .is_err()
+        );
+
+        let shallow_assets = template.bind(1)?;
+        assert_eq!(shallow_assets.recursive_depth_count(), 1);
+        let CpuRecursionProver::Root(root) = shallow_assets.hydrate_cpu(RecursionNodeKind::Root)?
+        else {
+            unreachable!()
+        };
+        assert_eq!(
+            serialized(root.get_vk().as_ref()),
+            serialized(shallow_assets.root_vk().as_ref())
         );
         Ok(())
     }

--- a/ceno_recursion_v2/src/continuation/tests/mod.rs
+++ b/ceno_recursion_v2/src/continuation/tests/mod.rs
@@ -3,8 +3,9 @@ mod prover_integration {
     use crate::{
         circuit::{Circuit, root::CenoRootCircuit},
         continuation::prover::{
-            AggProver, AggregationOptions, ChildVkKind, InnerCpuProver,
-            internal_aggregation_chunk_plan,
+            AggProver, AggregationOptions, ChildVkKind, CpuRecursionProver, InnerCpuProver,
+            RecursionHostAssets, RecursionNodeKind, internal_aggregation_chunk_plan,
+            verify_root_proof,
         },
         system::{
             AggregationSubCircuit, RecursionField, RecursionProof, RecursionVk, VerifierSubCircuit,
@@ -240,6 +241,170 @@ mod prover_integration {
         let elapsed = start.elapsed();
         println!(
             "agg prover ({shard_count} shards): elapsed={elapsed:?}, produced and verified root proof",
+        );
+        Ok(())
+    }
+
+    fn serialized<T: serde::Serialize>(value: &T) -> Vec<u8> {
+        bincode::serialize(value).expect("VK serialization should succeed")
+    }
+
+    #[test]
+    fn host_assets_hydrate_identical_cpu_vks_for_every_planned_kind() -> Result<()> {
+        let Some((_, child_vk)) = load_fixtures()? else {
+            return Ok(());
+        };
+        let options = AggregationOptions::new(test_system_params_zero_pow(5, 16, 3));
+        let assets = RecursionHostAssets::<2, 2>::new(Arc::new(child_vk), 17, &options)?;
+        assert_eq!(assets.recursive_depth_count(), 3);
+
+        let CpuRecursionProver::Leaf(leaf) = assets.hydrate_cpu(RecursionNodeKind::Leaf)? else {
+            unreachable!()
+        };
+        assert_eq!(
+            serialized(leaf.get_vk().as_ref()),
+            serialized(assets.leaf_vk().as_ref())
+        );
+
+        let CpuRecursionProver::LeafBridge(bridge) =
+            assets.hydrate_cpu(RecursionNodeKind::LeafBridge)?
+        else {
+            unreachable!()
+        };
+        assert_eq!(
+            serialized(bridge.get_vk().as_ref()),
+            serialized(assets.leaf_bridge_vk().as_ref())
+        );
+
+        for level in 0..assets.recursive_depth_count() {
+            let CpuRecursionProver::Recursive(recursive) =
+                assets.hydrate_cpu(RecursionNodeKind::Recursive { level })?
+            else {
+                unreachable!()
+            };
+            assert_eq!(
+                serialized(recursive.get_vk().as_ref()),
+                serialized(assets.recursive_vk(level).unwrap().as_ref())
+            );
+        }
+
+        let CpuRecursionProver::Root(root) = assets.hydrate_cpu(RecursionNodeKind::Root)? else {
+            unreachable!()
+        };
+        assert_eq!(
+            serialized(root.get_vk().as_ref()),
+            serialized(assets.root_vk().as_ref())
+        );
+        assert!(
+            assets
+                .hydrate_cpu(RecursionNodeKind::Recursive {
+                    level: assets.recursive_depth_count(),
+                })
+                .is_err()
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn host_assets_switch_gpu_kind_after_drop_and_trim() -> Result<()> {
+        let Some((_, child_vk)) = load_fixtures()? else {
+            return Ok(());
+        };
+        let options = AggregationOptions::new(test_system_params_zero_pow(5, 16, 3));
+        let assets = RecursionHostAssets::<2, 2>::new(Arc::new(child_vk), 17, &options)?;
+
+        let leaf = assets.hydrate_gpu_on(0, RecursionNodeKind::Leaf)?;
+        drop(leaf);
+        openvm_cuda_common::memory_manager::synchronize_and_trim_device(0)?;
+
+        let leaf_bridge = assets.hydrate_gpu_on(0, RecursionNodeKind::LeafBridge)?;
+        drop(leaf_bridge);
+        openvm_cuda_common::memory_manager::synchronize_and_trim_device(0)?;
+        Ok(())
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn gpu_worker_batch_matches_sequential_single_shard() -> Result<()> {
+        let Some((loaded_proofs, child_vk)) = load_fixtures()? else {
+            return Ok(());
+        };
+        let shard_proofs = select_proofs(&loaded_proofs, 1)?;
+        let options = AggregationOptions::new(test_system_params_zero_pow(5, 16, 3));
+        openvm_cuda_common::common::set_device_by_id(0)?;
+        let sequential = {
+            let prover = AggProver::<2, 2>::new(Arc::new(child_vk.clone()), options.clone());
+            prover.prove_with_root_vk(&shard_proofs)?
+        };
+        openvm_cuda_common::memory_manager::synchronize_and_trim_device(0)?;
+
+        let batch = crate::continuation::prover::prove_batch_with_gpu_workers::<2, 2>(
+            Arc::new(child_vk),
+            shard_proofs,
+            options,
+            &[0],
+        )?;
+        assert_eq!(
+            serialized(&batch.root_output.root_vk),
+            serialized(&sequential.root_vk)
+        );
+        verify_root_proof(&sequential.root_vk, &sequential.root_proof)?;
+        verify_root_proof(&batch.root_output.root_vk, &batch.root_output.root_proof)?;
+        verify_root_proof(&batch.root_output.root_vk, &sequential.root_proof)?;
+        verify_root_proof(&sequential.root_vk, &batch.root_output.root_proof)?;
+        // Valid GPU proofs are not byte-deterministic, including repeated legacy sequential runs.
+        // Compare the public statement and proof shape, then require cryptographic verification.
+        assert!(
+            batch.root_output.root_proof.proof.public_values
+                == sequential.root_proof.proof.public_values,
+            "worker and sequential root proofs have different public values"
+        );
+        assert!(
+            batch.root_output.root_proof.proof.trace_vdata
+                == sequential.root_proof.proof.trace_vdata,
+            "worker and sequential root proofs have different trace metadata"
+        );
+        let [metrics] = batch.worker_metrics.as_slice() else {
+            panic!("one-device batch must report exactly one worker")
+        };
+        assert_eq!(metrics.device_id, 0);
+        assert_eq!(metrics.task_count, 4);
+        assert_eq!(metrics.leaf_tasks, 1);
+        assert_eq!(metrics.leaf_bridge_tasks, 1);
+        assert_eq!(metrics.recursive_tasks, 1);
+        assert_eq!(metrics.root_tasks, 1);
+        assert_eq!(metrics.asset_hydrations, 4);
+        assert_eq!(metrics.asset_switches, 3);
+        Ok(())
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn gpu_worker_batch_two_device_gate() -> Result<()> {
+        if std::env::var_os("OPENVM_RUN_MULTI_GPU_TESTS").as_deref() != Some("1".as_ref()) {
+            println!("skipping physical multi-GPU recursion test");
+            return Ok(());
+        }
+        let Some((loaded_proofs, child_vk)) = load_fixtures()? else {
+            return Ok(());
+        };
+        let shard_proofs = select_proofs(&loaded_proofs, 2)?;
+        let options = AggregationOptions::new(test_system_params_zero_pow(5, 16, 3));
+        let output = crate::continuation::prover::prove_batch_with_gpu_workers::<2, 2>(
+            Arc::new(child_vk),
+            shard_proofs,
+            options,
+            &[0, 1],
+        )?;
+        assert_eq!(output.worker_metrics.len(), 2);
+        assert_eq!(
+            output
+                .worker_metrics
+                .iter()
+                .map(|metrics| metrics.task_count)
+                .sum::<usize>(),
+            4
         );
         Ok(())
     }

--- a/ceno_recursion_v2/src/continuation/tests/mod.rs
+++ b/ceno_recursion_v2/src/continuation/tests/mod.rs
@@ -4,8 +4,7 @@ mod prover_integration {
         circuit::{Circuit, root::CenoRootCircuit},
         continuation::prover::{
             AggProver, AggregationOptions, ChildVkKind, CpuRecursionProver, InnerCpuProver,
-            RecursionHostAssets, RecursionHostAssetsTemplate, RecursionNodeKind,
-            internal_aggregation_chunk_plan, verify_root_proof,
+            RecursionHostAssetsTemplate, RecursionNodeKind, internal_aggregation_chunk_plan,
         },
         system::{
             AggregationSubCircuit, RecursionField, RecursionProof, RecursionVk, VerifierSubCircuit,
@@ -32,6 +31,9 @@ mod prover_integration {
         time::Instant,
     };
     use tracing_subscriber::EnvFilter;
+
+    #[cfg(feature = "cuda")]
+    use crate::continuation::prover::verify_root_proof;
 
     type Engine = BabyBearPoseidon2CpuEngine<DuplexSponge>;
     type E = RecursionField;
@@ -324,7 +326,8 @@ mod prover_integration {
             return Ok(());
         };
         let options = AggregationOptions::new(test_system_params_zero_pow(5, 16, 3));
-        let assets = RecursionHostAssets::<2, 2>::new(Arc::new(child_vk), 17, &options)?;
+        let assets =
+            RecursionHostAssetsTemplate::<2, 2>::new(Arc::new(child_vk), &options)?.bind(17)?;
 
         let leaf = assets.hydrate_gpu_on(0, RecursionNodeKind::Leaf)?;
         drop(leaf);

--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -88,7 +88,13 @@ default = [
 flamegraph = ["pprof2/flamegraph", "pprof2/criterion"]
 forbid_overflow = []
 goldilocks = ["forbid_overflow", "nightly-features", "parallel", "bigint-rug"]
-gpu = ["gkr_iop/gpu", "dep:ceno_gpu", "dep:cudarc", "dep:nvtx"]
+gpu = [
+  "aot-x86_64",
+  "gkr_iop/gpu",
+  "dep:ceno_gpu",
+  "dep:cudarc",
+  "dep:nvtx",
+]
 jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
 jemalloc-prof = ["jemalloc", "tikv-jemallocator?/profiling"]
 nightly-features = [

--- a/ceno_zkvm/Cargo.toml
+++ b/ceno_zkvm/Cargo.toml
@@ -62,6 +62,7 @@ tiny-keccak.workspace = true
 typenum.workspace = true
 
 [target.'cfg(unix)'.dependencies]
+libc = "0.2"
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats"], optional = true }
 tikv-jemallocator = { version = "0.6", optional = true }
 

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -34,6 +34,8 @@ use either::Either;
 use ff_ext::{ExtensionField, SmallField};
 #[cfg(debug_assertions)]
 use ff_ext::{Instrumented, PoseidonField};
+#[cfg(feature = "gpu")]
+use gkr_iop::gpu::get_cuda_hal;
 use gkr_iop::{RAMType, hal::ProverBackend};
 use itertools::Itertools;
 #[cfg(debug_assertions)]
@@ -144,6 +146,7 @@ pub struct FullMemState<Record> {
 pub(crate) type InitMemState = FullMemState<MemInitRecord>;
 type FinalMemState = FullMemState<MemFinalRecord>;
 
+#[derive(Clone)]
 pub struct EmulationResult<'a> {
     pub exit_code: Option<u32>,
     pub final_mem_state: FinalMemState,
@@ -713,6 +716,7 @@ impl ShardStepSummary {
     }
 }
 
+#[derive(Clone)]
 pub struct ShardContextBuilder {
     pub cur_shard_id: usize,
     next_accesses: Arc<NextCycleAccess>,
@@ -1192,6 +1196,7 @@ struct CompactReplayPipelineInput {
     shard_cycle_boundaries: Arc<Vec<Cycle>>,
     range_descriptors: Arc<Vec<ceno_emul::GpuReplayRangeDescriptor>>,
     chunk_capacity: usize,
+    ownership: Option<(usize, usize)>,
     #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
     aot: Arc<ceno_emul::aot::AotProgram>,
 }
@@ -1200,6 +1205,32 @@ struct CompactReplayPipelineInput {
 struct CompactReplayPipeline {
     ready: std::sync::mpsc::Receiver<CompactReplayShard>,
     recycle: std::sync::mpsc::SyncSender<Vec<ceno_emul::GpuReplayTypedRange>>,
+}
+
+fn worker_owns_shard(ownership: Option<(usize, usize)>, shard_id: usize) -> bool {
+    ownership.is_none_or(|(worker_index, worker_count)| shard_id % worker_count == worker_index)
+}
+
+#[cfg(any(feature = "gpu", test))]
+fn shard_replay_summary_digest(summary: ShardStepSummary) -> [u8; 32] {
+    let mut keccak = Keccak::v256();
+    keccak.update(b"ceno-replay-summary-v1");
+    for value in [
+        u64::try_from(summary.step_count).expect("replay step count exceeds u64"),
+        summary.first_cycle,
+        summary.last_cycle,
+        u64::from(summary.first_pc_before),
+        u64::from(summary.last_pc_after),
+        u64::from(summary.first_heap_before),
+        u64::from(summary.last_heap_after),
+        u64::from(summary.first_hint_before),
+        u64::from(summary.last_hint_after),
+    ] {
+        keccak.update(&value.to_le_bytes());
+    }
+    let mut digest = [0; 32];
+    keccak.finalize(&mut digest);
+    digest
 }
 
 #[cfg(feature = "gpu")]
@@ -1252,8 +1283,9 @@ fn spawn_compact_replay_pipeline(input: CompactReplayPipelineInput) -> CompactRe
             );
             replay.vm.tracer_mut().enable_retained_shard_mode();
             let shard_count = replay.shard_step_counts.len();
+            let mut previous_retained = false;
             for shard_id in 0..shard_count {
-                if shard_id != 0 {
+                if previous_retained {
                     let Ok(ranges) = recycle_rx.recv() else {
                         return;
                     };
@@ -1267,18 +1299,24 @@ fn spawn_compact_replay_pipeline(input: CompactReplayPipelineInput) -> CompactRe
                     phase = "cpu_replay_start",
                     "compact replay pipeline event"
                 );
+                let owned = worker_owns_shard(input.ownership, shard_id);
                 let shard = replay
-                    .next_shard(false, Some)
+                    .next_shard(!owned, |range| Some(range))
                     .expect("compact replay ended before its shard plan");
+                let replay_digest = shard_replay_summary_digest(shard.summary);
                 tracing::info!(
-                    target: "ceno_pipeline",
+                    target: "ceno_multi_gpu",
                     shard_id,
+                    worker_index = input.ownership.map(|value| value.0),
+                    replay_mode = if owned { "compact" } else { "light" },
+                    replay_digest = ?replay_digest,
                     phase = "cpu_replay_ready",
                     "compact replay pipeline event"
                 );
                 if ready_tx.send(shard).is_err() {
                     return;
                 }
+                previous_retained = owned;
             }
         })
         .expect("failed to spawn compact replay pipeline");
@@ -2160,12 +2198,39 @@ pub fn generate_fixed_traces<E: ExtensionField>(
 
 pub fn generate_witness<'a, E: ExtensionField>(
     system_config: &ConstraintSystemConfig<E>,
-    mut emul_result: EmulationResult<'a>,
+    emul_result: EmulationResult<'a>,
     program: Arc<Program>,
     platform: &Platform,
     init_mem_state: &InitMemState,
     // this is for debug purpose, which only run target shard id and skip all others
     target_shard_id: Option<usize>,
+) -> impl Iterator<
+    Item = (
+        ZKVMWitnesses<E>,
+        ShardContext<'a>,
+        PublicValues,
+        Option<u64>,
+    ),
+> {
+    generate_witness_for_owner(
+        system_config,
+        emul_result,
+        program,
+        platform,
+        init_mem_state,
+        target_shard_id,
+        None,
+    )
+}
+
+fn generate_witness_for_owner<'a, E: ExtensionField>(
+    system_config: &ConstraintSystemConfig<E>,
+    mut emul_result: EmulationResult<'a>,
+    program: Arc<Program>,
+    platform: &Platform,
+    init_mem_state: &InitMemState,
+    target_shard_id: Option<usize>,
+    ownership: Option<(usize, usize)>,
 ) -> impl Iterator<
     Item = (
         ZKVMWitnesses<E>,
@@ -2227,6 +2292,7 @@ pub fn generate_witness<'a, E: ExtensionField>(
             shard_cycle_boundaries: emul_result.shard_cycle_boundaries.clone(),
             range_descriptors: emul_result.replay_range_descriptors.clone(),
             chunk_capacity: emul_result.replay_range_capacity,
+            ownership,
             #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
             aot: emul_result.replay_aot_program.clone(),
         })
@@ -2260,7 +2326,11 @@ pub fn generate_witness<'a, E: ExtensionField>(
             instrunction_dispatch_ctx.begin_shard();
             }
             let (mut shard_ctx, shard_summary) = if use_compact_replay {
-                instrunction_dispatch_ctx.begin_compact_ingest();
+                let shard_id = shard_ctx_builder.cur_shard_id;
+                let owned = worker_owns_shard(ownership, shard_id);
+                if owned {
+                    instrunction_dispatch_ctx.begin_compact_ingest();
+                }
                 // Replay and typed arena preparation are CPU-only and may run
                 // one shard ahead. All GPU setup and assignment below remain
                 // on this consumer thread, after the previous proof returned.
@@ -2406,20 +2476,22 @@ pub fn generate_witness<'a, E: ExtensionField>(
                     phase = "gpu_assignment_start",
                     "compact replay pipeline event"
                 );
-                for range in &compact_shard.arenas.ranges {
-                    for (kind, arena) in InsnKind::iter().zip(&range.typed) {
-                        if let Some(arena) = arena {
-                            instrunction_dispatch_ctx.ingest_compact_count(kind, arena.len());
+                if owned {
+                    for range in &compact_shard.arenas.ranges {
+                        for (kind, arena) in InsnKind::iter().zip(&range.typed) {
+                            if let Some(arena) = arena {
+                                instrunction_dispatch_ctx.ingest_compact_count(kind, arena.len());
+                            }
                         }
                     }
+                    for (idx, record) in compact_shard.fallback_steps.iter().enumerate() {
+                        instrunction_dispatch_ctx.ingest_step(idx, record);
+                    }
+                    instrunction_dispatch_ctx.finish_compact_ingest();
                 }
-                for (idx, record) in compact_shard.fallback_steps.iter().enumerate() {
-                    instrunction_dispatch_ctx.ingest_step(idx, record);
-                }
-                instrunction_dispatch_ctx.finish_compact_ingest();
                 let positioned = shard_ctx_builder.position_compact_shard(compact_shard.summary);
                 #[cfg(feature = "gpu")]
-                if !stream_owned_ranges {
+                if owned && !stream_owned_ranges {
                     crate::instructions::gpu::dispatch::install_compact_replay_arenas(
                         compact_shard.arenas,
                     );
@@ -2499,6 +2571,17 @@ pub fn generate_witness<'a, E: ExtensionField>(
             pi.hint_shard_len = (shard_ctx.shard_hint_addr_range.end
                 - shard_ctx.shard_hint_addr_range.start)
                 / (WORD_SIZE as u32);
+
+            if !worker_owns_shard(ownership, shard_ctx.shard_id) {
+                tracing::info!(
+                    target: "ceno_multi_gpu",
+                    worker_index = ownership.map(|value| value.0),
+                    shard_id = shard_ctx.shard_id,
+                    phase = "light_replay_complete",
+                    "unowned shard replayed without retained compact witness arenas"
+                );
+                return Some((zkvm_witness, shard_ctx, pi, None));
+            }
 
 
             if let Some(target_shard_id) = target_shard_id {
@@ -3479,6 +3562,22 @@ pub struct E2ECheckpointResult<E: ExtensionField, PCS: PolynomialCommitmentSchem
 }
 
 impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> E2ECheckpointResult<E, PCS> {
+    pub fn deferred(vk: ZKVMVerifyingKey<E, PCS>, next_step: impl FnOnce() + 'static) -> Self {
+        Self {
+            proofs: None,
+            vk: Some(vk),
+            next_step: Some(Box::new(next_step)),
+        }
+    }
+
+    pub fn completed(proofs: Vec<ZKVMProof<E, PCS>>, vk: ZKVMVerifyingKey<E, PCS>) -> Self {
+        Self {
+            proofs: Some(proofs),
+            vk: Some(vk),
+            next_step: None,
+        }
+    }
+
     pub fn next_step(self) {
         if let Some(next_step) = self.next_step {
             next_step();
@@ -3858,6 +3957,547 @@ pub fn run_e2e_proof_with_precompiled_aot<
     )
 }
 
+#[cfg(feature = "gpu")]
+pub struct BaseProofReady<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> {
+    pub shard_id: usize,
+    pub proof: ZKVMProof<E, PCS>,
+    pub device_id: usize,
+    diagnostics: BaseWorkerDiagnostics,
+}
+
+#[cfg(feature = "gpu")]
+#[derive(Clone, Copy)]
+struct BaseWorkerDiagnostics {
+    worker_index: usize,
+    device_id: usize,
+    active_shard: Option<usize>,
+    last_completed_shard: Option<usize>,
+    memory_start_free_bytes: usize,
+    memory_current_free_bytes: usize,
+    memory_total_bytes: usize,
+    memory_minimum_free_bytes: usize,
+    queue_state: &'static str,
+}
+
+#[cfg(feature = "gpu")]
+impl BaseWorkerDiagnostics {
+    fn new(worker_index: usize, device_id: usize) -> Self {
+        Self {
+            worker_index,
+            device_id,
+            active_shard: None,
+            last_completed_shard: None,
+            memory_start_free_bytes: 0,
+            memory_current_free_bytes: 0,
+            memory_total_bytes: 0,
+            memory_minimum_free_bytes: 0,
+            queue_state: "initializing",
+        }
+    }
+
+    fn observe_memory(&mut self, free_bytes: usize, total_bytes: usize) {
+        if self.memory_total_bytes == 0 {
+            self.memory_start_free_bytes = free_bytes;
+            self.memory_minimum_free_bytes = free_bytes;
+        } else {
+            self.memory_minimum_free_bytes = self.memory_minimum_free_bytes.min(free_bytes);
+        }
+        self.memory_current_free_bytes = free_bytes;
+        self.memory_total_bytes = total_bytes;
+    }
+
+    fn peak_memory_used_bytes(&self) -> usize {
+        self.memory_total_bytes
+            .saturating_sub(self.memory_minimum_free_bytes)
+    }
+
+    fn describe(&self, error: &str) -> String {
+        format!(
+            "GPU device {} worker {} shard {:?} failed: {}; last_completed_shard={:?} cuda_error_class={} queue_state={} memory_start_free_bytes={} memory_current_free_bytes={} memory_total_bytes={} peak_memory_used_bytes={}",
+            self.device_id,
+            self.worker_index,
+            self.active_shard,
+            error,
+            self.last_completed_shard,
+            classify_cuda_error(error),
+            self.queue_state,
+            self.memory_start_free_bytes,
+            self.memory_current_free_bytes,
+            self.memory_total_bytes,
+            self.peak_memory_used_bytes(),
+        )
+    }
+}
+
+#[cfg(feature = "gpu")]
+fn classify_cuda_error(error: &str) -> &'static str {
+    let lower = error.to_ascii_lowercase();
+    if lower.contains("out of memory") || lower.contains("cuda_error_out_of_memory") {
+        "out_of_memory"
+    } else if lower.contains("cuda") {
+        "cuda"
+    } else {
+        "non_cuda"
+    }
+}
+
+#[cfg(feature = "gpu")]
+struct BaseProofCollectorState {
+    seen: Vec<bool>,
+}
+
+#[cfg(feature = "gpu")]
+impl BaseProofCollectorState {
+    fn new(total_shards: usize) -> Self {
+        Self {
+            seen: vec![false; total_shards],
+        }
+    }
+
+    fn accept(
+        &mut self,
+        config: &crate::multi_gpu::MultiGpuConfig,
+        shard_id: usize,
+        device_id: usize,
+    ) -> Result<(), String> {
+        if shard_id >= self.seen.len() {
+            return Err(format!("out-of-range base proof shard {shard_id}"));
+        }
+        let expected_device = config.device_ids[config.owner_index(shard_id)];
+        if device_id != expected_device {
+            return Err(format!(
+                "shard {shard_id} arrived from GPU {device_id}, expected GPU {expected_device}"
+            ));
+        }
+        if std::mem::replace(&mut self.seen[shard_id], true) {
+            return Err(format!("duplicate base proof shard {shard_id}"));
+        }
+        Ok(())
+    }
+
+    fn missing(&self) -> Option<usize> {
+        self.seen.iter().position(|seen| !seen)
+    }
+}
+
+#[cfg(feature = "gpu")]
+enum BaseWorkerEvent<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> {
+    Ready(BaseProofReady<E, PCS>),
+    Failed(String),
+}
+
+#[cfg(feature = "gpu")]
+#[allow(clippy::too_many_arguments)]
+pub fn run_e2e_multi_gpu_proof_with_precompiled_aot<
+    E: ExtensionField + LkMultiplicityKey,
+    PCS: PolynomialCommitmentScheme<E> + Serialize + 'static,
+>(
+    pk: Arc<ZKVMProvingKey<E, PCS>>,
+    backend: Arc<gkr_iop::gpu::GpuBackend<E, PCS>>,
+    prepared: &crate::multi_gpu::PreparedMultiGpu,
+    config: &crate::multi_gpu::MultiGpuConfig,
+    init_full_mem: &InitMemState,
+    public_io_digest: [u32; 8],
+    max_steps: usize,
+    #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+    precompiled_aot: Option<Arc<ceno_emul::aot::AotProgram>>,
+    #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+    precompiled_fulltracer_aot: Option<Arc<ceno_emul::aot::AotProgram>>,
+) -> Result<Vec<ZKVMProof<E, PCS>>, String>
+where
+    PCS::ProverParam: Send + Sync,
+    PCS::VerifierParam: Send + Sync,
+    PCS::Commitment: Send + Sync,
+    PCS::CommitmentWithWitness: Send + Sync,
+    PCS::Proof: Send,
+{
+    config.validate_shape()?;
+    if prepared.workers.len() != config.device_ids.len() {
+        return Err("prepared GPU worker count does not match configuration".to_owned());
+    }
+    let ctx = pk
+        .program_ctx
+        .as_ref()
+        .ok_or("proving key has no program context")?;
+    gkr_iop::gpu::set_thread_cuda_hal(prepared.workers[0].hal.clone());
+    let raw_step_cell_extractor = Arc::clone(&ctx.system_config.config);
+    let step_cell_extractor: Arc<dyn StepCellExtractor> = raw_step_cell_extractor;
+    let emulation_result = emulate_program(
+        ctx.program.clone(),
+        max_steps,
+        init_full_mem,
+        public_io_digest,
+        &ctx.platform,
+        &ctx.multi_prover,
+        step_cell_extractor,
+        #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+        precompiled_aot,
+        #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+        precompiled_fulltracer_aot,
+    );
+    let total_shards = emulation_result.shard_ctx_builder.total_shards();
+    let exit_code = emulation_result.exit_code;
+    let verifier = Arc::new(ZKVMVerifier::new(pk.get_vk_slow()));
+    let cancelled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let started = std::time::Instant::now();
+
+    std::thread::scope(|scope| -> Result<Vec<ZKVMProof<E, PCS>>, String> {
+        let mut handles = Vec::with_capacity(prepared.workers.len());
+        let mut ready_receivers = Vec::with_capacity(prepared.workers.len());
+        for (worker_index, worker) in prepared.workers.iter().enumerate() {
+            let (tx, rx) = std::sync::mpsc::sync_channel::<BaseWorkerEvent<E, PCS>>(1);
+            ready_receivers.push(Some(rx));
+            let hal = worker.hal.clone();
+            let backend = backend.clone();
+            let pk = pk.clone();
+            let emulation_result = emulation_result.clone();
+            let init_full_mem = init_full_mem.clone();
+            let cancelled = cancelled.clone();
+            let device_id = worker.info.logical_ordinal;
+            handles.push(scope.spawn(move || {
+                let worker_started = std::time::Instant::now();
+                let mut diagnostics = BaseWorkerDiagnostics::new(worker_index, device_id);
+                let run = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let device = gkr_iop::gpu::GpuProver::new(backend, hal);
+                    let memory_start = ceno_gpu::get_cuda_mem_info().unwrap_or((0, 0));
+                    diagnostics.observe_memory(memory_start.0, memory_start.1);
+                    diagnostics.queue_state = "fifo_empty";
+                    let prover = ZKVMProver::new(pk.clone(), device);
+                    let ctx = pk.program_ctx.as_ref().unwrap();
+                    let witnesses = generate_witness_for_owner(
+                        &ctx.system_config,
+                        emulation_result,
+                        ctx.program.clone(),
+                        &ctx.platform,
+                        &init_full_mem,
+                        None,
+                        Some((worker_index, prepared.workers.len())),
+                    );
+                    for (zkvm_witness, shard_ctx, pi, _) in witnesses {
+                        if cancelled.load(std::sync::atomic::Ordering::Acquire) {
+                            break;
+                        }
+                        if shard_ctx.shard_id % prepared.workers.len() != worker_index {
+                            continue;
+                        }
+                        let shard_id = shard_ctx.shard_id;
+                        diagnostics.active_shard = Some(shard_id);
+                        tracing::info!(
+                            target: "ceno_multi_gpu",
+                            worker_index,
+                            device_id,
+                            shard_id,
+                            phase = "proof_start",
+                            "multi-GPU base worker event"
+                        );
+                        let proof_started = std::time::Instant::now();
+                        let proof = prover
+                            .create_proof(&shard_ctx, zkvm_witness, pi, Transcript::new(b"riscv"))
+                            .map_err(|error| format!("proof failed: {error:?}"))?;
+                        let proof_elapsed = proof_started.elapsed();
+                        if let Ok((free_bytes, total_bytes)) = ceno_gpu::get_cuda_mem_info() {
+                            diagnostics.observe_memory(free_bytes, total_bytes);
+                        }
+                        let queue_started = std::time::Instant::now();
+                        diagnostics.queue_state = "fifo_send_pending";
+                        tx.send(BaseWorkerEvent::Ready(BaseProofReady {
+                            shard_id,
+                            proof,
+                            device_id,
+                            diagnostics,
+                        }))
+                        .map_err(|_| {
+                            diagnostics.queue_state = "fifo_receiver_closed";
+                            "collector closed while publishing proof".to_owned()
+                        })?;
+                        diagnostics.queue_state = "fifo_empty_or_dequeued";
+                        diagnostics.last_completed_shard = Some(shard_id);
+                        diagnostics.active_shard = None;
+                        tracing::info!(
+                            target: "ceno_multi_gpu",
+                            worker_index,
+                            device_id,
+                            shard_id,
+                            proof_ms = proof_elapsed.as_millis(),
+                            queue_wait_ms = queue_started.elapsed().as_millis(),
+                            queue_depth = 1,
+                            queue_high_water = 1,
+                            phase = "proof_ready",
+                            "multi-GPU base worker event"
+                        );
+                    }
+                    if let Ok((free_bytes, total_bytes)) = ceno_gpu::get_cuda_mem_info() {
+                        diagnostics.observe_memory(free_bytes, total_bytes);
+                    }
+                    tracing::info!(
+                        target: "ceno_multi_gpu",
+                        worker_index,
+                        device_id,
+                        elapsed_ms = worker_started.elapsed().as_millis(),
+                        last_completed_shard = ?diagnostics.last_completed_shard,
+                        queue_state = diagnostics.queue_state,
+                        memory_start_free_bytes = diagnostics.memory_start_free_bytes,
+                        memory_end_free_bytes = diagnostics.memory_current_free_bytes,
+                        memory_total_bytes = diagnostics.memory_total_bytes,
+                        peak_memory_used_bytes = diagnostics.peak_memory_used_bytes(),
+                        transfer_between_devices_bytes = 0,
+                        phase = "worker_complete",
+                        "multi-GPU base worker event"
+                    );
+                    Ok::<(), String>(())
+                }));
+                let result = match run {
+                    Ok(result) => result,
+                    Err(payload) => Err(format!(
+                        "worker panicked: {}",
+                        payload
+                            .downcast_ref::<&str>()
+                            .copied()
+                            .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+                            .unwrap_or("unknown panic")
+                    )),
+                };
+                if let Err(error) = result {
+                    cancelled.store(true, std::sync::atomic::Ordering::Release);
+                    let error = diagnostics.describe(&error);
+                    let _ = tx.send(BaseWorkerEvent::Failed(error.clone()));
+                    Some(error)
+                } else {
+                    None
+                }
+            }));
+        }
+
+        let mut proofs = (0..total_shards).map(|_| None).collect::<Vec<_>>();
+        let mut collector = BaseProofCollectorState::new(total_shards);
+        let mut received = 0usize;
+        let mut collector_error = None;
+        while received < total_shards && collector_error.is_none() {
+            let mut made_progress = false;
+            for receiver in &mut ready_receivers {
+                let Some(rx) = receiver else { continue };
+                let event = match rx.try_recv() {
+                    Ok(event) => {
+                        made_progress = true;
+                        event
+                    }
+                    Err(std::sync::mpsc::TryRecvError::Empty) => continue,
+                    Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                        *receiver = None;
+                        made_progress = true;
+                        continue;
+                    }
+                };
+                let ready = match event {
+                    BaseWorkerEvent::Ready(ready) => ready,
+                    BaseWorkerEvent::Failed(error) => {
+                        collector_error = Some(error);
+                        break;
+                    }
+                };
+                let mut diagnostics = ready.diagnostics;
+                diagnostics.queue_state = "collector_dequeued";
+                if let Err(error) = collector.accept(config, ready.shard_id, ready.device_id) {
+                    collector_error = Some(diagnostics.describe(&error));
+                    break;
+                }
+                let verification_started = std::time::Instant::now();
+                let expect_halt = ready.proof.has_halt(&verifier.vk);
+                let verified = verifier
+                    .verify_single_shard_segment_halt(
+                        ready.proof.clone(),
+                        Transcript::new(b"riscv"),
+                        expect_halt,
+                    )
+                    .map_err(|error| {
+                        format!(
+                            "shard {} independent verification failed: {error:?}",
+                            ready.shard_id
+                        )
+                    });
+                let verified = match verified {
+                    Ok(verified) => verified,
+                    Err(error) => {
+                        collector_error = Some(diagnostics.describe(&error));
+                        break;
+                    }
+                };
+                if !verified {
+                    collector_error = Some(diagnostics.describe(&format!(
+                        "shard {} independent verification returned false",
+                        ready.shard_id
+                    )));
+                    break;
+                }
+                tracing::info!(
+                    target: "ceno_multi_gpu",
+                    shard_id = ready.shard_id,
+                    device_id = ready.device_id,
+                    verification_ms = verification_started.elapsed().as_millis(),
+                    phase = "segment_verified",
+                    "multi-GPU collector event"
+                );
+                let shard_id = ready.shard_id;
+                proofs[shard_id] = Some(ready.proof);
+                received += 1;
+            }
+            if received < total_shards
+                && ready_receivers.iter().all(Option::is_none)
+                && collector_error.is_none()
+            {
+                collector_error = Some(format!(
+                    "GPU device unknown worker unknown shard unknown failed: workers closed after {received}/{total_shards} shards; last_completed_shard=unknown cuda_error_class=non_cuda queue_state=all_fifos_disconnected memory_metrics=unavailable"
+                ));
+            }
+            if !made_progress && collector_error.is_none() {
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+        }
+        if collector_error.is_some() {
+            cancelled.store(true, std::sync::atomic::Ordering::Release);
+        }
+        drop(ready_receivers);
+        let mut join_error = None;
+        for handle in handles {
+            match handle.join() {
+                Ok(Some(error)) if join_error.is_none() => join_error = Some(error),
+                Err(_) if join_error.is_none() => {
+                    join_error = Some(
+                        "GPU device unknown worker unknown shard unknown failed: worker join failed; last_completed_shard=unknown cuda_error_class=non_cuda queue_state=unknown memory_metrics=unavailable"
+                            .to_owned(),
+                    )
+                }
+                _ => {}
+            }
+        }
+        if let Some(error) = collector_error.or(join_error) {
+            return Err(error);
+        }
+        if let Some(shard_id) = collector.missing() {
+            return Err(format!(
+                "GPU device unknown worker unknown shard {shard_id} failed: missing base proof; last_completed_shard=unknown cuda_error_class=non_cuda queue_state=all_workers_joined memory_metrics=unavailable"
+            ));
+        }
+        let proofs = proofs
+            .into_iter()
+            .enumerate()
+            .map(|(shard_id, proof)| {
+                proof.ok_or_else(|| format!("missing base proof shard {shard_id}"))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        run_e2e_full_trace_verify(&verifier, proofs.clone(), exit_code, max_steps);
+        tracing::info!(
+            target: "ceno_multi_gpu",
+            devices = ?config.device_ids,
+            shards = total_shards,
+            elapsed_ms = started.elapsed().as_millis(),
+            recursion_overlap_ratio = 0.0,
+            device_local_recursion_ratio = 0.0,
+            "Stage 1 multi-GPU base proving complete"
+        );
+        Ok(proofs)
+    })
+}
+
+#[cfg(all(test, feature = "gpu"))]
+mod multi_gpu_collector_tests {
+    use super::{BaseProofCollectorState, BaseWorkerDiagnostics, classify_cuda_error};
+    use crate::multi_gpu::MultiGpuConfig;
+    use std::{sync::mpsc, time::Duration};
+
+    #[test]
+    fn collector_accepts_out_of_order_round_robin_results() {
+        let config = MultiGpuConfig::new(vec![4, 7]).unwrap();
+        let mut collector = BaseProofCollectorState::new(4);
+        for (shard, device) in [(3, 7), (0, 4), (2, 4), (1, 7)] {
+            collector.accept(&config, shard, device).unwrap();
+        }
+        assert_eq!(collector.missing(), None);
+    }
+
+    #[test]
+    fn collector_rejects_invalid_results_and_reports_missing() {
+        let config = MultiGpuConfig::new(vec![4, 7]).unwrap();
+        let mut collector = BaseProofCollectorState::new(3);
+        assert!(
+            collector
+                .accept(&config, 3, 7)
+                .unwrap_err()
+                .contains("out-of-range")
+        );
+        assert!(
+            collector
+                .accept(&config, 1, 4)
+                .unwrap_err()
+                .contains("expected GPU 7")
+        );
+        collector.accept(&config, 0, 4).unwrap();
+        assert!(
+            collector
+                .accept(&config, 0, 4)
+                .unwrap_err()
+                .contains("duplicate")
+        );
+        assert_eq!(collector.missing(), Some(1));
+    }
+
+    #[test]
+    fn depth_one_fifo_backpressures_and_receiver_drop_cancels_sender() {
+        let (tx, rx) = mpsc::sync_channel(1);
+        let (first_sent_tx, first_sent_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            tx.send(1).unwrap();
+            first_sent_tx.send(()).unwrap();
+            done_tx.send(tx.send(2).is_err()).unwrap();
+        });
+        first_sent_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(done_rx.recv_timeout(Duration::from_millis(20)).is_err());
+        drop(rx);
+        assert!(done_rx.recv_timeout(Duration::from_secs(1)).unwrap());
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn worker_failure_diagnostics_include_cuda_queue_shard_and_memory_state() {
+        assert_eq!(
+            classify_cuda_error("CUDA_ERROR_OUT_OF_MEMORY"),
+            "out_of_memory"
+        );
+        assert_eq!(classify_cuda_error("cuda launch failed"), "cuda");
+        assert_eq!(classify_cuda_error("verification failed"), "non_cuda");
+
+        let mut diagnostics = BaseWorkerDiagnostics::new(1, 7);
+        diagnostics.active_shard = Some(3);
+        diagnostics.last_completed_shard = Some(1);
+        diagnostics.queue_state = "fifo_send_pending";
+        diagnostics.observe_memory(12, 20);
+        diagnostics.observe_memory(8, 20);
+        let report = diagnostics.describe("CUDA_ERROR_OUT_OF_MEMORY");
+        for expected in [
+            "GPU device 7 worker 1 shard Some(3)",
+            "last_completed_shard=Some(1)",
+            "cuda_error_class=out_of_memory",
+            "queue_state=fifo_send_pending",
+            "peak_memory_used_bytes=12",
+        ] {
+            assert!(report.contains(expected), "missing {expected} in {report}");
+        }
+    }
+
+    #[test]
+    fn two_device_hal_smoke_test_when_available() {
+        let devices = crate::multi_gpu::discover_cuda_devices().unwrap();
+        if devices.len() < 2 {
+            return;
+        }
+        let prepared = MultiGpuConfig::new(vec![0, 1]).unwrap().prepare(1).unwrap();
+        assert_eq!(prepared.workers.len(), 2);
+        assert_eq!(prepared.workers[0].info.logical_ordinal, 0);
+        assert_eq!(prepared.workers[1].info.logical_ordinal, 1);
+    }
+}
+
 /// Consume assigned witnesses and prove them sequentially. In GPU mode,
 /// `generate_witness` internally prepares one CPU replay shard ahead through a
 /// capacity-one channel. Its iterator performs all GPU assignment work before
@@ -4192,6 +4832,31 @@ mod tests {
         assert!(super::compact_replay_selected(false, false));
         assert!(!super::compact_replay_selected(true, false));
         assert!(!super::compact_replay_selected(false, true));
+    }
+
+    #[test]
+    fn replay_summary_digest_is_independent_of_witness_materialization() {
+        let replay_summary = super::ShardStepSummary {
+            step_count: 17,
+            first_cycle: 4,
+            last_cycle: 68,
+            first_pc_before: 0x1000,
+            last_pc_after: 0x1044,
+            first_heap_before: 0x2000,
+            last_heap_after: 0x2080,
+            first_hint_before: 0x3000,
+            last_hint_after: 0x3020,
+        };
+        let compact_digest = super::shard_replay_summary_digest(replay_summary);
+        let light_digest = super::shard_replay_summary_digest(replay_summary);
+        assert_eq!(compact_digest, light_digest);
+
+        let mut different_state = replay_summary;
+        different_state.last_pc_after += 4;
+        assert_ne!(
+            compact_digest,
+            super::shard_replay_summary_digest(different_state)
+        );
     }
 
     #[test]

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -4092,8 +4092,12 @@ pub fn run_e2e_multi_gpu_proof_with_precompiled_aot<
     E: ExtensionField + LkMultiplicityKey,
     PCS: PolynomialCommitmentScheme<E> + Serialize + 'static,
 >(
-    pk: Arc<ZKVMProvingKey<E, PCS>>,
-    backend: Arc<gkr_iop::gpu::GpuBackend<E, PCS>>,
+    sdk_prover: &ZKVMProver<
+        E,
+        PCS,
+        gkr_iop::gpu::GpuBackend<E, PCS>,
+        gkr_iop::gpu::GpuProver<gkr_iop::gpu::GpuBackend<E, PCS>>,
+    >,
     prepared: &crate::multi_gpu::PreparedMultiGpu,
     config: &crate::multi_gpu::MultiGpuConfig,
     init_full_mem: &InitMemState,
@@ -4111,6 +4115,10 @@ where
     PCS::CommitmentWithWitness: Send + Sync,
     PCS::Proof: Send,
 {
+    let pipeline_started = std::time::Instant::now();
+    let pk = sdk_prover.pk.clone();
+    let backend = sdk_prover.device().backend.clone();
+    let vk_digest = sdk_prover.vk_digest();
     config.validate_shape()?;
     if prepared.workers.len() != config.device_ids.len() {
         return Err("prepared GPU worker count does not match configuration".to_owned());
@@ -4122,6 +4130,7 @@ where
     gkr_iop::gpu::set_thread_cuda_hal(prepared.workers[0].hal.clone());
     let raw_step_cell_extractor = Arc::clone(&ctx.system_config.config);
     let step_cell_extractor: Arc<dyn StepCellExtractor> = raw_step_cell_extractor;
+    let emulation_started = std::time::Instant::now();
     let emulation_result = emulate_program(
         ctx.program.clone(),
         max_steps,
@@ -4135,9 +4144,22 @@ where
         #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
         precompiled_fulltracer_aot,
     );
+    let emulation_elapsed = emulation_started.elapsed();
     let total_shards = emulation_result.shard_ctx_builder.total_shards();
     let exit_code = emulation_result.exit_code;
-    let verifier = Arc::new(ZKVMVerifier::new(pk.get_vk_slow()));
+    let verifier_started = std::time::Instant::now();
+    let verifier = sdk_prover
+        .cached_verifier()
+        .ok_or("initial GPU prover has no cached verifier")?;
+    tracing::info!(
+        target: "ceno_multi_gpu",
+        emulation_ms = emulation_elapsed.as_millis(),
+        vk_materialize_ms = 0,
+        verifier_construct_ms = verifier_started.elapsed().as_millis(),
+        total_ms = pipeline_started.elapsed().as_millis(),
+        phase = "pre_worker_setup",
+        "multi-GPU base setup event"
+    );
     let cancelled = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let started = std::time::Instant::now();
 
@@ -4147,6 +4169,7 @@ where
         for (worker_index, worker) in prepared.workers.iter().enumerate() {
             let (tx, rx) = std::sync::mpsc::sync_channel::<BaseWorkerEvent<E, PCS>>(1);
             ready_receivers.push(Some(rx));
+            let worker_inputs_started = std::time::Instant::now();
             let hal = worker.hal.clone();
             let backend = backend.clone();
             let pk = pk.clone();
@@ -4154,16 +4177,40 @@ where
             let init_full_mem = init_full_mem.clone();
             let cancelled = cancelled.clone();
             let device_id = worker.info.logical_ordinal;
+            let existing_prover = (worker_index == 0).then_some(sdk_prover);
+            tracing::info!(
+                target: "ceno_multi_gpu",
+                worker_index,
+                device_id,
+                elapsed_ms = worker_inputs_started.elapsed().as_millis(),
+                phase = "worker_input_clone",
+                "multi-GPU base setup event"
+            );
             handles.push(scope.spawn(move || {
                 let worker_started = std::time::Instant::now();
                 let mut diagnostics = BaseWorkerDiagnostics::new(worker_index, device_id);
                 let run = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    let device = gkr_iop::gpu::GpuProver::new(backend, hal);
+                    let device_started = std::time::Instant::now();
+                    let device = existing_prover
+                        .is_none()
+                        .then(|| gkr_iop::gpu::GpuProver::new(backend, hal.clone()));
+                    let device_elapsed = device_started.elapsed();
+                    if existing_prover.is_some() {
+                        gkr_iop::gpu::set_thread_cuda_hal(hal);
+                    }
                     let memory_start = ceno_gpu::get_cuda_mem_info().unwrap_or((0, 0));
                     diagnostics.observe_memory(memory_start.0, memory_start.1);
                     diagnostics.queue_state = "fifo_empty";
-                    let prover = ZKVMProver::new(pk.clone(), device);
+                    let prover_started = std::time::Instant::now();
+                    let owned_prover = device.map(|device| {
+                        ZKVMProver::new_with_vk_digest(pk.clone(), device, vk_digest)
+                    });
+                    let prover = existing_prover
+                        .or(owned_prover.as_ref())
+                        .expect("worker prover must be borrowed or constructed");
+                    let prover_elapsed = prover_started.elapsed();
                     let ctx = pk.program_ctx.as_ref().unwrap();
+                    let witness_iterator_started = std::time::Instant::now();
                     let witnesses = generate_witness_for_owner(
                         &ctx.system_config,
                         emulation_result,
@@ -4172,6 +4219,17 @@ where
                         &init_full_mem,
                         None,
                         Some((worker_index, prepared.workers.len())),
+                    );
+                    tracing::info!(
+                        target: "ceno_multi_gpu",
+                        worker_index,
+                        device_id,
+                        device_construct_ms = device_elapsed.as_millis(),
+                        prover_construct_ms = prover_elapsed.as_millis(),
+                        reused_prover = existing_prover.is_some(),
+                        witness_iterator_ms = witness_iterator_started.elapsed().as_millis(),
+                        phase = "worker_setup",
+                        "multi-GPU base setup event"
                     );
                     for (zkvm_witness, shard_ctx, pi, _) in witnesses {
                         if cancelled.load(std::sync::atomic::Ordering::Acquire) {

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -4058,6 +4058,7 @@ impl BaseProofCollectorState {
         &mut self,
         config: &crate::multi_gpu::MultiGpuConfig,
         shard_id: usize,
+        proof_shard_id: u32,
         device_id: usize,
     ) -> Result<(), String> {
         if shard_id >= self.seen.len() {
@@ -4067,6 +4068,11 @@ impl BaseProofCollectorState {
         if device_id != expected_device {
             return Err(format!(
                 "shard {shard_id} arrived from GPU {device_id}, expected GPU {expected_device}"
+            ));
+        }
+        if proof_shard_id as usize != shard_id {
+            return Err(format!(
+                "base proof envelope shard {shard_id} does not match embedded shard {proof_shard_id}"
             ));
         }
         if std::mem::replace(&mut self.seen[shard_id], true) {
@@ -4355,46 +4361,15 @@ where
                 };
                 let mut diagnostics = ready.diagnostics;
                 diagnostics.queue_state = "collector_dequeued";
-                if let Err(error) = collector.accept(config, ready.shard_id, ready.device_id) {
+                if let Err(error) = collector.accept(
+                    config,
+                    ready.shard_id,
+                    ready.proof.public_values.shard_id,
+                    ready.device_id,
+                ) {
                     collector_error = Some(diagnostics.describe(&error));
                     break;
                 }
-                let verification_started = std::time::Instant::now();
-                let expect_halt = ready.proof.has_halt(&verifier.vk);
-                let verified = verifier
-                    .verify_single_shard_segment_halt(
-                        ready.proof.clone(),
-                        Transcript::new(b"riscv"),
-                        expect_halt,
-                    )
-                    .map_err(|error| {
-                        format!(
-                            "shard {} independent verification failed: {error:?}",
-                            ready.shard_id
-                        )
-                    });
-                let verified = match verified {
-                    Ok(verified) => verified,
-                    Err(error) => {
-                        collector_error = Some(diagnostics.describe(&error));
-                        break;
-                    }
-                };
-                if !verified {
-                    collector_error = Some(diagnostics.describe(&format!(
-                        "shard {} independent verification returned false",
-                        ready.shard_id
-                    )));
-                    break;
-                }
-                tracing::info!(
-                    target: "ceno_multi_gpu",
-                    shard_id = ready.shard_id,
-                    device_id = ready.device_id,
-                    verification_ms = verification_started.elapsed().as_millis(),
-                    phase = "segment_verified",
-                    "multi-GPU collector event"
-                );
                 let shard_id = ready.shard_id;
                 proofs[shard_id] = Some(ready.proof);
                 received += 1;
@@ -4468,7 +4443,9 @@ mod multi_gpu_collector_tests {
         let config = MultiGpuConfig::new(vec![4, 7]).unwrap();
         let mut collector = BaseProofCollectorState::new(4);
         for (shard, device) in [(3, 7), (0, 4), (2, 4), (1, 7)] {
-            collector.accept(&config, shard, device).unwrap();
+            collector
+                .accept(&config, shard, shard as u32, device)
+                .unwrap();
         }
         assert_eq!(collector.missing(), None);
     }
@@ -4479,20 +4456,26 @@ mod multi_gpu_collector_tests {
         let mut collector = BaseProofCollectorState::new(3);
         assert!(
             collector
-                .accept(&config, 3, 7)
+                .accept(&config, 3, 3, 7)
                 .unwrap_err()
                 .contains("out-of-range")
         );
         assert!(
             collector
-                .accept(&config, 1, 4)
+                .accept(&config, 1, 1, 4)
                 .unwrap_err()
                 .contains("expected GPU 7")
         );
-        collector.accept(&config, 0, 4).unwrap();
         assert!(
             collector
-                .accept(&config, 0, 4)
+                .accept(&config, 1, 2, 7)
+                .unwrap_err()
+                .contains("does not match embedded shard")
+        );
+        collector.accept(&config, 0, 0, 4).unwrap();
+        assert!(
+            collector
+                .accept(&config, 0, 0, 4)
                 .unwrap_err()
                 .contains("duplicate")
         );

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -4172,6 +4172,7 @@ where
     std::thread::scope(|scope| -> Result<Vec<ZKVMProof<E, PCS>>, String> {
         let mut handles = Vec::with_capacity(prepared.workers.len());
         let mut ready_receivers = Vec::with_capacity(prepared.workers.len());
+        let mut emulation_result = Some(emulation_result);
         for (worker_index, worker) in prepared.workers.iter().enumerate() {
             let (tx, rx) = std::sync::mpsc::sync_channel::<BaseWorkerEvent<E, PCS>>(1);
             ready_receivers.push(Some(rx));
@@ -4179,8 +4180,16 @@ where
             let hal = worker.hal.clone();
             let backend = backend.clone();
             let pk = pk.clone();
-            let emulation_result = emulation_result.clone();
-            let init_full_mem = init_full_mem.clone();
+            let emulation_result = if worker_index + 1 == prepared.workers.len() {
+                emulation_result
+                    .take()
+                    .expect("last worker must own the original emulation result")
+            } else {
+                emulation_result
+                    .as_ref()
+                    .expect("original emulation result must remain until the last worker")
+                    .clone()
+            };
             let cancelled = cancelled.clone();
             let device_id = worker.info.logical_ordinal;
             let existing_prover = (worker_index == 0).then_some(sdk_prover);
@@ -4222,7 +4231,7 @@ where
                         emulation_result,
                         ctx.program.clone(),
                         &ctx.platform,
-                        &init_full_mem,
+                        init_full_mem,
                         None,
                         Some((worker_index, prepared.workers.len())),
                     );
@@ -4418,12 +4427,27 @@ where
                 proof.ok_or_else(|| format!("missing base proof shard {shard_id}"))
             })
             .collect::<Result<Vec<_>, _>>()?;
+        let base_proofs_ready_elapsed = pipeline_started.elapsed();
+        tracing::info!(
+            target: "ceno_multi_gpu",
+            devices = ?config.device_ids,
+            shards = total_shards,
+            base_proofs_ready_ms = base_proofs_ready_elapsed.as_millis(),
+            phase = "base_proofs_ready",
+            "Stage 1 canonical base proofs ready"
+        );
+        let base_verification_started = std::time::Instant::now();
         run_e2e_full_trace_verify(&verifier, proofs.clone(), exit_code, max_steps);
+        let base_verification_elapsed = base_verification_started.elapsed();
+        let verified_base_elapsed = pipeline_started.elapsed();
         tracing::info!(
             target: "ceno_multi_gpu",
             devices = ?config.device_ids,
             shards = total_shards,
             elapsed_ms = started.elapsed().as_millis(),
+            base_proofs_ready_ms = base_proofs_ready_elapsed.as_millis(),
+            base_verification_ms = base_verification_elapsed.as_millis(),
+            verified_base_ms = verified_base_elapsed.as_millis(),
             recursion_overlap_ratio = 0.0,
             device_local_recursion_ratio = 0.0,
             "Stage 1 multi-GPU base proving complete"

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1197,14 +1197,68 @@ struct CompactReplayPipelineInput {
     range_descriptors: Arc<Vec<ceno_emul::GpuReplayRangeDescriptor>>,
     chunk_capacity: usize,
     ownership: Option<(usize, usize)>,
+    device_id: usize,
+    cpu_affinity: Option<Vec<usize>>,
+    start_gate: Option<Arc<ReplayStartGate>>,
+    cancelled: Arc<std::sync::atomic::AtomicBool>,
     #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
     aot: Arc<ceno_emul::aot::AotProgram>,
 }
 
 #[cfg(feature = "gpu")]
 struct CompactReplayPipeline {
-    ready: std::sync::mpsc::Receiver<CompactReplayShard>,
+    ready: std::sync::mpsc::Receiver<Result<CompactReplayShard, String>>,
     recycle: std::sync::mpsc::SyncSender<Vec<ceno_emul::GpuReplayTypedRange>>,
+}
+
+#[cfg(feature = "gpu")]
+#[derive(Default)]
+struct ReplayStartState {
+    arrived: usize,
+    aborted: bool,
+}
+
+#[cfg(feature = "gpu")]
+struct ReplayStartGate {
+    expected: usize,
+    state: std::sync::Mutex<ReplayStartState>,
+    changed: std::sync::Condvar,
+}
+
+#[cfg(feature = "gpu")]
+impl ReplayStartGate {
+    fn new(expected: usize) -> Self {
+        Self {
+            expected,
+            state: std::sync::Mutex::new(ReplayStartState::default()),
+            changed: std::sync::Condvar::new(),
+        }
+    }
+
+    fn arrive_and_wait(&self) -> Result<(), String> {
+        let mut state = self.state.lock().unwrap_or_else(|err| err.into_inner());
+        state.arrived += 1;
+        if state.arrived == self.expected {
+            self.changed.notify_all();
+        }
+        while state.arrived < self.expected && !state.aborted {
+            state = self
+                .changed
+                .wait(state)
+                .unwrap_or_else(|err| err.into_inner());
+        }
+        if state.aborted {
+            Err("concurrent replay start aborted".to_owned())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn abort(&self) {
+        let mut state = self.state.lock().unwrap_or_else(|err| err.into_inner());
+        state.aborted = true;
+        self.changed.notify_all();
+    }
 }
 
 fn worker_owns_shard(ownership: Option<(usize, usize)>, shard_id: usize) -> bool {
@@ -1235,12 +1289,13 @@ fn shard_replay_summary_digest(summary: ShardStepSummary) -> [u8; 32] {
 
 #[cfg(feature = "gpu")]
 fn recv_compact_replay_shard(
-    ready: &std::sync::mpsc::Receiver<CompactReplayShard>,
+    ready: &std::sync::mpsc::Receiver<Result<CompactReplayShard, String>>,
 ) -> Option<CompactReplayShard> {
     Some(
         ready
             .recv()
-            .expect("compact replay pipeline stopped before producing every planned shard"),
+            .expect("compact replay pipeline stopped before producing every planned shard")
+            .unwrap_or_else(|error| panic!("compact replay pipeline failed: {error}")),
     )
 }
 
@@ -1258,15 +1313,51 @@ fn recycle_compact_replay_owners(
 }
 
 #[cfg(feature = "gpu")]
-fn spawn_compact_replay_pipeline(input: CompactReplayPipelineInput) -> CompactReplayPipeline {
+fn spawn_compact_replay_pipeline(
+    input: CompactReplayPipelineInput,
+) -> Result<CompactReplayPipeline, String> {
     // One prepared shard may wait while the current shard is proving. The
     // producer must recover the previous shard's arenas before replaying the
     // next one, which bounds retained CPU storage and preserves tracer reuse.
     let (ready_tx, ready) = std::sync::mpsc::sync_channel(1);
     let (recycle, recycle_rx) = std::sync::mpsc::sync_channel(1);
+    let thread_name = input.ownership.map_or_else(
+        || "ceno-compact-replay".to_owned(),
+        |(worker, _)| format!("ceno-replay-{worker}"),
+    );
+    let start_gate_on_spawn_failure = input.start_gate.clone();
     std::thread::Builder::new()
-        .name("ceno-compact-replay".to_string())
+        .name(thread_name)
         .spawn(move || {
+            let worker_index = input.ownership.map(|value| value.0);
+            let effective_affinity = match input.cpu_affinity.as_deref() {
+                Some(cpus) => match crate::multi_gpu::pin_current_thread(cpus) {
+                    Ok(effective) => Some(effective),
+                    Err(error) => {
+                        if let Some(gate) = &input.start_gate {
+                            gate.abort();
+                        }
+                        let _ = ready_tx.send(Err(error));
+                        return;
+                    }
+                },
+                None => None,
+            };
+            if let Some(gate) = &input.start_gate
+                && let Err(error) = gate.arrive_and_wait()
+            {
+                let _ = ready_tx.send(Err(error));
+                return;
+            }
+            let producer_started = std::time::Instant::now();
+            tracing::info!(
+                target: "ceno_multi_gpu",
+                worker_index,
+                device_id = input.device_id,
+                cpu_affinity = ?effective_affinity,
+                phase = "replay_producer_start",
+                "multi-GPU replay producer event"
+            );
             // Construct the VM and native replay state at their final address
             // on the producer thread. The AOT replay path contains native
             // pointers into that state and must not be moved after setup.
@@ -1284,10 +1375,20 @@ fn spawn_compact_replay_pipeline(input: CompactReplayPipelineInput) -> CompactRe
             replay.vm.tracer_mut().enable_retained_shard_mode();
             let shard_count = replay.shard_step_counts.len();
             let mut previous_retained = false;
+            let mut owned_shards = 0usize;
+            let mut unowned_shards = 0usize;
             for shard_id in 0..shard_count {
+                if input.cancelled.load(std::sync::atomic::Ordering::Acquire) {
+                    return;
+                }
                 if previous_retained {
-                    let Ok(ranges) = recycle_rx.recv() else {
-                        return;
+                    let ranges = loop {
+                        match recycle_rx.recv_timeout(std::time::Duration::from_millis(10)) {
+                            Ok(ranges) => break ranges,
+                            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+                                if !input.cancelled.load(std::sync::atomic::Ordering::Acquire) => {}
+                            Err(_) => return,
+                        }
                     };
                     for range in ranges {
                         replay.vm.tracer_mut().recycle_range(range);
@@ -1300,27 +1401,48 @@ fn spawn_compact_replay_pipeline(input: CompactReplayPipelineInput) -> CompactRe
                     "compact replay pipeline event"
                 );
                 let owned = worker_owns_shard(input.ownership, shard_id);
+                if owned {
+                    owned_shards += 1;
+                } else {
+                    unowned_shards += 1;
+                }
                 let shard = replay
-                    .next_shard(!owned, |range| Some(range))
+                    .next_shard(owned, false, Some)
                     .expect("compact replay ended before its shard plan");
                 let replay_digest = shard_replay_summary_digest(shard.summary);
                 tracing::info!(
                     target: "ceno_multi_gpu",
                     shard_id,
                     worker_index = input.ownership.map(|value| value.0),
-                    replay_mode = if owned { "compact" } else { "light" },
+                    replay_mode = if owned { "compact" } else { "fast_flight" },
                     replay_digest = ?replay_digest,
                     phase = "cpu_replay_ready",
                     "compact replay pipeline event"
                 );
-                if ready_tx.send(shard).is_err() {
+                if ready_tx.send(Ok(shard)).is_err() {
                     return;
                 }
                 previous_retained = owned;
             }
+            tracing::info!(
+                target: "ceno_multi_gpu",
+                worker_index,
+                device_id = input.device_id,
+                cpu_affinity = ?effective_affinity,
+                owned_shards,
+                unowned_shards,
+                wall_ms = producer_started.elapsed().as_millis(),
+                phase = "replay_producer_finish",
+                "multi-GPU replay producer event"
+            );
         })
-        .expect("failed to spawn compact replay pipeline");
-    CompactReplayPipeline { ready, recycle }
+        .map_err(|error| {
+            if let Some(gate) = start_gate_on_spawn_failure {
+                gate.abort();
+            }
+            format!("failed to spawn compact replay pipeline: {error}")
+        })?;
+    Ok(CompactReplayPipeline { ready, recycle })
 }
 
 #[cfg(feature = "gpu")]
@@ -1414,6 +1536,7 @@ impl CompactStepReplay {
 
     fn next_shard(
         &mut self,
+        capture_compact: bool,
         stream_owned_ranges: bool,
         mut on_range: impl FnMut(
             ceno_emul::GpuReplayTypedRange,
@@ -1428,13 +1551,91 @@ impl CompactStepReplay {
             expected_range_count > 0,
             "GPU replay shard has no descriptors"
         );
-        if self.shard_id != 0 {
-            self.vm.tracer_mut().start_shard();
+        if self.shard_id == 0 {
+            self.vm
+                .tracer_mut()
+                .set_first_shard_capture(capture_compact);
+        } else {
+            self.vm
+                .tracer_mut()
+                .start_shard_with_capture(capture_compact);
         }
         let first_heap_before = self.vm.tracer().max_heap_addr_access().0;
         let first_hint_before = self.vm.tracer().max_hint_addr_access().0;
         let first_pc_before = self.vm.get_pc().0;
         let shard_start_cycle = self.vm.tracer().cycle();
+        if !capture_compact {
+            let replay_started = std::time::Instant::now();
+            #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+            let executed = self
+                .aot
+                .run_gpu_replay_fast_flight_to_halt(&mut self.vm, expected_steps)
+                .unwrap_or_else(|err| {
+                    panic!(
+                        "AOT fast-flight replay failed at pc={:#010x}: {err:?}",
+                        self.vm.get_pc().0
+                    )
+                })
+                .executed_steps;
+            #[cfg(not(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux")))]
+            let executed = {
+                for _ in 0..expected_steps {
+                    self.vm
+                        .next_step_record()
+                        .unwrap_or_else(|err| panic!("fast-flight replay failed: {err:?}"));
+                }
+                expected_steps
+            };
+            assert_eq!(executed, expected_steps);
+            assert!(self.vm.tracer_mut().take_sealed_chunks().is_empty());
+            assert!(self.vm.tracer().syscall_witnesses().is_empty());
+            self.vm
+                .tracer_mut()
+                .finish_fast_flight_ranges(expected_range_count);
+            self.next_range_descriptor += expected_range_count;
+            let descriptors = &self.range_descriptors
+                [self.next_range_descriptor - expected_range_count..self.next_range_descriptor];
+            let (avoided_rows, avoided_bytes) =
+                streamed_descriptor_payload_totals(descriptors, true);
+            let avoided_fallback = descriptors
+                .iter()
+                .map(|descriptor| descriptor.fallback_count)
+                .sum::<usize>();
+            let last_pc_after = self.vm.get_pc().0;
+            let summary = ShardStepSummary {
+                step_count: expected_steps,
+                first_cycle: shard_start_cycle,
+                last_cycle: shard_start_cycle
+                    + (expected_steps - 1) as Cycle * FullTracer::SUBCYCLES_PER_INSN,
+                first_pc_before,
+                last_pc_after,
+                first_heap_before,
+                last_heap_after: self.vm.tracer().max_heap_addr_access().0,
+                first_hint_before,
+                last_hint_after: self.vm.tracer().max_hint_addr_access().0,
+            };
+            tracing::info!(
+                target: "ceno_multi_gpu",
+                shard_id = self.shard_id,
+                instructions = expected_steps,
+                wall_ms = replay_started.elapsed().as_millis(),
+                compact_rows = 0,
+                compact_bytes = 0,
+                fallback_records = 0,
+                syscall_witnesses = 0,
+                avoided_rows,
+                avoided_bytes,
+                avoided_fallback,
+                "fast-flight replay complete"
+            );
+            self.shard_id += 1;
+            return Some(CompactReplayShard {
+                arenas: GpuReplayShardArenas::provisional([0; InsnKind::COUNT]),
+                fallback_steps: Vec::new(),
+                syscall_witnesses: Vec::new(),
+                summary,
+            });
+        }
         let mut executed = 0usize;
         let (mut arenas, streamed_fallback, replay_elapsed, chunk_count) =
             info_span!("compact_replay_direct_ranges").in_scope(|| {
@@ -2220,7 +2421,17 @@ pub fn generate_witness<'a, E: ExtensionField>(
         init_mem_state,
         target_shard_id,
         None,
+        #[cfg(feature = "gpu")]
+        None,
     )
+}
+
+#[cfg(feature = "gpu")]
+struct ReplayWorkerRuntime {
+    device_id: usize,
+    cpu_affinity: Option<Vec<usize>>,
+    start_gate: Arc<ReplayStartGate>,
+    cancelled: Arc<std::sync::atomic::AtomicBool>,
 }
 
 fn generate_witness_for_owner<'a, E: ExtensionField>(
@@ -2231,6 +2442,7 @@ fn generate_witness_for_owner<'a, E: ExtensionField>(
     init_mem_state: &InitMemState,
     target_shard_id: Option<usize>,
     ownership: Option<(usize, usize)>,
+    #[cfg(feature = "gpu")] replay_runtime: Option<ReplayWorkerRuntime>,
 ) -> impl Iterator<
     Item = (
         ZKVMWitnesses<E>,
@@ -2284,6 +2496,23 @@ fn generate_witness_for_owner<'a, E: ExtensionField>(
     });
     #[cfg(feature = "gpu")]
     let compact_pipeline = use_compact_replay.then(|| {
+        let (device_id, cpu_affinity, start_gate, cancelled) = replay_runtime
+            .map(|runtime| {
+                (
+                    runtime.device_id,
+                    runtime.cpu_affinity,
+                    Some(runtime.start_gate),
+                    runtime.cancelled,
+                )
+            })
+            .unwrap_or_else(|| {
+                (
+                    0,
+                    None,
+                    None,
+                    Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                )
+            });
         spawn_compact_replay_pipeline(CompactReplayPipelineInput {
             platform: platform.clone(),
             program: program.clone(),
@@ -2293,9 +2522,14 @@ fn generate_witness_for_owner<'a, E: ExtensionField>(
             range_descriptors: emul_result.replay_range_descriptors.clone(),
             chunk_capacity: emul_result.replay_range_capacity,
             ownership,
+            device_id,
+            cpu_affinity,
+            start_gate,
+            cancelled,
             #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
             aot: emul_result.replay_aot_program.clone(),
         })
+        .unwrap_or_else(|error| panic!("{error}"))
     });
     let mut current_compact_shard: Option<CompactReplayShard> = None;
     std::iter::from_fn(move || {
@@ -2465,7 +2699,7 @@ fn generate_witness_for_owner<'a, E: ExtensionField>(
                     #[cfg(not(feature = "gpu"))]
                     {
                         compact_iter.as_mut().and_then(|compact_iter| {
-                            compact_iter.next_shard(stream_owned_ranges, Some)
+                            compact_iter.next_shard(owned, stream_owned_ranges, Some)
                         })
                     }
                 })?;
@@ -4167,6 +4401,7 @@ where
         "multi-GPU base setup event"
     );
     let cancelled = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let replay_start_gate = Arc::new(ReplayStartGate::new(prepared.workers.len()));
     let started = std::time::Instant::now();
 
     std::thread::scope(|scope| -> Result<Vec<ZKVMProof<E, PCS>>, String> {
@@ -4191,7 +4426,12 @@ where
                     .clone()
             };
             let cancelled = cancelled.clone();
+            let replay_start_gate = replay_start_gate.clone();
             let device_id = worker.info.logical_ordinal;
+            let cpu_affinity = config
+                .worker_cpu_affinity
+                .as_ref()
+                .map(|sets| sets[worker_index].clone());
             let existing_prover = (worker_index == 0).then_some(sdk_prover);
             tracing::info!(
                 target: "ceno_multi_gpu",
@@ -4205,6 +4445,27 @@ where
                 let worker_started = std::time::Instant::now();
                 let mut diagnostics = BaseWorkerDiagnostics::new(worker_index, device_id);
                 let run = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let effective_affinity = cpu_affinity
+                        .as_deref()
+                        .map(crate::multi_gpu::pin_current_thread)
+                        .transpose()?;
+                    let ctx = pk.program_ctx.as_ref().unwrap();
+                    let witness_iterator_started = std::time::Instant::now();
+                    let witnesses = generate_witness_for_owner(
+                        &ctx.system_config,
+                        emulation_result,
+                        ctx.program.clone(),
+                        &ctx.platform,
+                        init_full_mem,
+                        None,
+                        Some((worker_index, prepared.workers.len())),
+                        Some(ReplayWorkerRuntime {
+                            device_id,
+                            cpu_affinity: cpu_affinity.clone(),
+                            start_gate: replay_start_gate.clone(),
+                            cancelled: cancelled.clone(),
+                        }),
+                    );
                     let device_started = std::time::Instant::now();
                     let device = existing_prover
                         .is_none()
@@ -4224,17 +4485,6 @@ where
                         .or(owned_prover.as_ref())
                         .expect("worker prover must be borrowed or constructed");
                     let prover_elapsed = prover_started.elapsed();
-                    let ctx = pk.program_ctx.as_ref().unwrap();
-                    let witness_iterator_started = std::time::Instant::now();
-                    let witnesses = generate_witness_for_owner(
-                        &ctx.system_config,
-                        emulation_result,
-                        ctx.program.clone(),
-                        &ctx.platform,
-                        init_full_mem,
-                        None,
-                        Some((worker_index, prepared.workers.len())),
-                    );
                     tracing::info!(
                         target: "ceno_multi_gpu",
                         worker_index,
@@ -4242,6 +4492,7 @@ where
                         device_construct_ms = device_elapsed.as_millis(),
                         prover_construct_ms = prover_elapsed.as_millis(),
                         reused_prover = existing_prover.is_some(),
+                        cpu_affinity = ?effective_affinity,
                         witness_iterator_ms = witness_iterator_started.elapsed().as_millis(),
                         phase = "worker_setup",
                         "multi-GPU base setup event"
@@ -4332,6 +4583,7 @@ where
                 };
                 if let Err(error) = result {
                     cancelled.store(true, std::sync::atomic::Ordering::Release);
+                    replay_start_gate.abort();
                     let error = diagnostics.describe(&error);
                     let _ = tx.send(BaseWorkerEvent::Failed(error.clone()));
                     Some(error)
@@ -4458,9 +4710,50 @@ where
 
 #[cfg(all(test, feature = "gpu"))]
 mod multi_gpu_collector_tests {
-    use super::{BaseProofCollectorState, BaseWorkerDiagnostics, classify_cuda_error};
+    use super::{
+        BaseProofCollectorState, BaseWorkerDiagnostics, ReplayStartGate, classify_cuda_error,
+    };
     use crate::multi_gpu::MultiGpuConfig;
     use std::{sync::mpsc, time::Duration};
+
+    #[test]
+    fn replay_start_gate_releases_concurrent_producers() {
+        let gate = std::sync::Arc::new(ReplayStartGate::new(2));
+        let (tx, rx) = mpsc::channel();
+        std::thread::scope(|scope| {
+            for worker in 0..2 {
+                let gate = gate.clone();
+                let tx = tx.clone();
+                scope.spawn(move || {
+                    gate.arrive_and_wait().unwrap();
+                    tx.send(worker).unwrap();
+                });
+            }
+        });
+        let mut workers = vec![rx.recv().unwrap(), rx.recv().unwrap()];
+        workers.sort_unstable();
+        assert_eq!(workers, vec![0, 1]);
+    }
+
+    #[test]
+    fn replay_start_gate_abort_releases_waiter() {
+        let gate = std::sync::Arc::new(ReplayStartGate::new(2));
+        let waiter = {
+            let gate = gate.clone();
+            std::thread::spawn(move || gate.arrive_and_wait())
+        };
+        while gate
+            .state
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .arrived
+            == 0
+        {
+            std::thread::yield_now();
+        }
+        gate.abort();
+        assert!(waiter.join().unwrap().is_err());
+    }
 
     #[test]
     fn collector_accepts_out_of_order_round_robin_results() {

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -4452,6 +4452,36 @@ fn validate_debug_shard_request(
 }
 
 #[cfg(feature = "gpu")]
+fn materialize_mock_witness<E: ExtensionField>(
+    witness: &ZKVMWitnesses<E>,
+) -> Result<ZKVMWitnesses<E>, ZKVMError> {
+    let mut host_witness = witness.clone();
+    for (name, host_inputs) in &mut host_witness.witnesses {
+        let device_inputs = witness
+            .witnesses
+            .get(name)
+            .expect("cloned witness lost a circuit");
+        if host_inputs.len() != device_inputs.len() {
+            return Err(ZKVMError::InvalidWitness(
+                format!("mock witness input count changed for {name}").into(),
+            ));
+        }
+        for (host_input, device_input) in host_inputs.iter_mut().zip(device_inputs) {
+            for (host_rmm, device_rmm) in host_input
+                .witness_rmms
+                .iter_mut()
+                .zip(&device_input.witness_rmms)
+            {
+                *host_rmm = crate::instructions::gpu::utils::d2h::materialize_device_backed_rmm::<E>(
+                    device_rmm,
+                )?;
+            }
+        }
+    }
+    Ok(host_witness)
+}
+
+#[cfg(feature = "gpu")]
 enum BaseWorkerEvent<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> {
     Ready {
         ready: BaseProofReady<E, PCS>,
@@ -4731,11 +4761,15 @@ where
                             "multi-GPU base worker event"
                         );
                         if debug_mock_proving {
+                            // Normal GPU proving keeps witness matrices device-resident with
+                            // empty host storage. MockProver is CPU-only, so materialize a
+                            // diagnostic clone without disturbing the proof's device backing.
+                            let mock_witness = materialize_mock_witness(&zkvm_witness)?;
                             MockProver::assert_satisfied_full(
                                 &shard_ctx,
                                 &ctx.system_config.zkvm_cs,
                                 ctx.zkvm_fixed_traces.clone(),
-                                &zkvm_witness,
+                                &mock_witness,
                                 &pi,
                                 &ctx.program,
                             );

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -4707,6 +4707,10 @@ where
                             .unwrap_or("unknown panic")
                     )),
                 };
+                // GPU 0 reuses the prover built before the worker scope, whereas the other
+                // workers build theirs inside `run`. Drop the reused prover at the same
+                // lifecycle boundary so its device proving keys do not survive pool trim.
+                drop(existing_prover);
                 if result.is_ok() {
                     // All device-backed prover state lived inside `run` and is now dropped. Only
                     // after synchronization and pool trim may this physical GPU join recursion.

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1175,26 +1175,6 @@ struct CompactReplayShard {
     fallback_steps: Vec<StepRecord>,
     syscall_witnesses: Vec<SyscallWitness>,
     summary: ShardStepSummary,
-    // Read by the multi-GPU pipeline; single-device replay consumes the other fields directly.
-    #[cfg_attr(not(feature = "gpu"), allow(dead_code))]
-    state_audit_before_digest: Option<[u8; 32]>,
-    #[cfg_attr(not(feature = "gpu"), allow(dead_code))]
-    state_audit_digest: Option<[u8; 32]>,
-}
-
-fn replay_state_audit_selected(shard_id: usize) -> bool {
-    let selected = std::env::var("CENO_MULTI_GPU_REPLAY_AUDIT_SHARD")
-        .ok()
-        .map(|value| {
-            value
-                .parse::<usize>()
-                .unwrap_or_else(|_| panic!("CENO_MULTI_GPU_REPLAY_AUDIT_SHARD must be a shard ID"))
-        });
-    selected == Some(shard_id)
-}
-
-fn replay_state_audit_digest(vm: &VMState<GpuReplayTracer>, shard_id: usize) -> Option<[u8; 32]> {
-    replay_state_audit_selected(shard_id).then(|| vm.replay_state_audit_digest())
 }
 
 struct CompactStepReplay {
@@ -1451,8 +1431,6 @@ fn spawn_compact_replay_pipeline(
                     worker_index = input.ownership.map(|value| value.0),
                     replay_mode = if owned { "compact" } else { "fast_flight" },
                     replay_digest = ?replay_digest,
-                    state_audit_before_digest = ?shard.state_audit_before_digest,
-                    state_audit_digest = ?shard.state_audit_digest,
                     phase = "cpu_replay_ready",
                     "compact replay pipeline event"
                 );
@@ -1580,8 +1558,6 @@ impl CompactStepReplay {
         ) -> Option<ceno_emul::GpuReplayTypedRange>,
     ) -> Option<CompactReplayShard> {
         let expected_steps = *self.shard_step_counts.get(self.shard_id)?;
-        let state_audit_before_digest =
-            replay_state_audit_selected(self.shard_id).then(|| self.vm.replay_state_audit_digest());
         let expected_range_count = self.range_descriptors[self.next_range_descriptor..]
             .iter()
             .take_while(|descriptor| descriptor.shard_id as usize == self.shard_id)
@@ -1653,7 +1629,6 @@ impl CompactStepReplay {
                 first_hint_before,
                 last_hint_after: self.vm.tracer().max_hint_addr_access().0,
             };
-            let state_audit_digest = replay_state_audit_digest(&self.vm, self.shard_id);
             tracing::info!(
                 target: "ceno_multi_gpu",
                 shard_id = self.shard_id,
@@ -1666,7 +1641,6 @@ impl CompactStepReplay {
                 avoided_rows,
                 avoided_bytes,
                 avoided_fallback,
-                ?state_audit_digest,
                 "fast-flight replay complete"
             );
             self.shard_id += 1;
@@ -1675,8 +1649,6 @@ impl CompactStepReplay {
                 fallback_steps: Vec::new(),
                 syscall_witnesses: Vec::new(),
                 summary,
-                state_audit_before_digest,
-                state_audit_digest,
             });
         }
         let mut executed = 0usize;
@@ -1858,15 +1830,12 @@ impl CompactStepReplay {
             last_hint_after: self.vm.tracer().max_hint_addr_access().0,
         };
         let syscall_witnesses = self.vm.tracer_mut().take_syscall_witnesses();
-        let state_audit_digest = replay_state_audit_digest(&self.vm, self.shard_id);
         self.shard_id += 1;
         Some(CompactReplayShard {
             arenas,
             fallback_steps,
             syscall_witnesses,
             summary,
-            state_audit_before_digest,
-            state_audit_digest,
         })
     }
 }
@@ -2870,11 +2839,11 @@ fn generate_witness_for_owner<'a, E: ExtensionField>(
             }
 
 
-            if let Some(target_shard_id) = target_shard_id {
-                if shard_ctx.shard_id < target_shard_id {
-                    tracing::debug!("{}th shard skipped", shard_ctx.shard_id);
-                    return Some((zkvm_witness, shard_ctx, pi, None));
-                }
+            if let Some(target_shard_id) = target_shard_id
+                && shard_ctx.shard_id < target_shard_id
+            {
+                tracing::debug!("{}th shard skipped", shard_ctx.shard_id);
+                return Some((zkvm_witness, shard_ctx, pi, None));
             }
 
             #[allow(unused_variables)]
@@ -4586,7 +4555,6 @@ where
     gkr_iop::gpu::set_thread_cuda_hal(prepared.workers[0].hal.clone());
     let raw_step_cell_extractor = Arc::clone(&ctx.system_config.config);
     let step_cell_extractor: Arc<dyn StepCellExtractor> = raw_step_cell_extractor;
-    let emulation_started = std::time::Instant::now();
     let emulation_result = emulate_program(
         ctx.program.clone(),
         max_steps,
@@ -4600,7 +4568,6 @@ where
         #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
         precompiled_fulltracer_aot,
     );
-    let emulation_elapsed = emulation_started.elapsed();
     let total_shards = emulation_result.shard_ctx_builder.total_shards();
     if let Some(target_shard_id) = target_shard_id
         && target_shard_id >= total_shards
@@ -4610,26 +4577,12 @@ where
         ));
     }
     let exit_code = emulation_result.exit_code;
-    let verifier_started = std::time::Instant::now();
     let verifier = sdk_prover
         .cached_verifier()
         .ok_or("initial GPU prover has no cached verifier")?;
-    let cached_verifier_clone_elapsed = verifier_started.elapsed();
-    let recursion_session_started = std::time::Instant::now();
     if let Some(sink) = &event_sink {
         sink.on_started(total_shards, verifier.vk.clone(), vk_digest)?;
     }
-    let recursion_session_start_elapsed = recursion_session_started.elapsed();
-    tracing::info!(
-        target: "ceno_multi_gpu",
-        emulation_ms = emulation_elapsed.as_millis(),
-        vk_materialize_ms = 0,
-        cached_verifier_clone_ms = cached_verifier_clone_elapsed.as_millis(),
-        recursion_session_start_ms = recursion_session_start_elapsed.as_millis(),
-        total_ms = pipeline_started.elapsed().as_millis(),
-        phase = "pre_worker_setup",
-        "multi-GPU base setup event"
-    );
     let cancelled = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let replay_start_gate = Arc::new(ReplayStartGate::new(prepared.workers.len()));
     let started = std::time::Instant::now();
@@ -4650,7 +4603,6 @@ where
             // A depth-one FIFO bounds the extra full-proof footprint and backpressures its owner.
             let (tx, rx) = std::sync::mpsc::sync_channel::<BaseWorkerEvent<E, PCS>>(1);
             ready_receivers.push(Some(rx));
-            let worker_inputs_started = std::time::Instant::now();
             let hal = worker.hal.clone();
             let backend = backend.clone();
             let pk = pk.clone();
@@ -4677,14 +4629,6 @@ where
                     .expect("GPU0 prover must be available")
             });
             let event_sink = event_sink.clone();
-            tracing::info!(
-                target: "ceno_multi_gpu",
-                worker_index,
-                device_id,
-                elapsed_ms = worker_inputs_started.elapsed().as_millis(),
-                phase = "worker_input_clone",
-                "multi-GPU base setup event"
-            );
             handles.push(scope.spawn(move || {
                 let worker_started = std::time::Instant::now();
                 let mut diagnostics = BaseWorkerDiagnostics::new(worker_index, device_id);
@@ -4696,7 +4640,6 @@ where
                     let _worker_cuda_binding =
                         gkr_iop::gpu::bind_thread_default_stream(hal.clone());
                     let ctx = pk.program_ctx.as_ref().unwrap();
-                    let witness_iterator_started = std::time::Instant::now();
                     let witnesses = generate_witness_for_owner(
                         &ctx.system_config,
                         emulation_result,
@@ -4712,15 +4655,12 @@ where
                             cancelled: cancelled.clone(),
                         }),
                     );
-                    let device_started = std::time::Instant::now();
                     let device = existing_prover
                         .is_none()
                         .then(|| gkr_iop::gpu::GpuProver::new(backend, hal.clone()));
-                    let device_elapsed = device_started.elapsed();
                     let memory_start = ceno_gpu::get_cuda_mem_info().unwrap_or((0, 0));
                     diagnostics.observe_memory(memory_start.0, memory_start.1);
                     diagnostics.queue_state = "fifo_empty";
-                    let prover_started = std::time::Instant::now();
                     let owned_prover = device.map(|device| {
                         ZKVMProver::new_with_vk_digest(pk.clone(), device, vk_digest)
                     });
@@ -4728,16 +4668,12 @@ where
                         .as_ref()
                         .or(owned_prover.as_ref())
                         .expect("worker prover must be owned or constructed");
-                    let prover_elapsed = prover_started.elapsed();
                     tracing::info!(
                         target: "ceno_multi_gpu",
                         worker_index,
                         device_id,
-                        device_construct_ms = device_elapsed.as_millis(),
-                        prover_construct_ms = prover_elapsed.as_millis(),
                         reused_prover = existing_prover.is_some(),
                         cpu_affinity = ?effective_affinity,
-                        witness_iterator_ms = witness_iterator_started.elapsed().as_millis(),
                         phase = "worker_setup",
                         "multi-GPU base setup event"
                     );
@@ -5047,8 +4983,6 @@ where
             base_proofs_ready_ms = base_proofs_ready_elapsed.as_millis(),
             base_verification_ms = base_verification_elapsed.as_millis(),
             verified_base_ms = verified_base_elapsed.as_millis(),
-            recursion_overlap_ratio = 0.0,
-            device_local_recursion_ratio = 0.0,
             "Stage 1 multi-GPU base proving complete"
         );
         Ok(proofs)

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1217,6 +1217,7 @@ struct CompactReplayPipelineInput {
     range_descriptors: Arc<Vec<ceno_emul::GpuReplayRangeDescriptor>>,
     chunk_capacity: usize,
     ownership: Option<(usize, usize)>,
+    target_shard_id: Option<usize>,
     device_id: usize,
     cpu_affinity: Option<Vec<usize>>,
     start_gate: Option<Arc<ReplayStartGate>>,
@@ -1283,6 +1284,15 @@ impl ReplayStartGate {
 
 fn worker_owns_shard(ownership: Option<(usize, usize)>, shard_id: usize) -> bool {
     ownership.is_none_or(|(worker_index, worker_count)| shard_id % worker_count == worker_index)
+}
+
+fn worker_captures_shard(
+    ownership: Option<(usize, usize)>,
+    target_shard_id: Option<usize>,
+    shard_id: usize,
+) -> bool {
+    worker_owns_shard(ownership, shard_id)
+        && target_shard_id.is_none_or(|target| target == shard_id)
 }
 
 #[cfg(any(feature = "gpu", test))]
@@ -1420,7 +1430,10 @@ fn spawn_compact_replay_pipeline(
                     phase = "cpu_replay_start",
                     "compact replay pipeline event"
                 );
-                let owned = worker_owns_shard(input.ownership, shard_id);
+                // Targeted proving still executes every predecessor to preserve VM state,
+                // but retaining its compact arenas would perform the expensive GPU work
+                // that the diagnostic selector exists to avoid.
+                let owned = worker_captures_shard(input.ownership, input.target_shard_id, shard_id);
                 if owned {
                     owned_shards += 1;
                 } else {
@@ -2555,6 +2568,7 @@ fn generate_witness_for_owner<'a, E: ExtensionField>(
             range_descriptors: emul_result.replay_range_descriptors.clone(),
             chunk_capacity: emul_result.replay_range_capacity,
             ownership,
+            target_shard_id,
             device_id,
             cpu_affinity,
             start_gate,
@@ -2594,7 +2608,7 @@ fn generate_witness_for_owner<'a, E: ExtensionField>(
             }
             let (mut shard_ctx, shard_summary) = if use_compact_replay {
                 let shard_id = shard_ctx_builder.cur_shard_id;
-                let owned = worker_owns_shard(ownership, shard_id);
+                let owned = worker_captures_shard(ownership, target_shard_id, shard_id);
                 if owned {
                     instrunction_dispatch_ctx.begin_compact_ingest();
                 }
@@ -2839,7 +2853,12 @@ fn generate_witness_for_owner<'a, E: ExtensionField>(
                 - shard_ctx.shard_hint_addr_range.start)
                 / (WORD_SIZE as u32);
 
-            if !worker_owns_shard(ownership, shard_ctx.shard_id) {
+            if target_shard_id.is_some_and(|target| shard_ctx.shard_id > target) {
+                tracing::debug!("{}th shard skipped", shard_ctx.shard_id);
+                return None;
+            }
+
+            if !worker_captures_shard(ownership, target_shard_id, shard_ctx.shard_id) {
                 tracing::info!(
                     target: "ceno_multi_gpu",
                     worker_index = ownership.map(|value| value.0),
@@ -2855,9 +2874,6 @@ fn generate_witness_for_owner<'a, E: ExtensionField>(
                 if shard_ctx.shard_id < target_shard_id {
                     tracing::debug!("{}th shard skipped", shard_ctx.shard_id);
                     return Some((zkvm_witness, shard_ctx, pi, None));
-                } else if shard_ctx.shard_id > target_shard_id {
-                    tracing::debug!("{}th shard skipped", shard_ctx.shard_id);
-                    return None;
                 }
             }
 
@@ -5543,6 +5559,15 @@ mod tests {
         assert!(super::compact_replay_selected(false, false));
         assert!(!super::compact_replay_selected(true, false));
         assert!(!super::compact_replay_selected(false, true));
+    }
+
+    #[test]
+    fn targeted_replay_captures_only_the_selected_owned_shard() {
+        assert!(!super::worker_captures_shard(Some((0, 1)), Some(10), 0));
+        assert!(super::worker_captures_shard(Some((0, 1)), Some(10), 10));
+        assert!(super::worker_captures_shard(Some((1, 2)), None, 3));
+        assert!(!super::worker_captures_shard(Some((1, 2)), None, 2));
+        assert!(!super::worker_captures_shard(Some((0, 2)), Some(3), 3));
     }
 
     #[test]

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -4216,6 +4216,7 @@ pub trait BaseProvingEventSink<E: ExtensionField, PCS: PolynomialCommitmentSchem
         &self,
         total_shards: usize,
         app_vk: ZKVMVerifyingKey<E, PCS>,
+        app_vk_digest: [E; crate::structs::VK_DIGEST_LEN],
     ) -> Result<(), String>;
     fn on_proof_ready(&self, ready: BaseProofReady<E, PCS>) -> Result<(), String>;
     fn on_device_released(&self, released: BaseDeviceReleased) -> Result<(), String>;
@@ -4496,14 +4497,18 @@ where
     let verifier = sdk_prover
         .cached_verifier()
         .ok_or("initial GPU prover has no cached verifier")?;
+    let cached_verifier_clone_elapsed = verifier_started.elapsed();
+    let recursion_session_started = std::time::Instant::now();
     if let Some(sink) = &event_sink {
-        sink.on_started(total_shards, verifier.vk.clone())?;
+        sink.on_started(total_shards, verifier.vk.clone(), vk_digest)?;
     }
+    let recursion_session_start_elapsed = recursion_session_started.elapsed();
     tracing::info!(
         target: "ceno_multi_gpu",
         emulation_ms = emulation_elapsed.as_millis(),
         vk_materialize_ms = 0,
-        verifier_construct_ms = verifier_started.elapsed().as_millis(),
+        cached_verifier_clone_ms = cached_verifier_clone_elapsed.as_millis(),
+        recursion_session_start_ms = recursion_session_start_elapsed.as_millis(),
         total_ms = pipeline_started.elapsed().as_millis(),
         phase = "pre_worker_setup",
         "multi-GPU base setup event"

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -4449,6 +4449,8 @@ where
                         .as_deref()
                         .map(crate::multi_gpu::pin_current_thread)
                         .transpose()?;
+                    let _worker_cuda_binding =
+                        gkr_iop::gpu::bind_thread_default_stream(hal.clone());
                     let ctx = pk.program_ctx.as_ref().unwrap();
                     let witness_iterator_started = std::time::Instant::now();
                     let witnesses = generate_witness_for_owner(
@@ -4471,9 +4473,6 @@ where
                         .is_none()
                         .then(|| gkr_iop::gpu::GpuProver::new(backend, hal.clone()));
                     let device_elapsed = device_started.elapsed();
-                    if existing_prover.is_some() {
-                        gkr_iop::gpu::set_thread_cuda_hal(hal);
-                    }
                     let memory_start = ceno_gpu::get_cuda_mem_info().unwrap_or((0, 0));
                     diagnostics.observe_memory(memory_start.0, memory_start.1);
                     diagnostics.queue_state = "fifo_empty";

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -4764,7 +4764,13 @@ where
                             // Normal GPU proving keeps witness matrices device-resident with
                             // empty host storage. MockProver is CPU-only, so materialize a
                             // diagnostic clone without disturbing the proof's device backing.
-                            let mock_witness = materialize_mock_witness(&zkvm_witness)?;
+                            let mock_witness = materialize_mock_witness(&zkvm_witness).map_err(
+                                |error| {
+                                    format!(
+                                        "failed to materialize GPU mock witness for shard {shard_id} on device {device_id}: {error:?}"
+                                    )
+                                },
+                            )?;
                             MockProver::assert_satisfied_full(
                                 &shard_ctx,
                                 &ctx.system_config.zkvm_cs,

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -4414,6 +4414,28 @@ fn verify_complete_base_proofs<P: Clone>(
 }
 
 #[cfg(feature = "gpu")]
+fn validate_debug_shard_request(
+    config: &crate::multi_gpu::MultiGpuConfig,
+    target_shard_id: Option<usize>,
+    has_event_sink: bool,
+) -> Result<(), String> {
+    if target_shard_id.is_none() {
+        return Ok(());
+    }
+    // A shard-scoped proof is a diagnostic segment, not a complete distributed result.
+    // Keeping it on one worker avoids inventing collector ownership or recursion semantics.
+    if config.device_ids.len() != 1 {
+        return Err("GPU --shard-id debug proving requires exactly one selected device".to_owned());
+    }
+    if has_event_sink {
+        return Err(
+            "GPU --shard-id debug proving cannot stream incomplete proofs to recursion".to_owned(),
+        );
+    }
+    Ok(())
+}
+
+#[cfg(feature = "gpu")]
 enum BaseWorkerEvent<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> {
     Ready {
         ready: BaseProofReady<E, PCS>,
@@ -4439,6 +4461,7 @@ pub fn run_e2e_multi_gpu_proof_with_precompiled_aot<
     init_full_mem: &InitMemState,
     public_io_digest: [u32; 8],
     max_steps: usize,
+    target_shard_id: Option<usize>,
     #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
     precompiled_aot: Option<Arc<ceno_emul::aot::AotProgram>>,
     #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
@@ -4458,6 +4481,7 @@ where
         init_full_mem,
         public_io_digest,
         max_steps,
+        target_shard_id,
         None,
         #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
         precompiled_aot,
@@ -4483,6 +4507,7 @@ pub fn run_e2e_multi_gpu_proof_with_precompiled_aot_and_sink<
     init_full_mem: &InitMemState,
     public_io_digest: [u32; 8],
     max_steps: usize,
+    target_shard_id: Option<usize>,
     event_sink: Option<Arc<dyn BaseProvingEventSink<E, PCS>>>,
     #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
     precompiled_aot: Option<Arc<ceno_emul::aot::AotProgram>>,
@@ -4501,6 +4526,7 @@ where
     let backend = sdk_prover.device().backend.clone();
     let vk_digest = sdk_prover.vk_digest();
     config.validate_shape()?;
+    validate_debug_shard_request(config, target_shard_id, event_sink.is_some())?;
     if prepared.workers.len() != config.device_ids.len() {
         return Err("prepared GPU worker count does not match configuration".to_owned());
     }
@@ -4527,6 +4553,13 @@ where
     );
     let emulation_elapsed = emulation_started.elapsed();
     let total_shards = emulation_result.shard_ctx_builder.total_shards();
+    if let Some(target_shard_id) = target_shard_id
+        && target_shard_id >= total_shards
+    {
+        return Err(format!(
+            "GPU debug shard {target_shard_id} is out of range for {total_shards} shards"
+        ));
+    }
     let exit_code = emulation_result.exit_code;
     let verifier_started = std::time::Instant::now();
     let verifier = sdk_prover
@@ -4551,6 +4584,13 @@ where
     let cancelled = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let replay_start_gate = Arc::new(ReplayStartGate::new(prepared.workers.len()));
     let started = std::time::Instant::now();
+    let debug_mock_proving = target_shard_id.is_some() && std::env::var("MOCK_PROVING").is_ok();
+    let debug_compare =
+        target_shard_id.is_some() && crate::instructions::gpu::config::is_debug_compare_enabled();
+    if debug_compare {
+        crate::instructions::gpu::utils::debug_compare::init_debug_compare_report();
+    }
+    let expected_proofs = target_shard_id.map_or(total_shards, |_| 1);
 
     let proofs = std::thread::scope(|scope| -> Result<Vec<ZKVMProof<E, PCS>>, String> {
         let mut handles = Vec::with_capacity(prepared.workers.len());
@@ -4614,7 +4654,7 @@ where
                         ctx.program.clone(),
                         &ctx.platform,
                         init_full_mem,
-                        None,
+                        target_shard_id,
                         Some((worker_index, prepared.workers.len())),
                         Some(ReplayWorkerRuntime {
                             device_id,
@@ -4659,6 +4699,11 @@ where
                         if shard_ctx.shard_id % prepared.workers.len() != worker_index {
                             continue;
                         }
+                        // Targeted proving still replays every preceding shard to preserve VM
+                        // state, but only the selected shard may enter mock/proof generation.
+                        if target_shard_id.is_some_and(|target| shard_ctx.shard_id != target) {
+                            continue;
+                        }
                         let shard_id = shard_ctx.shard_id;
                         diagnostics.active_shard = Some(shard_id);
                         tracing::info!(
@@ -4669,6 +4714,17 @@ where
                             phase = "proof_start",
                             "multi-GPU base worker event"
                         );
+                        if debug_mock_proving {
+                            MockProver::assert_satisfied_full(
+                                &shard_ctx,
+                                &ctx.system_config.zkvm_cs,
+                                ctx.zkvm_fixed_traces.clone(),
+                                &zkvm_witness,
+                                &pi,
+                                &ctx.program,
+                            );
+                            tracing::info!(shard_id, "Mock proving passed");
+                        }
                         let proof_started = std::time::Instant::now();
                         let proof = prover
                             .create_proof(&shard_ctx, zkvm_witness, pi, Transcript::new(b"riscv"))
@@ -4807,7 +4863,7 @@ where
         let mut collector_error = None;
         // Drain each bounded FIFO fairly. The first invalid proof or worker error cancels every
         // producer, but all scoped workers are still joined before the error is returned.
-        while received < total_shards && collector_error.is_none() {
+        while received < expected_proofs && collector_error.is_none() {
             let mut made_progress = false;
             for receiver in &mut ready_receivers {
                 let Some(rx) = receiver else { continue };
@@ -4852,12 +4908,12 @@ where
                 }
                 received += 1;
             }
-            if received < total_shards
+            if received < expected_proofs
                 && ready_receivers.iter().all(Option::is_none)
                 && collector_error.is_none()
             {
                 collector_error = Some(format!(
-                    "GPU device unknown worker unknown shard unknown failed: workers closed after {received}/{total_shards} shards; last_completed_shard=unknown cuda_error_class=non_cuda queue_state=all_fifos_disconnected memory_metrics=unavailable"
+                    "GPU device unknown worker unknown shard unknown failed: workers closed after {received}/{expected_proofs} expected proofs; last_completed_shard=unknown cuda_error_class=non_cuda queue_state=all_fifos_disconnected memory_metrics=unavailable"
                 ));
             }
             if !made_progress && collector_error.is_none() {
@@ -4888,6 +4944,25 @@ where
             return Err(error);
         }
         let base_proofs_ready_elapsed = pipeline_started.elapsed();
+        if let Some(target_shard_id) = target_shard_id {
+            tracing::info!(
+                target: "ceno_multi_gpu",
+                device_id = config.device_ids[0],
+                shard_id = target_shard_id,
+                elapsed_ms = base_proofs_ready_elapsed.as_millis(),
+                phase = "debug_shard_proof_ready",
+                "GPU debug shard proof ready"
+            );
+            if debug_compare {
+                crate::instructions::gpu::utils::debug_compare::assert_debug_compare_report();
+            }
+            let proof = proofs[target_shard_id]
+                .take()
+                .ok_or_else(|| format!("missing GPU debug shard proof {target_shard_id}"))?;
+            run_e2e_single_shard_debug_verify(&verifier, proof.clone(), exit_code, max_steps);
+            return Ok(vec![proof]);
+        }
+
         tracing::info!(
             target: "ceno_multi_gpu",
             devices = ?config.device_ids,
@@ -4896,6 +4971,7 @@ where
             phase = "base_proofs_ready",
             "Stage 1 canonical base proofs ready"
         );
+
         // Verification runs exactly once, after range/owner/duplicate checks and canonical
         // shard ordering are complete. Recursion may overlap, but cannot publish its root yet.
         let base_verification_started = std::time::Instant::now();
@@ -4925,8 +5001,27 @@ where
 mod multi_gpu_collector_tests {
     use super::{
         BaseProofCollectorState, BaseWorkerDiagnostics, ReplayStartGate, classify_cuda_error,
-        verify_complete_base_proofs,
+        validate_debug_shard_request, verify_complete_base_proofs,
     };
+
+    #[test]
+    fn debug_shard_request_requires_one_device_and_no_recursion_sink() {
+        let single = MultiGpuConfig::new(vec![4]).unwrap();
+        let multiple = MultiGpuConfig::new(vec![4, 7]).unwrap();
+
+        validate_debug_shard_request(&single, Some(10), false).unwrap();
+        validate_debug_shard_request(&multiple, None, true).unwrap();
+        assert!(
+            validate_debug_shard_request(&multiple, Some(10), false)
+                .unwrap_err()
+                .contains("exactly one selected device")
+        );
+        assert!(
+            validate_debug_shard_request(&single, Some(10), true)
+                .unwrap_err()
+                .contains("cannot stream incomplete proofs")
+        );
+    }
     use crate::multi_gpu::MultiGpuConfig;
     use std::{
         sync::{Arc, Mutex, mpsc},

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -4478,6 +4478,9 @@ fn materialize_mock_witness<E: ExtensionField>(
             }
         }
     }
+    // GPU shard accumulation stores one combined lookup map; its empty per-chip
+    // maps are ownership markers, not expectations for the CPU mock comparison.
+    host_witness.omit_gpu_lk_placeholders_for_mock();
     Ok(host_witness)
 }
 

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -4196,7 +4196,30 @@ pub struct BaseProofReady<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>
     pub shard_id: usize,
     pub proof: ZKVMProof<E, PCS>,
     pub device_id: usize,
-    diagnostics: BaseWorkerDiagnostics,
+}
+
+#[cfg(feature = "gpu")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BaseDeviceReleased {
+    pub worker_index: usize,
+    pub device_id: usize,
+    pub memory_before_free_bytes: usize,
+    pub memory_after_free_bytes: usize,
+    pub memory_total_bytes: usize,
+}
+
+#[cfg(feature = "gpu")]
+pub trait BaseProvingEventSink<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>:
+    Send + Sync
+{
+    fn on_started(
+        &self,
+        total_shards: usize,
+        app_vk: ZKVMVerifyingKey<E, PCS>,
+    ) -> Result<(), String>;
+    fn on_proof_ready(&self, ready: BaseProofReady<E, PCS>) -> Result<(), String>;
+    fn on_device_released(&self, released: BaseDeviceReleased) -> Result<(), String>;
+    fn on_failure(&self, error: &str);
 }
 
 #[cfg(feature = "gpu")]
@@ -4318,11 +4341,48 @@ impl BaseProofCollectorState {
     fn missing(&self) -> Option<usize> {
         self.seen.iter().position(|seen| !seen)
     }
+
+    fn accept_and_then<T>(
+        &mut self,
+        config: &crate::multi_gpu::MultiGpuConfig,
+        shard_id: usize,
+        proof_shard_id: u32,
+        device_id: usize,
+        after_validation: impl FnOnce() -> Result<T, String>,
+    ) -> Result<T, String> {
+        self.accept(config, shard_id, proof_shard_id, device_id)?;
+        after_validation()
+    }
+}
+
+#[cfg(feature = "gpu")]
+fn verify_complete_base_proofs<P: Clone>(
+    collector: &BaseProofCollectorState,
+    proofs: Vec<Option<P>>,
+    verify_once: impl FnOnce(Vec<P>),
+) -> Result<Vec<P>, String> {
+    if let Some(shard_id) = collector.missing() {
+        return Err(format!(
+            "GPU device unknown worker unknown shard {shard_id} failed: missing base proof; last_completed_shard=unknown cuda_error_class=non_cuda queue_state=all_workers_joined memory_metrics=unavailable"
+        ));
+    }
+    let proofs = proofs
+        .into_iter()
+        .enumerate()
+        .map(|(shard_id, proof)| {
+            proof.ok_or_else(|| format!("missing base proof shard {shard_id}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    verify_once(proofs.clone());
+    Ok(proofs)
 }
 
 #[cfg(feature = "gpu")]
 enum BaseWorkerEvent<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> {
-    Ready(BaseProofReady<E, PCS>),
+    Ready {
+        ready: BaseProofReady<E, PCS>,
+        diagnostics: BaseWorkerDiagnostics,
+    },
     Failed(String),
 }
 
@@ -4332,7 +4392,7 @@ pub fn run_e2e_multi_gpu_proof_with_precompiled_aot<
     E: ExtensionField + LkMultiplicityKey,
     PCS: PolynomialCommitmentScheme<E> + Serialize + 'static,
 >(
-    sdk_prover: &ZKVMProver<
+    sdk_prover: ZKVMProver<
         E,
         PCS,
         gkr_iop::gpu::GpuBackend<E, PCS>,
@@ -4343,6 +4403,51 @@ pub fn run_e2e_multi_gpu_proof_with_precompiled_aot<
     init_full_mem: &InitMemState,
     public_io_digest: [u32; 8],
     max_steps: usize,
+    #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+    precompiled_aot: Option<Arc<ceno_emul::aot::AotProgram>>,
+    #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+    precompiled_fulltracer_aot: Option<Arc<ceno_emul::aot::AotProgram>>,
+) -> Result<Vec<ZKVMProof<E, PCS>>, String>
+where
+    PCS::ProverParam: Send + Sync,
+    PCS::VerifierParam: Send + Sync,
+    PCS::Commitment: Send + Sync,
+    PCS::CommitmentWithWitness: Send + Sync,
+    PCS::Proof: Send,
+{
+    run_e2e_multi_gpu_proof_with_precompiled_aot_and_sink(
+        sdk_prover,
+        prepared,
+        config,
+        init_full_mem,
+        public_io_digest,
+        max_steps,
+        None,
+        #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+        precompiled_aot,
+        #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
+        precompiled_fulltracer_aot,
+    )
+}
+
+#[cfg(feature = "gpu")]
+#[allow(clippy::too_many_arguments)]
+pub fn run_e2e_multi_gpu_proof_with_precompiled_aot_and_sink<
+    E: ExtensionField + LkMultiplicityKey,
+    PCS: PolynomialCommitmentScheme<E> + Serialize + 'static,
+>(
+    sdk_prover: ZKVMProver<
+        E,
+        PCS,
+        gkr_iop::gpu::GpuBackend<E, PCS>,
+        gkr_iop::gpu::GpuProver<gkr_iop::gpu::GpuBackend<E, PCS>>,
+    >,
+    prepared: &crate::multi_gpu::PreparedMultiGpu,
+    config: &crate::multi_gpu::MultiGpuConfig,
+    init_full_mem: &InitMemState,
+    public_io_digest: [u32; 8],
+    max_steps: usize,
+    event_sink: Option<Arc<dyn BaseProvingEventSink<E, PCS>>>,
     #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
     precompiled_aot: Option<Arc<ceno_emul::aot::AotProgram>>,
     #[cfg(all(feature = "aot-x86_64", target_arch = "x86_64", target_os = "linux"))]
@@ -4391,6 +4496,9 @@ where
     let verifier = sdk_prover
         .cached_verifier()
         .ok_or("initial GPU prover has no cached verifier")?;
+    if let Some(sink) = &event_sink {
+        sink.on_started(total_shards, verifier.vk.clone())?;
+    }
     tracing::info!(
         target: "ceno_multi_gpu",
         emulation_ms = emulation_elapsed.as_millis(),
@@ -4408,6 +4516,7 @@ where
         let mut handles = Vec::with_capacity(prepared.workers.len());
         let mut ready_receivers = Vec::with_capacity(prepared.workers.len());
         let mut emulation_result = Some(emulation_result);
+        let mut initial_prover = Some(sdk_prover);
         for (worker_index, worker) in prepared.workers.iter().enumerate() {
             let (tx, rx) = std::sync::mpsc::sync_channel::<BaseWorkerEvent<E, PCS>>(1);
             ready_receivers.push(Some(rx));
@@ -4432,7 +4541,12 @@ where
                 .worker_cpu_affinity
                 .as_ref()
                 .map(|sets| sets[worker_index].clone());
-            let existing_prover = (worker_index == 0).then_some(sdk_prover);
+            let existing_prover = (worker_index == 0).then(|| {
+                initial_prover
+                    .take()
+                    .expect("GPU0 prover must be available")
+            });
+            let event_sink = event_sink.clone();
             tracing::info!(
                 target: "ceno_multi_gpu",
                 worker_index,
@@ -4481,8 +4595,9 @@ where
                         ZKVMProver::new_with_vk_digest(pk.clone(), device, vk_digest)
                     });
                     let prover = existing_prover
+                        .as_ref()
                         .or(owned_prover.as_ref())
-                        .expect("worker prover must be borrowed or constructed");
+                        .expect("worker prover must be owned or constructed");
                     let prover_elapsed = prover_started.elapsed();
                     tracing::info!(
                         target: "ceno_multi_gpu",
@@ -4523,12 +4638,14 @@ where
                         }
                         let queue_started = std::time::Instant::now();
                         diagnostics.queue_state = "fifo_send_pending";
-                        tx.send(BaseWorkerEvent::Ready(BaseProofReady {
-                            shard_id,
-                            proof,
-                            device_id,
+                        tx.send(BaseWorkerEvent::Ready {
+                            ready: BaseProofReady {
+                                shard_id,
+                                proof,
+                                device_id,
+                            },
                             diagnostics,
-                        }))
+                        })
                         .map_err(|_| {
                             diagnostics.queue_state = "fifo_receiver_closed";
                             "collector closed while publishing proof".to_owned()
@@ -4569,7 +4686,7 @@ where
                     );
                     Ok::<(), String>(())
                 }));
-                let result = match run {
+                let mut result = match run {
                     Ok(result) => result,
                     Err(payload) => Err(format!(
                         "worker panicked: {}",
@@ -4580,10 +4697,55 @@ where
                             .unwrap_or("unknown panic")
                     )),
                 };
+                if result.is_ok() {
+                    let released_started = std::time::Instant::now();
+                    let _binding = gkr_iop::gpu::bind_thread_default_stream(hal.clone());
+                    let memory_before = ceno_gpu::get_cuda_mem_info().unwrap_or((0, 0));
+                    result = hal
+                        .inner()
+                        .synchronize()
+                        .map_err(|error| format!("failed to synchronize released GPU: {error}"))
+                        .and_then(|_| {
+                            hal.inner()
+                                .trim_mem_pool()
+                                .map_err(|error| format!("failed to trim released GPU: {error}"))
+                        })
+                        .and_then(|_| {
+                            hal.inner().synchronize().map_err(|error| {
+                                format!("failed to synchronize trimmed GPU: {error}")
+                            })
+                        });
+                    let memory_after = ceno_gpu::get_cuda_mem_info().unwrap_or((0, 0));
+                    if result.is_ok() {
+                        tracing::info!(
+                            target: "ceno_multi_gpu",
+                            worker_index,
+                            device_id,
+                            elapsed_ms = released_started.elapsed().as_millis(),
+                            memory_before_free_bytes = memory_before.0,
+                            memory_after_free_bytes = memory_after.0,
+                            memory_total_bytes = memory_after.1,
+                            phase = "device_released",
+                            "base GPU became recursion-eligible"
+                        );
+                        if let Some(sink) = &event_sink {
+                            result = sink.on_device_released(BaseDeviceReleased {
+                                worker_index,
+                                device_id,
+                                memory_before_free_bytes: memory_before.0,
+                                memory_after_free_bytes: memory_after.0,
+                                memory_total_bytes: memory_after.1,
+                            });
+                        }
+                    }
+                }
                 if let Err(error) = result {
                     cancelled.store(true, std::sync::atomic::Ordering::Release);
                     replay_start_gate.abort();
                     let error = diagnostics.describe(&error);
+                    if let Some(sink) = &event_sink {
+                        sink.on_failure(&error);
+                    }
                     let _ = tx.send(BaseWorkerEvent::Failed(error.clone()));
                     Some(error)
                 } else {
@@ -4612,26 +4774,33 @@ where
                         continue;
                     }
                 };
-                let ready = match event {
-                    BaseWorkerEvent::Ready(ready) => ready,
+                let (ready, mut diagnostics) = match event {
+                    BaseWorkerEvent::Ready { ready, diagnostics } => (ready, diagnostics),
                     BaseWorkerEvent::Failed(error) => {
                         collector_error = Some(error);
                         break;
                     }
                 };
-                let mut diagnostics = ready.diagnostics;
                 diagnostics.queue_state = "collector_dequeued";
-                if let Err(error) = collector.accept(
+                let shard_id = ready.shard_id;
+                if let Err(error) = collector.accept_and_then(
                     config,
                     ready.shard_id,
                     ready.proof.public_values.shard_id,
                     ready.device_id,
+                    || {
+                        if let Some(sink) = &event_sink {
+                            proofs[shard_id] = Some(ready.proof.clone());
+                            sink.on_proof_ready(ready)
+                        } else {
+                            proofs[shard_id] = Some(ready.proof);
+                            Ok(())
+                        }
+                    },
                 ) {
                     collector_error = Some(diagnostics.describe(&error));
                     break;
                 }
-                let shard_id = ready.shard_id;
-                proofs[shard_id] = Some(ready.proof);
                 received += 1;
             }
             if received < total_shards
@@ -4648,6 +4817,9 @@ where
         }
         if collector_error.is_some() {
             cancelled.store(true, std::sync::atomic::Ordering::Release);
+            if let (Some(sink), Some(error)) = (&event_sink, &collector_error) {
+                sink.on_failure(error);
+            }
         }
         drop(ready_receivers);
         let mut join_error = None;
@@ -4666,18 +4838,6 @@ where
         if let Some(error) = collector_error.or(join_error) {
             return Err(error);
         }
-        if let Some(shard_id) = collector.missing() {
-            return Err(format!(
-                "GPU device unknown worker unknown shard {shard_id} failed: missing base proof; last_completed_shard=unknown cuda_error_class=non_cuda queue_state=all_workers_joined memory_metrics=unavailable"
-            ));
-        }
-        let proofs = proofs
-            .into_iter()
-            .enumerate()
-            .map(|(shard_id, proof)| {
-                proof.ok_or_else(|| format!("missing base proof shard {shard_id}"))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
         let base_proofs_ready_elapsed = pipeline_started.elapsed();
         tracing::info!(
             target: "ceno_multi_gpu",
@@ -4688,7 +4848,9 @@ where
             "Stage 1 canonical base proofs ready"
         );
         let base_verification_started = std::time::Instant::now();
-        run_e2e_full_trace_verify(&verifier, proofs.clone(), exit_code, max_steps);
+        let proofs = verify_complete_base_proofs(&collector, proofs, |proofs| {
+            run_e2e_full_trace_verify(&verifier, proofs, exit_code, max_steps)
+        })?;
         let base_verification_elapsed = base_verification_started.elapsed();
         let verified_base_elapsed = pipeline_started.elapsed();
         tracing::info!(
@@ -4705,95 +4867,20 @@ where
         );
         Ok(proofs)
     })?;
-    let proofs =
-        finish_gpu_base_proving(proofs, || handoff_gpu_pool_to_recursion(prepared, config))?;
-    tracing::info!(
-        target: "ceno_multi_gpu",
-        device_id = config.recursion_device,
-        recursion_ready_ms = pipeline_started.elapsed().as_millis(),
-        phase = "recursion_ready",
-        "Stage 1 base pipeline ready for single-device recursion"
-    );
     Ok(proofs)
-}
-
-#[cfg(feature = "gpu")]
-fn finish_gpu_base_proving<T>(
-    result: T,
-    handoff: impl FnOnce() -> Result<(), String>,
-) -> Result<T, String> {
-    handoff()?;
-    Ok(result)
-}
-
-#[cfg(feature = "gpu")]
-fn handoff_gpu_pool_to_recursion(
-    prepared: &crate::multi_gpu::PreparedMultiGpu,
-    config: &crate::multi_gpu::MultiGpuConfig,
-) -> Result<(), String> {
-    let worker = prepared
-        .workers
-        .iter()
-        .find(|worker| worker.info.logical_ordinal == config.recursion_device)
-        .ok_or_else(|| {
-            format!(
-                "recursion GPU {} was not prepared for pool handoff",
-                config.recursion_device
-            )
-        })?;
-    let hal = worker.hal.clone();
-    let started = std::time::Instant::now();
-    let (memory_before, memory_after) = {
-        let _binding = gkr_iop::gpu::bind_thread_default_stream(hal.clone());
-        let memory_before = ceno_gpu::get_cuda_mem_info().unwrap_or((0, 0));
-        hal.inner().synchronize().map_err(|error| {
-            format!("failed to synchronize recursion GPU before handoff: {error}")
-        })?;
-        hal.inner().trim_mem_pool().map_err(|error| {
-            format!("failed to trim recursion GPU pool during handoff: {error}")
-        })?;
-        hal.inner().synchronize().map_err(|error| {
-            format!("failed to synchronize recursion GPU after handoff: {error}")
-        })?;
-        (
-            memory_before,
-            ceno_gpu::get_cuda_mem_info().unwrap_or((0, 0)),
-        )
-    };
-    gkr_iop::gpu::set_thread_cuda_hal(hal);
-    tracing::info!(
-        target: "ceno_multi_gpu",
-        device_id = config.recursion_device,
-        elapsed_ms = started.elapsed().as_millis(),
-        memory_before_free_bytes = memory_before.0,
-        memory_after_free_bytes = memory_after.0,
-        memory_total_bytes = memory_after.1,
-        phase = "post_base_pool_handoff",
-        "Stage 1 GPU pool handed off to recursion"
-    );
-    Ok(())
 }
 
 #[cfg(all(test, feature = "gpu"))]
 mod multi_gpu_collector_tests {
     use super::{
         BaseProofCollectorState, BaseWorkerDiagnostics, ReplayStartGate, classify_cuda_error,
-        finish_gpu_base_proving,
+        verify_complete_base_proofs,
     };
     use crate::multi_gpu::MultiGpuConfig;
-    use std::{sync::mpsc, time::Duration};
-
-    #[test]
-    fn post_base_pool_handoff_runs_exactly_once() {
-        let mut handoffs = 0;
-        let result = finish_gpu_base_proving(7, || {
-            handoffs += 1;
-            Ok(())
-        })
-        .unwrap();
-        assert_eq!(result, 7);
-        assert_eq!(handoffs, 1);
-    }
+    use std::{
+        sync::{Arc, Mutex, mpsc},
+        time::Duration,
+    };
 
     #[test]
     fn replay_start_gate_releases_concurrent_producers() {
@@ -4876,6 +4963,62 @@ mod multi_gpu_collector_tests {
                 .contains("duplicate")
         );
         assert_eq!(collector.missing(), Some(1));
+    }
+
+    #[test]
+    fn metadata_validation_precedes_fake_sink_notification() {
+        let config = MultiGpuConfig::new(vec![4]).unwrap();
+        let mut collector = BaseProofCollectorState::new(1);
+        let events = Arc::new(Mutex::new(vec!["started"]));
+
+        let invalid_events = events.clone();
+        assert!(
+            collector
+                .accept_and_then(&config, 0, 1, 4, || {
+                    invalid_events.lock().unwrap().push("proof_ready");
+                    Ok(())
+                })
+                .is_err()
+        );
+        assert_eq!(*events.lock().unwrap(), vec!["started"]);
+
+        let valid_events = events.clone();
+        collector
+            .accept_and_then(&config, 0, 0, 4, || {
+                valid_events.lock().unwrap().push("proof_ready");
+                Ok(())
+            })
+            .unwrap();
+        events.lock().unwrap().push("device_released");
+        assert_eq!(
+            *events.lock().unwrap(),
+            vec!["started", "proof_ready", "device_released"]
+        );
+    }
+
+    #[test]
+    fn canonical_verifier_runs_once_and_only_after_completeness() {
+        let config = MultiGpuConfig::new(vec![0]).unwrap();
+        let mut incomplete = BaseProofCollectorState::new(2);
+        incomplete.accept(&config, 0, 0, 0).unwrap();
+        let verify_count = std::cell::Cell::new(0);
+        assert!(
+            verify_complete_base_proofs(&incomplete, vec![Some(10), None], |_| {
+                verify_count.set(verify_count.get() + 1)
+            })
+            .is_err()
+        );
+        assert_eq!(verify_count.get(), 0);
+
+        let mut complete = BaseProofCollectorState::new(2);
+        complete.accept(&config, 0, 0, 0).unwrap();
+        complete.accept(&config, 1, 1, 0).unwrap();
+        let proofs = verify_complete_base_proofs(&complete, vec![Some(10), Some(11)], |_| {
+            verify_count.set(verify_count.get() + 1)
+        })
+        .unwrap();
+        assert_eq!(proofs, vec![10, 11]);
+        assert_eq!(verify_count.get(), 1);
     }
 
     #[test]

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1175,6 +1175,26 @@ struct CompactReplayShard {
     fallback_steps: Vec<StepRecord>,
     syscall_witnesses: Vec<SyscallWitness>,
     summary: ShardStepSummary,
+    // Read by the multi-GPU pipeline; single-device replay consumes the other fields directly.
+    #[cfg_attr(not(feature = "gpu"), allow(dead_code))]
+    state_audit_before_digest: Option<[u8; 32]>,
+    #[cfg_attr(not(feature = "gpu"), allow(dead_code))]
+    state_audit_digest: Option<[u8; 32]>,
+}
+
+fn replay_state_audit_selected(shard_id: usize) -> bool {
+    let selected = std::env::var("CENO_MULTI_GPU_REPLAY_AUDIT_SHARD")
+        .ok()
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .unwrap_or_else(|_| panic!("CENO_MULTI_GPU_REPLAY_AUDIT_SHARD must be a shard ID"))
+        });
+    selected == Some(shard_id)
+}
+
+fn replay_state_audit_digest(vm: &VMState<GpuReplayTracer>, shard_id: usize) -> Option<[u8; 32]> {
+    replay_state_audit_selected(shard_id).then(|| vm.replay_state_audit_digest())
 }
 
 struct CompactStepReplay {
@@ -1418,6 +1438,8 @@ fn spawn_compact_replay_pipeline(
                     worker_index = input.ownership.map(|value| value.0),
                     replay_mode = if owned { "compact" } else { "fast_flight" },
                     replay_digest = ?replay_digest,
+                    state_audit_before_digest = ?shard.state_audit_before_digest,
+                    state_audit_digest = ?shard.state_audit_digest,
                     phase = "cpu_replay_ready",
                     "compact replay pipeline event"
                 );
@@ -1545,6 +1567,8 @@ impl CompactStepReplay {
         ) -> Option<ceno_emul::GpuReplayTypedRange>,
     ) -> Option<CompactReplayShard> {
         let expected_steps = *self.shard_step_counts.get(self.shard_id)?;
+        let state_audit_before_digest =
+            replay_state_audit_selected(self.shard_id).then(|| self.vm.replay_state_audit_digest());
         let expected_range_count = self.range_descriptors[self.next_range_descriptor..]
             .iter()
             .take_while(|descriptor| descriptor.shard_id as usize == self.shard_id)
@@ -1616,6 +1640,7 @@ impl CompactStepReplay {
                 first_hint_before,
                 last_hint_after: self.vm.tracer().max_hint_addr_access().0,
             };
+            let state_audit_digest = replay_state_audit_digest(&self.vm, self.shard_id);
             tracing::info!(
                 target: "ceno_multi_gpu",
                 shard_id = self.shard_id,
@@ -1628,6 +1653,7 @@ impl CompactStepReplay {
                 avoided_rows,
                 avoided_bytes,
                 avoided_fallback,
+                ?state_audit_digest,
                 "fast-flight replay complete"
             );
             self.shard_id += 1;
@@ -1636,6 +1662,8 @@ impl CompactStepReplay {
                 fallback_steps: Vec::new(),
                 syscall_witnesses: Vec::new(),
                 summary,
+                state_audit_before_digest,
+                state_audit_digest,
             });
         }
         let mut executed = 0usize;
@@ -1817,12 +1845,15 @@ impl CompactStepReplay {
             last_hint_after: self.vm.tracer().max_hint_addr_access().0,
         };
         let syscall_witnesses = self.vm.tracer_mut().take_syscall_witnesses();
+        let state_audit_digest = replay_state_audit_digest(&self.vm, self.shard_id);
         self.shard_id += 1;
         Some(CompactReplayShard {
             arenas,
             fallback_steps,
             syscall_witnesses,
             summary,
+            state_audit_before_digest,
+            state_audit_digest,
         })
     }
 }

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -29,13 +29,13 @@ use ceno_emul::{
     SyscallWitness, Tracer, VM_REG_COUNT, VMState, WORD_SIZE, Word, WordAddr,
     host_utils::read_all_messages,
 };
+#[cfg(feature = "gpu")]
+use ceno_gpu::CudaHal;
 use clap::ValueEnum;
 use either::Either;
 use ff_ext::{ExtensionField, SmallField};
 #[cfg(debug_assertions)]
 use ff_ext::{Instrumented, PoseidonField};
-#[cfg(feature = "gpu")]
-use gkr_iop::gpu::get_cuda_hal;
 use gkr_iop::{RAMType, hal::ProverBackend};
 use itertools::Itertools;
 #[cfg(debug_assertions)]
@@ -4404,7 +4404,7 @@ where
     let replay_start_gate = Arc::new(ReplayStartGate::new(prepared.workers.len()));
     let started = std::time::Instant::now();
 
-    std::thread::scope(|scope| -> Result<Vec<ZKVMProof<E, PCS>>, String> {
+    let proofs = std::thread::scope(|scope| -> Result<Vec<ZKVMProof<E, PCS>>, String> {
         let mut handles = Vec::with_capacity(prepared.workers.len());
         let mut ready_receivers = Vec::with_capacity(prepared.workers.len());
         let mut emulation_result = Some(emulation_result);
@@ -4704,16 +4704,96 @@ where
             "Stage 1 multi-GPU base proving complete"
         );
         Ok(proofs)
-    })
+    })?;
+    let proofs =
+        finish_gpu_base_proving(proofs, || handoff_gpu_pool_to_recursion(prepared, config))?;
+    tracing::info!(
+        target: "ceno_multi_gpu",
+        device_id = config.recursion_device,
+        recursion_ready_ms = pipeline_started.elapsed().as_millis(),
+        phase = "recursion_ready",
+        "Stage 1 base pipeline ready for single-device recursion"
+    );
+    Ok(proofs)
+}
+
+#[cfg(feature = "gpu")]
+fn finish_gpu_base_proving<T>(
+    result: T,
+    handoff: impl FnOnce() -> Result<(), String>,
+) -> Result<T, String> {
+    handoff()?;
+    Ok(result)
+}
+
+#[cfg(feature = "gpu")]
+fn handoff_gpu_pool_to_recursion(
+    prepared: &crate::multi_gpu::PreparedMultiGpu,
+    config: &crate::multi_gpu::MultiGpuConfig,
+) -> Result<(), String> {
+    let worker = prepared
+        .workers
+        .iter()
+        .find(|worker| worker.info.logical_ordinal == config.recursion_device)
+        .ok_or_else(|| {
+            format!(
+                "recursion GPU {} was not prepared for pool handoff",
+                config.recursion_device
+            )
+        })?;
+    let hal = worker.hal.clone();
+    let started = std::time::Instant::now();
+    let (memory_before, memory_after) = {
+        let _binding = gkr_iop::gpu::bind_thread_default_stream(hal.clone());
+        let memory_before = ceno_gpu::get_cuda_mem_info().unwrap_or((0, 0));
+        hal.inner().synchronize().map_err(|error| {
+            format!("failed to synchronize recursion GPU before handoff: {error}")
+        })?;
+        hal.inner().trim_mem_pool().map_err(|error| {
+            format!("failed to trim recursion GPU pool during handoff: {error}")
+        })?;
+        hal.inner().synchronize().map_err(|error| {
+            format!("failed to synchronize recursion GPU after handoff: {error}")
+        })?;
+        (
+            memory_before,
+            ceno_gpu::get_cuda_mem_info().unwrap_or((0, 0)),
+        )
+    };
+    gkr_iop::gpu::set_thread_cuda_hal(hal);
+    tracing::info!(
+        target: "ceno_multi_gpu",
+        device_id = config.recursion_device,
+        elapsed_ms = started.elapsed().as_millis(),
+        memory_before_free_bytes = memory_before.0,
+        memory_after_free_bytes = memory_after.0,
+        memory_total_bytes = memory_after.1,
+        phase = "post_base_pool_handoff",
+        "Stage 1 GPU pool handed off to recursion"
+    );
+    Ok(())
 }
 
 #[cfg(all(test, feature = "gpu"))]
 mod multi_gpu_collector_tests {
     use super::{
         BaseProofCollectorState, BaseWorkerDiagnostics, ReplayStartGate, classify_cuda_error,
+        finish_gpu_base_proving,
     };
     use crate::multi_gpu::MultiGpuConfig;
     use std::{sync::mpsc, time::Duration};
+
+    #[test]
+    fn post_base_pool_handoff_runs_exactly_once() {
+        let mut handoffs = 0;
+        let result = finish_gpu_base_proving(7, || {
+            handoffs += 1;
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(result, 7);
+        assert_eq!(handoffs, 1);
+    }
 
     #[test]
     fn replay_start_gate_releases_concurrent_producers() {
@@ -4955,21 +5035,6 @@ fn create_proofs_streaming<
         }
     });
     metrics::gauge!("num_shards").set(proofs.len() as f64);
-
-    // Currently, due to mixed usage with other GPU backends,
-    // we need to trim ceno-gpu's memory pool while still retaining 424MB.
-    // Once the GPU backend is unified, skipping this trim
-    // could improve performance by a few seconds.
-    #[cfg(feature = "gpu")]
-    {
-        use gkr_iop::gpu::gpu_prover::*;
-
-        info_span!("[ceno] trim_gpu_mem_pool").in_scope(|| {
-            let cuda_hal = get_cuda_hal().unwrap();
-            cuda_hal.inner().trim_mem_pool().unwrap();
-            cuda_hal.inner().synchronize().unwrap();
-        });
-    };
 
     #[cfg(feature = "gpu")]
     if crate::instructions::gpu::config::is_debug_compare_enabled() {

--- a/ceno_zkvm/src/e2e.rs
+++ b/ceno_zkvm/src/e2e.rs
@@ -1406,6 +1406,8 @@ fn spawn_compact_replay_pipeline(
                 } else {
                     unowned_shards += 1;
                 }
+                // Every replay advances canonical VM state and contributes the same digest.
+                // Only the owning worker retains compact arenas for witness construction.
                 let shard = replay
                     .next_shard(owned, false, Some)
                     .expect("compact replay ended before its shard plan");
@@ -4212,6 +4214,8 @@ pub struct BaseDeviceReleased {
 pub trait BaseProvingEventSink<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>:
     Send + Sync
 {
+    // Events may start speculative recursion, but they cannot authorize root publication; the
+    // caller opens that gate only after the complete canonical base verification succeeds.
     fn on_started(
         &self,
         total_shards: usize,
@@ -4523,6 +4527,7 @@ where
         let mut emulation_result = Some(emulation_result);
         let mut initial_prover = Some(sdk_prover);
         for (worker_index, worker) in prepared.workers.iter().enumerate() {
+            // A depth-one FIFO bounds the extra full-proof footprint and backpressures its owner.
             let (tx, rx) = std::sync::mpsc::sync_channel::<BaseWorkerEvent<E, PCS>>(1);
             ready_receivers.push(Some(rx));
             let worker_inputs_started = std::time::Instant::now();
@@ -4703,6 +4708,8 @@ where
                     )),
                 };
                 if result.is_ok() {
+                    // All device-backed prover state lived inside `run` and is now dropped. Only
+                    // after synchronization and pool trim may this physical GPU join recursion.
                     let released_started = std::time::Instant::now();
                     let _binding = gkr_iop::gpu::bind_thread_default_stream(hal.clone());
                     let memory_before = ceno_gpu::get_cuda_mem_info().unwrap_or((0, 0));
@@ -4763,6 +4770,8 @@ where
         let mut collector = BaseProofCollectorState::new(total_shards);
         let mut received = 0usize;
         let mut collector_error = None;
+        // Drain each bounded FIFO fairly. The first invalid proof or worker error cancels every
+        // producer, but all scoped workers are still joined before the error is returned.
         while received < total_shards && collector_error.is_none() {
             let mut made_progress = false;
             for receiver in &mut ready_receivers {
@@ -4852,6 +4861,8 @@ where
             phase = "base_proofs_ready",
             "Stage 1 canonical base proofs ready"
         );
+        // Verification runs exactly once, after range/owner/duplicate checks and canonical
+        // shard ordering are complete. Recursion may overlap, but cannot publish its root yet.
         let base_verification_started = std::time::Instant::now();
         let proofs = verify_complete_base_proofs(&collector, proofs, |proofs| {
             run_e2e_full_trace_verify(&verifier, proofs, exit_code, max_steps)

--- a/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
+++ b/ceno_zkvm/src/instructions/gpu/chips/shard_ram.rs
@@ -292,7 +292,7 @@ pub(crate) fn try_gpu_assign_shard_ram<E: ExtensionField>(
         bb31::CudaHalBB31,
         common::{transpose::matrix_transpose, witgen::types::GpuShardRamRecord},
     };
-    use gkr_iop::gpu::gpu_prover::get_cuda_hal;
+    use gkr_iop::gpu::get_cuda_hal;
     use p3::field::PrimeField32;
     use witness::{DeviceMatrixLayout, InstancePaddingStrategy, next_pow2_instance_padding};
 
@@ -542,7 +542,7 @@ pub(crate) fn try_gpu_assign_shard_ram_from_device<E: ExtensionField>(
     num_local_writes: usize,
 ) -> Result<Option<crate::tables::RMMCollections<E::BaseField>>, ZKVMError> {
     use ceno_gpu::{Buffer, bb31::CudaHalBB31, common::transpose::matrix_transpose};
-    use gkr_iop::gpu::gpu_prover::get_cuda_hal;
+    use gkr_iop::gpu::get_cuda_hal;
     use witness::{DeviceMatrixLayout, InstancePaddingStrategy, next_pow2_instance_padding};
 
     type BB = <ff_ext::BabyBearExt4 as ExtensionField>::BaseField;
@@ -736,7 +736,7 @@ pub(crate) fn try_gpu_assign_shard_ram_ec_tree_from_device<E: ExtensionField>(
     num_write_records: usize,
 ) -> Result<Option<crate::tables::RMMCollections<E::BaseField>>, ZKVMError> {
     use ceno_gpu::{Buffer, CudaHal, bb31::CudaHalBB31, common::transpose::matrix_transpose};
-    use gkr_iop::gpu::gpu_prover::get_cuda_hal;
+    use gkr_iop::gpu::get_cuda_hal;
     use witness::{DeviceMatrixLayout, InstancePaddingStrategy, next_pow2_instance_padding};
 
     type BB = <ff_ext::BabyBearExt4 as ExtensionField>::BaseField;

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -65,8 +65,66 @@ fn checked_producer_base(base: usize, range_rows: usize, count: usize) -> u32 {
     u32::try_from(base).expect("producer base exceeds u32")
 }
 
+// `ShardContext` stores each Rayon bucket in a BTreeMap, so a later
+// `assign_opcode_circuit` call replaces an earlier record for the same
+// address. Device finalization must use that assignment order rather than the
+// enum discriminant; the two orders differ for logic, div/rem, loads, and stores.
+const PRODUCER_ASSIGNMENT_ORDER: &[InsnKind] = &[
+    InsnKind::ADD,
+    InsnKind::SUB,
+    InsnKind::AND,
+    InsnKind::OR,
+    InsnKind::XOR,
+    InsnKind::SLL,
+    InsnKind::SRL,
+    InsnKind::SRA,
+    InsnKind::SLT,
+    InsnKind::SLTU,
+    InsnKind::MUL,
+    InsnKind::MULH,
+    InsnKind::MULHSU,
+    InsnKind::MULHU,
+    InsnKind::DIVU,
+    InsnKind::REMU,
+    InsnKind::DIV,
+    InsnKind::REM,
+    InsnKind::ADDI,
+    InsnKind::ANDI,
+    InsnKind::ORI,
+    InsnKind::XORI,
+    InsnKind::SLLI,
+    InsnKind::SRLI,
+    InsnKind::SRAI,
+    InsnKind::SLTI,
+    InsnKind::SLTIU,
+    #[cfg(feature = "u16limb_circuit")]
+    InsnKind::LUI,
+    #[cfg(feature = "u16limb_circuit")]
+    InsnKind::AUIPC,
+    InsnKind::BEQ,
+    InsnKind::BNE,
+    InsnKind::BLT,
+    InsnKind::BLTU,
+    InsnKind::BGE,
+    InsnKind::BGEU,
+    InsnKind::JAL,
+    InsnKind::JALR,
+    InsnKind::LW,
+    InsnKind::LB,
+    InsnKind::LBU,
+    InsnKind::LH,
+    InsnKind::LHU,
+    InsnKind::SW,
+    InsnKind::SH,
+    InsnKind::SB,
+];
+
 fn producer_order(kind: InsnKind) -> u32 {
-    let order = kind as u32;
+    let order = PRODUCER_ASSIGNMENT_ORDER
+        .iter()
+        .position(|candidate| *candidate == kind)
+        .unwrap_or_else(|| panic!("non-fused instruction kind {kind:?} has no producer order"))
+        as u32;
     let max_priority =
         (u64::from(order) << 30) | (u64::try_from(MAX_PRODUCER_ROWS - 1).unwrap() << 2) | 3;
     assert_eq!(
@@ -2870,11 +2928,16 @@ mod tests {
     }
 
     #[test]
-    fn producer_metadata_preserves_count_and_kind_priority() {
+    fn producer_metadata_preserves_count_and_assignment_priority() {
         assert_eq!(producer_count(123), 123);
-        assert_eq!(producer_order(InsnKind::ADD), InsnKind::ADD as u32);
-        assert_eq!(producer_order(InsnKind::SUB), InsnKind::SUB as u32);
-        assert_ne!(producer_order(InsnKind::ADD), producer_order(InsnKind::SUB));
+        assert_eq!(
+            PRODUCER_ASSIGNMENT_ORDER
+                .iter()
+                .copied()
+                .map(producer_order)
+                .collect::<Vec<_>>(),
+            (0..PRODUCER_ASSIGNMENT_ORDER.len() as u32).collect::<Vec<_>>()
+        );
     }
 
     #[test]
@@ -3039,6 +3102,9 @@ mod tests {
     #[cfg(feature = "u16limb_circuit")]
     #[test]
     fn compact_and_field_soa_fused_assignments_match_every_layout() {
+        let hal = std::sync::Arc::new(CudaHalBB31::new(0).unwrap());
+        let _binding = gkr_iop::gpu::bind_thread_default_stream(hal);
+
         use ceno_emul::{
             ByteAddr, Change, GpuReplayTypedRange, ReadOp, WordAddr, WriteOp, encode_rv32,
         };

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -3116,7 +3116,8 @@ mod tests {
             instructions::{
                 Instruction,
                 riscv::{
-                    AddInstruction, JalInstruction, JalrInstruction, LwInstruction, SwInstruction,
+                    AddInstruction, JalInstruction, JalrInstruction, LbInstruction, LbuInstruction,
+                    LhInstruction, LhuInstruction, LwInstruction, SwInstruction,
                     arith_imm::AddiInstruction, branch::BeqInstruction, lui::LuiInstruction,
                 },
             },
@@ -3208,6 +3209,58 @@ mod tests {
                 Change::new(0x33, 0x12000),
                 0,
             ),
+            StepRecord::new_im_instruction(
+                36,
+                ByteAddr(0x1020),
+                with_raw(encode_rv32(InsnKind::LB, 1, 0, 3, 10), 0x00a0_8183),
+                0x0400_0000,
+                Change::new(0x33, 0xffff_ffff),
+                ReadOp {
+                    addr: WordAddr(0x0100_0002),
+                    value: 0x80ff_7f01,
+                    previous_cycle: 0,
+                },
+                0,
+            ),
+            StepRecord::new_im_instruction(
+                40,
+                ByteAddr(0x1024),
+                with_raw(encode_rv32(InsnKind::LBU, 1, 0, 3, 9), 0x0090_c183),
+                0x0400_0000,
+                Change::new(0x33, 0x7f),
+                ReadOp {
+                    addr: WordAddr(0x0100_0002),
+                    value: 0x80ff_7f01,
+                    previous_cycle: 0,
+                },
+                0,
+            ),
+            StepRecord::new_im_instruction(
+                44,
+                ByteAddr(0x1028),
+                with_raw(encode_rv32(InsnKind::LH, 1, 0, 3, 10), 0x00a0_9183),
+                0x0400_0000,
+                Change::new(0x33, 0xffff_80ff),
+                ReadOp {
+                    addr: WordAddr(0x0100_0002),
+                    value: 0x80ff_7f01,
+                    previous_cycle: 0,
+                },
+                0,
+            ),
+            StepRecord::new_im_instruction(
+                48,
+                ByteAddr(0x102c),
+                with_raw(encode_rv32(InsnKind::LHU, 1, 0, 3, 8), 0x0080_d183),
+                0x0400_0000,
+                Change::new(0x33, 0x7f01),
+                ReadOp {
+                    addr: WordAddr(0x0100_0002),
+                    value: 0x80ff_7f01,
+                    previous_cycle: 0,
+                },
+                0,
+            ),
         ];
 
         fn arenas(steps: &[StepRecord], compact: bool) -> GpuReplayShardArenas {
@@ -3279,6 +3332,10 @@ mod tests {
             let jal = cs.register_opcode_circuit::<JalInstruction<E>>();
             let jalr = cs.register_opcode_circuit::<JalrInstruction<E>>();
             let lw = cs.register_opcode_circuit::<LwInstruction<E>>();
+            let lb = cs.register_opcode_circuit::<LbInstruction<E>>();
+            let lbu = cs.register_opcode_circuit::<LbuInstruction<E>>();
+            let lh = cs.register_opcode_circuit::<LhInstruction<E>>();
+            let lhu = cs.register_opcode_circuit::<LhuInstruction<E>>();
             let sw = cs.register_opcode_circuit::<SwInstruction<E>>();
             let lui = cs.register_opcode_circuit::<LuiInstruction<E>>();
 
@@ -3302,11 +3359,43 @@ mod tests {
             prepare!(JalInstruction<E>, &jal, GpuWitgenKind::Jal);
             prepare!(JalrInstruction<E>, &jalr, GpuWitgenKind::Jalr);
             prepare!(LwInstruction<E>, &lw, GpuWitgenKind::Lw);
+            prepare!(
+                LbInstruction<E>,
+                &lb,
+                GpuWitgenKind::LoadSub {
+                    load_width: 8,
+                    is_signed: 1,
+                }
+            );
+            prepare!(
+                LbuInstruction<E>,
+                &lbu,
+                GpuWitgenKind::LoadSub {
+                    load_width: 8,
+                    is_signed: 0,
+                }
+            );
+            prepare!(
+                LhInstruction<E>,
+                &lh,
+                GpuWitgenKind::LoadSub {
+                    load_width: 16,
+                    is_signed: 1,
+                }
+            );
+            prepare!(
+                LhuInstruction<E>,
+                &lhu,
+                GpuWitgenKind::LoadSub {
+                    load_width: 16,
+                    is_signed: 0,
+                }
+            );
             prepare!(SwInstruction<E>, &sw, GpuWitgenKind::Sw);
             prepare!(LuiInstruction<E>, &lui, GpuWitgenKind::Lui);
 
             let mut shard_ctx = ShardContext::default();
-            shard_ctx.cur_shard_cycle_range = 4..36;
+            shard_ctx.cur_shard_cycle_range = 4..52;
             launch_fused_assignments(&shard_ctx).unwrap();
 
             let mut witness = ZKVMWitnesses::<E>::default();
@@ -3329,6 +3418,10 @@ mod tests {
             assign!(JalInstruction<E>, &jal);
             assign!(JalrInstruction<E>, &jalr);
             assign!(LwInstruction<E>, &lw);
+            assign!(LbInstruction<E>, &lb);
+            assign!(LbuInstruction<E>, &lbu);
+            assign!(LhInstruction<E>, &lh);
+            assign!(LhuInstruction<E>, &lhu);
             assign!(SwInstruction<E>, &sw);
             assign!(LuiInstruction<E>, &lui);
             clear_compact_replay_arenas();

--- a/ceno_zkvm/src/instructions/gpu/dispatch.rs
+++ b/ceno_zkvm/src/instructions/gpu/dispatch.rs
@@ -65,66 +65,7 @@ fn checked_producer_base(base: usize, range_rows: usize, count: usize) -> u32 {
     u32::try_from(base).expect("producer base exceeds u32")
 }
 
-// `ShardContext` stores each Rayon bucket in a BTreeMap, so a later
-// `assign_opcode_circuit` call replaces an earlier record for the same
-// address. Device finalization must use that assignment order rather than the
-// enum discriminant; the two orders differ for logic, div/rem, loads, and stores.
-const PRODUCER_ASSIGNMENT_ORDER: &[InsnKind] = &[
-    InsnKind::ADD,
-    InsnKind::SUB,
-    InsnKind::AND,
-    InsnKind::OR,
-    InsnKind::XOR,
-    InsnKind::SLL,
-    InsnKind::SRL,
-    InsnKind::SRA,
-    InsnKind::SLT,
-    InsnKind::SLTU,
-    InsnKind::MUL,
-    InsnKind::MULH,
-    InsnKind::MULHSU,
-    InsnKind::MULHU,
-    InsnKind::DIVU,
-    InsnKind::REMU,
-    InsnKind::DIV,
-    InsnKind::REM,
-    InsnKind::ADDI,
-    InsnKind::ANDI,
-    InsnKind::ORI,
-    InsnKind::XORI,
-    InsnKind::SLLI,
-    InsnKind::SRLI,
-    InsnKind::SRAI,
-    InsnKind::SLTI,
-    InsnKind::SLTIU,
-    #[cfg(feature = "u16limb_circuit")]
-    InsnKind::LUI,
-    #[cfg(feature = "u16limb_circuit")]
-    InsnKind::AUIPC,
-    InsnKind::BEQ,
-    InsnKind::BNE,
-    InsnKind::BLT,
-    InsnKind::BLTU,
-    InsnKind::BGE,
-    InsnKind::BGEU,
-    InsnKind::JAL,
-    InsnKind::JALR,
-    InsnKind::LW,
-    InsnKind::LB,
-    InsnKind::LBU,
-    InsnKind::LH,
-    InsnKind::LHU,
-    InsnKind::SW,
-    InsnKind::SH,
-    InsnKind::SB,
-];
-
-fn producer_order(kind: InsnKind) -> u32 {
-    let order = PRODUCER_ASSIGNMENT_ORDER
-        .iter()
-        .position(|candidate| *candidate == kind)
-        .unwrap_or_else(|| panic!("non-fused instruction kind {kind:?} has no producer order"))
-        as u32;
+fn check_producer_order(order: u32) {
     let max_priority =
         (u64::from(order) << 30) | (u64::try_from(MAX_PRODUCER_ROWS - 1).unwrap() << 2) | 3;
     assert_eq!(
@@ -132,7 +73,6 @@ fn producer_order(kind: InsnKind) -> u32 {
         0,
         "producer order overlaps continuation class"
     );
-    order
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -275,6 +215,7 @@ type Bb = <ff_ext::BabyBearExt4 as ExtensionField>::BaseField;
 struct FusedRegistration {
     owner: TypeId,
     kind: InsnKind,
+    producer_order: u32,
     tag: u32,
     arg0: u32,
     arg1: u32,
@@ -833,7 +774,7 @@ pub(crate) fn submit_provisional_fused_range(
                 row_count: u32::try_from(arena.len()).unwrap(),
                 producer_base: checked_producer_base(producer_base, arena.len(), registration.rows),
                 producer_count: producer_count(registration.rows),
-                producer_order: producer_order(arena.kind()),
+                producer_order: registration.producer_order,
                 num_cols: u32::try_from(registration.num_cols).unwrap(),
                 arg0: registration.arg0,
                 arg1: registration.arg1,
@@ -1098,6 +1039,7 @@ pub(crate) fn prepare_fused_assignment<
     num_structural_witin: usize,
     expected_rows: usize,
     kind: GpuWitgenKind,
+    producer_order: u32,
 ) -> Result<(), ZKVMError> {
     if !FUSED_INGRESS.with(|slot| slot.borrow().is_some()) {
         return Ok(());
@@ -1162,6 +1104,8 @@ pub(crate) fn prepare_fused_assignment<
         });
         return Ok(());
     }
+
+    check_producer_order(producer_order);
 
     macro_rules! map_config {
         ($ty:ty, $extract:path) => {{
@@ -1338,6 +1282,7 @@ pub(crate) fn prepare_fused_assignment<
             .push(FusedRegistration {
                 owner: TypeId::of::<I>(),
                 kind: insn_kind,
+                producer_order,
                 tag,
                 arg0,
                 arg1,
@@ -1507,7 +1452,7 @@ pub(crate) fn launch_fused_assignments(shard_ctx: &ShardContext) -> Result<(), Z
                         registration.rows,
                     ),
                     producer_count: producer_count(registration.rows),
-                    producer_order: producer_order(arena.kind()),
+                    producer_order: registration.producer_order,
                     num_cols: u32::try_from(registration.num_cols)
                         .expect("column count exceeds u32"),
                     arg0: registration.arg0,
@@ -2928,16 +2873,63 @@ mod tests {
     }
 
     #[test]
-    fn producer_metadata_preserves_count_and_assignment_priority() {
-        assert_eq!(producer_count(123), 123);
-        assert_eq!(
-            PRODUCER_ASSIGNMENT_ORDER
+    fn producer_order_is_stable_for_sparse_registration_paths() {
+        use crate::{
+            instructions::riscv::{LEGACY_PRODUCER_ORDER, Rv32imConfig},
+            structs::{ProgramParams, ZKVMConstraintSystem},
+        };
+        let hal = std::sync::Arc::new(CudaHalBB31::new(0).unwrap());
+        let _binding = gkr_iop::gpu::bind_thread_default_stream(hal);
+        let mut cs = ZKVMConstraintSystem::<ff_ext::BabyBearExt4>::new_with_platform(
+            ProgramParams::default(),
+        );
+        let (config, builder) = Rv32imConfig::construct_circuits(&mut cs);
+        for active in [
+            &[InsnKind::SB][..],
+            &[InsnKind::OR, InsnKind::REMU, InsnKind::LW, InsnKind::SB][..],
+        ] {
+            let mut counts = [0; InsnKind::COUNT];
+            let mut dispatch = builder.to_dispatch_ctx();
+            dispatch.begin_compact_ingest();
+            for &kind in active {
+                counts[kind as usize] = 1;
+                dispatch.ingest_compact_count(kind, 1);
+            }
+            let expected: Vec<_> = LEGACY_PRODUCER_ORDER
                 .iter()
                 .copied()
-                .map(producer_order)
-                .collect::<Vec<_>>(),
-            (0..PRODUCER_ASSIGNMENT_ORDER.len() as u32).collect::<Vec<_>>()
-        );
+                .enumerate()
+                .filter(|(_, kind)| active.contains(kind))
+                .map(|(order, kind)| (kind, order as u32))
+                .collect();
+            for provisional in [false, true] {
+                install_compact_replay_arenas(GpuReplayShardArenas::provisional(counts));
+                if provisional {
+                    config
+                        .prepare_provisional_fused_assignments(&cs, &counts)
+                        .unwrap();
+                } else {
+                    config.prepare_fused_assignments(&cs, &dispatch).unwrap();
+                }
+                let actual = FUSED_INGRESS.with(|slot| {
+                    slot.borrow()
+                        .as_ref()
+                        .unwrap()
+                        .registrations
+                        .iter()
+                        .map(|r| (r.kind, r.producer_order))
+                        .collect::<Vec<_>>()
+                });
+                assert_eq!(actual, expected, "provisional={provisional}");
+                abort_fused_session();
+            }
+        }
+    }
+
+    #[test]
+    fn producer_order_accepts_full_u32_domain() {
+        check_producer_order(0);
+        check_producer_order(u32::MAX);
     }
 
     #[test]
@@ -3349,6 +3341,10 @@ mod tests {
                         chip.zkvm_v1_css.num_structural_witin as usize,
                         1,
                         $kind,
+                        crate::instructions::riscv::LEGACY_PRODUCER_ORDER
+                            .iter()
+                            .position(|kind| *kind == <$instruction>::inst_kinds()[0])
+                            .unwrap() as u32,
                     )
                     .unwrap();
                 }};

--- a/ceno_zkvm/src/instructions/gpu/utils/d2h.rs
+++ b/ceno_zkvm/src/instructions/gpu/utils/d2h.rs
@@ -55,21 +55,29 @@ pub(crate) fn materialize_device_backed_rmm<E: ExtensionField>(
 
     let height = rmm.height();
     let width = rmm.width();
-    let expected_len = height
+    let padded_len = height
+        .checked_mul(width)
+        .ok_or_else(|| ZKVMError::InvalidWitness("GPU witness shape overflow".into()))?;
+    let occupied_rows = rmm.occupied_physical_rows();
+    let occupied_len = occupied_rows
         .checked_mul(width)
         .ok_or_else(|| ZKVMError::InvalidWitness("GPU witness shape overflow".into()))?;
     let backing = rmm
         .device_backing_ref::<WitBuf>()
         .ok_or_else(|| ZKVMError::InvalidWitness("unexpected GPU witness backing type".into()))?;
-    if backing.len() != expected_len {
+    let backing_rows = if backing.len() == occupied_len {
+        occupied_rows
+    } else if backing.len() == padded_len {
+        height
+    } else {
         return Err(ZKVMError::InvalidWitness(
             format!(
-                "GPU witness backing length mismatch: got {}, expected {expected_len}",
-                backing.len()
+                "GPU witness backing length mismatch: got {}, expected compact {occupied_len} or padded {padded_len}",
+                backing.len(),
             )
             .into(),
         ));
-    }
+    };
 
     let device_values = backing.to_vec().map_err(|err| {
         ZKVMError::InvalidWitness(format!("GPU witness D2H failed: {err:?}").into())
@@ -85,10 +93,10 @@ pub(crate) fn materialize_device_backed_rmm<E: ExtensionField>(
     let host_values = match rmm.device_backing_layout() {
         Some(DeviceMatrixLayout::RowMajor) => device_values,
         Some(DeviceMatrixLayout::ColMajor) => {
-            let mut row_major = vec![E::BaseField::default(); expected_len];
-            for row in 0..height {
+            let mut row_major = vec![E::BaseField::default(); backing.len()];
+            for row in 0..backing_rows {
                 for col in 0..width {
-                    row_major[row * width + col] = device_values[col * height + row];
+                    row_major[row * width + col] = device_values[col * backing_rows + row];
                 }
             }
             row_major
@@ -122,8 +130,7 @@ pub(crate) fn materialize_device_backed_rmm<E: ExtensionField>(
         width,
         InstancePaddingStrategy::Default,
     );
-    std::ops::DerefMut::deref_mut(&mut host)
-        .values
+    std::ops::DerefMut::deref_mut(&mut host).values[..host_values.len()]
         .copy_from_slice(&host_values);
     Ok(host)
 }

--- a/ceno_zkvm/src/instructions/gpu/utils/d2h.rs
+++ b/ceno_zkvm/src/instructions/gpu/utils/d2h.rs
@@ -35,6 +35,99 @@ pub(crate) type WitResult = ceno_gpu::common::witgen::types::GpuWitnessResult<Wi
 pub(crate) type LkResult = ceno_gpu::common::witgen::types::GpuLookupCountersResult<LkBuf>;
 pub(crate) type CompactEcBuf = ceno_gpu::common::witgen::types::CompactEcResult<RamBuf>;
 
+/// Materialize a host-only copy of a GPU witness matrix for CPU diagnostics.
+///
+/// Production proving intentionally elides these host values. Callers must keep this
+/// transfer behind an explicit diagnostic gate rather than adding it to the GPU path.
+pub(crate) fn materialize_device_backed_rmm<E: ExtensionField>(
+    rmm: &RowMajorMatrix<E::BaseField>,
+) -> Result<RowMajorMatrix<E::BaseField>, ZKVMError> {
+    type BB = <ff_ext::BabyBearExt4 as ExtensionField>::BaseField;
+
+    if !rmm.has_device_backing() {
+        return Ok(rmm.clone());
+    }
+    if std::any::TypeId::of::<E::BaseField>() != std::any::TypeId::of::<BB>() {
+        return Err(ZKVMError::InvalidWitness(
+            "GPU witness materialization only supports BabyBear".into(),
+        ));
+    }
+
+    let height = rmm.height();
+    let width = rmm.width();
+    let expected_len = height
+        .checked_mul(width)
+        .ok_or_else(|| ZKVMError::InvalidWitness("GPU witness shape overflow".into()))?;
+    let backing = rmm
+        .device_backing_ref::<WitBuf>()
+        .ok_or_else(|| ZKVMError::InvalidWitness("unexpected GPU witness backing type".into()))?;
+    if backing.len() != expected_len {
+        return Err(ZKVMError::InvalidWitness(
+            format!(
+                "GPU witness backing length mismatch: got {}, expected {expected_len}",
+                backing.len()
+            )
+            .into(),
+        ));
+    }
+
+    let device_values = backing.to_vec().map_err(|err| {
+        ZKVMError::InvalidWitness(format!("GPU witness D2H failed: {err:?}").into())
+    })?;
+    let device_values: Vec<E::BaseField> = unsafe {
+        let mut values = std::mem::ManuallyDrop::new(device_values);
+        Vec::from_raw_parts(
+            values.as_mut_ptr() as *mut E::BaseField,
+            values.len(),
+            values.capacity(),
+        )
+    };
+    let host_values = match rmm.device_backing_layout() {
+        Some(DeviceMatrixLayout::RowMajor) => device_values,
+        Some(DeviceMatrixLayout::ColMajor) => {
+            let mut row_major = vec![E::BaseField::default(); expected_len];
+            for row in 0..height {
+                for col in 0..width {
+                    row_major[row * width + col] = device_values[col * height + row];
+                }
+            }
+            row_major
+        }
+        None => {
+            return Err(ZKVMError::InvalidWitness(
+                "GPU witness backing has no layout".into(),
+            ));
+        }
+    };
+
+    let padded_logical_rows = rmm.num_instances().next_power_of_two();
+    if padded_logical_rows == 0
+        || height % padded_logical_rows != 0
+        || !(height / padded_logical_rows).is_power_of_two()
+    {
+        return Err(ZKVMError::InvalidWitness(
+            format!(
+                "GPU witness rotation shape mismatch: logical_rows={}, height={height}",
+                rmm.num_instances()
+            )
+            .into(),
+        ));
+    }
+    let log2_num_rotation = (height / padded_logical_rows).ilog2() as usize;
+    // All GPU-backed witness producers use default padding. Reconstructing from logical
+    // rows plus rotation retains their exact physical shape while clearing device backing.
+    let mut host = RowMajorMatrix::new_by_rotation(
+        rmm.num_instances(),
+        log2_num_rotation,
+        width,
+        InstancePaddingStrategy::Default,
+    );
+    std::ops::DerefMut::deref_mut(&mut host)
+        .values
+        .copy_from_slice(&host_values);
+    Ok(host)
+}
+
 /// Read selected cells from one logical row of a GPU-backed witness matrix.
 ///
 /// Normal GPU witgen deliberately keeps a zero-filled host placeholder and the

--- a/ceno_zkvm/src/instructions/riscv.rs
+++ b/ceno_zkvm/src/instructions/riscv.rs
@@ -1,6 +1,8 @@
 use ceno_emul::InsnKind;
 
 mod rv32im;
+#[cfg(all(test, feature = "gpu"))]
+pub(crate) use rv32im::LEGACY_PRODUCER_ORDER;
 pub use rv32im::{
     DummyExtraConfig, InstructionDispatchBuilder, InstructionDispatchCtx, Rv32imConfig,
     mmu::{MemPadder, MmuConfig},

--- a/ceno_zkvm/src/instructions/riscv/rv32im.rs
+++ b/ceno_zkvm/src/instructions/riscv/rv32im.rs
@@ -76,50 +76,59 @@ use std::{
 use strum::{EnumCount, IntoEnumIterator};
 use tracing::info_span;
 
-#[cfg(feature = "gpu")]
-macro_rules! for_each_fused_opcode {
-    ($m:ident) => {
-        $m!(AddInstruction<E>, add_config, K::Add);
-        $m!(SubInstruction<E>, sub_config, K::Sub);
-        $m!(AndInstruction<E>, and_config, K::LogicR(0));
-        $m!(OrInstruction<E>, or_config, K::LogicR(1));
-        $m!(XorInstruction<E>, xor_config, K::LogicR(2));
-        $m!(SllInstruction<E>, sll_config, K::ShiftR(0));
-        $m!(SrlInstruction<E>, srl_config, K::ShiftR(1));
-        $m!(SraInstruction<E>, sra_config, K::ShiftR(2));
-        $m!(SltInstruction<E>, slt_config, K::Slt(1));
-        $m!(SltuInstruction<E>, sltu_config, K::Slt(0));
-        $m!(MulInstruction<E>, mul_config, K::Mul(0));
-        $m!(MulhInstruction<E>, mulh_config, K::Mul(1));
-        $m!(MulhsuInstruction<E>, mulhsu_config, K::Mul(3));
-        $m!(MulhuInstruction<E>, mulhu_config, K::Mul(2));
-        $m!(DivuInstruction<E>, divu_config, K::Div(1));
-        $m!(RemuInstruction<E>, remu_config, K::Div(3));
-        $m!(DivInstruction<E>, div_config, K::Div(0));
-        $m!(RemInstruction<E>, rem_config, K::Div(2));
-        $m!(AddiInstruction<E>, addi_config, K::Addi);
-        $m!(AndiInstruction<E>, andi_config, K::LogicI(0));
-        $m!(OriInstruction<E>, ori_config, K::LogicI(1));
-        $m!(XoriInstruction<E>, xori_config, K::LogicI(2));
-        $m!(SlliInstruction<E>, slli_config, K::ShiftI(0));
-        $m!(SrliInstruction<E>, srli_config, K::ShiftI(1));
-        $m!(SraiInstruction<E>, srai_config, K::ShiftI(2));
-        $m!(SltiInstruction<E>, slti_config, K::Slti(1));
-        $m!(SltiuInstruction<E>, sltiu_config, K::Slti(0));
+// ShardContext replaces records for the same address in assignment order.
+// Keep CPU assignment and GPU producer priority in this ISA-owned traversal.
+macro_rules! for_each_opcode {
+    ($m:ident) => {{
+        let mut next_order = 0u32;
+        macro_rules! visit_opcode {
+            ($instruction:ty, $config:ident, $kind:expr) => {{
+                let order = next_order;
+                next_order += 1;
+                $m!($instruction, $config, $kind, order);
+            }};
+        }
+        visit_opcode!(AddInstruction<E>, add_config, K::Add);
+        visit_opcode!(SubInstruction<E>, sub_config, K::Sub);
+        visit_opcode!(AndInstruction<E>, and_config, K::LogicR(0));
+        visit_opcode!(OrInstruction<E>, or_config, K::LogicR(1));
+        visit_opcode!(XorInstruction<E>, xor_config, K::LogicR(2));
+        visit_opcode!(SllInstruction<E>, sll_config, K::ShiftR(0));
+        visit_opcode!(SrlInstruction<E>, srl_config, K::ShiftR(1));
+        visit_opcode!(SraInstruction<E>, sra_config, K::ShiftR(2));
+        visit_opcode!(SltInstruction<E>, slt_config, K::Slt(1));
+        visit_opcode!(SltuInstruction<E>, sltu_config, K::Slt(0));
+        visit_opcode!(MulInstruction<E>, mul_config, K::Mul(0));
+        visit_opcode!(MulhInstruction<E>, mulh_config, K::Mul(1));
+        visit_opcode!(MulhsuInstruction<E>, mulhsu_config, K::Mul(3));
+        visit_opcode!(MulhuInstruction<E>, mulhu_config, K::Mul(2));
+        visit_opcode!(DivuInstruction<E>, divu_config, K::Div(1));
+        visit_opcode!(RemuInstruction<E>, remu_config, K::Div(3));
+        visit_opcode!(DivInstruction<E>, div_config, K::Div(0));
+        visit_opcode!(RemInstruction<E>, rem_config, K::Div(2));
+        visit_opcode!(AddiInstruction<E>, addi_config, K::Addi);
+        visit_opcode!(AndiInstruction<E>, andi_config, K::LogicI(0));
+        visit_opcode!(OriInstruction<E>, ori_config, K::LogicI(1));
+        visit_opcode!(XoriInstruction<E>, xori_config, K::LogicI(2));
+        visit_opcode!(SlliInstruction<E>, slli_config, K::ShiftI(0));
+        visit_opcode!(SrliInstruction<E>, srli_config, K::ShiftI(1));
+        visit_opcode!(SraiInstruction<E>, srai_config, K::ShiftI(2));
+        visit_opcode!(SltiInstruction<E>, slti_config, K::Slti(1));
+        visit_opcode!(SltiuInstruction<E>, sltiu_config, K::Slti(0));
         #[cfg(feature = "u16limb_circuit")]
-        $m!(LuiInstruction<E>, lui_config, K::Lui);
+        visit_opcode!(LuiInstruction<E>, lui_config, K::Lui);
         #[cfg(feature = "u16limb_circuit")]
-        $m!(AuipcInstruction<E>, auipc_config, K::Auipc);
-        $m!(BeqInstruction<E>, beq_config, K::BranchEq(1));
-        $m!(BneInstruction<E>, bne_config, K::BranchEq(0));
-        $m!(BltInstruction<E>, blt_config, K::BranchCmp(1));
-        $m!(BltuInstruction<E>, bltu_config, K::BranchCmp(0));
-        $m!(BgeInstruction<E>, bge_config, K::BranchCmp(1));
-        $m!(BgeuInstruction<E>, bgeu_config, K::BranchCmp(0));
-        $m!(JalInstruction<E>, jal_config, K::Jal);
-        $m!(JalrInstruction<E>, jalr_config, K::Jalr);
-        $m!(LwInstruction<E>, lw_config, K::Lw);
-        $m!(
+        visit_opcode!(AuipcInstruction<E>, auipc_config, K::Auipc);
+        visit_opcode!(BeqInstruction<E>, beq_config, K::BranchEq(1));
+        visit_opcode!(BneInstruction<E>, bne_config, K::BranchEq(0));
+        visit_opcode!(BltInstruction<E>, blt_config, K::BranchCmp(1));
+        visit_opcode!(BltuInstruction<E>, bltu_config, K::BranchCmp(0));
+        visit_opcode!(BgeInstruction<E>, bge_config, K::BranchCmp(1));
+        visit_opcode!(BgeuInstruction<E>, bgeu_config, K::BranchCmp(0));
+        visit_opcode!(JalInstruction<E>, jal_config, K::Jal);
+        visit_opcode!(JalrInstruction<E>, jalr_config, K::Jalr);
+        visit_opcode!(LwInstruction<E>, lw_config, K::Lw);
+        visit_opcode!(
             LbInstruction<E>,
             lb_config,
             K::LoadSub {
@@ -127,7 +136,7 @@ macro_rules! for_each_fused_opcode {
                 is_signed: 1
             }
         );
-        $m!(
+        visit_opcode!(
             LbuInstruction<E>,
             lbu_config,
             K::LoadSub {
@@ -135,7 +144,7 @@ macro_rules! for_each_fused_opcode {
                 is_signed: 0
             }
         );
-        $m!(
+        visit_opcode!(
             LhInstruction<E>,
             lh_config,
             K::LoadSub {
@@ -143,7 +152,7 @@ macro_rules! for_each_fused_opcode {
                 is_signed: 1
             }
         );
-        $m!(
+        visit_opcode!(
             LhuInstruction<E>,
             lhu_config,
             K::LoadSub {
@@ -151,10 +160,11 @@ macro_rules! for_each_fused_opcode {
                 is_signed: 0
             }
         );
-        $m!(SwInstruction<E>, sw_config, K::Sw);
-        $m!(ShInstruction<E>, sh_config, K::Sh);
-        $m!(SbInstruction<E>, sb_config, K::Sb);
-    };
+        visit_opcode!(SwInstruction<E>, sw_config, K::Sw);
+        visit_opcode!(ShInstruction<E>, sh_config, K::Sh);
+        visit_opcode!(SbInstruction<E>, sb_config, K::Sb);
+        let _ = next_order;
+    }};
 }
 
 pub mod mmu;
@@ -900,7 +910,7 @@ impl<E: ExtensionField> Rv32imConfig<E> {
     ) -> Result<(), ZKVMError> {
         use crate::instructions::gpu::dispatch::{self, GpuWitgenKind as K};
         macro_rules! prepare_opcode {
-            ($instruction:ty, $config:ident, $kind:expr) => {{
+            ($instruction:ty, $config:ident, $kind:expr, $order:expr) => {{
                 let chip_cs = cs.get_cs(&<$instruction>::name()).unwrap();
                 let kind = <$instruction>::inst_kinds()[0];
                 dispatch::prepare_fused_assignment::<E, $instruction>(
@@ -909,10 +919,37 @@ impl<E: ExtensionField> Rv32imConfig<E> {
                     chip_cs.zkvm_v1_css.num_structural_witin as usize,
                     family_counts[kind as usize],
                     $kind,
+                    $order,
                 )?;
             }};
         }
-        for_each_fused_opcode!(prepare_opcode);
+        for_each_opcode!(prepare_opcode);
+        Ok(())
+    }
+
+    #[cfg(feature = "gpu")]
+    pub(crate) fn prepare_fused_assignments(
+        &self,
+        cs: &ZKVMConstraintSystem<E>,
+        instrunction_dispatch_ctx: &InstructionDispatchCtx,
+    ) -> Result<(), ZKVMError> {
+        use crate::instructions::gpu::dispatch::{self, GpuWitgenKind as K};
+        macro_rules! prepare_opcode {
+            ($instruction:ty, $config:ident, $kind:expr, $order:expr) => {{
+                let expected_rows =
+                    instrunction_dispatch_ctx.record_count_for_kinds::<E, $instruction>();
+                let chip_cs = cs.get_cs(&<$instruction>::name()).unwrap();
+                dispatch::prepare_fused_assignment::<E, $instruction>(
+                    &self.$config,
+                    chip_cs.zkvm_v1_css.num_witin as usize,
+                    chip_cs.zkvm_v1_css.num_structural_witin as usize,
+                    expected_rows,
+                    $kind,
+                    $order,
+                )?;
+            }};
+        }
+        for_each_opcode!(prepare_opcode);
         Ok(())
     }
 
@@ -967,7 +1004,8 @@ impl<E: ExtensionField> Rv32imConfig<E> {
         log_ecall!("sha_extend_records", Sha256ExtendSpec::CODE);
 
         macro_rules! assign_opcode {
-            ($instruction:ty, $config:ident) => {{
+            ($instruction:ty, $config:ident, $kind:expr, $order:expr) => {{
+                let _ = $order;
                 let n = instrunction_dispatch_ctx
                     .record_count_for_kinds::<E, $instruction>();
                 #[cfg(feature = "gpu")]
@@ -1020,77 +1058,11 @@ impl<E: ExtensionField> Rv32imConfig<E> {
 
         #[cfg(feature = "gpu")]
         {
-            use crate::instructions::gpu::dispatch::{self, GpuWitgenKind as K};
-            macro_rules! prepare_opcode {
-                ($instruction:ty, $config:ident, $kind:expr) => {{
-                    let expected_rows =
-                        instrunction_dispatch_ctx.record_count_for_kinds::<E, $instruction>();
-                    let chip_cs = cs.get_cs(&<$instruction>::name()).unwrap();
-                    dispatch::prepare_fused_assignment::<E, $instruction>(
-                        &self.$config,
-                        chip_cs.zkvm_v1_css.num_witin as usize,
-                        chip_cs.zkvm_v1_css.num_structural_witin as usize,
-                        expected_rows,
-                        $kind,
-                    )?;
-                }};
-            }
-            for_each_fused_opcode!(prepare_opcode);
-            dispatch::launch_fused_assignments(shard_ctx)?;
+            self.prepare_fused_assignments(cs, instrunction_dispatch_ctx)?;
+            crate::instructions::gpu::dispatch::launch_fused_assignments(shard_ctx)?;
         }
 
-        // alu
-        assign_opcode!(AddInstruction<E>, add_config);
-        assign_opcode!(SubInstruction<E>, sub_config);
-        assign_opcode!(AndInstruction<E>, and_config);
-        assign_opcode!(OrInstruction<E>, or_config);
-        assign_opcode!(XorInstruction<E>, xor_config);
-        assign_opcode!(SllInstruction<E>, sll_config);
-        assign_opcode!(SrlInstruction<E>, srl_config);
-        assign_opcode!(SraInstruction<E>, sra_config);
-        assign_opcode!(SltInstruction<E>, slt_config);
-        assign_opcode!(SltuInstruction<E>, sltu_config);
-        assign_opcode!(MulInstruction<E>, mul_config);
-        assign_opcode!(MulhInstruction<E>, mulh_config);
-        assign_opcode!(MulhsuInstruction<E>, mulhsu_config);
-        assign_opcode!(MulhuInstruction<E>, mulhu_config);
-        assign_opcode!(DivuInstruction<E>, divu_config);
-        assign_opcode!(RemuInstruction<E>, remu_config);
-        assign_opcode!(DivInstruction<E>, div_config);
-        assign_opcode!(RemInstruction<E>, rem_config);
-        // alu with imm
-        assign_opcode!(AddiInstruction<E>, addi_config);
-        assign_opcode!(AndiInstruction<E>, andi_config);
-        assign_opcode!(OriInstruction<E>, ori_config);
-        assign_opcode!(XoriInstruction<E>, xori_config);
-        assign_opcode!(SlliInstruction<E>, slli_config);
-        assign_opcode!(SrliInstruction<E>, srli_config);
-        assign_opcode!(SraiInstruction<E>, srai_config);
-        assign_opcode!(SltiInstruction<E>, slti_config);
-        assign_opcode!(SltiuInstruction<E>, sltiu_config);
-        #[cfg(feature = "u16limb_circuit")]
-        assign_opcode!(LuiInstruction<E>, lui_config);
-        #[cfg(feature = "u16limb_circuit")]
-        assign_opcode!(AuipcInstruction<E>, auipc_config);
-        // branching
-        assign_opcode!(BeqInstruction<E>, beq_config);
-        assign_opcode!(BneInstruction<E>, bne_config);
-        assign_opcode!(BltInstruction<E>, blt_config);
-        assign_opcode!(BltuInstruction<E>, bltu_config);
-        assign_opcode!(BgeInstruction<E>, bge_config);
-        assign_opcode!(BgeuInstruction<E>, bgeu_config);
-        // jump
-        assign_opcode!(JalInstruction<E>, jal_config);
-        assign_opcode!(JalrInstruction<E>, jalr_config);
-        // memory
-        assign_opcode!(LwInstruction<E>, lw_config);
-        assign_opcode!(LbInstruction<E>, lb_config);
-        assign_opcode!(LbuInstruction<E>, lbu_config);
-        assign_opcode!(LhInstruction<E>, lh_config);
-        assign_opcode!(LhuInstruction<E>, lhu_config);
-        assign_opcode!(SwInstruction<E>, sw_config);
-        assign_opcode!(ShInstruction<E>, sh_config);
-        assign_opcode!(SbInstruction<E>, sb_config);
+        for_each_opcode!(assign_opcode);
 
         // ecall / halt
         assign_ecall!(HaltInstruction<E>, halt_config, ECALL_HALT);
@@ -1817,5 +1789,81 @@ mod compact_dispatch_tests {
         dispatch.begin_compact_ingest();
         dispatch.compact_record_counts[0] = usize::MAX;
         dispatch.ingest_compact_count(InsnKind::ADD, 1);
+    }
+}
+
+// Captured before unifying the CPU assignment and GPU priority lists.
+#[cfg(test)]
+pub(crate) const LEGACY_PRODUCER_ORDER: &[InsnKind] = &[
+    InsnKind::ADD,
+    InsnKind::SUB,
+    InsnKind::AND,
+    InsnKind::OR,
+    InsnKind::XOR,
+    InsnKind::SLL,
+    InsnKind::SRL,
+    InsnKind::SRA,
+    InsnKind::SLT,
+    InsnKind::SLTU,
+    InsnKind::MUL,
+    InsnKind::MULH,
+    InsnKind::MULHSU,
+    InsnKind::MULHU,
+    InsnKind::DIVU,
+    InsnKind::REMU,
+    InsnKind::DIV,
+    InsnKind::REM,
+    InsnKind::ADDI,
+    InsnKind::ANDI,
+    InsnKind::ORI,
+    InsnKind::XORI,
+    InsnKind::SLLI,
+    InsnKind::SRLI,
+    InsnKind::SRAI,
+    InsnKind::SLTI,
+    InsnKind::SLTIU,
+    #[cfg(feature = "u16limb_circuit")]
+    InsnKind::LUI,
+    #[cfg(feature = "u16limb_circuit")]
+    InsnKind::AUIPC,
+    InsnKind::BEQ,
+    InsnKind::BNE,
+    InsnKind::BLT,
+    InsnKind::BLTU,
+    InsnKind::BGE,
+    InsnKind::BGEU,
+    InsnKind::JAL,
+    InsnKind::JALR,
+    InsnKind::LW,
+    InsnKind::LB,
+    InsnKind::LBU,
+    InsnKind::LH,
+    InsnKind::LHU,
+    InsnKind::SW,
+    InsnKind::SH,
+    InsnKind::SB,
+];
+
+#[cfg(test)]
+mod producer_order_tests {
+    use super::*;
+    type E = ff_ext::BabyBearExt4;
+
+    #[test]
+    fn opcode_ordinals_preserve_legacy_assignment_order() {
+        let mut generated = Vec::new();
+        macro_rules! collect {
+            ($instruction:ty, $config:ident, $kind:expr, $order:expr) => {
+                generated.push((<$instruction>::inst_kinds()[0], $order));
+            };
+        }
+        for_each_opcode!(collect);
+        let expected: Vec<_> = LEGACY_PRODUCER_ORDER
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(order, kind)| (kind, order as u32))
+            .collect();
+        assert_eq!(generated, expected);
     }
 }

--- a/ceno_zkvm/src/lib.rs
+++ b/ceno_zkvm/src/lib.rs
@@ -5,6 +5,8 @@
 
 pub mod error;
 pub mod instructions;
+#[cfg(feature = "gpu")]
+pub mod multi_gpu;
 pub mod scheme;
 pub mod tables;
 pub use utils::u64vec;

--- a/ceno_zkvm/src/multi_gpu.rs
+++ b/ceno_zkvm/src/multi_gpu.rs
@@ -1,0 +1,333 @@
+use std::{collections::HashSet, sync::Arc};
+
+pub use ceno_gpu::device::discover_cuda_devices;
+use ceno_gpu::{
+    CudaHal,
+    bb31::CudaHalBB31,
+    device::{CudaDeviceInfo, EmbeddedFatbinVariant},
+};
+
+const FIXED_BUFFER_BYTES: usize = 512 * 1024 * 1024;
+const SHARD_CELL_BYTES: usize = std::mem::size_of::<u32>();
+
+fn conservative_shard_cap(
+    usable_memory_bytes: impl IntoIterator<Item = usize>,
+) -> Result<u64, String> {
+    usable_memory_bytes
+        .into_iter()
+        .map(|usable| {
+            usable
+                .checked_sub(FIXED_BUFFER_BYTES)
+                .map(|bytes| (bytes / SHARD_CELL_BYTES) as u64)
+                .ok_or_else(|| {
+                    "GPU has insufficient usable memory for fixed prover buffers".to_owned()
+                })
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .min()
+        .ok_or_else(|| "GPU device list must not be empty".to_owned())
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ShardAssignmentPolicy {
+    #[default]
+    RoundRobin,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MultiGpuConfig {
+    pub device_ids: Vec<usize>,
+    pub shard_policy: ShardAssignmentPolicy,
+    pub replay_queue_depth: usize,
+    pub recursion_device: usize,
+}
+
+impl MultiGpuConfig {
+    pub fn new(device_ids: Vec<usize>) -> Result<Self, String> {
+        let recursion_device = *device_ids
+            .first()
+            .ok_or("GPU device list must not be empty")?;
+        let config = Self {
+            device_ids,
+            shard_policy: ShardAssignmentPolicy::RoundRobin,
+            replay_queue_depth: 1,
+            recursion_device,
+        };
+        config.validate_shape()?;
+        Ok(config)
+    }
+
+    pub fn with_recursion_device(mut self, device_id: usize) -> Result<Self, String> {
+        self.recursion_device = device_id;
+        self.validate_shape()?;
+        Ok(self)
+    }
+
+    pub fn validate_shape(&self) -> Result<(), String> {
+        if self.device_ids.is_empty() {
+            return Err("GPU device list must not be empty".to_owned());
+        }
+        if self.replay_queue_depth != 1 {
+            return Err("Stage 1 requires replay_queue_depth=1".to_owned());
+        }
+        let mut unique = HashSet::with_capacity(self.device_ids.len());
+        for device_id in &self.device_ids {
+            if !unique.insert(*device_id) {
+                return Err(format!("duplicate GPU device {device_id}"));
+            }
+        }
+        if !unique.contains(&self.recursion_device) {
+            return Err(format!(
+                "recursion GPU {} is not in the selected device list",
+                self.recursion_device
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn owner_index(&self, shard_id: usize) -> usize {
+        match self.shard_policy {
+            ShardAssignmentPolicy::RoundRobin => shard_id % self.device_ids.len(),
+        }
+    }
+
+    pub fn prepare(&self, requested_max_cells: u64) -> Result<PreparedMultiGpu, String> {
+        self.validate_shape()?;
+        let discovered = discover_cuda_devices().map_err(|error| error.to_string())?;
+        let (selected, max_cell_per_shard) =
+            self.validate_device_profiles(&discovered, requested_max_cells)?;
+        let mut workers = Vec::with_capacity(self.device_ids.len());
+        for (device_id, info) in self.device_ids.iter().zip(selected) {
+            tracing::info!(
+                device_id = info.logical_ordinal,
+                model = %info.name,
+                compute_capability = ?info.compute_capability,
+                total_memory_bytes = info.total_memory_bytes,
+                free_memory_bytes = info.free_memory_bytes,
+                usable_memory_bytes = info.usable_memory_bytes,
+                memory_pool_supported = info.memory_pool_supported,
+                concurrent_kernels_supported = info.concurrent_kernels_supported,
+                peer_access = ?info.peer_access,
+                embedded_fatbin_variant = ?info.embedded_fatbin_variant,
+                runtime_safety_headroom_bytes = ceno_gpu::device::DEVICE_MEMORY_HEADROOM_BYTES,
+                fixed_buffer_bytes = FIXED_BUFFER_BYTES,
+                "selected CUDA device profile"
+            );
+            let hal = Arc::new(CudaHalBB31::new(*device_id).map_err(|error| {
+                format!("failed to construct HAL for GPU device {device_id}: {error}")
+            })?);
+            hal.inner().synchronize().map_err(|error| {
+                format!("failed HAL smoke test for GPU device {device_id}: {error}")
+            })?;
+            workers.push(PreparedGpu { info, hal });
+        }
+        Ok(PreparedMultiGpu {
+            workers,
+            max_cell_per_shard,
+        })
+    }
+
+    fn validate_device_profiles(
+        &self,
+        discovered: &[CudaDeviceInfo],
+        requested_max_cells: u64,
+    ) -> Result<(Vec<CudaDeviceInfo>, u64), String> {
+        self.validate_shape()?;
+        let mut selected = Vec::with_capacity(self.device_ids.len());
+        for device_id in &self.device_ids {
+            let info = discovered.get(*device_id).ok_or_else(|| {
+                format!(
+                    "GPU device {device_id} is out of range 0..{}",
+                    discovered.len()
+                )
+            })?;
+            if info.logical_ordinal != *device_id {
+                return Err(format!(
+                    "GPU discovery profile at index {device_id} reports logical ordinal {}",
+                    info.logical_ordinal
+                ));
+            }
+            if !info.memory_pool_supported || !info.concurrent_kernels_supported {
+                return Err(format!(
+                    "GPU device {device_id} lacks required memory-pool or concurrent-stream support"
+                ));
+            }
+            if matches!(
+                info.embedded_fatbin_variant,
+                EmbeddedFatbinVariant::Unsupported
+            ) {
+                return Err(format!(
+                    "GPU device {device_id} compute capability {}.{} is unsupported by embedded architectures {}",
+                    info.compute_capability.0,
+                    info.compute_capability.1,
+                    ceno_gpu::device::PACKAGED_CUDA_ARCHES,
+                ));
+            }
+            selected.push(info.clone());
+        }
+        let common_max_cells =
+            conservative_shard_cap(selected.iter().map(|info| info.usable_memory_bytes))?;
+        let max_cell_per_shard = if requested_max_cells == u64::MAX {
+            common_max_cells
+        } else if requested_max_cells > common_max_cells {
+            return Err(format!(
+                "requested max_cell_per_shard {requested_max_cells} exceeds conservative multi-GPU cap {common_max_cells}"
+            ));
+        } else {
+            requested_max_cells
+        };
+        tracing::info!(
+            conservative_max_cell_per_shard = common_max_cells,
+            selected_max_cell_per_shard = max_cell_per_shard,
+            "conservative multi-GPU shard cap"
+        );
+        Ok((selected, max_cell_per_shard))
+    }
+}
+
+pub struct PreparedGpu {
+    pub info: CudaDeviceInfo,
+    pub hal: Arc<CudaHalBB31>,
+}
+
+pub struct PreparedMultiGpu {
+    pub workers: Vec<PreparedGpu>,
+    pub max_cell_per_shard: u64,
+}
+
+pub fn select_device_ids(
+    explicit: Option<&[usize]>,
+    count: Option<usize>,
+    available: usize,
+) -> Result<Vec<usize>, String> {
+    let selected = if let Some(explicit) = explicit {
+        if explicit.is_empty() {
+            return Err("GPU device list must not be empty".to_owned());
+        }
+        explicit.to_vec()
+    } else if let Some(count) = count {
+        if count == 0 {
+            return Err("GPU count must be greater than zero".to_owned());
+        }
+        (0..count).collect()
+    } else {
+        vec![0]
+    };
+    if let Some(device_id) = selected.iter().find(|device_id| **device_id >= available) {
+        return Err(format!(
+            "GPU device {device_id} is out of range 0..{available}"
+        ));
+    }
+    MultiGpuConfig::new(selected.clone())?;
+    Ok(selected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile(
+        logical_ordinal: usize,
+        usable_memory_bytes: usize,
+        memory_pool_supported: bool,
+        concurrent_kernels_supported: bool,
+        embedded_fatbin_variant: EmbeddedFatbinVariant,
+    ) -> CudaDeviceInfo {
+        CudaDeviceInfo {
+            logical_ordinal,
+            name: format!("synthetic-{logical_ordinal}"),
+            compute_capability: (8, 9),
+            total_memory_bytes: usable_memory_bytes
+                + ceno_gpu::device::DEVICE_MEMORY_HEADROOM_BYTES,
+            free_memory_bytes: usable_memory_bytes + ceno_gpu::device::DEVICE_MEMORY_HEADROOM_BYTES,
+            usable_memory_bytes,
+            memory_pool_supported,
+            concurrent_kernels_supported,
+            peer_access: vec![true],
+            embedded_fatbin_variant,
+        }
+    }
+
+    #[test]
+    fn device_selection_precedence() {
+        assert_eq!(
+            select_device_ids(Some(&[2, 0]), Some(1), 3).unwrap(),
+            vec![2, 0]
+        );
+        assert_eq!(select_device_ids(None, Some(2), 3).unwrap(), vec![0, 1]);
+        assert_eq!(select_device_ids(None, None, 3).unwrap(), vec![0]);
+    }
+
+    #[test]
+    fn invalid_device_selections() {
+        assert!(select_device_ids(Some(&[]), None, 2).is_err());
+        assert!(select_device_ids(Some(&[0, 0]), None, 2).is_err());
+        assert!(select_device_ids(Some(&[2]), None, 2).is_err());
+        assert!(select_device_ids(None, Some(0), 2).is_err());
+    }
+
+    #[test]
+    fn round_robin_coverage() {
+        let config = MultiGpuConfig::new(vec![4, 7]).unwrap();
+        assert_eq!(
+            (0..6).map(|id| config.owner_index(id)).collect::<Vec<_>>(),
+            vec![0, 1, 0, 1, 0, 1]
+        );
+    }
+
+    #[test]
+    fn recursion_device_must_be_selected() {
+        assert!(
+            MultiGpuConfig::new(vec![0, 1])
+                .unwrap()
+                .with_recursion_device(2)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn conservative_cap_uses_least_capable_device() {
+        let gib = 1024 * 1024 * 1024;
+        assert_eq!(
+            conservative_shard_cap([16 * gib, 8 * gib]).unwrap(),
+            ((8 * gib - FIXED_BUFFER_BYTES) / SHARD_CELL_BYTES) as u64
+        );
+        assert!(conservative_shard_cap([FIXED_BUFFER_BYTES - 1]).is_err());
+    }
+
+    #[test]
+    fn synthetic_profiles_use_least_device_and_reject_unsupported_capabilities() {
+        let gib = 1024 * 1024 * 1024;
+        let config = MultiGpuConfig::new(vec![0, 1]).unwrap();
+        let profiles = vec![
+            profile(0, 16 * gib, true, true, EmbeddedFatbinVariant::Sass(89)),
+            profile(1, 8 * gib, true, true, EmbeddedFatbinVariant::Sass(89)),
+        ];
+        let (_, cap) = config
+            .validate_device_profiles(&profiles, u64::MAX)
+            .unwrap();
+        assert_eq!(
+            cap,
+            ((8 * gib - FIXED_BUFFER_BYTES) / SHARD_CELL_BYTES) as u64
+        );
+        assert!(config.validate_device_profiles(&profiles, cap + 1).is_err());
+
+        let mut unsupported = profiles.clone();
+        unsupported[1].embedded_fatbin_variant = EmbeddedFatbinVariant::Unsupported;
+        assert!(
+            config
+                .validate_device_profiles(&unsupported, 1)
+                .unwrap_err()
+                .contains("unsupported by embedded architectures")
+        );
+        let mut missing_stream_support = profiles;
+        missing_stream_support[0].concurrent_kernels_supported = false;
+        assert!(
+            config
+                .validate_device_profiles(&missing_stream_support, 1)
+                .unwrap_err()
+                .contains("lacks required memory-pool or concurrent-stream support")
+        );
+    }
+}

--- a/ceno_zkvm/src/multi_gpu.rs
+++ b/ceno_zkvm/src/multi_gpu.rs
@@ -134,6 +134,8 @@ impl MultiGpuConfig {
                 fixed_buffer_bytes = FIXED_BUFFER_BYTES,
                 "selected CUDA device profile"
             );
+            // The configured ordinal is authoritative: every worker owns a HAL created and
+            // smoke-tested on that device, rather than consulting process-global selection.
             let hal = Arc::new(CudaHalBB31::new(*device_id).map_err(|error| {
                 format!("failed to construct HAL for GPU device {device_id}: {error}")
             })?);

--- a/ceno_zkvm/src/multi_gpu.rs
+++ b/ceno_zkvm/src/multi_gpu.rs
@@ -40,31 +40,20 @@ pub struct MultiGpuConfig {
     pub device_ids: Vec<usize>,
     pub shard_policy: ShardAssignmentPolicy,
     pub replay_queue_depth: usize,
-    pub recursion_device: usize,
     /// Exclusive logical CPU sets, one per selected GPU worker.
     pub worker_cpu_affinity: Option<Vec<Vec<usize>>>,
 }
 
 impl MultiGpuConfig {
     pub fn new(device_ids: Vec<usize>) -> Result<Self, String> {
-        let recursion_device = *device_ids
-            .first()
-            .ok_or("GPU device list must not be empty")?;
         let config = Self {
             device_ids,
             shard_policy: ShardAssignmentPolicy::RoundRobin,
             replay_queue_depth: 1,
-            recursion_device,
             worker_cpu_affinity: None,
         };
         config.validate_shape()?;
         Ok(config)
-    }
-
-    pub fn with_recursion_device(mut self, device_id: usize) -> Result<Self, String> {
-        self.recursion_device = device_id;
-        self.validate_shape()?;
-        Ok(self)
     }
 
     pub fn with_worker_cpu_affinity(
@@ -88,12 +77,6 @@ impl MultiGpuConfig {
             if !unique.insert(*device_id) {
                 return Err(format!("duplicate GPU device {device_id}"));
             }
-        }
-        if !unique.contains(&self.recursion_device) {
-            return Err(format!(
-                "recursion GPU {} is not in the selected device list",
-                self.recursion_device
-            ));
         }
         if let Some(affinity) = &self.worker_cpu_affinity {
             if affinity.len() != self.device_ids.len() {
@@ -397,16 +380,6 @@ mod tests {
         assert_eq!(
             (0..6).map(|id| config.owner_index(id)).collect::<Vec<_>>(),
             vec![0, 1, 0, 1, 0, 1]
-        );
-    }
-
-    #[test]
-    fn recursion_device_must_be_selected() {
-        assert!(
-            MultiGpuConfig::new(vec![0, 1])
-                .unwrap()
-                .with_recursion_device(2)
-                .is_err()
         );
     }
 

--- a/ceno_zkvm/src/multi_gpu.rs
+++ b/ceno_zkvm/src/multi_gpu.rs
@@ -373,7 +373,14 @@ mod tests {
             vec![2, 0]
         );
         assert_eq!(select_device_ids(None, Some(2), 3).unwrap(), vec![0, 1]);
-        assert_eq!(select_device_ids(None, None, 3).unwrap(), vec![0]);
+        let default = select_device_ids(None, None, 3).unwrap();
+        let explicit = select_device_ids(Some(&[0]), None, 3).unwrap();
+        assert_eq!(default, vec![0]);
+        assert_eq!(default, explicit);
+        assert_eq!(
+            MultiGpuConfig::new(default).unwrap(),
+            MultiGpuConfig::new(explicit).unwrap()
+        );
     }
 
     #[test]

--- a/ceno_zkvm/src/multi_gpu.rs
+++ b/ceno_zkvm/src/multi_gpu.rs
@@ -41,6 +41,8 @@ pub struct MultiGpuConfig {
     pub shard_policy: ShardAssignmentPolicy,
     pub replay_queue_depth: usize,
     pub recursion_device: usize,
+    /// Exclusive logical CPU sets, one per selected GPU worker.
+    pub worker_cpu_affinity: Option<Vec<Vec<usize>>>,
 }
 
 impl MultiGpuConfig {
@@ -53,6 +55,7 @@ impl MultiGpuConfig {
             shard_policy: ShardAssignmentPolicy::RoundRobin,
             replay_queue_depth: 1,
             recursion_device,
+            worker_cpu_affinity: None,
         };
         config.validate_shape()?;
         Ok(config)
@@ -60,6 +63,15 @@ impl MultiGpuConfig {
 
     pub fn with_recursion_device(mut self, device_id: usize) -> Result<Self, String> {
         self.recursion_device = device_id;
+        self.validate_shape()?;
+        Ok(self)
+    }
+
+    pub fn with_worker_cpu_affinity(
+        mut self,
+        worker_cpu_affinity: Vec<Vec<usize>>,
+    ) -> Result<Self, String> {
+        self.worker_cpu_affinity = Some(worker_cpu_affinity);
         self.validate_shape()?;
         Ok(self)
     }
@@ -83,6 +95,28 @@ impl MultiGpuConfig {
                 self.recursion_device
             ));
         }
+        if let Some(affinity) = &self.worker_cpu_affinity {
+            if affinity.len() != self.device_ids.len() {
+                return Err(format!(
+                    "GPU worker CPU affinity has {} entries, expected {}",
+                    affinity.len(),
+                    self.device_ids.len()
+                ));
+            }
+            let mut assigned = HashSet::new();
+            for (worker, cpus) in affinity.iter().enumerate() {
+                if cpus.is_empty() {
+                    return Err(format!("GPU worker {worker} CPU set must not be empty"));
+                }
+                for cpu in cpus {
+                    if !assigned.insert(*cpu) {
+                        return Err(format!(
+                            "logical CPU {cpu} appears in more than one exclusive GPU worker set"
+                        ));
+                    }
+                }
+            }
+        }
         Ok(())
     }
 
@@ -94,6 +128,9 @@ impl MultiGpuConfig {
 
     pub fn prepare(&self, requested_max_cells: u64) -> Result<PreparedMultiGpu, String> {
         self.validate_shape()?;
+        if let Some(affinity) = &self.worker_cpu_affinity {
+            validate_worker_cpu_affinity(affinity, &available_logical_cpus()?)?;
+        }
         let discovered = discover_cuda_devices().map_err(|error| error.to_string())?;
         let (selected, max_cell_per_shard) =
             self.validate_device_profiles(&discovered, requested_max_cells)?;
@@ -184,6 +221,86 @@ impl MultiGpuConfig {
         );
         Ok((selected, max_cell_per_shard))
     }
+}
+
+pub fn parse_worker_cpu_affinity(values: &[String]) -> Result<Option<Vec<Vec<usize>>>, String> {
+    if values.is_empty() {
+        return Ok(None);
+    }
+    values
+        .iter()
+        .enumerate()
+        .map(|(worker, value)| {
+            if value.is_empty() {
+                return Err(format!("GPU worker {worker} CPU set must not be empty"));
+            }
+            value
+                .split(',')
+                .map(|cpu| {
+                    cpu.parse::<usize>()
+                        .map_err(|_| format!("invalid logical CPU {cpu:?} for GPU worker {worker}"))
+                })
+                .collect()
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Some)
+}
+
+fn validate_worker_cpu_affinity(
+    affinity: &[Vec<usize>],
+    available: &[usize],
+) -> Result<(), String> {
+    let available = available.iter().copied().collect::<HashSet<_>>();
+    for (worker, cpus) in affinity.iter().enumerate() {
+        for cpu in cpus {
+            if !available.contains(cpu) {
+                return Err(format!(
+                    "logical CPU {cpu} for GPU worker {worker} is unavailable to this process"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+pub fn available_logical_cpus() -> Result<Vec<usize>, String> {
+    let mut set = unsafe { std::mem::zeroed::<libc::cpu_set_t>() };
+    if unsafe { libc::sched_getaffinity(0, std::mem::size_of_val(&set), &mut set) } != 0 {
+        return Err(format!(
+            "failed to query logical CPU affinity: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    Ok((0..libc::CPU_SETSIZE as usize)
+        .filter(|cpu| unsafe { libc::CPU_ISSET(*cpu, &set) })
+        .collect())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn available_logical_cpus() -> Result<Vec<usize>, String> {
+    Err("GPU worker CPU affinity is supported only on Linux".to_owned())
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn pin_current_thread(cpus: &[usize]) -> Result<Vec<usize>, String> {
+    let mut set = unsafe { std::mem::zeroed::<libc::cpu_set_t>() };
+    unsafe { libc::CPU_ZERO(&mut set) };
+    for cpu in cpus {
+        unsafe { libc::CPU_SET(*cpu, &mut set) };
+    }
+    if unsafe { libc::sched_setaffinity(0, std::mem::size_of_val(&set), &set) } != 0 {
+        return Err(format!(
+            "failed to pin current thread to CPUs {cpus:?}: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    available_logical_cpus()
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn pin_current_thread(_cpus: &[usize]) -> Result<Vec<usize>, String> {
+    Err("GPU worker CPU affinity is supported only on Linux".to_owned())
 }
 
 pub struct PreparedGpu {
@@ -284,6 +401,44 @@ mod tests {
                 .with_recursion_device(2)
                 .is_err()
         );
+    }
+
+    #[test]
+    fn worker_cpu_affinity_is_exclusive_and_matches_workers() {
+        let valid = MultiGpuConfig::new(vec![0, 1])
+            .unwrap()
+            .with_worker_cpu_affinity(vec![vec![2, 3], vec![4]])
+            .unwrap();
+        assert_eq!(valid.worker_cpu_affinity, Some(vec![vec![2, 3], vec![4]]));
+        assert!(
+            MultiGpuConfig::new(vec![0, 1])
+                .unwrap()
+                .with_worker_cpu_affinity(vec![vec![2]])
+                .is_err()
+        );
+        assert!(
+            MultiGpuConfig::new(vec![0, 1])
+                .unwrap()
+                .with_worker_cpu_affinity(vec![vec![2], vec![2]])
+                .is_err()
+        );
+        assert!(
+            MultiGpuConfig::new(vec![0])
+                .unwrap()
+                .with_worker_cpu_affinity(vec![vec![]])
+                .is_err()
+        );
+        assert!(validate_worker_cpu_affinity(&[vec![7]], &[2, 3, 4]).is_err());
+    }
+
+    #[test]
+    fn worker_cpu_affinity_cli_shape_parses_repeated_sets() {
+        assert_eq!(
+            parse_worker_cpu_affinity(&["2,3".to_owned(), "4".to_owned()]).unwrap(),
+            Some(vec![vec![2, 3], vec![4]])
+        );
+        assert!(parse_worker_cpu_affinity(&["2,x".to_owned()]).is_err());
+        assert_eq!(parse_worker_cpu_affinity(&[]).unwrap(), None);
     }
 
     #[test]

--- a/ceno_zkvm/src/multi_gpu.rs
+++ b/ceno_zkvm/src/multi_gpu.rs
@@ -29,17 +29,9 @@ fn conservative_shard_cap(
         .ok_or_else(|| "GPU device list must not be empty".to_owned())
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum ShardAssignmentPolicy {
-    #[default]
-    RoundRobin,
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MultiGpuConfig {
     pub device_ids: Vec<usize>,
-    pub shard_policy: ShardAssignmentPolicy,
-    pub replay_queue_depth: usize,
     /// Exclusive logical CPU sets, one per selected GPU worker.
     pub worker_cpu_affinity: Option<Vec<Vec<usize>>>,
 }
@@ -48,8 +40,6 @@ impl MultiGpuConfig {
     pub fn new(device_ids: Vec<usize>) -> Result<Self, String> {
         let config = Self {
             device_ids,
-            shard_policy: ShardAssignmentPolicy::RoundRobin,
-            replay_queue_depth: 1,
             worker_cpu_affinity: None,
         };
         config.validate_shape()?;
@@ -68,9 +58,6 @@ impl MultiGpuConfig {
     pub fn validate_shape(&self) -> Result<(), String> {
         if self.device_ids.is_empty() {
             return Err("GPU device list must not be empty".to_owned());
-        }
-        if self.replay_queue_depth != 1 {
-            return Err("Stage 1 requires replay_queue_depth=1".to_owned());
         }
         let mut unique = HashSet::with_capacity(self.device_ids.len());
         for device_id in &self.device_ids {
@@ -104,9 +91,7 @@ impl MultiGpuConfig {
     }
 
     pub fn owner_index(&self, shard_id: usize) -> usize {
-        match self.shard_policy {
-            ShardAssignmentPolicy::RoundRobin => shard_id % self.device_ids.len(),
-        }
+        shard_id % self.device_ids.len()
     }
 
     pub fn prepare(&self, requested_max_cells: u64) -> Result<PreparedMultiGpu, String> {

--- a/ceno_zkvm/src/scheme.rs
+++ b/ceno_zkvm/src/scheme.rs
@@ -401,5 +401,14 @@ pub fn create_backend<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
 pub fn create_prover<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
     backend: Arc<gkr_iop::gpu::GpuBackend<E, PCS>>,
 ) -> gkr_iop::gpu::GpuProver<gkr_iop::gpu::GpuBackend<E, PCS>> {
-    gkr_iop::gpu::GpuProver::new(backend)
+    create_prover_on_device(backend, 0).expect("failed to initialize CUDA device 0")
+}
+
+#[cfg(feature = "gpu")]
+pub fn create_prover_on_device<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
+    backend: Arc<gkr_iop::gpu::GpuBackend<E, PCS>>,
+    device_id: usize,
+) -> Result<gkr_iop::gpu::GpuProver<gkr_iop::gpu::GpuBackend<E, PCS>>, ceno_gpu::HalError> {
+    let cuda_hal = Arc::new(ceno_gpu::bb31::CudaHalBB31::new(device_id)?);
+    Ok(gkr_iop::gpu::GpuProver::new(backend, cuda_hal))
 }

--- a/ceno_zkvm/src/scheme.rs
+++ b/ceno_zkvm/src/scheme.rs
@@ -401,14 +401,7 @@ pub fn create_backend<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
 pub fn create_prover<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
     backend: Arc<gkr_iop::gpu::GpuBackend<E, PCS>>,
 ) -> gkr_iop::gpu::GpuProver<gkr_iop::gpu::GpuBackend<E, PCS>> {
-    create_prover_on_device(backend, 0).expect("failed to initialize CUDA device 0")
-}
-
-#[cfg(feature = "gpu")]
-pub fn create_prover_on_device<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>(
-    backend: Arc<gkr_iop::gpu::GpuBackend<E, PCS>>,
-    device_id: usize,
-) -> Result<gkr_iop::gpu::GpuProver<gkr_iop::gpu::GpuBackend<E, PCS>>, ceno_gpu::HalError> {
-    let cuda_hal = Arc::new(ceno_gpu::bb31::CudaHalBB31::new(device_id)?);
-    Ok(gkr_iop::gpu::GpuProver::new(backend, cuda_hal))
+    let cuda_hal =
+        Arc::new(ceno_gpu::bb31::CudaHalBB31::new(0).expect("failed to initialize CUDA device 0"));
+    gkr_iop::gpu::GpuProver::new(backend, cuda_hal)
 }

--- a/ceno_zkvm/src/scheme/gpu/mod.rs
+++ b/ceno_zkvm/src/scheme/gpu/mod.rs
@@ -44,7 +44,7 @@ use gkr_iop::{
     },
     gpu::{
         GpuBackend, GpuBasefoldPcsData, GpuJaggedPcsData, GpuJaggedTraceLayout, GpuPcsData,
-        GpuProver, gpu_prover::BB31Ext,
+        GpuProver, get_cuda_hal, gpu_prover::BB31Ext,
     },
     hal::ProverBackend,
 };

--- a/ceno_zkvm/src/scheme/mock_prover.rs
+++ b/ceno_zkvm/src/scheme/mock_prover.rs
@@ -49,6 +49,84 @@ const MAX_CONSTRAINT_DEGREE: usize = 3;
 const MOCK_PROGRAM_SIZE: usize = 32;
 pub const MOCK_PC_START: ByteAddr = ByteAddr(0x0800_0000);
 
+struct RamRecordGroup<E> {
+    records: Vec<(E, usize)>,
+    field_columns: Vec<Vec<u64>>,
+    circuit_name: String,
+}
+
+impl<E> RamRecordGroup<E> {
+    fn tuple(&self, record_index: usize) -> Vec<u64> {
+        self.field_columns
+            .iter()
+            .map(|field| field[record_index])
+            .collect()
+    }
+}
+
+type RamRecordDiagnostics<E> = HashMap<String, RamRecordGroup<E>>;
+
+fn ram_columnar_tuple_distance<E>(
+    target: &[u64],
+    candidate: &RamRecordGroup<E>,
+    record_index: usize,
+) -> (usize, u128) {
+    let differing_fields = target
+        .iter()
+        .zip(&candidate.field_columns)
+        .filter(|(target, field)| **target != field[record_index])
+        .count()
+        + target.len().abs_diff(candidate.field_columns.len());
+    let absolute_delta = target
+        .iter()
+        .zip(&candidate.field_columns)
+        .map(|(target, field)| target.abs_diff(field[record_index]) as u128)
+        .sum();
+    (differing_fields, absolute_delta)
+}
+
+fn closest_ram_tuple<'a, E>(
+    target: &[u64],
+    candidates: &'a RamRecordDiagnostics<E>,
+) -> Option<(&'a str, &'a str, usize, Vec<u64>)> {
+    let (annotation, group, record_index) = candidates
+        .iter()
+        .flat_map(|(annotation, group)| {
+            group
+                .records
+                .iter()
+                .enumerate()
+                .map(move |(record_index, _)| (annotation.as_str(), group, record_index))
+        })
+        .min_by(|a, b| {
+            ram_columnar_tuple_distance(target, a.1, a.2)
+                .cmp(&ram_columnar_tuple_distance(target, b.1, b.2))
+                .then_with(|| {
+                    a.1.field_columns
+                        .iter()
+                        .map(|field| field[a.2])
+                        .cmp(b.1.field_columns.iter().map(|field| field[b.2]))
+                })
+                .then_with(|| a.0.cmp(b.0))
+                .then_with(|| a.1.circuit_name.cmp(&b.1.circuit_name))
+                .then_with(|| a.1.records[a.2].1.cmp(&b.1.records[b.2].1))
+        })?;
+    Some((
+        annotation,
+        group.circuit_name.as_str(),
+        group.records[record_index].1,
+        group.tuple(record_index),
+    ))
+}
+
+fn ram_tuple_delta(target: &[u64], candidate: &[u64]) -> Vec<i128> {
+    target
+        .iter()
+        .zip(candidate)
+        .map(|(target, candidate)| *candidate as i128 - *target as i128)
+        .collect()
+}
+
 /// Allow LK Multiplicity's key to be used with `u64` and `GoldilocksExt2`.
 pub trait LkMultiplicityKey: Copy + Clone + Debug + Eq + Hash + Send {
     /// If key is u64, return Some(u64), otherwise None.
@@ -1175,7 +1253,7 @@ Hints:
                             .into()
                         };
 
-                    for ((w_rlc_expr, annotation), (ram_type_expr, _)) in (cs
+                    for ((w_rlc_expr, annotation), (ram_type_expr, w_exprs)) in (cs
                         .w_expressions
                         .iter()
                         .chain(cs.w_table_expressions.iter().map(|expr| &expr.expr)))
@@ -1221,6 +1299,31 @@ Hints:
                             continue;
                         }
 
+                        let write_record_fields = w_exprs
+                            .iter()
+                            .map(|expr| {
+                                let values = wit_infer_by_expr(
+                                    expr,
+                                    cs.num_witin,
+                                    cs.num_fixed as WitnessId,
+                                    0,
+                                    fixed,
+                                    witness,
+                                    structural_witness,
+                                    &circuit_pi_mles,
+                                    &circuit_pub_io_evals,
+                                    &challenges,
+                                );
+                                filter_mle_by_predicate(values, |i, _v| {
+                                    ram_type_vec[i] == E::from_u32($ram_type as u32)
+                                        && w_selector_vec[i] == E::BaseField::ONE
+                                })
+                                .into_iter()
+                                .map(|value| value.to_canonical_u64())
+                                .collect()
+                            })
+                            .collect_vec();
+
                         let mut records = vec![];
                         let mut writes_within_expr_dedup = HashSet::new();
                         for (row, record_rlc) in enumerate(write_rlc_records) {
@@ -1241,8 +1344,14 @@ Hints:
                             );
                             records.push((record_rlc, row));
                         }
-                        writes_grp_by_annotations
-                            .insert(annotation.clone(), (records, circuit_name.clone()));
+                        writes_grp_by_annotations.insert(
+                            annotation.clone(),
+                            RamRecordGroup {
+                                records,
+                                field_columns: write_record_fields,
+                                circuit_name: circuit_name.clone(),
+                            },
+                        );
                     }
                 }
 
@@ -1320,6 +1429,31 @@ Hints:
                             continue;
                         }
 
+                        let read_record_fields = r_exprs
+                            .iter()
+                            .map(|expr| {
+                                let values = wit_infer_by_expr(
+                                    expr,
+                                    cs.num_witin,
+                                    cs.num_fixed as WitnessId,
+                                    0,
+                                    fixed,
+                                    witness,
+                                    structural_witness,
+                                    &circuit_pi_mles,
+                                    &circuit_pub_io_evals,
+                                    &challenges,
+                                );
+                                filter_mle_by_predicate(values, |i, _v| {
+                                    ram_type_vec[i] == E::from_u32($ram_type as u32)
+                                        && r_selector_vec[i] == E::BaseField::ONE
+                                })
+                                .into_iter()
+                                .map(|value| value.to_canonical_u64())
+                                .collect()
+                            })
+                            .collect_vec();
+
                         if $ram_type == RAMType::GlobalState {
                             // r_exprs = [GlobalState, pc, timestamp]
                             assert_eq!(r_exprs.len(), 3);
@@ -1371,8 +1505,14 @@ Hints:
                             );
                             records.push((record, row));
                         }
-                        reads_grp_by_annotations
-                            .insert(annotation.clone(), (records, circuit_name.clone()));
+                        reads_grp_by_annotations.insert(
+                            annotation.clone(),
+                            RamRecordGroup {
+                                records,
+                                field_columns: read_record_fields,
+                                circuit_name: circuit_name.clone(),
+                            },
+                        );
                     }
                 }
 
@@ -1387,9 +1527,10 @@ Hints:
         }
         macro_rules! find_rw_mismatch {
             ($reads:ident,$reads_grp_by_annotations:ident,$writes:ident,$writes_grp_by_annotations:ident,$ram_type:expr,$gs:expr) => {
-                for (annotation, (reads, circuit_name)) in &$reads_grp_by_annotations {
+                for (annotation, group) in &$reads_grp_by_annotations {
+                    let reads = &group.records;
                     // (pc, timestamp)
-                    let gs_of_circuit = $gs.get(circuit_name);
+                    let gs_of_circuit = $gs.get(&group.circuit_name);
                     let num_missing = reads
                         .iter()
                         .filter(|(read, _)| !$writes.contains(read))
@@ -1397,19 +1538,30 @@ Hints:
                     let num_reads = reads.len();
                     reads
                         .iter()
-                        .filter(|(read, _)| !$writes.contains(read))
+                        .enumerate()
+                        .filter(|(_, (read, _))| !$writes.contains(read))
                         .take(10)
-                        .for_each(|(_, row)| {
+                        .for_each(|(record_index, (_, row))| {
+                            let tuple = group.tuple(record_index);
                             let pc = gs_of_circuit.map_or(0, |gs| gs[*row][0].to_canonical_u64());
                             let ts = gs_of_circuit.map_or(0, |gs| gs[*row][1].to_canonical_u64());
                             tracing::error!(
-                                "{} at row {} (pc={:x},ts={}) not found in {:?} writes",
+                                "{} at row {} (pc={:x},ts={}) tuple={:?} not found in {:?} writes",
                                 annotation,
                                 row,
                                 pc,
                                 ts,
+                                &tuple,
                                 $ram_type,
-                            )
+                            );
+                            if let Some((candidate_annotation, candidate_circuit, candidate_row, candidate)) =
+                                closest_ram_tuple(&tuple, &$writes_grp_by_annotations)
+                            {
+                                tracing::error!(
+                                    "closest write: {candidate_circuit}/{candidate_annotation} row {candidate_row} tuple={candidate:?} delta={:?}",
+                                    ram_tuple_delta(&tuple, &candidate),
+                                );
+                            }
                         });
 
                     if num_missing > 10 {
@@ -1424,8 +1576,9 @@ Hints:
                     }
                     num_rw_mismatch_errors += num_missing;
                 }
-                for (annotation, (writes, circuit_name)) in &$writes_grp_by_annotations {
-                    let gs_of_circuit = $gs.get(circuit_name);
+                for (annotation, group) in &$writes_grp_by_annotations {
+                    let writes = &group.records;
+                    let gs_of_circuit = $gs.get(&group.circuit_name);
                     let num_missing = writes
                         .iter()
                         .filter(|(write, _)| !$reads.contains(write))
@@ -1433,19 +1586,30 @@ Hints:
                     let num_writes = writes.len();
                     writes
                         .iter()
-                        .filter(|(write, _)| !$reads.contains(write))
+                        .enumerate()
+                        .filter(|(_, (write, _))| !$reads.contains(write))
                         .take(10)
-                        .for_each(|(_, row)| {
+                        .for_each(|(record_index, (_, row))| {
+                            let tuple = group.tuple(record_index);
                             let pc = gs_of_circuit.map_or(0, |gs| gs[*row][0].to_canonical_u64());
                             let ts = gs_of_circuit.map_or(0, |gs| gs[*row][1].to_canonical_u64());
                             tracing::error!(
-                                "{} at row {} (pc={:x},ts={}) not found in {:?} reads",
+                                "{} at row {} (pc={:x},ts={}) tuple={:?} not found in {:?} reads",
                                 annotation,
                                 row,
                                 pc,
                                 ts,
+                                &tuple,
                                 $ram_type,
-                            )
+                            );
+                            if let Some((candidate_annotation, candidate_circuit, candidate_row, candidate)) =
+                                closest_ram_tuple(&tuple, &$reads_grp_by_annotations)
+                            {
+                                tracing::error!(
+                                    "closest read: {candidate_circuit}/{candidate_annotation} row {candidate_row} tuple={candidate:?} delta={:?}",
+                                    ram_tuple_delta(&tuple, &candidate),
+                                );
+                            }
                         });
 
                     if num_missing > 10 {
@@ -1605,6 +1769,33 @@ mod tests {
     use multilinear_extensions::{ToExpr, WitIn, mle::IntoMLE};
     use p3::{field::PrimeCharacteristicRing as FieldAlgebra, goldilocks::Goldilocks};
     use witness::{InstancePaddingStrategy, RowMajorMatrix, set_val};
+
+    #[test]
+    fn closest_ram_tuple_is_deterministic_and_reports_field_delta() {
+        let mut candidates = RamRecordDiagnostics::<u64>::new();
+        candidates.insert(
+            "z_annotation".to_owned(),
+            RamRecordGroup {
+                records: vec![(0, 9)],
+                field_columns: vec![vec![1], vec![4], vec![1]],
+                circuit_name: "z_circuit".to_owned(),
+            },
+        );
+        candidates.insert(
+            "a_annotation".to_owned(),
+            RamRecordGroup {
+                records: vec![(0, 7)],
+                field_columns: vec![vec![1], vec![0], vec![5]],
+                circuit_name: "a_circuit".to_owned(),
+            },
+        );
+
+        let (annotation, circuit, row, tuple) = closest_ram_tuple(&[1, 2, 3], &candidates).unwrap();
+
+        assert_eq!((annotation, circuit, row), ("a_annotation", "a_circuit", 7));
+        assert_eq!(tuple, [1, 0, 5]);
+        assert_eq!(ram_tuple_delta(&[1, 2, 3], &tuple), [0, -2, 2]);
+    }
 
     #[derive(Debug)]
     struct AssertZeroCircuit {

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -14,6 +14,8 @@ use std::collections::HashMap;
 use crate::scheme::gpu::{
     estimate_chip_proof_memory, estimate_chip_proof_reservations, is_babybear_jagged_pcs,
 };
+#[cfg(feature = "gpu")]
+use crate::scheme::verifier::ZKVMVerifier;
 use crate::scheme::{
     hal::{MainConstraintJob, MainConstraintResult, MainSumcheckEvals},
     scheduler::{ChipScheduler, ChipTask, ChipTaskResult},
@@ -242,6 +244,8 @@ pub struct ZKVMProver<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>, PB:
 {
     pub pk: Arc<ZKVMProvingKey<E, PCS>>,
     vk_digest: [E; VK_DIGEST_LEN],
+    #[cfg(feature = "gpu")]
+    cached_verifier: Option<Arc<ZKVMVerifier<E, PCS>>>,
     device: PD,
     // device_pk might be none if there is no fixed commitment
     device_first_shard_pk: Option<DeviceProvingKey<'static, PB>>,
@@ -268,6 +272,8 @@ impl<
         ZKVMProver {
             pk,
             vk_digest,
+            #[cfg(feature = "gpu")]
+            cached_verifier: None,
             device,
             device_first_shard_pk,
             device_non_first_shard_pk: None,
@@ -276,7 +282,43 @@ impl<
     }
 
     pub fn new(pk: Arc<ZKVMProvingKey<E, PCS>>, device: PD) -> Self {
+        let digest_started = std::time::Instant::now();
         let vk_digest = pk.compute_vk_digest::<RV32imMemStateConfig>();
+        let vk_digest_elapsed = digest_started.elapsed();
+        #[cfg(feature = "gpu")]
+        let cached_verifier = Arc::new(ZKVMVerifier::new_with_vk_digest(
+            pk.get_vk_slow(),
+            vk_digest,
+        ));
+        Self::new_with_vk_digest_inner(
+            pk,
+            device,
+            vk_digest,
+            vk_digest_elapsed,
+            false,
+            #[cfg(feature = "gpu")]
+            Some(cached_verifier),
+        )
+    }
+
+    #[cfg(feature = "gpu")]
+    pub(crate) fn new_with_vk_digest(
+        pk: Arc<ZKVMProvingKey<E, PCS>>,
+        device: PD,
+        vk_digest: [E; VK_DIGEST_LEN],
+    ) -> Self {
+        Self::new_with_vk_digest_inner(pk, device, vk_digest, std::time::Duration::ZERO, true, None)
+    }
+
+    fn new_with_vk_digest_inner(
+        pk: Arc<ZKVMProvingKey<E, PCS>>,
+        device: PD,
+        vk_digest: [E; VK_DIGEST_LEN],
+        vk_digest_elapsed: std::time::Duration,
+        reused_vk_digest: bool,
+        #[cfg(feature = "gpu")] cached_verifier: Option<Arc<ZKVMVerifier<E, PCS>>>,
+    ) -> Self {
+        let device_pk_started = std::time::Instant::now();
         let (device_first_shard_pk, device_non_first_shard_pk) =
             if pk.as_ref().has_fixed_commitment() {
                 (
@@ -286,15 +328,35 @@ impl<
             } else {
                 (None, None)
             };
+        tracing::info!(
+            target: "ceno_multi_gpu",
+            vk_digest_ms = vk_digest_elapsed.as_millis(),
+            device_pk_ms = device_pk_started.elapsed().as_millis(),
+            reused_vk_digest,
+            phase = "prover_rehydration",
+            "multi-GPU base setup event"
+        );
 
         ZKVMProver {
             pk,
             vk_digest,
+            #[cfg(feature = "gpu")]
+            cached_verifier,
             device,
             device_first_shard_pk,
             device_non_first_shard_pk,
             _marker: PhantomData,
         }
+    }
+
+    #[cfg(feature = "gpu")]
+    pub(crate) fn vk_digest(&self) -> [E; VK_DIGEST_LEN] {
+        self.vk_digest
+    }
+
+    #[cfg(feature = "gpu")]
+    pub(crate) fn cached_verifier(&self) -> Option<Arc<ZKVMVerifier<E, PCS>>> {
+        self.cached_verifier.clone()
     }
 
     pub fn get_device_proving_key(

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -314,6 +314,10 @@ impl<
         };
         ctx.setup_init_mem(hints)
     }
+
+    pub fn device(&self) -> &PD {
+        &self.device
+    }
 }
 
 impl<

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -282,9 +282,7 @@ impl<
     }
 
     pub fn new(pk: Arc<ZKVMProvingKey<E, PCS>>, device: PD) -> Self {
-        let digest_started = std::time::Instant::now();
         let vk_digest = pk.compute_vk_digest::<RV32imMemStateConfig>();
-        let vk_digest_elapsed = digest_started.elapsed();
         #[cfg(feature = "gpu")]
         let cached_verifier = Arc::new(ZKVMVerifier::new_with_vk_digest(
             pk.get_vk_slow(),
@@ -294,8 +292,6 @@ impl<
             pk,
             device,
             vk_digest,
-            vk_digest_elapsed,
-            false,
             #[cfg(feature = "gpu")]
             Some(cached_verifier),
         )
@@ -307,18 +303,15 @@ impl<
         device: PD,
         vk_digest: [E; VK_DIGEST_LEN],
     ) -> Self {
-        Self::new_with_vk_digest_inner(pk, device, vk_digest, std::time::Duration::ZERO, true, None)
+        Self::new_with_vk_digest_inner(pk, device, vk_digest, None)
     }
 
     fn new_with_vk_digest_inner(
         pk: Arc<ZKVMProvingKey<E, PCS>>,
         device: PD,
         vk_digest: [E; VK_DIGEST_LEN],
-        vk_digest_elapsed: std::time::Duration,
-        reused_vk_digest: bool,
         #[cfg(feature = "gpu")] cached_verifier: Option<Arc<ZKVMVerifier<E, PCS>>>,
     ) -> Self {
-        let device_pk_started = std::time::Instant::now();
         let (device_first_shard_pk, device_non_first_shard_pk) =
             if pk.as_ref().has_fixed_commitment() {
                 (
@@ -328,14 +321,6 @@ impl<
             } else {
                 (None, None)
             };
-        tracing::info!(
-            target: "ceno_multi_gpu",
-            vk_digest_ms = vk_digest_elapsed.as_millis(),
-            device_pk_ms = device_pk_started.elapsed().as_millis(),
-            reused_vk_digest,
-            phase = "prover_rehydration",
-            "multi-GPU base setup event"
-        );
 
         ZKVMProver {
             pk,

--- a/ceno_zkvm/src/scheme/prover.rs
+++ b/ceno_zkvm/src/scheme/prover.rs
@@ -350,12 +350,12 @@ impl<
     }
 
     #[cfg(feature = "gpu")]
-    pub(crate) fn vk_digest(&self) -> [E; VK_DIGEST_LEN] {
+    pub fn vk_digest(&self) -> [E; VK_DIGEST_LEN] {
         self.vk_digest
     }
 
     #[cfg(feature = "gpu")]
-    pub(crate) fn cached_verifier(&self) -> Option<Arc<ZKVMVerifier<E, PCS>>> {
+    pub fn cached_verifier(&self) -> Option<Arc<ZKVMVerifier<E, PCS>>> {
         self.cached_verifier.clone()
     }
 

--- a/ceno_zkvm/src/scheme/scheduler.rs
+++ b/ceno_zkvm/src/scheme/scheduler.rs
@@ -19,6 +19,8 @@ use crate::{
     structs::ProvingKey,
 };
 use ff_ext::ExtensionField;
+#[cfg(feature = "gpu")]
+use gkr_iop::gpu::get_cuda_hal;
 use gkr_iop::hal::ProverBackend;
 use mpcs::Point;
 use std::sync::OnceLock;
@@ -767,6 +769,7 @@ impl ChipScheduler {
                 let phase_tx = phase_tx.clone();
                 let execute_fn = &execute_task;
                 let tr = &transcript_ref;
+                let lane_cuda_hal = cuda_hal.clone();
 
                 s.spawn(move || {
                     nvtx::name_thread!("ceno-chip-lane-{}", lane_id);
@@ -816,7 +819,10 @@ impl ChipScheduler {
                         let outcome =
                             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                                 let _lane_binding = lane_stream.as_ref().map(|stream| {
-                                    gkr_iop::gpu::bind_thread_stream(stream.stream().clone())
+                                    gkr_iop::gpu::bind_thread_stream(
+                                        lane_cuda_hal.clone(),
+                                        stream.stream().clone(),
+                                    )
                                 });
                                 let _phase_release_context = phase_release_enabled.then(|| {
                                     bind_phase_release_context(PhaseReleaseContext {

--- a/ceno_zkvm/src/scheme/tests.rs
+++ b/ceno_zkvm/src/scheme/tests.rs
@@ -23,7 +23,7 @@ use ceno_emul::{
 use ff_ext::{ExtensionField, FieldInto, FromUniformBytes, GoldilocksExt2};
 use gkr_iop::cpu::default_backend_config;
 #[cfg(feature = "gpu")]
-use gkr_iop::gpu::{MultilinearExtensionGpu, gpu_prover::*};
+use gkr_iop::gpu::{MultilinearExtensionGpu, get_cuda_hal};
 use multilinear_extensions::{ToExpr, WitIn, mle::MultilinearExtension};
 use p3::field::PrimeCharacteristicRing;
 use std::marker::PhantomData;

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -274,7 +274,29 @@ where
     M: Clone + Default + serde::Serialize + serde::de::DeserializeOwned,
 {
     pub fn new(vk: ZKVMVerifyingKey<E, PCS, M>) -> Self {
+        let digest_started = std::time::Instant::now();
         let vk_digest = vk.compute_digest();
+        tracing::info!(
+            target: "ceno_multi_gpu",
+            elapsed_ms = digest_started.elapsed().as_millis(),
+            phase = "verifier_vk_digest",
+            "multi-GPU base setup event"
+        );
+        ZKVMVerifier { vk, vk_digest }
+    }
+
+    #[cfg(feature = "gpu")]
+    pub(crate) fn new_with_vk_digest(
+        vk: ZKVMVerifyingKey<E, PCS, M>,
+        vk_digest: [E; VK_DIGEST_LEN],
+    ) -> Self {
+        tracing::info!(
+            target: "ceno_multi_gpu",
+            elapsed_ms = 0,
+            reused_vk_digest = true,
+            phase = "verifier_vk_digest",
+            "multi-GPU base setup event"
+        );
         ZKVMVerifier { vk, vk_digest }
     }
 

--- a/ceno_zkvm/src/scheme/verifier.rs
+++ b/ceno_zkvm/src/scheme/verifier.rs
@@ -274,14 +274,7 @@ where
     M: Clone + Default + serde::Serialize + serde::de::DeserializeOwned,
 {
     pub fn new(vk: ZKVMVerifyingKey<E, PCS, M>) -> Self {
-        let digest_started = std::time::Instant::now();
         let vk_digest = vk.compute_digest();
-        tracing::info!(
-            target: "ceno_multi_gpu",
-            elapsed_ms = digest_started.elapsed().as_millis(),
-            phase = "verifier_vk_digest",
-            "multi-GPU base setup event"
-        );
         ZKVMVerifier { vk, vk_digest }
     }
 
@@ -290,13 +283,6 @@ where
         vk: ZKVMVerifyingKey<E, PCS, M>,
         vk_digest: [E; VK_DIGEST_LEN],
     ) -> Self {
-        tracing::info!(
-            target: "ceno_multi_gpu",
-            elapsed_ms = 0,
-            reused_vk_digest = true,
-            phase = "verifier_vk_digest",
-            "multi-GPU base setup event"
-        );
         ZKVMVerifier { vk, vk_digest }
     }
 

--- a/ceno_zkvm/src/structs.rs
+++ b/ceno_zkvm/src/structs.rs
@@ -416,6 +416,24 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
         );
     }
 
+    /// Omit empty per-chip lookup maps when a GPU shard owns their counters.
+    ///
+    /// Shard accumulation deliberately returns empty maps from each GPU chip and
+    /// stores their sum under `__gpu_shard_lk`. A CPU mock must infer those chip
+    /// lookups from the materialized traces instead of comparing them with the
+    /// empty placeholders. The final table-versus-opcode comparison remains the
+    /// authoritative check of the shard-wide accumulated counters.
+    #[cfg(feature = "gpu")]
+    pub(crate) fn omit_gpu_lk_placeholders_for_mock(&mut self) {
+        const SHARD_LK_NAME: &str = "__gpu_shard_lk";
+        if !self.lk_mlts.contains_key(SHARD_LK_NAME) {
+            return;
+        }
+        self.lk_mlts.retain(|name, multiplicity| {
+            name == SHARD_LK_NAME || multiplicity.iter().any(|counts| !counts.is_empty())
+        });
+    }
+
     pub fn assign_opcode_circuit<OC: Instruction<E>>(
         &mut self,
         cs: &ZKVMConstraintSystem<E>,
@@ -937,6 +955,42 @@ impl<E: ExtensionField> ZKVMWitnesses<E> {
             record: global_write,
             ec_point,
         })
+    }
+}
+
+#[cfg(all(test, feature = "gpu"))]
+mod gpu_mock_lk_tests {
+    use super::*;
+    use ff_ext::BabyBearExt4;
+
+    #[test]
+    fn shard_gpu_mock_omits_only_empty_per_chip_lookup_maps() {
+        let mut witnesses = ZKVMWitnesses::<BabyBearExt4>::default();
+        witnesses
+            .lk_mlts
+            .insert("ADD".to_owned(), Multiplicity::default());
+        let mut retained = Multiplicity::default();
+        retained[LookupTable::Instruction as usize].insert(4, 1);
+        witnesses.lk_mlts.insert("CPU".to_owned(), retained);
+        witnesses.insert_shard_gpu_lk_multiplicity(Multiplicity::default());
+
+        witnesses.omit_gpu_lk_placeholders_for_mock();
+
+        assert!(!witnesses.lk_mlts.contains_key("ADD"));
+        assert!(witnesses.lk_mlts.contains_key("CPU"));
+        assert!(witnesses.lk_mlts.contains_key("__gpu_shard_lk"));
+    }
+
+    #[test]
+    fn cpu_mock_keeps_empty_per_chip_lookup_maps() {
+        let mut witnesses = ZKVMWitnesses::<BabyBearExt4>::default();
+        witnesses
+            .lk_mlts
+            .insert("ADD".to_owned(), Multiplicity::default());
+
+        witnesses.omit_gpu_lk_placeholders_for_mock();
+
+        assert!(witnesses.lk_mlts.contains_key("ADD"));
     }
 }
 

--- a/gkr_iop/src/gkr/layer/gpu/mod.rs
+++ b/gkr_iop/src/gkr/layer/gpu/mod.rs
@@ -7,7 +7,7 @@ use crate::{
             zerocheck_layer::RotationPoints,
         },
     },
-    gpu::{GpuBackend, GpuProver},
+    gpu::{GpuBackend, GpuProver, get_cuda_hal},
 };
 use either::Either;
 use ff_ext::ExtensionField;
@@ -408,6 +408,7 @@ pub fn prove_rotation_gpu<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>
     // Capture parent thread's CUDA stream so Rayon workers can reuse it.
     // TODO: GPU batch evaluation and its batch version
     let parent_stream = crate::gpu::get_thread_stream();
+    let parent_hal = crate::gpu::get_cuda_hal().ok();
     let evals = evals_gpu_e
         .par_chunks_exact(2)
         .zip_eq(raw_rotation_exprs.par_iter())
@@ -415,7 +416,8 @@ pub fn prove_rotation_gpu<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>
             // Propagate parent thread's CUDA stream to Rayon worker
             let _guard = parent_stream
                 .as_ref()
-                .map(|s| crate::gpu::bind_thread_stream(s.clone()));
+                .zip(parent_hal.as_ref())
+                .map(|(stream, hal)| crate::gpu::bind_thread_stream(hal.clone(), stream.clone()));
             let [rotated_eval, target_eval] = evals else {
                 unreachable!()
             };

--- a/gkr_iop/src/gpu/mod.rs
+++ b/gkr_iop/src/gpu/mod.rs
@@ -29,7 +29,7 @@ pub mod gpu_prover {
             CacheLevel,
             basefold::utils::convert_ceno_to_gpu_basefold_commitment,
             buffer::BufferImpl,
-            get_ceno_gpu_device_id, get_gpu_cache_level, get_mem_tracking_mode,
+            get_gpu_cache_level, get_mem_tracking_mode,
             jagged::GpuJaggedPreprocessed,
             mem_pool::MemTracker,
             mle::{
@@ -43,27 +43,8 @@ pub mod gpu_prover {
     // Re-export CudaStream for concurrent GPU stream operations
     pub use cudarc::driver::CudaStream;
 
-    use once_cell::sync::Lazy;
-    use std::sync::Arc;
-
     pub type BB31Base = p3::babybear::BabyBear;
     pub type BB31Ext = ff_ext::BabyBearExt4;
-
-    #[allow(clippy::type_complexity)]
-    pub static CUDA_HAL: Lazy<Result<Arc<CudaHalBB31>, Box<dyn std::error::Error + Send + Sync>>> =
-        Lazy::new(|| {
-            let device_id: usize = get_ceno_gpu_device_id(0);
-            CudaHalBB31::new(device_id)
-                .map(Arc::new)
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)
-        });
-
-    pub fn get_cuda_hal() -> Result<Arc<CudaHalBB31>, String> {
-        CUDA_HAL
-            .as_ref()
-            .map(|hal_arc| hal_arc.clone())
-            .map_err(|e| format!("HAL not available: {:?}", e))
-    }
 }
 
 use crate::{evaluation::EvalExpression, gkr::layer::Layer};
@@ -77,34 +58,54 @@ use std::{
 static DEFAULT_STREAM_FALLBACK_FORBIDDEN: AtomicUsize = AtomicUsize::new(0);
 
 thread_local! {
+    static THREAD_CUDA_HAL: RefCell<Option<Arc<CudaHalBB31>>> = const { RefCell::new(None) };
     static THREAD_CUDA_STREAM: RefCell<Option<Arc<CudaStream>>> = const { RefCell::new(None) };
+}
+
+pub fn get_cuda_hal() -> Result<Arc<CudaHalBB31>, String> {
+    THREAD_CUDA_HAL.with(|cell| {
+        cell.borrow()
+            .clone()
+            .ok_or_else(|| "CUDA HAL is not bound to this worker thread".to_owned())
+    })
+}
+
+/// Bind a worker-owned HAL to the current thread until another worker binds one.
+pub fn set_thread_cuda_hal(cuda_hal: Arc<CudaHalBB31>) {
+    cuda_hal.inner.ensure_context();
+    THREAD_CUDA_HAL.with(|cell| *cell.borrow_mut() = Some(cuda_hal));
 }
 
 /// Bind a CUDA stream to the current thread for use by all GPU operations.
 /// Also ensures the CUDA context is active on this thread, which is necessary
 /// for Rayon workers that receive a propagated stream from a parent thread.
 /// Returns a guard that clears the thread-local on drop.
-pub fn bind_thread_stream(stream: Arc<CudaStream>) -> ThreadStreamGuard {
+pub fn bind_thread_stream(
+    cuda_hal: Arc<CudaHalBB31>,
+    stream: Arc<CudaStream>,
+) -> ThreadCudaBindingGuard {
     // Ensure CUDA context is bound to this thread.
     // Without this, threads that receive a propagated stream (e.g. Rayon workers)
     // would have a stream but no active CUDA context, causing CUDA_ERROR_INVALID_CONTEXT.
-    let cuda_hal = get_cuda_hal().expect("Failed to get CUDA HAL");
     cuda_hal.inner.ensure_context();
-
-    THREAD_CUDA_STREAM.with(|cell| {
-        *cell.borrow_mut() = Some(stream);
-    });
-    ThreadStreamGuard
+    let previous_hal = THREAD_CUDA_HAL.with(|cell| cell.replace(Some(cuda_hal)));
+    let previous_stream = THREAD_CUDA_STREAM.with(|cell| cell.replace(Some(stream)));
+    ThreadCudaBindingGuard {
+        previous_hal,
+        previous_stream,
+    }
 }
 
 /// RAII guard that clears the thread-local CUDA stream on drop.
-pub struct ThreadStreamGuard;
+pub struct ThreadCudaBindingGuard {
+    previous_hal: Option<Arc<CudaHalBB31>>,
+    previous_stream: Option<Arc<CudaStream>>,
+}
 
-impl Drop for ThreadStreamGuard {
+impl Drop for ThreadCudaBindingGuard {
     fn drop(&mut self) {
-        THREAD_CUDA_STREAM.with(|cell| {
-            *cell.borrow_mut() = None;
-        });
+        THREAD_CUDA_HAL.with(|cell| *cell.borrow_mut() = self.previous_hal.take());
+        THREAD_CUDA_STREAM.with(|cell| *cell.borrow_mut() = self.previous_stream.take());
     }
 }
 
@@ -452,11 +453,13 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ProverBackend for Gp
 
 pub struct GpuProver<PB: ProverBackend + 'static> {
     pub backend: Arc<PB>,
+    pub cuda_hal: Arc<CudaHalBB31>,
 }
 
 impl<PB: ProverBackend> GpuProver<PB> {
-    pub fn new(backend: Arc<PB>) -> Self {
-        Self { backend }
+    pub fn new(backend: Arc<PB>, cuda_hal: Arc<CudaHalBB31>) -> Self {
+        set_thread_cuda_hal(cuda_hal.clone());
+        Self { backend, cuda_hal }
     }
 }
 

--- a/gkr_iop/src/gpu/mod.rs
+++ b/gkr_iop/src/gpu/mod.rs
@@ -96,6 +96,12 @@ pub fn bind_thread_stream(
     }
 }
 
+/// Bind a worker-owned HAL and its default stream to the current thread.
+pub fn bind_thread_default_stream(cuda_hal: Arc<CudaHalBB31>) -> ThreadCudaBindingGuard {
+    let stream = cuda_hal.inner.default_stream().clone();
+    bind_thread_stream(cuda_hal, stream)
+}
+
 /// RAII guard that clears the thread-local CUDA stream on drop.
 pub struct ThreadCudaBindingGuard {
     previous_hal: Option<Arc<CudaHalBB31>>,
@@ -640,5 +646,50 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>>
             })
             .map(Arc::new)
             .collect_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CudaHalBB31, bind_thread_default_stream, forbid_default_stream_fallback, get_thread_stream,
+    };
+    use std::sync::{Arc, Barrier};
+
+    #[test]
+    fn bound_parent_stream_survives_another_scheduler_guard() {
+        let hal = Arc::new(CudaHalBB31::new(0).unwrap());
+        let expected_stream = hal.inner.default_stream().clone();
+        {
+            let _binding = bind_thread_default_stream(hal);
+            let barrier = Arc::new(Barrier::new(2));
+
+            std::thread::scope(|scope| {
+                let worker_barrier = barrier.clone();
+                scope.spawn(move || {
+                    let _fallback_guard = forbid_default_stream_fallback();
+                    worker_barrier.wait();
+                    worker_barrier.wait();
+                });
+
+                barrier.wait();
+                let bound_stream = get_thread_stream().expect("parent stream must remain bound");
+                assert!(Arc::ptr_eq(&bound_stream, &expected_stream));
+                barrier.wait();
+            });
+        }
+
+        let barrier = Arc::new(Barrier::new(2));
+        std::thread::scope(|scope| {
+            let worker_barrier = barrier.clone();
+            scope.spawn(move || {
+                let _fallback_guard = forbid_default_stream_fallback();
+                worker_barrier.wait();
+                worker_barrier.wait();
+            });
+            barrier.wait();
+            assert!(std::panic::catch_unwind(get_thread_stream).is_err());
+            barrier.wait();
+        });
     }
 }

--- a/gkr_iop/src/gpu/mod.rs
+++ b/gkr_iop/src/gpu/mod.rs
@@ -459,6 +459,7 @@ impl<E: ExtensionField, PCS: PolynomialCommitmentScheme<E>> ProverBackend for Gp
 
 pub struct GpuProver<PB: ProverBackend + 'static> {
     pub backend: Arc<PB>,
+    /// Owned for the prover lifetime; thread bindings only borrow this device identity via `Arc`.
     pub cuda_hal: Arc<CudaHalBB31>,
 }
 


### PR DESCRIPTION
## Problem

Ceno used process-global CUDA state and could prove base shards and recursion on only one device. Device ownership, memory validation, replay assignment, failure propagation, and base-to-recursion GPU reuse were implicit.

## Design Rationale

Each selected GPU owns its HAL, CUDA context, stream bindings, AOT replay state, and base prover. Round-robin ownership (`shard_id % device_count`) is deterministic: owned shards retain compact witnesses, while unowned shards fast-flight through canonical execution and replay-digest updates without compact witness arenas. Depth-one queues bound memory and apply backpressure.

The collector accepts out-of-order results, validates ownership and completeness, restores canonical shard order, and runs one full-trace Rust verification. Failures cancel all workers without cross-device retry.

Recursion V2 uses an event-driven DAG over the same GPU set. Consecutive base proofs immediately unlock leaf tasks; completed nodes notify eligible parents through a blocking scheduler. Leaf work is prioritized, followed by the deepest ready intermediate layer and root. A GPU joins recursion only after its base state is dropped, synchronized, and trimmed.

Shard-independent exact-VK recursion assets are built once and overlapped with AOT/base work. Shard count later binds the lightweight recursion plan and constructs only additional required depths. Recursion may run speculatively, but root publication remains gated on canonical base verification and the root proof is independently verified.

## Change Highlights

- `gkr_iop`: worker-owned HALs with scoped context and stream bindings.
- `ceno_emul`: canonical AOT replay with owned compact capture and unowned fast flight.
- `ceno_zkvm`: device discovery, validation, conservative shared shard limits, round-robin replay/proving, bounded collection, fail-first diagnostics, and base-to-recursion release events.
- `ceno_recursion_v2`: exact-VK host-asset templates, deterministic recursion DAG, blocking multi-worker scheduling, device-local hydration, and streaming root completion.
- CLI/SDK: GPU device list/count and optional worker CPU affinity; logical device 0 remains the default. GPU builds require AOT.

## Benchmark / Performance Impact

Workload: Reth block `23817600`, chain ID 1, 11 shards, `max_cell_per_shard=4500000000`, lanes 4, cache level 1, jagged reshape height 23, and a 3048 MiB booking margin. Both comparisons ran serially on the same dual-RTX-4090 self-hosted runner; only the selected device list differs.

### One GPU (`--gpu-devices 0`)

| Metric | Baseline | Latest | Change |
|---|---:|---:|---:|
| Base-prover setup | 13.308552 s | 13.868011 s | 4.20% slower |
| Base proof vector ready | 42.662679 s | 44.259000 s | 3.74% slower |
| Raw recursion worker | 5.759648 s | 6.371000 s | 10.61% slower |
| Recursion tail exposed after base work | 5.759648 s | 5.207741 s | **9.58% faster** |
| Raw proof timer | 48.488613 s | 50.846579 s | 4.86% slower* |
| Setup-normalized proof wall | 51.807145 s | 50.846579 s | **1.85% faster** (1.0189x) |
| Full measured lifecycle | 65.125955 s | 64.724166 s | **0.62% faster** |
| Root verification | 27.733 ms | 27.684 ms | 0.18% faster |

The raw proof timer is not an equivalent comparison: the baseline built exact-VK recursion assets for 3.318532 s outside that timer. The latest path starts the 6.229 s host-template build during setup and fully overlaps it (`template_wait_ms=0`, `bind_ms=0`), so the setup-normalized and full-lifecycle rows are the fair comparisons. The raw recursion worker is slower because it performs four legal post-trim device hydrations (425 ms total), but streaming overlaps 1.163 s with base proving and reduces the exposed recursion tail by 0.552 s.

### Two GPUs (`--gpu-devices 0,1`)

| Metric | Baseline | Latest | Change |
|---|---:|---:|---:|
| Base-prover setup | 13.539582 s | 13.898621 s | 2.65% slower |
| Base proof vector ready | 25.914000 s | 27.740000 s | 7.05% slower |
| Recursion critical path | 6.146068 s | 5.074000 s | **17.44% faster** |
| Recursion tail exposed after base work | 6.146068 s | 2.793161 s | **54.55% faster** |
| Raw proof timer | 33.674897 s | 31.831985 s | **5.47% faster** |
| Setup-normalized proof wall | 37.001080 s | 31.831985 s | **13.97% faster** (1.1624x) |
| Full measured lifecycle | 50.548843 s | 45.739433 s | **9.51% faster** |
| Root verification | 27.697 ms | 27 ms | 2.52% faster |

GPU 0 proves even shards and GPU 1 proves odd shards. All 11 proof-queue waits are zero, so replay produces every next owned shard before its current proof finishes. Unowned shards use fast-flight replay with zero compact rows/bytes. Streaming recursion schedules the six-task 4/4 DAG as dependencies become ready: GPU 0 executes four tasks and GPU 1 executes two leaf tasks. This overlaps 2.281 s of recursion with base proving and cuts the exposed recursion tail by 3.353 s. The remaining base-vector slowdown comes from duplicated replay/resource contention, six-even/five-odd round-robin imbalance, and run variance; it does not erase the E2E improvement.

### Latest one GPU vs. two GPUs

| Metric | One GPU | Two GPUs | Two-GPU improvement |
|---|---:|---:|---:|
| Base-prover setup | 13.868011 s | 13.898621 s | 0.22% slower |
| Base proof vector ready | 44.259000 s | 27.740000 s | **37.32% faster** (1.5955x) |
| Recursion critical path | 6.371000 s | 5.074000 s | **20.36% faster** (1.2556x) |
| Recursion tail exposed after base work | 5.207741 s | 2.793161 s | **46.36% faster** (1.8645x) |
| Proof wall | 50.846579 s | 31.831985 s | **37.40% faster** (1.5973x) |
| Full measured lifecycle | 64.724166 s | 45.739433 s | **29.33% faster** (1.4151x) |

The same-revision two-GPU run therefore improves proof wall by 37.40%, rather than the ideal 50%. The gap is expected from duplicated replay, non-shard serial work and verification, six-versus-five round-robin imbalance, and GPU/host resource contention. The zero queue waits show that replay is not starving either prover after its first owned shard.

### Correctness and evidence

- Both latest runs completed all 11 canonical shard proofs, canonical Rust full-trace verification, recursion, independent root verification, and exited successfully with an empty failure scan.
- The two-GPU ownership map is exact: GPU 0 owns shards `0,2,4,6,8,10`; GPU 1 owns `1,3,5,7,9`.
- Both GPUs trim/release base allocations before recursion; GPU 1 begins eligible leaf work without waiting for GPU 0 to finish all base work.
- Build identity: Ceno `c08df94610ba7e74c27c97019cb572d834f096bb`, benchmark `038f4e97f68c423691ddcdc14ca236dba71534a2`, ceno-gpu `dceb5e7e04dddf7f49ac0c7ffb2ef8cf91c536d3`, `CUDA_ARCH=89,120` (RTX 4090 loads SASS 89).

Raw logs:

- One-GPU baseline: [Actions run 32964242819](https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/32964242819)
- One-GPU latest: [Actions run 34201583159](https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/34201583159)
- Two-GPU baseline: [Actions run 34038286261](https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/34038286261)
- Two-GPU latest: [Actions run 34201591833](https://github.com/scroll-tech/ceno-reth-benchmark/actions/runs/34201591833)
## Testing

```sh
cargo fmt --all --check
cargo make clippy
CUDA_ARCH=120 cargo test -p ceno_zkvm multi_gpu --features gpu,aot-x86_64
cargo test -p ceno_recursion_v2 continuation::prover::scheduler::tests --lib
CUDA_ARCH=120 cargo test -p cargo-ceno streaming_recursion_tests --features gpu,aot-x86_64
```

- Device selection, ownership, fast-flight replay, bounded queues, cancellation, canonical collection, and CUDA binding tests pass.
- Recursion planning, notification, priority, exact-VK reuse, device hydration, failure propagation, and root-publication gate tests pass.
- One- and two-GPU RTX 4090 E2E runs pass all 11 base proofs, canonical verification, streaming recursion, independent root verification, and failure scans.

## Risks and Rollout

- Replay remains duplicated per GPU and round-robin assignment can leave uneven shard work.
- CUDA ownership and base-to-recursion transitions are correctness-sensitive; focused concurrency tests and dual-GPU E2E cover both.
- Recursion scheduling is non-preemptive and retains single-task DAG bottlenecks near the root.
- Device capability, module loading, HAL construction, and usable memory are validated before proving. The default remains logical GPU 0.

## Follow-ups (optional)

- Shared replay and cost-aware shard assignment.
- Retry/reassignment and peer-to-peer transfer.

## Copilot Reviewer Directive (keep this section)

When Copilot reviews this PR, apply `.github/copilot-instructions.md` strictly.
